### PR TITLE
ci: strip release.yml to minimum to isolate startup_failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,13 @@
 name: Release
 
 # Triggered when a release is published via the GitHub UI or API.
-# We deliberately do NOT trigger on tag pushes — four consecutive
-# `push: tags:` runs on v0.0.1-preview.{1,2,3,4} hit silent
-# startup_failures (0s, no steps, no banner) on this repo even after
-# correcting environment, permissions, allowed-actions, and dropping
-# the env directive. The release-event trigger sidesteps whatever
-# tag-trigger gating is biting us.
 #
-# Workflow:
-# 1. Maintainer publishes a release at v<version> via Releases UI
-#    (leaving title/body blank; a-version-only checkbox for prerelease).
-# 2. This workflow runs, builds + tests + publishes + Velopack-packs.
-# 3. softprops/action-gh-release@v3 *updates* the just-created release
-#    with the proper title, CHANGELOG body, prerelease flag, and
-#    Velopack artifact files.
+# THIS IS A DEBUG VARIANT. release.yml has been silently
+# rejected (no jobs spawned) for v0.0.1-preview.{1..5} despite
+# every visible config fix. Reduced to a near-minimal shape to
+# verify the workflow can even start. Once a release publish
+# triggers a visibly-running job here, the build/test/publish/
+# Velopack-pack/upload steps will be re-added incrementally.
 on:
   release:
     types: [published]
@@ -22,108 +15,13 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: release-${{ github.event.release.tag_name }}
-  cancel-in-progress: false
-
 jobs:
   release:
-    name: Build and publish unsigned preview to GitHub Releases
-    runs-on: windows-latest
-    timeout-minutes: 60
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Resolve version
-        id: version
-        shell: pwsh
+      - name: Confirm workflow started
         run: |
-          $v = '${{ github.event.release.tag_name }}' -replace '^v',''
-          if ($v -match '-(preview|rc)\.') {
-            $prerelease = 'true'
-          } else {
-            $prerelease = 'false'
-          }
-          "version=$v"            | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "prerelease=$prerelease" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          Write-Host "Releasing version $v (prerelease=$prerelease)"
-
-      - name: Setup .NET 9
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 9.0.x
-
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build (Release)
-        run: dotnet build --configuration Release --no-restore /p:Version=${{ steps.version.outputs.version }}
-
-      - name: Test
-        run: dotnet test --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
-
-      - name: Publish (self-contained win-x64)
-        run: dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish /p:Version=${{ steps.version.outputs.version }}
-
-      - name: Install Velopack CLI
-        run: dotnet tool install -g vpk
-
-      - name: Pack with Velopack
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path releases | Out-Null
-          vpk pack `
-            --packId pty-speak `
-            --packTitle 'pty-speak' `
-            --packAuthors 'pty-speak contributors' `
-            --packVersion ${{ steps.version.outputs.version }} `
-            --packDir publish `
-            --mainExe Terminal.App.exe `
-            --outputDir releases
-
-      - name: Generate release notes from CHANGELOG.md
-        id: notes
-        shell: pwsh
-        run: |
-          $version = '${{ steps.version.outputs.version }}'
-          $content = Get-Content CHANGELOG.md -Raw
-          $pattern = "(?ms)^## \[$version\].*?(?=^## \[|\z)"
-          $match = [regex]::Match($content, $pattern)
-          if ($match.Success) {
-            $body = $match.Value.Trim()
-          } else {
-            $body = "Release $version. See CHANGELOG.md for details."
-          }
-          $banner = @"
-> [!WARNING]
-> **Unsigned preview build.** Releases tagged before v0.1.0 are not
-> Authenticode-signed and have no Ed25519 manifest signature. Windows
-> SmartScreen will warn on first install. Authenticode + Ed25519
-> signing return before v0.1.0 — see SECURITY.md.
-
-"@
-          $body = $banner + $body
-          $delim = "EOF_$([guid]::NewGuid().ToString('N'))"
-          "body<<$delim" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          $body          | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          $delim         | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Update GitHub Release with body and artifacts
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.event.release.tag_name }}
-          name: pty-speak ${{ steps.version.outputs.version }}
-          body: ${{ steps.notes.outputs.body }}
-          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          fail_on_unmatched_files: true
-          files: |
-            releases/*Setup.exe
-            releases/*-full.nupkg
-            releases/*-delta.nupkg
-            releases/releases.json
-            releases/RELEASES
+          echo "Release workflow started"
+          echo "Tag: ${{ github.event.release.tag_name }}"
+          echo "Release ID: ${{ github.event.release.id }}"
+          echo "Event name: ${{ github.event_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,23 +13,24 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.5] — 2026-04-26
+## [0.0.1-preview.6] — 2026-04-26
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.
 > See [`SECURITY.md`](SECURITY.md).
 
-> Note: `v0.0.1-preview.{1,2,3,4}` were tagged but never shipped
-> artifacts — every run of the `push: tags:`-triggered release
-> workflow hit a silent startup_failure (0s, no steps, no banner)
-> on this repo despite incrementally fixing every visible cause:
-> environment name, workflow permissions, allowed-actions,
-> and finally dropping the `environment:` directive entirely. The
-> `release.yml` trigger has been switched to `release: published`,
-> which fires when a release is published via the website and
-> bypasses whatever tag-trigger gating was biting us. `.5` is the
-> first preview that actually ships artifacts; scope is otherwise
-> identical to what `.1`–`.4` would have shipped.
+> Note: `v0.0.1-preview.{1..5}` were tagged but never shipped
+> artifacts — every release-workflow run on this repo silently
+> failed to spawn any job at all (workflow-level startup rejection
+> with no diagnostic info), despite incrementally fixing every
+> visible cause. A minimal echo-only diagnose workflow runs fine on
+> `workflow_dispatch`, so the issue is specific to release.yml's
+> content. release.yml has been temporarily reduced to a minimal
+> shape to verify it can start at all. The full build/test/publish/
+> Velopack-pack/upload steps will be re-added incrementally once
+> we see a visibly-running job. `.6` is the test publish for that
+> minimal shape; subsequent .7+ will incrementally restore work
+> until we identify the offending construct.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Strip `release.yml` to a near-minimal echo-only shape so we can verify it's even capable of starting on this repo. Once we see a visibly-running job, the real release work gets added back incrementally to find the offending construct.

## Why

Five consecutive failed release-workflow runs on `v0.0.1-preview.{1..5}`, each with **no jobs spawned** at all (workflow-level rejection, no diagnostic info). Meanwhile a deliberately minimal `diagnose.yml` running on `workflow_dispatch` + `ubuntu-latest` works fine — so the issue is specific to release.yml's content, not Actions overall.

## What changes

`release.yml` becomes:
- Same trigger (`on: release: types: [published]`)
- One job, `runs-on: ubuntu-latest`
- `permissions: contents: write` (parity with what we'll need later)
- One step that echoes the release tag/id/event-name

Removed (temporarily):
- `concurrency` block
- Long job `name:` field
- `timeout-minutes: 60`
- `runs-on: windows-latest`
- All build/test/publish/Velopack/notes-generation/upload steps

`CHANGELOG.md` heading bumped to `[0.0.1-preview.6]`.

## Test plan

After merge:

1. Publish `v0.0.1-preview.6` via the Releases UI same as before
2. Open https://github.com/KyleKeane/pty-speak/actions/workflows/release.yml
3. Check the run state:
   - **Job spawned, "Confirm workflow started" step visible with echoed values** → the trigger and basic shape work; we restore work incrementally
   - **Same "no jobs spawned" silent rejection** → the `release: published` trigger itself is being rejected on this repo (very weird) and we need to escalate (rewrite to use `workflow_dispatch` + manual tag input, or contact GitHub support)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_