### PR TITLE
ci: fix YAML-breaking PowerShell heredoc in release-notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,14 +95,15 @@ jobs:
           } else {
             $body = "Release $version. See CHANGELOG.md for details."
           }
-          $banner = @"
-> [!WARNING]
-> **Unsigned preview build.** Releases tagged before v0.1.0 are not
-> Authenticode-signed and have no Ed25519 manifest signature. Windows
-> SmartScreen will warn on first install. Authenticode + Ed25519
-> signing return before v0.1.0 — see SECURITY.md.
-
-"@
+          $bannerLines = @(
+            "> [!WARNING]",
+            "> **Unsigned preview build.** Releases tagged before v0.1.0 are not",
+            "> Authenticode-signed and have no Ed25519 manifest signature. Windows",
+            "> SmartScreen will warn on first install. Authenticode + Ed25519",
+            "> signing return before v0.1.0 — see SECURITY.md.",
+            ""
+          )
+          $banner = ($bannerLines -join "`n") + "`n"
           $body = $banner + $body
           Set-Content -Path release-body.md -Value $body -Encoding UTF8
           Write-Host "Release body written to release-body.md ($($body.Length) chars)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.11] — 2026-04-27
+## [0.0.1-preview.12] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

`v0.0.1-preview.11` confirmed: the release-notes step's PowerShell `@"..."@` heredoc was the breaker. The heredoc body lines were at column 0 in the YAML source while the surrounding `run: |` block has 10-space indentation. YAML literal blocks require content lines to be indented at least as much as the block's first line; column-0 lines terminate the block early, leaving the rest of the heredoc content as malformed YAML. GitHub silently rejects malformed workflow files.

This is also the cause of the **original** silent startup_failures on `v0.0.1-preview.{1..5}` — the original release.yml had the same heredoc shape.

## Fix

Replace the heredoc with an array of properly-indented strings joined by `` `n``. Functionally equivalent (same banner text, trailing blank line preserved), but every line is indented to the run-block's level so YAML parses cleanly.

CHANGELOG bumped to `[0.0.1-preview.12]`.

## Test plan

After merge, publish `v0.0.1-preview.12`:

- **Job spawns and runs through** → confirmed; the heredoc was the (only) issue
- **Silent no-job-spawned** → something else is also wrong; we keep bisecting

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_