### PR TITLE
ci: restore delta-nupkg pattern with fail_on_unmatched_files: false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,17 @@ jobs:
           name: pty-speak ${{ steps.version.outputs.version }}
           body_path: release-body.md
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          fail_on_unmatched_files: true
+          # fail_on_unmatched_files: false — vpk pack only produces a
+          # *-delta.nupkg when there's a previous release to diff
+          # against, so the delta pattern legitimately matches no files
+          # on the very first release. Required artifacts (Setup.exe,
+          # full nupkg, releases.json, RELEASES) are always produced
+          # by vpk pack; if any of them are missing, the prior vpk
+          # pack step would have failed already.
+          fail_on_unmatched_files: false
           files: |
             releases/*Setup.exe
             releases/*-full.nupkg
+            releases/*-delta.nupkg
             releases/releases.json
             releases/RELEASES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ matching tag triggers the Velopack release workflow described in
 
 _(empty — Stage 1 work lands here)_
 
-## [0.0.1-preview.14] — 2026-04-27
+## [0.0.1-preview.15] — 2026-04-27
 
 > **Unsigned preview build.** Authenticode + Ed25519 signing are
 > deferred until before `v0.1.0`; SmartScreen will warn on first run.


### PR DESCRIPTION
## Summary

Per request: restore the `releases/*-delta.nupkg` pattern (dropped in PR #23) combined with `fail_on_unmatched_files: false` so missing optional files don't break the upload. CHANGELOG bumped to `[0.0.1-preview.15]`.

## Why this is safe

- `vpk pack` only produces a `*-delta.nupkg` when there's a previous release to diff against (it never does on the first release)
- The other four patterns (Setup.exe, full nupkg, releases.json, RELEASES) are always produced by `vpk pack`; if any are missing, the `vpk pack` step itself fails and we never reach softprops
- So `fail_on_unmatched_files: false` only loosens enforcement on the optional delta in practice — required artifacts are still gated upstream

Once we have a previous release, `vpk pack` will produce the delta and it gets uploaded automatically.

## Important: about `v0.0.1-preview.14`'s 0s failure

I dug into the API and found `target_commitish = claude/create-project-docs-xVA6n` on the `.14` release — meaning the tag was created against the **old Stage 0 branch's HEAD**, not `main`. The `release.yml` at that branch's HEAD is from before all the recent fixes and still has the broken heredoc. That's the only reason `.14` hit a 0s startup_failure — it ran an outdated workflow file.

**When you publish `v0.0.1-preview.15`, please double-check the Target dropdown is set to `main`.** The dropdown defaults to main, so just make sure it didn't pick up an old branch this time.

## Test plan

After merge, publish `v0.0.1-preview.15` (Target: `main`):

- Workflow runs end-to-end on a tag whose target is `main` (i.e., uses the up-to-date workflow file)
- Release page shows: proper title (`pty-speak 0.0.1-preview.15`), unsigned-preview banner + CHANGELOG body, four attached artifacts (no delta on this first run, which is fine)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_