### PR TITLE
ci: add minimal diagnostic workflow to isolate release.yml startup_failures

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -1,0 +1,18 @@
+name: Diagnose
+
+# Minimal diagnostic workflow. Triggered manually from the Actions tab
+# via "Run workflow". Used to determine whether silent startup_failures
+# we're seeing on release.yml are repo-level vs specific to that file's
+# content. If this workflow succeeds, the problem is in release.yml.
+# If it fails with the same 0s startup_failure shape, the problem is
+# at the repository or account level.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo a known-good string
+        run: echo "Diagnose workflow ran. The runner is alive."


### PR DESCRIPTION
## Summary

Add a minimal diagnostic workflow at `.github/workflows/diagnose.yml`. Its only purpose: determine whether the silent 0s startup_failures we keep hitting on `release.yml` are specific to that workflow's content, or whether they're a repo/account-level issue.

## Why

Five consecutive failed release-workflow runs on this repo (`v0.0.1-preview.{1,2,3,4,5}`), all matching the same shape:
- 0 seconds
- No steps shown
- No error banner

We've fixed the four obvious causes in sequence (env name → permissions → allowed-actions → env directive removed → trigger swapped from `push: tags:` to `release: published`). None changed the failure shape.

This workflow is deliberately as simple as GitHub Actions allows:
- `workflow_dispatch:` only — runs when you click "Run workflow"
- `ubuntu-latest` — different runner pool from `release.yml`'s windows-latest
- One job, one `echo` step
- No permissions block, no environment, no concurrency, no external actions

## Test plan after merge

1. Open https://github.com/KyleKeane/pty-speak/actions/workflows/diagnose.yml
2. Click **"Run workflow"** dropdown → select branch `main` → click **"Run workflow"**
3. Wait ~10 seconds and tell me the result:
   - **Succeeds** → release.yml has a content-specific issue. We narrow down by stripping it incrementally.
   - **Fails 0s same shape** → it's a repo/account-level issue (Actions disabled at org level? Spending limit? Account flag?). I'll switch to investigating that.
   - **Fails differently** (with steps/error message) → finally a real diagnostic, paste it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_