### PR TITLE
ci: add softprops/action-gh-release@v3 step to upload Velopack artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,18 @@ jobs:
           $body = $banner + $body
           Set-Content -Path release-body.md -Value $body -Encoding UTF8
           Write-Host "Release body written to release-body.md ($($body.Length) chars)"
+
+      - name: Update GitHub Release with body and artifacts
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          name: pty-speak ${{ steps.version.outputs.version }}
+          body_path: release-body.md
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+          fail_on_unmatched_files: true
+          files: |
+            releases/*Setup.exe
+            releases/*-full.nupkg
+            releases/*-delta.nupkg
+            releases/releases.json
+            releases/RELEASES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.12] — 2026-04-27
+## [0.0.1-preview.13] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

Final piece of the release pipeline: add `softprops/action-gh-release@v3` to upload Velopack artifacts to the release and update the release's body/title/prerelease flag. CHANGELOG bumped to `[0.0.1-preview.13]`.

## What this does on a release

1. The body file written by the previous step (release-body.md) becomes the release body
2. Title is set to `pty-speak <version>`
3. `prerelease: true` for `-preview.N` and `-rc.N` tags
4. Five artifact files attached: `pty-speak-Setup.exe`, `*-full.nupkg`, `*-delta.nupkg`, `releases.json`, `RELEASES`
5. `fail_on_unmatched_files: true` so missing artifacts fail the workflow loudly

## Test plan

After merge, publish `v0.0.1-preview.13`:

- **Job runs all the way; release page shows artifacts + proper title/body** → working release pipeline; end of the diagnostic ladder
- **Silent no-job-spawned** → `softprops/action-gh-release@v3` itself is the breaker (despite Dependabot PR #9 claiming v3 exists, we never validated until now); fallback is to pin `@v2.6.2`
- **Job runs but step fails with a real error** → standard debugging from the log

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_