### PR TITLE
feat: Stage 3a — screen model in Terminal.Core (Cell/Cursor/Screen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 3a — screen model.** `Terminal.Core` gains the data types
+  per spec §3.1 (`ColorSpec` DU, `SgrAttrs` struct, `Cell` struct,
+  `Cursor` mutable record) and a `Screen` class consuming `VtEvent`s
+  via `Apply`. Stage 3a coverage:
+  - **Print**: writes a cell at the cursor with the current SGR
+    attributes, advances Col, auto-wraps to the next row at
+    end-of-line, scrolls when wrapping past the bottom row.
+  - **C0 controls**: BS (cursor left, clamped), HT (next 8-column
+    boundary), LF (cursor down + scroll), CR (cursor to col 0).
+  - **CSI cursor movement**: A/B/C/D (relative, clamped at edges),
+    H/f (CUP/HVP, 1-indexed → 0-indexed).
+  - **CSI erase**: J (display, modes 0/1/2), K (line, modes 0/1/2).
+  - **CSI SGR**: reset (0), bold (1/22), italic (3/23), underline
+    (4/24), inverse (7/27); foreground colours 30-37 + bright
+    90-97 + default 39; background colours 40-47 + bright 100-107
+    + default 49. Empty-param CSI m equivalent to CSI 0m. 256-colour
+    and truecolor sub-parameter forms are deferred (the parser would
+    need to split on `:` vs `;` first).
+  - **DECSET / DECSC / OSC / DCS**: silently ignored at this stage;
+    Stage 4+ adds them as their owners need them.
+- Stage 3a tests in `tests/Tests.Unit/ScreenTests.fs` covering each
+  of the supported behaviours plus boundary clamping (cursor at
+  edges, oversize CSI A movements) and the auto-wrap → scroll
+  invariant.
 - **Stage 2 — VT500 parser.** `Terminal.Parser` now contains a
   pure-F# implementation of Paul Williams' DEC ANSI parser
   ([vt100.net/emu/dec_ansi_parser.html](https://vt100.net/emu/dec_ansi_parser.html)),

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -1,0 +1,212 @@
+namespace Terminal.Core
+
+open System.Text
+
+/// In-memory screen buffer. Maintains a `rows × cols` grid of
+/// `Cell`s, a cursor, and the current SGR attributes carried into
+/// future Print events.
+///
+/// Stage 3a coverage:
+///   * Print writes a cell at the cursor, advances Col, wraps to the
+///     next row at end-of-line, scrolls when wrapping past the
+///     bottom row.
+///   * Execute LF (0x0A) advances Row, scrolling at the bottom.
+///   * Execute CR (0x0D) returns Col to 0.
+///   * Execute BS (0x08) decrements Col (clamped at 0).
+///   * Execute HT (0x09) advances Col to next tab stop (every 8 cols).
+///   * CSI A/B/C/D — relative cursor movement.
+///   * CSI H / f — absolute cursor move (CUP / HVP).
+///   * CSI J — erase display (modes 0/1/2).
+///   * CSI K — erase line (modes 0/1/2).
+///   * CSI m — SGR for the basic 16 ANSI colours plus 0/1/3/4/7/22/23/24/27.
+///
+/// Deliberately *not* covered yet (later stages refine):
+///   * 256-colour and truecolor SGR (38;5;n, 38;2;r;g;b) — needs a
+///     parser that splits sub-parameters by `;` vs `:`.
+///   * DECSET modes (cursor visibility ?25, alt-screen ?1049, focus
+///     reporting ?1004, etc.) — Stage 4/5 territory.
+///   * Scrollback rotation beyond the active grid.
+///   * DECSC/DECRC ESC 7/8 cursor save/restore.
+type Screen(rows: int, cols: int) =
+    do
+        if rows <= 0 then invalidArg "rows" "rows must be positive"
+        if cols <= 0 then invalidArg "cols" "cols must be positive"
+
+    // Row-major grid. Row 0 is the top of the screen.
+    let cells: Cell[,] = Array2D.create rows cols Cell.blank
+    let cursor: Cursor = Cursor.create ()
+    let mutable currentAttrs: SgrAttrs = SgrAttrs.defaults
+
+    let clamp lo hi v = max lo (min hi v)
+
+    let scrollUp () =
+        // Move every row up by one; bottom row becomes blank.
+        for r in 0 .. rows - 2 do
+            for c in 0 .. cols - 1 do
+                cells.[r, c] <- cells.[r + 1, c]
+        for c in 0 .. cols - 1 do
+            cells.[rows - 1, c] <- Cell.blank
+
+    let advanceRow () =
+        if cursor.Row < rows - 1 then
+            cursor.Row <- cursor.Row + 1
+        else
+            scrollUp ()
+
+    let writeAt (r: int) (c: int) (cell: Cell) =
+        if r >= 0 && r < rows && c >= 0 && c < cols then
+            cells.[r, c] <- cell
+
+    let printRune (rune: Rune) =
+        if cursor.Col >= cols then
+            // Auto-wrap: advance to next row at column 0 before
+            // writing.
+            cursor.Col <- 0
+            advanceRow ()
+        writeAt cursor.Row cursor.Col { Ch = rune; Attrs = currentAttrs }
+        cursor.Col <- cursor.Col + 1
+
+    let executeC0 (b: byte) =
+        match b with
+        | 0x08uy ->
+            // BS — backspace
+            cursor.Col <- max 0 (cursor.Col - 1)
+        | 0x09uy ->
+            // HT — horizontal tab to next 8-column boundary
+            let next = ((cursor.Col / 8) + 1) * 8
+            cursor.Col <- min (cols - 1) next
+        | 0x0Auy ->
+            // LF — line feed (cursor down, possibly scrolling)
+            advanceRow ()
+        | 0x0Duy ->
+            // CR — carriage return
+            cursor.Col <- 0
+        | _ -> ()
+
+    let eraseDisplay (mode: int) =
+        // Mode 0: cursor → end. Mode 1: start → cursor. Mode 2: all.
+        // Mode 3: scrollback (no scrollback yet; treat as 2).
+        match mode with
+        | 0 ->
+            // Clear from cursor to end of current line, then clear
+            // following rows.
+            for c in cursor.Col .. cols - 1 do
+                cells.[cursor.Row, c] <- Cell.blank
+            for r in cursor.Row + 1 .. rows - 1 do
+                for c in 0 .. cols - 1 do
+                    cells.[r, c] <- Cell.blank
+        | 1 ->
+            for r in 0 .. cursor.Row - 1 do
+                for c in 0 .. cols - 1 do
+                    cells.[r, c] <- Cell.blank
+            for c in 0 .. cursor.Col do
+                if c < cols then cells.[cursor.Row, c] <- Cell.blank
+        | _ ->
+            for r in 0 .. rows - 1 do
+                for c in 0 .. cols - 1 do
+                    cells.[r, c] <- Cell.blank
+
+    let eraseLine (mode: int) =
+        match mode with
+        | 0 ->
+            for c in cursor.Col .. cols - 1 do
+                cells.[cursor.Row, c] <- Cell.blank
+        | 1 ->
+            for c in 0 .. cursor.Col do
+                if c < cols then cells.[cursor.Row, c] <- Cell.blank
+        | _ ->
+            for c in 0 .. cols - 1 do
+                cells.[cursor.Row, c] <- Cell.blank
+
+    /// Apply a single SGR parameter to currentAttrs.
+    let applySgrOne (n: int) =
+        match n with
+        | 0 -> currentAttrs <- SgrAttrs.defaults
+        | 1 -> currentAttrs <- { currentAttrs with Bold = true }
+        | 22 -> currentAttrs <- { currentAttrs with Bold = false }
+        | 3 -> currentAttrs <- { currentAttrs with Italic = true }
+        | 23 -> currentAttrs <- { currentAttrs with Italic = false }
+        | 4 -> currentAttrs <- { currentAttrs with Underline = true }
+        | 24 -> currentAttrs <- { currentAttrs with Underline = false }
+        | 7 -> currentAttrs <- { currentAttrs with Inverse = true }
+        | 27 -> currentAttrs <- { currentAttrs with Inverse = false }
+        // Foreground colours 30..37 (basic) and 90..97 (bright)
+        | n when n >= 30 && n <= 37 ->
+            currentAttrs <- { currentAttrs with Fg = Indexed(byte (n - 30)) }
+        | n when n >= 90 && n <= 97 ->
+            currentAttrs <- { currentAttrs with Fg = Indexed(byte (n - 90 + 8)) }
+        | 39 -> currentAttrs <- { currentAttrs with Fg = Default }
+        // Background colours 40..47 (basic) and 100..107 (bright)
+        | n when n >= 40 && n <= 47 ->
+            currentAttrs <- { currentAttrs with Bg = Indexed(byte (n - 40)) }
+        | n when n >= 100 && n <= 107 ->
+            currentAttrs <- { currentAttrs with Bg = Indexed(byte (n - 100 + 8)) }
+        | 49 -> currentAttrs <- { currentAttrs with Bg = Default }
+        | _ -> ()  // 256-colour / truecolor / unsupported — no-op for now
+
+    let applySgr (parms: int[]) =
+        if parms.Length = 0 then
+            // CSI m with no params is the same as CSI 0 m.
+            applySgrOne 0
+        else
+            for p in parms do
+                applySgrOne p
+
+    let csiDispatch (parms: int[]) (finalByte: char) =
+        // For most CSI sequences, missing params default to 1.
+        let p0Default1 = if parms.Length = 0 || parms.[0] = 0 then 1 else parms.[0]
+        let p0Default0 = if parms.Length = 0 then 0 else parms.[0]
+        match finalByte with
+        | 'A' ->
+            // CUU — cursor up
+            cursor.Row <- max 0 (cursor.Row - p0Default1)
+        | 'B' ->
+            // CUD — cursor down
+            cursor.Row <- min (rows - 1) (cursor.Row + p0Default1)
+        | 'C' ->
+            // CUF — cursor forward
+            cursor.Col <- min (cols - 1) (cursor.Col + p0Default1)
+        | 'D' ->
+            // CUB — cursor back
+            cursor.Col <- max 0 (cursor.Col - p0Default1)
+        | 'H' | 'f' ->
+            // CUP / HVP — set cursor (1-indexed in the protocol).
+            let row1 = if parms.Length >= 1 && parms.[0] > 0 then parms.[0] else 1
+            let col1 = if parms.Length >= 2 && parms.[1] > 0 then parms.[1] else 1
+            cursor.Row <- clamp 0 (rows - 1) (row1 - 1)
+            cursor.Col <- clamp 0 (cols - 1) (col1 - 1)
+        | 'J' -> eraseDisplay p0Default0
+        | 'K' -> eraseLine p0Default0
+        | 'm' -> applySgr parms
+        | _ -> ()  // Unsupported CSI final — silently ignored
+
+    member _.Rows = rows
+    member _.Cols = cols
+
+    /// Cursor position and visibility. Mutating this directly is
+    /// fine; tests do it for setup convenience.
+    member _.Cursor = cursor
+
+    /// Currently-active SGR attributes (carried into the next Print).
+    member _.CurrentAttrs = currentAttrs
+
+    /// Read-only access to a cell. (row, col) are 0-indexed.
+    member _.GetCell(row: int, col: int) : Cell = cells.[row, col]
+
+    /// Apply a single VT event to the buffer. Stage 3a covers the
+    /// minimum needed to render cmd.exe-style output; unsupported
+    /// sequences are silently no-ops so the parser can continue
+    /// streaming without exceptions.
+    member _.Apply(event: VtEvent) =
+        match event with
+        | Print rune -> printRune rune
+        | Execute b -> executeC0 b
+        | CsiDispatch(parms, _, finalByte, _priv) ->
+            // Private-marker sequences (DECSET ?h/?l) are ignored
+            // in Stage 3a; alt-screen and friends arrive later.
+            csiDispatch parms finalByte
+        | EscDispatch _
+        | OscDispatch _
+        | DcsHook _
+        | DcsPut _
+        | DcsUnhook -> ()  // Not yet handled — Stage 4+

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Types.fs" />
+    <Compile Include="Screen.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -5,11 +5,64 @@ open System.Text
 /// Marker type used by smoke tests to verify the assembly loads.
 type Marker = class end
 
-/// A single screen cell. Stage 3 fills in the real fields.
-type Cell = { Placeholder: unit }
+/// SGR colour for a foreground or background slot. Default tracks the
+/// terminal's current default; Indexed covers the 256-colour palette
+/// (0..15 = ANSI, 16..231 = 6×6×6 cube, 232..255 = grayscale); Rgb
+/// holds a 24-bit truecolor specifier from `\x1b[38;2;r;g;bm`.
+type ColorSpec =
+    | Default
+    | Indexed of byte
+    | Rgb of byte * byte * byte
 
-/// The screen buffer. Stage 3 fills in the real fields.
-type ScreenBuffer = { Placeholder: unit }
+/// SGR attribute set carried per cell. Inverse means foreground and
+/// background should swap at render time. Stage 3a covers the basic
+/// 16-colour set + bold/italic/underline/inverse; truecolor and
+/// 256-colour parsing arrive when the parser learns to handle their
+/// SGR sub-parameter forms (out of scope for this PR — the data
+/// type already supports them via ColorSpec).
+[<Struct>]
+type SgrAttrs =
+    { Fg: ColorSpec
+      Bg: ColorSpec
+      Bold: bool
+      Italic: bool
+      Underline: bool
+      Inverse: bool }
+
+module SgrAttrs =
+    /// Default attributes — reset SGR state.
+    let defaults : SgrAttrs =
+        { Fg = Default
+          Bg = Default
+          Bold = false
+          Italic = false
+          Underline = false
+          Inverse = false }
+
+/// A single screen cell. Empty cells carry a space rune.
+[<Struct>]
+type Cell =
+    { Ch: Rune
+      Attrs: SgrAttrs }
+
+module Cell =
+    /// A blank cell — space character with default SGR.
+    let blank : Cell = { Ch = Rune(int ' '); Attrs = SgrAttrs.defaults }
+
+/// Cursor position and visibility state. Row/Col are 0-indexed
+/// internally even though VT sequences address them 1-indexed.
+type Cursor =
+    { mutable Row: int
+      mutable Col: int
+      mutable Visible: bool
+      mutable SaveStack: (int * int) list }
+
+module Cursor =
+    let create () : Cursor =
+        { Row = 0
+          Col = 0
+          Visible = true
+          SaveStack = [] }
 
 /// Events emitted by the VT500 state machine in `Terminal.Parser`.
 ///
@@ -17,7 +70,7 @@ type ScreenBuffer = { Placeholder: unit }
 /// (https://vt100.net/emu/dec_ansi_parser.html) and alacritty/vte's
 /// `Perform` trait. Each variant captures the parsed structure
 /// without any screen-buffer or rendering interpretation; that work
-/// belongs to `Terminal.Semantics` (Stage 3+).
+/// belongs to `Screen` (Stage 3) and `Terminal.Semantics` (Stage 5+).
 ///
 /// Caps used by the parser (matching alacritty/vte):
 ///   * MAX_INTERMEDIATES = 2   — bytes in the 0x20..0x2F range during

--- a/tests/Tests.Unit/ScreenTests.fs
+++ b/tests/Tests.Unit/ScreenTests.fs
@@ -1,0 +1,199 @@
+module PtySpeak.Tests.Unit.ScreenTests
+
+open System.Text
+open Xunit
+open Terminal.Core
+open Terminal.Parser
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+let private feed (screen: Screen) (bytes: byte[]) =
+    let parser = Parser.create ()
+    let events = Parser.feedArray parser bytes
+    for e in events do screen.Apply(e)
+
+let private ascii (s: string) = Encoding.ASCII.GetBytes s
+
+let private rowText (screen: Screen) (row: int) : string =
+    let sb = StringBuilder()
+    for c in 0 .. screen.Cols - 1 do
+        sb.Append(screen.GetCell(row, c).Ch.ToString()) |> ignore
+    sb.ToString()
+
+// ---------------------------------------------------------------------
+// Construction + invariants
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``fresh screen is all blank cells`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    for r in 0 .. 2 do
+        for c in 0 .. 4 do
+            Assert.Equal(' ', screen.GetCell(r, c).Ch.ToString().[0])
+
+[<Fact>]
+let ``fresh screen cursor is at 0,0 visible`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    Assert.Equal(0, screen.Cursor.Row)
+    Assert.Equal(0, screen.Cursor.Col)
+    Assert.True(screen.Cursor.Visible)
+
+[<Fact>]
+let ``Screen constructor rejects nonpositive dimensions`` () =
+    Assert.Throws<System.ArgumentException>(fun () -> Screen(0, 5) |> ignore)
+    |> ignore
+    Assert.Throws<System.ArgumentException>(fun () -> Screen(5, 0) |> ignore)
+    |> ignore
+
+// ---------------------------------------------------------------------
+// Print + cursor advance
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Print writes char at cursor and advances column`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "Hi")
+    Assert.Equal('H', screen.GetCell(0, 0).Ch.ToString().[0])
+    Assert.Equal('i', screen.GetCell(0, 1).Ch.ToString().[0])
+    Assert.Equal(0, screen.Cursor.Row)
+    Assert.Equal(2, screen.Cursor.Col)
+
+[<Fact>]
+let ``Print past end of row auto-wraps to next row`` () =
+    let screen = Screen(rows = 2, cols = 3)
+    feed screen (ascii "abcXY")
+    Assert.Equal("abc", rowText screen 0)
+    Assert.Equal("XY ", rowText screen 1)
+    Assert.Equal(1, screen.Cursor.Row)
+    Assert.Equal(2, screen.Cursor.Col)
+
+[<Fact>]
+let ``Print past end of last row scrolls`` () =
+    let screen = Screen(rows = 2, cols = 3)
+    feed screen (ascii "abcdefXY")
+    // Row 0 should now be "def" (was "abc", scrolled up because
+    // "def" wrapped onto row 1, then "XY" wrapped again, scrolling).
+    Assert.Equal("def", rowText screen 0)
+    Assert.Equal("XY ", rowText screen 1)
+
+// ---------------------------------------------------------------------
+// C0 controls
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``LF moves cursor down without changing column`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "ab\ncd")
+    Assert.Equal('a', screen.GetCell(0, 0).Ch.ToString().[0])
+    Assert.Equal('b', screen.GetCell(0, 1).Ch.ToString().[0])
+    Assert.Equal('c', screen.GetCell(1, 2).Ch.ToString().[0])
+    Assert.Equal('d', screen.GetCell(1, 3).Ch.ToString().[0])
+
+[<Fact>]
+let ``CR moves cursor to column 0`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "ab\rXY")
+    Assert.Equal("XY   ", rowText screen 0)
+
+[<Fact>]
+let ``BS decrements column`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "abc\b\bX")
+    Assert.Equal("aXc  ", rowText screen 0)
+
+[<Fact>]
+let ``HT advances column to next 8-boundary`` () =
+    let screen = Screen(rows = 1, cols = 16)
+    feed screen [| byte 'a'; 0x09uy; byte 'b' |]
+    Assert.Equal('a', screen.GetCell(0, 0).Ch.ToString().[0])
+    Assert.Equal('b', screen.GetCell(0, 8).Ch.ToString().[0])
+
+// ---------------------------------------------------------------------
+// CSI cursor movement
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CSI 5;3H moves cursor to row 5 col 3 (1-indexed)`` () =
+    let screen = Screen(rows = 10, cols = 10)
+    feed screen (ascii "[5;3H")
+    Assert.Equal(4, screen.Cursor.Row)
+    Assert.Equal(2, screen.Cursor.Col)
+
+[<Fact>]
+let ``CSI A B C D move cursor relative`` () =
+    let screen = Screen(rows = 10, cols = 10)
+    feed screen (ascii "[5;5H")  // home to 5,5 (0-indexed 4,4)
+    feed screen (ascii "[2A")    // up 2
+    Assert.Equal(2, screen.Cursor.Row)
+    feed screen (ascii "[3B")    // down 3
+    Assert.Equal(5, screen.Cursor.Row)
+    feed screen (ascii "[2C")    // right 2
+    Assert.Equal(6, screen.Cursor.Col)
+    feed screen (ascii "[1D")    // left 1
+    Assert.Equal(5, screen.Cursor.Col)
+
+[<Fact>]
+let ``CSI cursor movement clamps at edges`` () =
+    let screen = Screen(rows = 3, cols = 3)
+    feed screen (ascii "[100A")
+    Assert.Equal(0, screen.Cursor.Row)
+    feed screen (ascii "[100B")
+    Assert.Equal(2, screen.Cursor.Row)
+    feed screen (ascii "[100C")
+    Assert.Equal(2, screen.Cursor.Col)
+
+// ---------------------------------------------------------------------
+// CSI erase
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CSI 2J clears the whole screen`` () =
+    let screen = Screen(rows = 2, cols = 4)
+    feed screen (ascii "ab\ncd")
+    feed screen (ascii "[2J")
+    for r in 0 .. 1 do
+        Assert.Equal("    ", rowText screen r)
+
+[<Fact>]
+let ``CSI 0K clears from cursor to end of line`` () =
+    let screen = Screen(rows = 1, cols = 6)
+    feed screen (ascii "abcdef")
+    feed screen (ascii "[1;3H")  // back to col 3 (0-indexed 2)
+    feed screen (ascii "[0K")
+    Assert.Equal("ab    ", rowText screen 0)
+
+// ---------------------------------------------------------------------
+// SGR
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CSI 31m sets foreground to red for following Prints`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "[31mR")
+    let cell = screen.GetCell(0, 0)
+    Assert.Equal('R', cell.Ch.ToString().[0])
+    Assert.Equal(Indexed 1uy, cell.Attrs.Fg)
+
+[<Fact>]
+let ``CSI 1m sets bold and CSI 0m resets all`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "[1;31mA[0mB")
+    Assert.True(screen.GetCell(0, 0).Attrs.Bold)
+    Assert.Equal(Indexed 1uy, screen.GetCell(0, 0).Attrs.Fg)
+    Assert.False(screen.GetCell(0, 1).Attrs.Bold)
+    Assert.Equal(Default, screen.GetCell(0, 1).Attrs.Fg)
+
+[<Fact>]
+let ``CSI 90m sets bright foreground`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "[91mR")  // bright red
+    Assert.Equal(Indexed 9uy, screen.GetCell(0, 0).Attrs.Fg)
+
+[<Fact>]
+let ``CSI m with no params is equivalent to CSI 0m`` () =
+    let screen = Screen(rows = 1, cols = 5)
+    feed screen (ascii "[1mA[mB")
+    Assert.True(screen.GetCell(0, 0).Attrs.Bold)
+    Assert.False(screen.GetCell(0, 1).Attrs.Bold)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="SmokeTests.fs" />
     <Compile Include="ConPtyHostTests.fs" />
     <Compile Include="VtParserTests.fs" />
+    <Compile Include="ScreenTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Implements the **data half** of [`spec/tech-plan.md`](spec/tech-plan.md) Stage 3: a `Screen` class consuming `VtEvent`s and mutating a `rows×cols` `Cell` grid. Pure F# in `Terminal.Core`, testable in isolation. Stage 3b (next PR) wires it into WPF.

Splitting Stage 3 into 3a + 3b reduces blast radius — the screen model is well-defined and unit-testable on its own; WPF rendering is a separate concern with its own iteration risk.

## Types added (`Terminal.Core/Types.fs`)

- `ColorSpec` DU (`Default | Indexed of byte | Rgb of byte*byte*byte`)
- `SgrAttrs` struct: `Fg`, `Bg`, `Bold`, `Italic`, `Underline`, `Inverse` + `SgrAttrs.defaults`
- `Cell` struct: `Ch` (Rune) + `Attrs` + `Cell.blank`
- `Cursor` mutable record: `Row`, `Col`, `Visible`, `SaveStack`

These replace the placeholder `Cell` / `ScreenBuffer` records previously in `Types.fs`.

## `Screen.fs` (new)

`Screen(rows, cols)` exposes `Apply(event: VtEvent)`:

- **Print** writes at cursor with current SGR, auto-wraps at `col >= cols`, scrolls when wrapping past the bottom row.
- **C0 controls** — BS, HT (next 8-col boundary), LF (with scroll), CR.
- **CSI cursor** — A/B/C/D (relative, clamped at edges), H/f (CUP/HVP, 1-indexed → 0-indexed).
- **CSI erase** — J 0/1/2 (display), K 0/1/2 (line).
- **CSI SGR** — reset, bold/italic/underline/inverse + cancellers (22/23/24/27), basic 16-colour fg (30-37, 90-97, 39) and bg (40-47, 100-107, 49). Empty-param `CSI m` ≡ `CSI 0m`.

`EscDispatch` / `OscDispatch` / `DcsHook` / `DcsPut` / `DcsUnhook` are silently ignored — Stage 4+ adds them as their owners need.

## Tests (`tests/Tests.Unit/ScreenTests.fs`)

- Construction invariants (blank cells, cursor at 0,0, dimension argument validation)
- Print + auto-wrap + scroll
- C0 controls (LF, CR, BS, HT)
- CSI cursor movement (absolute, relative, edge clamping)
- CSI erase
- CSI SGR (basic colours, bold, reset, bright variants, empty param)

## What this PR deliberately omits

Per the staging plan:

- 256-colour / truecolor SGR (`38;5;n`, `38;2;r;g;b`) — parser would need to split sub-parameters by `:` vs `;` first
- DECSET `?h`/`?l` (alt-screen, cursor visibility, focus reporting)
- DECSC/DECRC ESC 7/8 cursor save/restore
- Scrollback rotation beyond the active grid
- WPF rendering — Stage 3b

## Test plan

- [ ] CI green on `windows-latest` (build + unit test + Velopack pack smoke)
- [ ] All 18 new ScreenTests pass deterministically

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_