### PR TITLE
ci: drop optional delta-nupkg pattern from softprops files list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,5 @@ jobs:
           files: |
             releases/*Setup.exe
             releases/*-full.nupkg
-            releases/*-delta.nupkg
             releases/releases.json
             releases/RELEASES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.13] — 2026-04-27
+## [0.0.1-preview.14] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

`v0.0.1-preview.13` ran the full pipeline successfully — failing only at the softprops step with:

```
Error: Pattern 'releases/*-delta.nupkg' does not match any files.
```

`vpk pack` only produces a delta package when there's a previous release to diff against. Our `vpk pack` command doesn't pass `--baseDir` or `--releaseDir`, so the first release ships full installer + full nupkg only — no delta.

## Fix

Drop `releases/*-delta.nupkg` from the softprops files list. The remaining four patterns are all mandatory and present:

- `releases/*Setup.exe` — Velopack installer
- `releases/*-full.nupkg` — full release package
- `releases/releases.json` — Velopack manifest
- `releases/RELEASES` — legacy index

Re-add the delta pattern when we wire up the prior-release download step (and pass `--baseDir` / `--releaseDir` to `vpk pack`). That work belongs to whichever stage actually needs delta updates — likely Stage 11 (Velopack auto-update).

CHANGELOG bumped to `[0.0.1-preview.14]`.

## Test plan

After merge, publish `v0.0.1-preview.14`:

- Workflow runs all the way through and uploads four artifacts to the release; release body matches CHANGELOG section with unsigned-preview banner. End of the diagnostic ladder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_