### PR TITLE
docs: bump CHANGELOG entry to 0.0.1-preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.1] — 2026-04-25
+## [0.0.1-preview.2] — 2026-04-26
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.
 > See [`SECURITY.md`](SECURITY.md).
+
+> Note: `v0.0.1-preview.1` was tagged but never published — the
+> release workflow couldn't start because the targeted GitHub
+> Environment had a capitalised name (`Release` instead of `release`).
+> `v0.0.1-preview.2` is the first preview that actually ships
+> artifacts; the scope is otherwise identical to what
+> `v0.0.1-preview.1` would have shipped.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Bump the `CHANGELOG.md` heading from `[0.0.1-preview.1]` to `[0.0.1-preview.2]` so the release workflow's release-notes regex can find the matching section when `v0.0.1-preview.2` is tagged. Without this, the workflow falls back to a generic `"Release 0.0.1-preview.2. See CHANGELOG.md for details."` body.

## Why .2

`v0.0.1-preview.1` was tagged but the release workflow couldn't start — the targeted GitHub Environment was named `Release` (capital R) instead of the lowercase `release` the workflow expects. The environment was renamed afterward, but the tag's failed-startup workflow runs aren't re-runnable from the GitHub UI, and tag protection appears to prevent deleting `v0.0.1-preview.1`. Skipping to `.2` is the cleanest re-tag path.

A brief note in the changelog entry explains the gap so the published-releases history is self-explanatory.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, you can publish `v0.0.1-preview.2` from the Releases UI; the workflow runs end-to-end and the release body uses the matching CHANGELOG section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_