### PR TITLE
ci: bisect upload half — add release-notes step only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,27 @@ jobs:
         run: |
           echo "Velopack pack completed for tag ${{ github.event.release.tag_name }}"
           dir releases
+
+      - name: Generate release notes from CHANGELOG.md
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $content = Get-Content CHANGELOG.md -Raw
+          $pattern = "(?ms)^## \[$version\].*?(?=^## \[|\z)"
+          $match = [regex]::Match($content, $pattern)
+          if ($match.Success) {
+            $body = $match.Value.Trim()
+          } else {
+            $body = "Release $version. See CHANGELOG.md for details."
+          }
+          $banner = @"
+> [!WARNING]
+> **Unsigned preview build.** Releases tagged before v0.1.0 are not
+> Authenticode-signed and have no Ed25519 manifest signature. Windows
+> SmartScreen will warn on first install. Authenticode + Ed25519
+> signing return before v0.1.0 — see SECURITY.md.
+
+"@
+          $body = $banner + $body
+          Set-Content -Path release-body.md -Value $body -Encoding UTF8
+          Write-Host "Release body written to release-body.md ($($body.Length) chars)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.10] — 2026-04-27
+## [0.0.1-preview.11] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

Bisecting the upload half of PR #18. This adds **only** the release-notes generation step (PowerShell with `@"..."@` heredoc + regex match against CHANGELOG.md). softprops/action-gh-release is **not** added yet. CHANGELOG bumped to `[0.0.1-preview.11]`.

## Test plan

After merge, publish `v0.0.1-preview.11`:

- **Job runs through (release-body.md written)** → heredoc/regex is fine; the breaker is `softprops/action-gh-release@v3` and we'll iterate on that
- **Silent no-job-spawned** → the heredoc/regex is the breaker; we'll rewrite the release-notes step in a non-PowerShell way

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_