### PR TITLE
docs: bump CHANGELOG entry to 0.0.1-preview.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,18 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.2] — 2026-04-26
+## [0.0.1-preview.3] — 2026-04-26
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.
 > See [`SECURITY.md`](SECURITY.md).
 
-> Note: `v0.0.1-preview.1` was tagged but never published — the
-> release workflow couldn't start because the targeted GitHub
-> Environment had a capitalised name (`Release` instead of `release`).
-> `v0.0.1-preview.2` is the first preview that actually ships
-> artifacts; the scope is otherwise identical to what
-> `v0.0.1-preview.1` would have shipped.
+> Note: `v0.0.1-preview.1` and `v0.0.1-preview.2` were tagged but
+> never shipped artifacts — both release-workflow runs hit a
+> startup_failure (first one due to a capitalised environment name,
+> second one indeterminate). `v0.0.1-preview.3` is the first preview
+> that actually ships artifacts; the scope is otherwise identical to
+> what `.1` and `.2` would have shipped.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Bump `CHANGELOG.md` heading from `[0.0.1-preview.2]` to `[0.0.1-preview.3]` so the release-notes regex finds the right section when `v0.0.1-preview.3` is tagged.

## Why .3

Both `v0.0.1-preview.1` and `v0.0.1-preview.2` hit release-workflow startup_failures:

- **.1**: targeted GitHub Environment was named `Release` (capital R) instead of `release`. Fixed by renaming.
- **.2**: indeterminate startup_failure (0s, no steps, no banner) even after the env rename. Workflow permissions have since been widened to "Read and write" on the chance that was a contributing factor; we'll find out on .3.

Skipping to `.3` lets us re-trigger without contention against the existing failed releases and orphaned tags. Body otherwise identical in scope.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, publish `v0.0.1-preview.3` from the Releases UI; release workflow runs end-to-end this time and attaches Velopack artifacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_