### PR TITLE
ci: switch stripped release.yml to windows-latest runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Confirm workflow started
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.6] — 2026-04-26
+## [0.0.1-preview.7] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

Single-variable change: switch the stripped release.yml's `runs-on` from `ubuntu-latest` to `windows-latest` (which the real WPF build will need anyway). Bumps CHANGELOG to `[0.0.1-preview.7]`.

## Why

`v0.0.1-preview.6` with the echo-only ubuntu workflow ran successfully — proving the `release: published` trigger and basic workflow shape work. Now we restore the real pipeline incrementally to identify which earlier construct was causing the silent startup_failures on `.1`–`.5`.

This is the smallest possible next step: only the runner OS changes. If it runs, we keep adding (next: `actions/checkout@v4`, then `actions/setup-dotnet@v5`, then build, etc.). If it silently fails, we know windows-latest + release event is the issue and we pivot to a different shape.

## Test plan

After merge, publish `v0.0.1-preview.7`:

- **Job spawns and step echoes** → windows-latest is fine; next PR adds the next layer
- **No job spawned (silent startup_failure)** → windows-latest + release event is the issue; we'll restructure the workflow (likely split build/upload across runner types or fall back to manual workflow_dispatch with a tag input)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_