### PR TITLE
feat: Stage 3b — WPF TerminalView + end-to-end ConPty→Parser→Screen→View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 3b — WPF rendering + end-to-end wiring.** First visible
+  terminal surface. New `TerminalView : FrameworkElement` in
+  `src/Views/TerminalView.cs` overrides `OnRender(DrawingContext)`
+  per spec §3.3: contiguous cells with identical SGR attrs coalesce
+  into a single `FormattedText` run; backgrounds drawn first, text
+  on top; manual underline at baseline; bold/italic via
+  `FormattedText.SetFontWeight` / `SetFontStyle`. Default monospaced
+  font is "Cascadia Mono" with Consolas / Courier New fallbacks at
+  14pt; cell metrics computed once at construction. ANSI 16-colour
+  palette mapped to WPF brushes; truecolor brushes constructed
+  per-call.
+- `MainWindow.xaml` now hosts a `<views:TerminalView />` with
+  `x:FieldModifier="public"` so F# composition code in
+  `Terminal.App` can reach it across the assembly boundary.
+- `Program.fs` (Terminal.App) now wires the full Stage 3 pipeline:
+  on `Window.Loaded` it spawns a 120×30 `ConPtyHost` running
+  `cmd.exe`, then a background `Task` reads stdout chunks, feeds
+  them through the Stage 2 `Parser`, and dispatches the resulting
+  `VtEvent`s back to the UI thread via `Dispatcher.InvokeAsync`
+  to apply them to a single `Screen` and invalidate the
+  `TerminalView`. `Application.Exit` cancels the reader and
+  disposes the `ConPtyHost`.
+- `src/Views/Views.csproj` gains a `ProjectReference` to
+  `Terminal.Core` so the C# control can use `Screen` / `Cell` /
+  `SgrAttrs` / `ColorSpec` directly.
+
 - **Stage 3a — screen model.** `Terminal.Core` gains the data types
   per spec §3.1 (`ColorSpec` DU, `SgrAttrs` struct, `Cell` struct,
   `Cursor` mutable record) and a `Screen` class consuming `VtEvent`s

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1,15 +1,99 @@
 namespace PtySpeak.App
 
 open System
+open System.Threading
+open System.Threading.Tasks
 open System.Windows
+open System.Windows.Threading
 open Velopack
+open Terminal.Core
+open Terminal.Parser
+open Terminal.Pty
+open PtySpeak.Views
 
 module Program =
 
-    /// Composition seam. Stage 4 will plug Elmish.WPF in here.
-    let compose (app: Application) (window: Window) : unit =
-        ignore app
-        ignore window
+    let private ScreenRows = 30
+    let private ScreenCols = 120
+
+    /// Wire a freshly-spawned ConPtyHost into the screen + view. Spawns
+    /// a single background task that pulls byte chunks off the host's
+    /// stdout channel, feeds them through the parser, and applies the
+    /// resulting VtEvents to the screen (on the WPF dispatcher thread
+    /// for Stage 3b — Stage 5 will move parser mutation onto a
+    /// dedicated thread with snapshot-on-render semantics).
+    let private startReaderLoop
+            (dispatcher: Dispatcher)
+            (host: ConPtyHost)
+            (parser: Parser)
+            (screen: Screen)
+            (view: TerminalView)
+            (ct: CancellationToken) : Task =
+        Task.Run(fun () ->
+            task {
+                try
+                    while not ct.IsCancellationRequested do
+                        let! chunk = host.Stdout.ReadAsync(ct).AsTask()
+                        if chunk.Length > 0 then
+                            let events = Parser.feedArray parser chunk
+                            if events.Length > 0 then
+                                let action () =
+                                    for e in events do screen.Apply(e)
+                                    view.InvalidateScreen()
+                                let! _ =
+                                    dispatcher
+                                        .InvokeAsync(Action(action))
+                                        .Task
+                                ()
+                with
+                | :? OperationCanceledException -> ()
+                | _ -> ()
+            } :> Task)
+
+    /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
+    /// in here. For Stage 3b we just hold references to the long-lived
+    /// pieces and ensure they're disposed on Application.Exit.
+    let compose (app: Application) (window: MainWindow) : unit =
+        let cts = new CancellationTokenSource()
+        let screen = Screen(rows = ScreenRows, cols = ScreenCols)
+        let parser = Parser.create ()
+        window.TerminalSurface.SetScreen(screen)
+
+        let cfg : PtyConfig =
+            { Cols = int16 ScreenCols
+              Rows = int16 ScreenRows
+              CommandLine = "cmd.exe" }
+
+        let mutable hostHandle : ConPtyHost option = None
+
+        // Defer ConPTY spawn until the window has loaded so any startup
+        // failure can surface in the UI rather than crashing during
+        // Application.OnStartup.
+        window.Loaded.Add(fun _ ->
+            match ConPtyHost.start cfg with
+            | Error _ ->
+                // Stage 3b: silently ignore the failure for now —
+                // the empty terminal still renders. Stage 5 will add
+                // a UIA notification announcing the failure.
+                ()
+            | Ok host ->
+                hostHandle <- Some host
+                let _ =
+                    startReaderLoop
+                        window.Dispatcher
+                        host
+                        parser
+                        screen
+                        window.TerminalSurface
+                        cts.Token
+                ())
+
+        app.Exit.Add(fun _ ->
+            try cts.Cancel() with _ -> ()
+            match hostHandle with
+            | Some h -> (h :> IDisposable).Dispose()
+            | None -> ()
+            cts.Dispose())
 
     [<EntryPoint>]
     [<STAThread>]
@@ -19,7 +103,7 @@ module Program =
         // and short-circuits the process during install/update events.
         VelopackApp.Build().Run()
 
-        let app = PtySpeak.Views.App()
-        let window = PtySpeak.Views.MainWindow()
+        let app = App()
+        let window = MainWindow()
         compose app window
         app.Run(window)

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -1,11 +1,15 @@
 <Window x:Class="PtySpeak.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:PtySpeak.Views"
         Title="pty-speak"
         Height="600"
         Width="800"
+        Background="Black"
         AutomationProperties.Name="pty-speak terminal"
         AutomationProperties.AutomationId="pty-speak.MainWindow"
-        AutomationProperties.HelpText="Screen-reader-native Windows terminal. Stage 0 skeleton; no terminal surface yet.">
-    <Grid />
+        AutomationProperties.HelpText="Screen-reader-native Windows terminal. Stage 3b: bytes from a child shell are parsed and rendered; UIA exposure lands in Stage 4.">
+    <Grid>
+        <views:TerminalView x:Name="TerminalSurface" x:FieldModifier="public" />
+    </Grid>
 </Window>

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+using Terminal.Core;
+
+namespace PtySpeak.Views;
+
+/// <summary>
+/// WPF custom control that renders a <see cref="Screen"/> as a grid of
+/// monospaced text cells. Stage 3b's first visible terminal surface.
+///
+/// Threading: <see cref="SetScreen"/> and <see cref="InvalidateScreen"/>
+/// must be called on the WPF dispatcher thread (callers from a
+/// reader/parser thread must marshal via <c>Dispatcher.InvokeAsync</c>).
+/// Stage 3b consumes the screen on the UI thread for simplicity; later
+/// stages will move parser mutation onto a dedicated thread with a
+/// snapshot-on-render contract.
+///
+/// Rendering strategy: per spec/tech-plan.md §3.3 we use
+/// <see cref="DrawingContext"/> + <see cref="FormattedText"/> in
+/// <see cref="OnRender"/> rather than nested <c>TextBlock</c>s. For
+/// each row we coalesce contiguous cells with identical SGR attrs into
+/// a single FormattedText run to keep allocation per redraw bounded.
+/// </summary>
+public class TerminalView : FrameworkElement
+{
+    private const string FontFamilyName = "Cascadia Mono, Consolas, Courier New";
+    private const double FontSize = 14.0;
+
+    private readonly Typeface _typeface =
+        new(new FontFamily(FontFamilyName),
+            FontStyles.Normal,
+            FontWeights.Normal,
+            FontStretches.Normal);
+
+    private double _cellWidth;
+    private double _cellHeight;
+
+    private Screen? _screen;
+
+    public TerminalView()
+    {
+        Background = Brushes.Black;
+        Focusable = true;
+        FocusVisualStyle = null;
+        SnapsToDevicePixels = true;
+        UseLayoutRounding = true;
+
+        // Compute cell metrics once at construction. Monospaced fonts
+        // give us an em-quad-aligned cell that we can reuse across
+        // rows / columns. Stage 3b picks 14pt as a reasonable default;
+        // configurability lands in a later UX stage.
+        var sample = MakeFormattedText("M", Brushes.White);
+        _cellWidth = sample.WidthIncludingTrailingWhitespace;
+        _cellHeight = sample.Height;
+    }
+
+    /// <summary>
+    /// Attach a screen to render. Call once at startup; subsequent
+    /// updates flow through <see cref="InvalidateScreen"/>.
+    /// </summary>
+    public void SetScreen(Screen screen)
+    {
+        _screen = screen ?? throw new ArgumentNullException(nameof(screen));
+        InvalidateMeasure();
+        InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Tell WPF the screen's contents may have changed and a redraw
+    /// is required.
+    /// </summary>
+    public void InvalidateScreen()
+    {
+        InvalidateVisual();
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        if (_screen is null)
+        {
+            return Size.Empty;
+        }
+        var width = _cellWidth * _screen.Cols;
+        var height = _cellHeight * _screen.Rows;
+        return new Size(width, height);
+    }
+
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        // Always paint the background first so the grid has a consistent
+        // dark surface even when no screen is attached yet.
+        drawingContext.DrawRectangle(Background, null, new Rect(RenderSize));
+
+        if (_screen is null)
+        {
+            return;
+        }
+
+        for (int row = 0; row < _screen.Rows; row++)
+        {
+            RenderRow(drawingContext, row);
+        }
+    }
+
+    private void RenderRow(DrawingContext dc, int row)
+    {
+        if (_screen is null) return;
+
+        // Walk the row coalescing contiguous cells with identical
+        // SgrAttrs. For each run we draw the background (if non-default)
+        // then a single FormattedText for the run's characters.
+        int runStart = 0;
+        while (runStart < _screen.Cols)
+        {
+            var startAttrs = _screen.GetCell(row, runStart).Attrs;
+            int runEnd = runStart + 1;
+            while (runEnd < _screen.Cols
+                && SgrAttrsEqual(_screen.GetCell(row, runEnd).Attrs, startAttrs))
+            {
+                runEnd++;
+            }
+            DrawRun(dc, row, runStart, runEnd, startAttrs);
+            runStart = runEnd;
+        }
+    }
+
+    private void DrawRun(
+        DrawingContext dc,
+        int row,
+        int runStart,
+        int runEnd,
+        SgrAttrs attrs)
+    {
+        if (_screen is null) return;
+
+        var fg = ResolveBrush(attrs.Fg, isForeground: true);
+        var bg = ResolveBrush(attrs.Bg, isForeground: false);
+
+        if (attrs.Inverse)
+        {
+            (fg, bg) = (bg, fg);
+        }
+
+        // Background fill for the whole run if it's not the default.
+        if (!attrs.Bg.IsDefault || attrs.Inverse)
+        {
+            var x = runStart * _cellWidth;
+            var y = row * _cellHeight;
+            var width = (runEnd - runStart) * _cellWidth;
+            dc.DrawRectangle(bg, null, new Rect(x, y, width, _cellHeight));
+        }
+
+        // Build run text.
+        var sb = new System.Text.StringBuilder(runEnd - runStart);
+        for (int c = runStart; c < runEnd; c++)
+        {
+            var rune = _screen.GetCell(row, c).Ch;
+            sb.Append(rune.ToString());
+        }
+
+        var ft = MakeFormattedText(sb.ToString(), fg);
+        if (attrs.Bold)
+        {
+            ft.SetFontWeight(FontWeights.Bold);
+        }
+        if (attrs.Italic)
+        {
+            ft.SetFontStyle(FontStyles.Italic);
+        }
+
+        var origin = new Point(runStart * _cellWidth, row * _cellHeight);
+        dc.DrawText(ft, origin);
+
+        if (attrs.Underline)
+        {
+            // Manual underline at the baseline so we don't depend on
+            // FormattedText.SetTextDecorations being honoured under
+            // every WPF rendering mode.
+            var y = row * _cellHeight + _cellHeight - 1.5;
+            var x1 = runStart * _cellWidth;
+            var x2 = runEnd * _cellWidth;
+            var pen = new Pen(fg, 1.0);
+            dc.DrawLine(pen, new Point(x1, y), new Point(x2, y));
+        }
+    }
+
+    private FormattedText MakeFormattedText(string text, Brush fg)
+    {
+        var dpi = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+        return new FormattedText(
+            text,
+            CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight,
+            _typeface,
+            FontSize,
+            fg,
+            dpi);
+    }
+
+    private static bool SgrAttrsEqual(SgrAttrs a, SgrAttrs b)
+    {
+        return a.Bold == b.Bold
+            && a.Italic == b.Italic
+            && a.Underline == b.Underline
+            && a.Inverse == b.Inverse
+            && ColorSpecEqual(a.Fg, b.Fg)
+            && ColorSpecEqual(a.Bg, b.Bg);
+    }
+
+    private static bool ColorSpecEqual(ColorSpec a, ColorSpec b)
+    {
+        if (a.IsDefault && b.IsDefault) return true;
+        if (a.IsIndexed && b.IsIndexed) return ((ColorSpec.Indexed)a).Item == ((ColorSpec.Indexed)b).Item;
+        if (a.IsRgb && b.IsRgb)
+        {
+            var ra = (ColorSpec.Rgb)a;
+            var rb = (ColorSpec.Rgb)b;
+            return ra.Item1 == rb.Item1 && ra.Item2 == rb.Item2 && ra.Item3 == rb.Item3;
+        }
+        return false;
+    }
+
+    private static Brush ResolveBrush(ColorSpec spec, bool isForeground)
+    {
+        if (spec.IsDefault)
+        {
+            return isForeground ? Brushes.White : Brushes.Black;
+        }
+        if (spec.IsIndexed)
+        {
+            var idx = ((ColorSpec.Indexed)spec).Item;
+            return Ansi16ToBrush(idx);
+        }
+        if (spec.IsRgb)
+        {
+            var rgb = (ColorSpec.Rgb)spec;
+            return new SolidColorBrush(Color.FromRgb(rgb.Item1, rgb.Item2, rgb.Item3));
+        }
+        return isForeground ? Brushes.White : Brushes.Black;
+    }
+
+    private static Brush Ansi16ToBrush(byte idx)
+    {
+        // Standard xterm 16-colour palette. Colours 0..7 are normal,
+        // 8..15 are bright. Anything beyond is left at white as a
+        // visible "we didn't handle this yet" signal until 256-colour
+        // / truecolor SGR parsing lands.
+        return idx switch
+        {
+            0 => Brushes.Black,
+            1 => Brushes.Red,
+            2 => Brushes.Green,
+            3 => Brushes.Olive,
+            4 => Brushes.Blue,
+            5 => Brushes.Purple,
+            6 => Brushes.Teal,
+            7 => Brushes.LightGray,
+            8 => Brushes.DimGray,
+            9 => Brushes.OrangeRed,
+            10 => Brushes.LimeGreen,
+            11 => Brushes.Yellow,
+            12 => Brushes.RoyalBlue,
+            13 => Brushes.Magenta,
+            14 => Brushes.Cyan,
+            15 => Brushes.White,
+            _ => Brushes.White,
+        };
+    }
+}

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -39,9 +39,13 @@ public class TerminalView : FrameworkElement
 
     private Screen? _screen;
 
+    /// <summary>Default background fill for the terminal grid.
+    /// FrameworkElement (unlike Control / Panel) does not expose
+    /// `Background` itself, so we keep our own.</summary>
+    private readonly Brush _background = Brushes.Black;
+
     public TerminalView()
     {
-        Background = Brushes.Black;
         Focusable = true;
         FocusVisualStyle = null;
         SnapsToDevicePixels = true;
@@ -91,7 +95,7 @@ public class TerminalView : FrameworkElement
     {
         // Always paint the background first so the grid has a consistent
         // dark surface even when no screen is attached yet.
-        drawingContext.DrawRectangle(Background, null, new Rect(RenderSize));
+        drawingContext.DrawRectangle(_background, null, new Rect(RenderSize));
 
         if (_screen is null)
         {

--- a/src/Views/Views.csproj
+++ b/src/Views/Views.csproj
@@ -8,4 +8,8 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Terminal.Core\Terminal.Core.fsproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Implements the **rendering half** of [`spec/tech-plan.md`](spec/tech-plan.md) Stage 3: a custom WPF `FrameworkElement` that draws a `Screen` to the window, plus the end-to-end wiring `ConPtyHost → Parser → Screen → TerminalView`. First time text from a child shell appears in the WPF window.

## What's added

### `src/Views/TerminalView.cs` (new)

`FrameworkElement` subclass overriding `OnRender(DrawingContext)`:

- For each row, coalesces contiguous cells with identical `SgrAttrs` into a single `FormattedText` run.
- Backgrounds drawn first, text on top.
- Bold/italic via `FormattedText.SetFontWeight` / `SetFontStyle`.
- Underline drawn manually at baseline so it survives all WPF render modes.
- Cell metrics (width × height) computed once at construction from an `'M'` glyph at 14pt; default font Cascadia Mono → Consolas → Courier New.
- ANSI 16-colour palette mapped to standard WPF brushes; truecolor builds `SolidColorBrush` per-call. Default fg = white, default bg = black, inverse swaps them.
- `SetScreen` attaches the buffer; `InvalidateScreen` triggers a redraw. Both must be called on the WPF dispatcher thread.

### `src/Views/Views.csproj`

Adds `ProjectReference` to `Terminal.Core` so the C# control can use `Screen` / `Cell` / `SgrAttrs` / `ColorSpec` directly.

### `src/Views/MainWindow.xaml`

Hosts `<views:TerminalView x:Name="TerminalSurface" x:FieldModifier="public" />` so F# in `Terminal.App` can reach it across the assembly boundary.

### `src/Terminal.App/Program.fs`

`compose()` now wires the full Stage 3 pipeline:

1. On `Window.Loaded`, creates a `Screen(30, 120)`, a `Parser`, and starts a 120×30 `ConPtyHost` running `cmd.exe`.
2. A background `Task` reads stdout chunks off the host's channel, runs them through `Parser.feedArray`, and dispatches the resulting `VtEvent`s back to the UI thread via `Dispatcher.InvokeAsync`.
3. UI thread applies events to the `Screen` and calls `view.InvalidateScreen()`.
4. `Application.Exit` cancels the reader CTS and disposes the `ConPtyHost`.

`ConPtyHost.start` failures are silently ignored at this stage — the empty terminal still renders. Stage 5 will add a UIA notification announcing the failure.

## Architectural note: thread placement

Stage 3b mutates the `Screen` on the UI dispatcher thread. The spec ultimately calls for parser mutation on a dedicated thread (with a snapshot-on-render contract for the rendering thread + the future UIA peer). That migration belongs to **Stage 5** (streaming notifications), where the dedicated thread is needed anyway for the dedup/coalesce buffer feeding `RaiseNotificationEvent`.

## What this PR deliberately omits

- 256-colour / truecolor SGR — Screen.fs is data-ready (ColorSpec.Rgb is a constructor case) but the parser hasn't learned the `38;5;n` / `38;2;r;g;b` sub-parameter forms yet
- DECSET (`?h`/`?l`) modes — alt-screen, cursor visibility, focus reporting
- Keyboard input → PTY bytes — Stage 6
- UIA exposure — Stage 4

## Test plan

- [ ] CI green on `windows-latest` (build + unit test + Velopack pack smoke)
- [ ] Visual smoke (manual on a Windows VM): install the next preview build, run, see cmd.exe's prompt and any output rendered in the window. The ConPTY render-cadence quirk from Stage 1 (fast-exit `/c` commands lose output) does **not** apply here — we're running cmd.exe interactively, so the live REPL output flushes normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdRDRcnf5ZAuvsd8WwjzTH)_