### PR TITLE
release: prepare v0.0.1-preview.18 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+## [0.0.1-preview.18] — 2026-04-28
+
+First preview cut from the Stage-3b state of `main`. The window now
+shows live `cmd.exe` output (parser → screen → WPF rendering); the
+documentation set, spec, and working conventions all reflect the
+shipped-stage reality. **Unsigned preview build** — Authenticode +
+Ed25519 manifest signing return before `v0.1.0`; SmartScreen will
+warn on first run. See [`SECURITY.md`](SECURITY.md).
+
 ### Changed
 
 - **Documentation audit (post-Stage-3b).** Brought README,


### PR DESCRIPTION
Convert the [Unreleased] block into the v0.0.1-preview.18 release section with today's date and a one-paragraph narrative. The [Unreleased] heading stays at the top (now empty, ready for Stage 4 work).

Bumped to .18 because both v0.0.1-preview.16 and v0.0.1-preview.17 release attempts failed at the release-time CHANGELOG-matching gate. Per docs/RELEASE-PROCESS.md, 'release: published' won't re-fire for a tag GitHub has already seen, so each failed attempt has to bump the version. After this lands on main, delete the failed preview.16 + preview.17 releases and tags, then publish a new release at v0.0.1-preview.18 with Target=main and 'Set as a pre-release' ticked.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      validation rows for the touched stage were run against NVDA, or
      a follow-up issue is filed if validation is deferred.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
