### PR TITLE
ci(deps): bump softprops/action-gh-release from 2 to 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           $delim         | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Create GitHub Release and upload artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: pty-speak ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Bumps `softprops/action-gh-release` from v2 to v3 in `.github/workflows/release.yml`.

Replaces #3 (Dependabot), which couldn't auto-rebase cleanly after the Stage 0 release.yml rewrite (#7) reshaped the surrounding context.

## What changed in upstream v2 → v3

`v3.0.0` is *only* a Node.js 24 runtime bump — feature-equivalent to `v2.6.2`. It requires Actions Runner ≥ 2.327.1; `windows-latest` GitHub-hosted runners meet that.

We use only standard inputs (`tag_name`, `name`, `body`, `prerelease`, `fail_on_unmatched_files`, `files`), all unchanged across versions.

## Test plan

This action only runs on tag pushes (release pipeline). The smoke test will be when you push the `v0.0.1-preview.1` tag — the release workflow will use `@v3` to create the GitHub Release.

Once green (the workflow won't actually run until a tag, so CI will just be the markdown link check), this can be squash-merged. I'll close #3 with a comment pointing here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_