### PR TITLE
ci(deps): bump actions/upload-artifact from 4 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload test results
         if: always() && hashFiles('**/test-results.trx') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: '**/test-results.trx'
@@ -74,7 +74,7 @@ jobs:
             --outputDir releases
 
       - name: Upload Velopack smoke artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: velopack-smoke-${{ github.run_number }}
           path: releases/


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` from v4 to v7 in `.github/workflows/ci.yml` (two call sites).

Replaces #5 (Dependabot), which couldn't auto-rebase cleanly after the Stage 0 ci.yml rewrite (#7) added a second `upload-artifact` usage for the Velopack smoke artifact.

## What changed in upstream v4 → v7

- **v5** added preliminary Node.js 24 runtime support (still defaulted to Node 20).
- **v6** flipped the runtime default to Node.js 24 (requires Actions Runner ≥ 2.327.1; GitHub-hosted runners meet this).
- **v7** adds an optional `archive: false` parameter for direct (unzipped) single-file uploads, plus internal ESM module conversion. We don't use the new parameter; both of our call sites stick to the standard `name` / `path` inputs and remain compatible.

## Test plan

- [ ] CI runs and the test-results artifact is uploaded successfully
- [ ] CI runs and the `velopack-smoke-<run_number>` artifact is downloadable

Once green, this can be squash-merged. I'll close #5 with a comment pointing here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_