### PR TITLE
ci: restore checkout + setup-dotnet + restore + build + test in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,11 @@ name: Release
 
 # Triggered when a release is published via the GitHub UI or API.
 #
-# THIS IS A DEBUG VARIANT. release.yml has been silently
-# rejected (no jobs spawned) for v0.0.1-preview.{1..5} despite
-# every visible config fix. Reduced to a near-minimal shape to
-# verify the workflow can even start. Once a release publish
-# triggers a visibly-running job here, the build/test/publish/
-# Velopack-pack/upload steps will be re-added incrementally.
+# Incremental restoration. v0.0.1-preview.6 confirmed the trigger
+# and basic shape work on ubuntu-latest. v0.0.1-preview.7 confirmed
+# the same on windows-latest. This iteration restores
+# checkout + setup-dotnet + restore + build + test. Next iteration
+# will add publish + vpk pack + softprops/action-gh-release upload.
 on:
   release:
     types: [published]
@@ -24,4 +23,26 @@ jobs:
           echo "Release workflow started"
           echo "Tag: ${{ github.event.release.tag_name }}"
           echo "Release ID: ${{ github.event.release.id }}"
-          echo "Event name: ${{ github.event_name }}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Show .NET version
+        run: dotnet --version
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Confirm pipeline reached end
+        run: echo "Build and test pipeline completed for tag ${{ github.event.release.tag_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.7] — 2026-04-27
+## [0.0.1-preview.8] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

Restore checkout + setup-dotnet + restore + build + test in the release workflow. CHANGELOG bumped to `[0.0.1-preview.8]`.

## Why

Confirmed working so far:
- `release: published` trigger ✓ (`v0.0.1-preview.6`)
- `runs-on: windows-latest` ✓ (`v0.0.1-preview.7`)

Next layers added in this PR:
- `actions/checkout@v4` (default ref — release events set `GITHUB_REF` to `refs/tags/<tag>`)
- `actions/setup-dotnet@v5` with `dotnet-version: 9.0.x`
- `dotnet --version` smoke
- `dotnet restore`
- `dotnet build --configuration Release`
- `dotnet test --configuration Release --no-build`

If this works on `v0.0.1-preview.8`, only the publish + vpk-pack + softprops-upload steps remain. If it silently fails, we've narrowed the offending construct to one of these.

## Test plan

After merge, publish `v0.0.1-preview.8`:

- **Job spawns and all steps run (build/test pass or fail with a real error)** → these layers are fine; next PR adds publish + vpk pack + softprops
- **Silent no-job-spawned again** → one of `actions/checkout@v4` or `actions/setup-dotnet@v5` is the trigger; we bisect

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_