### PR TITLE
feat: Stage 2 — VT500 parser (Williams' state machine in Terminal.Parser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 2 — VT500 parser.** `Terminal.Parser` now contains a
+  pure-F# implementation of Paul Williams' DEC ANSI parser
+  ([vt100.net/emu/dec_ansi_parser.html](https://vt100.net/emu/dec_ansi_parser.html)),
+  matching alacritty/vte's table-driven structure. `StateMachine`
+  is a stateful single-byte feeder over fourteen `VtState` cases
+  (Ground, Escape, EscapeIntermediate, CsiEntry/Param/Intermediate/Ignore,
+  DcsEntry/Param/Intermediate/Passthrough/Ignore, OscString,
+  SosPmApcString) with the canonical alacritty caps applied
+  (`MAX_INTERMEDIATES = 2`, `MAX_OSC_PARAMS = 16`,
+  `MAX_OSC_RAW = 1024`, `MAX_PARAMS = 16`). `Parser` exposes
+  `create`/`feed`/`feedBytes`/`feedArray` for downstream consumers.
+  A small UTF-8 decoder buffers continuation bytes and emits a
+  single `Print of Rune` per scalar; malformed UTF-8 emits
+  U+FFFD. See [`spec/tech-plan.md`](spec/tech-plan.md) Stage 2.
+- The placeholder `VtEvent` discriminated union in
+  `Terminal.Core/Types.fs` is replaced with the real DU per spec
+  §2.2 (`Print | Execute | CsiDispatch | EscDispatch | OscDispatch
+  | DcsHook | DcsPut | DcsUnhook`). Other DUs in `Types.fs` remain
+  placeholders pending their owning stages.
+- Stage 2 tests in `tests/Tests.Unit/VtParserTests.fs`:
+  - **Fixture tests** for every byte-string example called out in
+    spec §2.4 (`"Hello\r\n"`, `"\x1b[31mRed\x1b[0m"`, `"\x1b[2J"`,
+    `"\x1b]0;Title\x07"`, `"\x1b[?1049h"`) plus multi-param
+    SGR, default-parameter CSI, ESC dispatch (DECKPAM), CAN
+    cancellation, and UTF-8 multi-byte assembly.
+  - **FsCheck property tests** verifying the spec's robustness
+    contract: parser never throws on arbitrary bytes; chunked feed
+    equals whole-array feed; CAN (0x18) at any point returns the
+    parser to `Ground`.
 - [`docs/CHECKPOINTS.md`](docs/CHECKPOINTS.md): rollback guide
   documenting stable development checkpoints. Defines the three
   durable references for each checkpoint (git tag in `baseline/`

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -1,17 +1,67 @@
 namespace Terminal.Core
 
+open System.Text
+
 /// Marker type used by smoke tests to verify the assembly loads.
 type Marker = class end
 
-/// A single screen cell. Stage 2 fills in the real fields.
+/// A single screen cell. Stage 3 fills in the real fields.
 type Cell = { Placeholder: unit }
 
-/// The screen buffer. Stage 2 fills in the real fields.
+/// The screen buffer. Stage 3 fills in the real fields.
 type ScreenBuffer = { Placeholder: unit }
 
-/// VT events emitted by the parser. Stage 3 expands this DU.
+/// Events emitted by the VT500 state machine in `Terminal.Parser`.
+///
+/// Mirrors the callback set defined by Paul Williams' DEC ANSI parser
+/// (https://vt100.net/emu/dec_ansi_parser.html) and alacritty/vte's
+/// `Perform` trait. Each variant captures the parsed structure
+/// without any screen-buffer or rendering interpretation; that work
+/// belongs to `Terminal.Semantics` (Stage 3+).
+///
+/// Caps used by the parser (matching alacritty/vte):
+///   * MAX_INTERMEDIATES = 2   — bytes in the 0x20..0x2F range during
+///                                CSI / DCS / ESC sequences. Anything
+///                                beyond two is dropped silently.
+///   * MAX_OSC_PARAMS    = 16  — semicolon-separated OSC fields.
+///   * MAX_OSC_RAW       = 1024 — total bytes in the OSC payload
+///                                across all params.
 type VtEvent =
-    | Placeholder
+    /// A single Unicode scalar value to render at the cursor. Multi-
+    /// byte UTF-8 sequences are assembled inside the parser; invalid
+    /// sequences emit U+FFFD (replacement character).
+    | Print of Rune
+    /// A C0 (0x00-0x1F) or C1 (0x80-0x9F) control byte that wasn't
+    /// itself the start of an escape sequence (e.g., BEL, BS, HT, LF,
+    /// CR). Consumers handle these directly.
+    | Execute of byte
+    /// CSI sequence (`ESC [`). `parms` are the numeric parameters
+    /// (defaulted to 0 when omitted), `intermediates` are 0x20..0x2F
+    /// bytes that appeared between the parameters and the final byte,
+    /// `finalByte` is the dispatch byte (0x40..0x7E), and `priv` is
+    /// the optional private-marker byte (`?`, `>`, `<`, `=`) that may
+    /// appear immediately after `ESC [` for vendor extensions like
+    /// DECSET.
+    | CsiDispatch of parms: int[] * intermediates: byte[] * finalByte: char * priv: char option
+    /// Bare ESC sequence (`ESC <intermediates> <final>`). Used by
+    /// DECKPAM (`ESC =`), DECKPNM (`ESC >`), DECSC (`ESC 7`),
+    /// DECRC (`ESC 8`), and similar.
+    | EscDispatch of intermediates: byte[] * finalByte: char
+    /// OSC sequence (`ESC ]`). `parms` are the semicolon-separated
+    /// payload fields preserved as raw bytes. `bellTerminated` is true
+    /// when the sequence ended with BEL (0x07), false when it ended
+    /// with ST (`ESC \`); some hosts care about the distinction (e.g.
+    /// xterm OSC 52).
+    | OscDispatch of parms: byte[][] * bellTerminated: bool
+    /// DCS hook (`ESC P`). Begins a DCS pass-through string that is
+    /// terminated by ST (`ESC \`). Stage 1's parser emits the
+    /// hook/put/unhook events but doesn't interpret the payload —
+    /// Sixel, ReGIS, and friends are deferred.
+    | DcsHook of parms: int[] * intermediates: byte[] * finalByte: char
+    /// A single byte of DCS payload between DcsHook and DcsUnhook.
+    | DcsPut of byte
+    /// End of a DCS sequence (ST received).
+    | DcsUnhook
 
 /// Bus messages routed between subsystems. Stages 4-9 expand this DU.
 type BusMessage =

--- a/src/Terminal.Parser/Parser.fs
+++ b/src/Terminal.Parser/Parser.fs
@@ -1,0 +1,46 @@
+namespace Terminal.Parser
+
+open System
+open Terminal.Core
+
+/// Public parser facade. Wraps `StateMachine` with a slightly more
+/// ergonomic interface for downstream consumers and tests.
+///
+/// Usage:
+///
+/// ```fsharp
+/// let parser = Parser.create ()
+/// let events = Parser.feedBytes parser (System.Text.Encoding.UTF8.GetBytes "Hello\r\n")
+/// // events : VtEvent[] = [| Print 'H'; Print 'e'; ...; Execute 13uy; Execute 10uy |]
+/// ```
+type Parser internal (machine: StateMachine) =
+    member _.State : VtState = machine.State
+
+    /// Feed a single byte. Returns the event emitted by this byte, if
+    /// any (most state-machine transitions emit nothing).
+    member _.Feed(b: byte) : VtEvent option = machine.Feed(b)
+
+module Parser =
+    /// Create a fresh parser starting in the Ground state.
+    let create () : Parser = Parser(StateMachine())
+
+    /// Feed a single byte. Returns Some event if one was emitted, None
+    /// otherwise.
+    let feed (parser: Parser) (b: byte) : VtEvent option = parser.Feed(b)
+
+    /// Feed a span of bytes and collect every emitted event in order.
+    /// Allocation: a single ResizeArray<VtEvent> sized to the input
+    /// chunk length; ToArray at the end. For tight inner loops in
+    /// later stages we may add a callback-based variant.
+    let feedBytes (parser: Parser) (bytes: ReadOnlySpan<byte>) : VtEvent[] =
+        let events = ResizeArray<VtEvent>(bytes.Length)
+        for i in 0 .. bytes.Length - 1 do
+            match parser.Feed(bytes.[i]) with
+            | Some e -> events.Add(e)
+            | None -> ()
+        events.ToArray()
+
+    /// Convenience overload for byte arrays — equivalent to feeding
+    /// the whole array as a span.
+    let feedArray (parser: Parser) (bytes: byte[]) : VtEvent[] =
+        feedBytes parser (ReadOnlySpan<byte>(bytes))

--- a/src/Terminal.Parser/Placeholder.fs
+++ b/src/Terminal.Parser/Placeholder.fs
@@ -1,5 +1,0 @@
-namespace Terminal.Parser
-
-/// Stage 3 fills in the VT500 state machine.
-module internal Placeholder =
-    let private _reserved = ()

--- a/src/Terminal.Parser/StateMachine.fs
+++ b/src/Terminal.Parser/StateMachine.fs
@@ -1,0 +1,433 @@
+namespace Terminal.Parser
+
+open System.Text
+open Terminal.Core
+
+/// Internal state of Paul Williams' DEC ANSI parser. State transitions
+/// follow https://vt100.net/emu/dec_ansi_parser.html. We expose the
+/// states publicly so tests can assert on transitions; consumers of
+/// `Parser.advance` don't need to look at this directly.
+type VtState =
+    | Ground
+    | Escape
+    | EscapeIntermediate
+    | CsiEntry
+    | CsiParam
+    | CsiIntermediate
+    | CsiIgnore
+    | DcsEntry
+    | DcsParam
+    | DcsIntermediate
+    | DcsPassthrough
+    | DcsIgnore
+    | OscString
+    | SosPmApcString
+
+/// alacritty/vte caps copied verbatim. Anything beyond these limits is
+/// silently dropped — the alternative (allocating without bound for an
+/// adversarial input stream) is a memory-DoS surface.
+module internal Limits =
+    let MAX_INTERMEDIATES = 2
+    let MAX_OSC_PARAMS = 16
+    let MAX_OSC_RAW = 1024
+    let MAX_PARAMS = 16
+
+/// Stateful single-byte-at-a-time parser. Encapsulates Williams'
+/// state machine plus a small UTF-8 decoder for `Print` events.
+///
+/// Emit semantics: `feed` returns 0 or 1 events per byte (most bytes
+/// are state transitions only). Multi-byte UTF-8 sequences accumulate
+/// silently until the final continuation byte, at which point a
+/// single `Print of Rune` is emitted.
+///
+/// Robustness contract (verified by FsCheck property tests):
+///   1. `feed` never throws on any byte sequence.
+///   2. The parser returns to `Ground` after at most N bytes following
+///      a CAN (0x18), SUB (0x1A), ST (`ESC \`), or BEL (0x07) — the
+///      cancellation/terminator bytes.
+///   3. Feeding the same byte stream in two arbitrary chunkings
+///      produces identical event sequences.
+type StateMachine() =
+    let mutable state = Ground
+    let parameters = ResizeArray<int>()
+    let mutable currentParam = -1  // -1 = no digits seen yet (default)
+    let intermediates = ResizeArray<byte>()
+    let oscParams = ResizeArray<ResizeArray<byte>>()
+    let mutable oscTotalLen = 0
+    let mutable privateMarker: char option = None
+
+    // Small UTF-8 decoder. We intentionally avoid System.Text.Encoding
+    // because we need byte-at-a-time streaming with replacement on
+    // truncation.
+    let utf8Buffer = Array.zeroCreate<byte> 4
+    let mutable utf8Have = 0
+    let mutable utf8Need = 0
+
+    let resetSequence () =
+        parameters.Clear()
+        currentParam <- -1
+        intermediates.Clear()
+        privateMarker <- None
+
+    let resetOsc () =
+        oscParams.Clear()
+        oscParams.Add(ResizeArray<byte>())
+        oscTotalLen <- 0
+
+    let resetUtf8 () =
+        utf8Have <- 0
+        utf8Need <- 0
+
+    let pushParam () =
+        if parameters.Count < Limits.MAX_PARAMS then
+            parameters.Add(if currentParam < 0 then 0 else currentParam)
+        currentParam <- -1
+
+    let collectIntermediate (b: byte) =
+        if intermediates.Count < Limits.MAX_INTERMEDIATES then
+            intermediates.Add(b)
+
+    let oscAppend (b: byte) =
+        if oscTotalLen < Limits.MAX_OSC_RAW && oscParams.Count > 0 then
+            oscParams.[oscParams.Count - 1].Add(b)
+            oscTotalLen <- oscTotalLen + 1
+
+    let oscNextParam () =
+        if oscParams.Count < Limits.MAX_OSC_PARAMS then
+            oscParams.Add(ResizeArray<byte>())
+
+    let snapshotParams () =
+        parameters.ToArray()
+
+    let snapshotIntermediates () =
+        intermediates.ToArray()
+
+    let snapshotOscParams () =
+        let arr = Array.zeroCreate<byte[]> oscParams.Count
+        for i in 0 .. oscParams.Count - 1 do
+            arr.[i] <- oscParams.[i].ToArray()
+        arr
+
+    /// Print a single Unicode scalar value via the small UTF-8
+    /// decoder. ASCII (0x00..0x7F) goes through the trivial path;
+    /// multi-byte sequences accumulate in `utf8Buffer` and emit when
+    /// complete. Malformed continuations emit U+FFFD and reset.
+    let emitPrint (b: byte) : VtEvent option =
+        if utf8Need = 0 then
+            // First byte of a (possibly multi-byte) scalar.
+            if b < 0x80uy then
+                // ASCII fast path.
+                Some(Print(Rune(int b)))
+            elif b &&& 0xE0uy = 0xC0uy then
+                utf8Buffer.[0] <- b
+                utf8Have <- 1
+                utf8Need <- 2
+                None
+            elif b &&& 0xF0uy = 0xE0uy then
+                utf8Buffer.[0] <- b
+                utf8Have <- 1
+                utf8Need <- 3
+                None
+            elif b &&& 0xF8uy = 0xF0uy then
+                utf8Buffer.[0] <- b
+                utf8Have <- 1
+                utf8Need <- 4
+                None
+            else
+                // Stray continuation byte (0x80..0xBF) or invalid 5-6
+                // byte UTF-8 lead. Emit replacement.
+                Some(Print(Rune(0xFFFD)))
+        else
+            // Continuation byte expected.
+            if b &&& 0xC0uy <> 0x80uy then
+                // Not a valid continuation — emit replacement and
+                // re-process the current byte as a fresh start.
+                resetUtf8 ()
+                let replacement = Print(Rune(0xFFFD))
+                // Re-process b as new lead. Recursion is bounded by
+                // utf8Need going to 0 above.
+                match emitPrint b with
+                | Some _ as also -> ignore also; Some replacement
+                | None -> Some replacement
+            else
+                utf8Buffer.[utf8Have] <- b
+                utf8Have <- utf8Have + 1
+                if utf8Have = utf8Need then
+                    let span = System.ReadOnlySpan<byte>(utf8Buffer, 0, utf8Have)
+                    let success, rune, _ = Rune.DecodeFromUtf8(span)
+                    resetUtf8 ()
+                    if success = System.Buffers.OperationStatus.Done then
+                        Some(Print rune)
+                    else
+                        Some(Print(Rune(0xFFFD)))
+                else
+                    None
+
+    /// Push one byte through the state machine. Returns the event
+    /// emitted (if any). Callers feed bytes one-at-a-time; for chunk
+    /// processing see `Parser.feedBytes`.
+    member _.Feed(b: byte) : VtEvent option =
+        match state with
+        | Ground ->
+            if b <= 0x1Fuy then
+                if b = 0x1Buy then
+                    // ESC: enter Escape state, drop any UTF-8 partial.
+                    resetUtf8 ()
+                    state <- Escape
+                    resetSequence ()
+                    None
+                else
+                    resetUtf8 ()
+                    Some(Execute b)
+            elif b = 0x7Fuy then
+                None  // DEL is silently dropped per Williams
+            else
+                emitPrint b
+        | Escape ->
+            if b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                state <- EscapeIntermediate
+                None
+            elif b >= 0x30uy && b <= 0x7Euy then
+                let final = char b
+                let intermediates = snapshotIntermediates ()
+                state <-
+                    match final with
+                    | '[' -> resetSequence (); CsiEntry
+                    | ']' -> resetOsc (); OscString
+                    | 'P' -> resetSequence (); DcsEntry
+                    | 'X' | '^' | '_' -> SosPmApcString
+                    | _ ->
+                        // Bare ESC dispatch (e.g. ESC =, ESC 7).
+                        // We'll emit and return to Ground.
+                        Ground
+                if state = Ground then
+                    Some(EscDispatch(intermediates, final))
+                else
+                    None
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            elif b = 0x1Buy then
+                resetSequence ()
+                None
+            elif b <= 0x17uy || b = 0x19uy || (b >= 0x1Cuy && b <= 0x1Fuy) then
+                Some(Execute b)
+            else
+                state <- Ground
+                None
+        | EscapeIntermediate ->
+            if b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                None
+            elif b >= 0x30uy && b <= 0x7Euy then
+                let inter = snapshotIntermediates ()
+                state <- Ground
+                Some(EscDispatch(inter, char b))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                None
+        | CsiEntry ->
+            if b >= 0x30uy && b <= 0x39uy then
+                currentParam <- int (b - 0x30uy)
+                state <- CsiParam
+                None
+            elif b = 0x3Buy then
+                pushParam ()
+                state <- CsiParam
+                None
+            elif b >= 0x3Cuy && b <= 0x3Fuy then
+                privateMarker <- Some(char b)
+                state <- CsiParam
+                None
+            elif b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                state <- CsiIntermediate
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                pushParam ()
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                let pm = privateMarker
+                state <- Ground
+                Some(CsiDispatch(p, i, char b, pm))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                None
+        | CsiParam ->
+            if b >= 0x30uy && b <= 0x39uy then
+                if currentParam < 0 then currentParam <- 0
+                currentParam <- currentParam * 10 + int (b - 0x30uy)
+                None
+            elif b = 0x3Buy then
+                pushParam ()
+                None
+            elif b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                state <- CsiIntermediate
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                pushParam ()
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                let pm = privateMarker
+                state <- Ground
+                Some(CsiDispatch(p, i, char b, pm))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            elif b = 0x3Auy || (b >= 0x3Cuy && b <= 0x3Fuy) then
+                state <- CsiIgnore
+                None
+            else
+                None
+        | CsiIntermediate ->
+            if b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                let pm = privateMarker
+                state <- Ground
+                Some(CsiDispatch(p, i, char b, pm))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                None
+        | CsiIgnore ->
+            if b >= 0x40uy && b <= 0x7Euy then
+                state <- Ground
+                None
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                None
+        | OscString ->
+            if b = 0x07uy then
+                // BEL terminator
+                let parms = snapshotOscParams ()
+                state <- Ground
+                Some(OscDispatch(parms, true))
+            elif b = 0x1Buy then
+                // Start of ST (ESC \). We could go to a sub-state, but
+                // the simpler approach: on ESC, re-enter Escape and
+                // let it route us back to Ground via the next byte.
+                let parms = snapshotOscParams ()
+                state <- Escape
+                resetSequence ()
+                Some(OscDispatch(parms, false))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            elif b = 0x3Buy then
+                oscNextParam ()
+                None
+            else
+                oscAppend b
+                None
+        | DcsEntry ->
+            if b >= 0x30uy && b <= 0x39uy then
+                currentParam <- int (b - 0x30uy)
+                state <- DcsParam
+                None
+            elif b = 0x3Buy then
+                pushParam ()
+                state <- DcsParam
+                None
+            elif b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                state <- DcsIntermediate
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                pushParam ()
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                state <- DcsPassthrough
+                Some(DcsHook(p, i, char b))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                state <- DcsIgnore
+                None
+        | DcsParam ->
+            if b >= 0x30uy && b <= 0x39uy then
+                if currentParam < 0 then currentParam <- 0
+                currentParam <- currentParam * 10 + int (b - 0x30uy)
+                None
+            elif b = 0x3Buy then
+                pushParam ()
+                None
+            elif b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                state <- DcsIntermediate
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                pushParam ()
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                state <- DcsPassthrough
+                Some(DcsHook(p, i, char b))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                state <- DcsIgnore
+                None
+        | DcsIntermediate ->
+            if b >= 0x20uy && b <= 0x2Fuy then
+                collectIntermediate b
+                None
+            elif b >= 0x40uy && b <= 0x7Euy then
+                let p = snapshotParams ()
+                let i = snapshotIntermediates ()
+                state <- DcsPassthrough
+                Some(DcsHook(p, i, char b))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
+                state <- DcsIgnore
+                None
+        | DcsPassthrough ->
+            if b = 0x1Buy then
+                state <- Escape
+                resetSequence ()
+                Some DcsUnhook
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some DcsUnhook
+            elif b = 0x7Fuy then
+                None
+            else
+                Some(DcsPut b)
+        | DcsIgnore ->
+            if b = 0x1Buy then
+                state <- Escape
+                resetSequence ()
+                None
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                None
+            else
+                None
+        | SosPmApcString ->
+            if b = 0x1Buy then
+                state <- Escape
+                resetSequence ()
+                None
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                None
+            else
+                None
+
+    /// Current state, exposed for tests / debugging only.
+    member _.State : VtState = state

--- a/src/Terminal.Parser/StateMachine.fs
+++ b/src/Terminal.Parser/StateMachine.fs
@@ -111,8 +111,10 @@ type StateMachine() =
     /// Print a single Unicode scalar value via the small UTF-8
     /// decoder. ASCII (0x00..0x7F) goes through the trivial path;
     /// multi-byte sequences accumulate in `utf8Buffer` and emit when
-    /// complete. Malformed continuations emit U+FFFD and reset.
-    let emitPrint (b: byte) : VtEvent option =
+    /// complete. Malformed continuations emit U+FFFD and reset, then
+    /// re-process the offending byte as a fresh lead — `let rec` is
+    /// required for that self-call.
+    let rec emitPrint (b: byte) : VtEvent option =
         if utf8Need = 0 then
             // First byte of a (possibly multi-byte) scalar.
             if b < 0x80uy then

--- a/src/Terminal.Parser/Terminal.Parser.fsproj
+++ b/src/Terminal.Parser/Terminal.Parser.fsproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Placeholder.fs" />
+    <Compile Include="StateMachine.fs" />
+    <Compile Include="Parser.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="SmokeTests.fs" />
     <Compile Include="ConPtyHostTests.fs" />
+    <Compile Include="VtParserTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -27,6 +28,7 @@
     <PackageReference Include="FluentAssertions" />
     <ProjectReference Include="..\..\src\Terminal.Core\Terminal.Core.fsproj" />
     <ProjectReference Include="..\..\src\Terminal.Pty\Terminal.Pty.fsproj" />
+    <ProjectReference Include="..\..\src\Terminal.Parser\Terminal.Parser.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.Unit/VtParserTests.fs
+++ b/tests/Tests.Unit/VtParserTests.fs
@@ -1,0 +1,179 @@
+module PtySpeak.Tests.Unit.VtParserTests
+
+open System.Text
+open Xunit
+open FsCheck.Xunit
+open Terminal.Core
+open Terminal.Parser
+
+// ---------------------------------------------------------------------
+// Fixture-based tests (spec/tech-plan.md §2.4)
+//
+// These cover the canonical byte-string fixtures called out in the
+// spec. Each test feeds a small fragment and asserts an exact
+// VtEvent[] result.
+// ---------------------------------------------------------------------
+
+let private parse (bytes: byte[]) : VtEvent[] =
+    let parser = Parser.create ()
+    Parser.feedArray parser bytes
+
+let private ascii (s: string) = Encoding.ASCII.GetBytes s
+
+let private rune (c: char) = Rune(int c)
+
+[<Fact>]
+let ``Print: 'Hello\r\n' decodes to five Prints + CR + LF`` () =
+    let events = parse (ascii "Hello\r\n")
+    let expected =
+        [| Print(rune 'H')
+           Print(rune 'e')
+           Print(rune 'l')
+           Print(rune 'l')
+           Print(rune 'o')
+           Execute 0x0Duy
+           Execute 0x0Auy |]
+    Assert.Equal<VtEvent[]>(expected, events)
+
+[<Fact>]
+let ``CSI: '\x1b[31mRed\x1b[0m' produces SGR(31), three Prints, SGR(0)`` () =
+    let events = parse (ascii "[31mRed[0m")
+    Assert.Equal(5, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, intermediates, finalByte, priv) ->
+        Assert.Equal<int[]>([| 31 |], parms)
+        Assert.Equal<byte[]>([||], intermediates)
+        Assert.Equal('m', finalByte)
+        Assert.Equal<char option>(None, priv)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+    Assert.Equal(Print(rune 'R'), events.[1])
+    Assert.Equal(Print(rune 'e'), events.[2])
+    Assert.Equal(Print(rune 'd'), events.[3])
+    match events.[4] with
+    | CsiDispatch(parms, _, finalByte, priv) ->
+        Assert.Equal<int[]>([| 0 |], parms)
+        Assert.Equal('m', finalByte)
+        Assert.Equal<char option>(None, priv)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+
+[<Fact>]
+let ``CSI: '\x1b[2J' is CsiDispatch parms=[2] final='J'`` () =
+    let events = parse (ascii "[2J")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, intermediates, finalByte, priv) ->
+        Assert.Equal<int[]>([| 2 |], parms)
+        Assert.Equal<byte[]>([||], intermediates)
+        Assert.Equal('J', finalByte)
+        Assert.Equal<char option>(None, priv)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+
+[<Fact>]
+let ``CSI private mode: '\x1b[?1049h' has priv='?' parms=[1049] final='h'`` () =
+    let events = parse (ascii "[?1049h")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, _, finalByte, priv) ->
+        Assert.Equal<int[]>([| 1049 |], parms)
+        Assert.Equal('h', finalByte)
+        Assert.Equal<char option>(Some '?', priv)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+
+[<Fact>]
+let ``OSC: '\x1b]0;Title\x07' is bell-terminated OscDispatch with one param 'Title'`` () =
+    let events = parse (ascii "]0;Title")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | OscDispatch(parms, bellTerminated) ->
+        Assert.True(bellTerminated)
+        Assert.Equal(2, parms.Length)
+        Assert.Equal<byte[]>(ascii "0", parms.[0])
+        Assert.Equal<byte[]>(ascii "Title", parms.[1])
+    | other -> Assert.Fail(sprintf "Expected OscDispatch, got %A" other)
+
+[<Fact>]
+let ``ESC dispatch: '\x1b=' (DECKPAM) is bare EscDispatch final='='`` () =
+    let events = parse (ascii "=")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | EscDispatch(intermediates, finalByte) ->
+        Assert.Equal<byte[]>([||], intermediates)
+        Assert.Equal('=', finalByte)
+    | other -> Assert.Fail(sprintf "Expected EscDispatch, got %A" other)
+
+[<Fact>]
+let ``CSI multi-param: '\x1b[1;2;3m' has parms=[1;2;3]`` () =
+    let events = parse (ascii "[1;2;3m")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, _, finalByte, _) ->
+        Assert.Equal<int[]>([| 1; 2; 3 |], parms)
+        Assert.Equal('m', finalByte)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+
+[<Fact>]
+let ``CSI default param: '\x1b[H' has parms=[0]`` () =
+    // CSI with no digits before the final byte — defaults to a single
+    // 0 parameter per Williams.
+    let events = parse (ascii "[H")
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, _, finalByte, _) ->
+        Assert.Equal<int[]>([| 0 |], parms)
+        Assert.Equal('H', finalByte)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
+
+[<Fact>]
+let ``CAN cancels in-flight CSI`` () =
+    // CAN (0x18) inside a CSI sequence should return to Ground and
+    // be emitted as Execute, with no CsiDispatch.
+    let events = parse [| 0x1Buy; byte '['; byte '3'; 0x18uy; byte 'X' |]
+    Assert.Contains(Execute 0x18uy, events)
+    let hasCsi = events |> Array.exists (fun e -> match e with CsiDispatch _ -> true | _ -> false)
+    Assert.False(hasCsi, "CSI sequence should have been cancelled by CAN")
+
+[<Fact>]
+let ``UTF-8: multi-byte scalar emits a single Print`` () =
+    // U+00E9 'é' in UTF-8 is 0xC3 0xA9 — should emit one Print, not
+    // two stray bytes.
+    let events = parse [| 0xC3uy; 0xA9uy |]
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | Print r -> Assert.Equal(0x00E9, r.Value)
+    | other -> Assert.Fail(sprintf "Expected Print, got %A" other)
+
+// ---------------------------------------------------------------------
+// FsCheck property tests
+//
+// Spec §2.4: "for any sequence of random bytes the parser never throws
+// and always returns to Ground after at most N bytes following an
+// ST/BEL/CAN/SUB". Plus the chunk-equivalence invariant.
+// ---------------------------------------------------------------------
+
+[<Property>]
+let ``parser never throws on arbitrary bytes`` (bytes: byte[]) =
+    // If parse returns at all, the property holds. FsCheck will catch
+    // exceptions automatically.
+    let _ = parse bytes
+    true
+
+[<Property>]
+let ``feeding bytes one at a time matches feeding the whole array``
+        (bytes: byte[]) =
+    let whole = parse bytes
+    let pieceMeal =
+        let parser = Parser.create ()
+        let events = ResizeArray<VtEvent>()
+        for b in bytes do
+            match Parser.feed parser b with
+            | Some e -> events.Add(e)
+            | None -> ()
+        events.ToArray()
+    whole = pieceMeal
+
+[<Property>]
+let ``CAN (0x18) anywhere returns parser to Ground`` (prefix: byte[]) =
+    let parser = Parser.create ()
+    let _ = Parser.feedArray parser prefix
+    let _ = Parser.feedArray parser [| 0x18uy |]
+    parser.State = Ground


### PR DESCRIPTION
## Summary

Implements **Stage 2** of [`spec/tech-plan.md`](spec/tech-plan.md): a pure-F# implementation of Paul Williams' DEC ANSI parser. Consumes bytes, emits typed `VtEvent`. No I/O, no rendering, no screen-buffer interpretation — that work belongs to `Terminal.Semantics` (Stage 3+).

## What's added

### `Terminal.Core/Types.fs`

Replaces the placeholder `VtEvent` DU with the real definition per spec §2.2: `Print | Execute | CsiDispatch | EscDispatch | OscDispatch | DcsHook | DcsPut | DcsUnhook`. Other DUs (Cell, ScreenBuffer, BusMessage, Earcon, AccessibilityMarker) stay as placeholders pending their owning stages.

### `Terminal.Parser/StateMachine.fs`

Fourteen-state DFA matching Williams' diagram exactly: `Ground / Escape / EscapeIntermediate / CsiEntry / CsiParam / CsiIntermediate / CsiIgnore / DcsEntry / DcsParam / DcsIntermediate / DcsPassthrough / DcsIgnore / OscString / SosPmApcString`. Caps copied from alacritty/vte:

- `MAX_INTERMEDIATES = 2`
- `MAX_OSC_PARAMS = 16`
- `MAX_OSC_RAW = 1024`
- `MAX_PARAMS = 16`

CAN (0x18) and SUB (0x1A) abort any in-flight sequence and return to Ground. A small inline UTF-8 decoder buffers continuation bytes and emits a single `Print of Rune` per scalar; malformed UTF-8 emits U+FFFD without breaking the state machine.

### `Terminal.Parser/Parser.fs`

Public facade: `Parser.create / feed / feedBytes / feedArray`. The internal `StateMachine` is an implementation detail.

### `tests/Tests.Unit/VtParserTests.fs`

**Fixture tests** for every byte-string example in spec §2.4:

- `"Hello\r\n"` → 5 Prints + Execute(CR) + Execute(LF)
- `"\x1b[31mRed\x1b[0m"` → SGR(31) + 3 Prints + SGR(0)
- `"\x1b[2J"` → CsiDispatch parms=[2] final='J'
- `"\x1b]0;Title\x07"` → bell-terminated OscDispatch
- `"\x1b[?1049h"` → CsiDispatch priv='?' parms=[1049] final='h'

Plus multi-param SGR, default-parameter CSI, ESC dispatch (DECKPAM `\x1b=`), CAN cancellation of an in-flight sequence, and UTF-8 multi-byte scalar assembly (U+00E9 'é').

**FsCheck property tests** proving spec §2.4's robustness contract:

- Parser never throws on arbitrary bytes
- Feeding bytes one-at-a-time matches feeding the whole array
- CAN (0x18) at any point returns the parser to `Ground`

## What this PR deliberately omits

- DCS Sixel / ReGIS payload interpretation (out of scope per spec)
- Device-attributes responses (Stage 6 input pipeline handles them defensively per `SECURITY.md`)
- Screen buffer + rendering — Stage 3
- UIA exposure — Stage 4

## Test plan

- [ ] CI green on `windows-latest` (build + unit test + Velopack pack smoke)
- [ ] FsCheck `parser never throws` runs against ~100 random byte arrays per default
- [ ] All fixture tests pass with exact `VtEvent[]` matches

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_