### PR TITLE
ci: trigger release workflow on release-published event, not tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,35 @@
 name: Release
 
+# Triggered when a release is published via the GitHub UI or API.
+# We deliberately do NOT trigger on tag pushes — four consecutive
+# `push: tags:` runs on v0.0.1-preview.{1,2,3,4} hit silent
+# startup_failures (0s, no steps, no banner) on this repo even after
+# correcting environment, permissions, allowed-actions, and dropping
+# the env directive. The release-event trigger sidesteps whatever
+# tag-trigger gating is biting us.
+#
+# Workflow:
+# 1. Maintainer publishes a release at v<version> via Releases UI
+#    (leaving title/body blank; a-version-only checkbox for prerelease).
+# 2. This workflow runs, builds + tests + publishes + Velopack-packs.
+# 3. softprops/action-gh-release@v3 *updates* the just-created release
+#    with the proper title, CHANGELOG body, prerelease flag, and
+#    Velopack artifact files.
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-preview.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g. 0.1.0 or 0.1.0-preview.1)'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
   release:
     name: Build and publish unsigned preview to GitHub Releases
     runs-on: windows-latest
-    # `environment:` deliberately omitted while we ship unsigned
-    # previews — three consecutive 0s startup_failures on
-    # v0.0.1-preview.{1,2,3} pointed at GitHub Environment integration
-    # as the suspect, despite the env existing with a matching name and
-    # default config. Re-add `environment: release` when SignPath /
-    # Ed25519 signing returns and we actually need the approval gate
-    # (see docs/RELEASE-PROCESS.md "Re-enabling signing (deferred)").
     timeout-minutes: 60
 
     steps:
@@ -38,16 +37,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Resolve version
         id: version
         shell: pwsh
         run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $v = '${{ inputs.version }}'
-          } else {
-            $v = '${{ github.ref_name }}' -replace '^v',''
-          }
+          $v = '${{ github.event.release.tag_name }}' -replace '^v',''
           if ($v -match '-(preview|rc)\.') {
             $prerelease = 'true'
           } else {
@@ -117,10 +113,10 @@ jobs:
           $body          | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           $delim         | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Create GitHub Release and upload artifacts
+      - name: Update GitHub Release with body and artifacts
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ github.event.release.tag_name }}
           name: pty-speak ${{ steps.version.outputs.version }}
           body: ${{ steps.notes.outputs.body }}
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,23 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.4] — 2026-04-26
+## [0.0.1-preview.5] — 2026-04-26
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.
 > See [`SECURITY.md`](SECURITY.md).
 
-> Note: `v0.0.1-preview.{1,2,3}` were tagged but never shipped
-> artifacts — three consecutive release-workflow startup_failures
-> traced (eventually) to GitHub Environment integration. Dropped
-> `environment: release` from the workflow for the unsigned preview
-> line; will restore when signing returns and the approval gate is
-> actually useful. `v0.0.1-preview.4` is the first preview that
-> actually ships artifacts; scope is otherwise identical to what
-> `.1`–`.3` would have shipped.
+> Note: `v0.0.1-preview.{1,2,3,4}` were tagged but never shipped
+> artifacts — every run of the `push: tags:`-triggered release
+> workflow hit a silent startup_failure (0s, no steps, no banner)
+> on this repo despite incrementally fixing every visible cause:
+> environment name, workflow permissions, allowed-actions,
+> and finally dropping the `environment:` directive entirely. The
+> `release.yml` trigger has been switched to `release: published`,
+> which fires when a release is published via the website and
+> bypasses whatever tag-trigger gating was biting us. `.5` is the
+> first preview that actually ships artifacts; scope is otherwise
+> identical to what `.1`–`.4` would have shipped.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Switch the release workflow trigger from `push: tags:` to `release: types: [published]`. This sidesteps whatever tag-trigger platform gating has been silently startup-failing every release attempt on this repo.

## Why

| Tag | Fix attempted | Result |
|---|---|---|
| `.1` | (initial) | startup_failure 0s |
| `.2` | env renamed `Release` → `release` | startup_failure 0s |
| `.3` | workflow permissions widened to read+write | startup_failure 0s |
| `.4` | `environment: release` removed entirely | startup_failure 0s |

Four consecutive 0s startup_failures with no steps and no error banner, despite addressing every visible config knob. `ci.yml` (`push: branches:`) keeps working, so the issue is specific to `push: tags:` triggers on this repo (most likely a tag protection / ruleset interaction GitHub isn't surfacing in the UI).

The `release: published` trigger fires when a maintainer publishes a release via the GitHub UI/API — no tag-push involvement on the workflow side.

## Workflow changes

- `on:` — replaced `push:` and `workflow_dispatch:` with `release: types: [published]`
- `concurrency` group keyed on `github.event.release.tag_name`
- Checkout step pins `ref:` to the release's `tag_name` (so the workflow file content matches the commit at the released tag, not just whatever's on `main`)
- Version resolution reads from `github.event.release.tag_name`
- `softprops/action-gh-release` `tag_name` uses `github.event.release.tag_name` (not `github.ref_name`, which is `main` on release events)

The `softprops/action-gh-release@v3` step now updates the just-created release: sets the proper title, replaces the auto-generated body with the matching CHANGELOG section + unsigned-preview banner, and attaches the Velopack artifacts.

## CHANGELOG

Bumped to `[0.0.1-preview.5]` with a note explaining the `.1`–`.4` gap.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, publish `v0.0.1-preview.5` via Releases UI
- [ ] Workflow runs end-to-end this time (release event fires; no tag-trigger gating)
- [ ] Release body and artifacts populate correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_