### PR TITLE
ci: relax release CHANGELOG-matching gate; fall back to [Unreleased]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,27 +43,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate CHANGELOG.md has a matching entry
-        shell: pwsh
-        # The release-notes step further down silently falls back to a
-        # generic "Release X. See CHANGELOG.md for details." body when
-        # CHANGELOG.md has no matching `## [<version>]` section. For
-        # `v0.0.1-preview.{2..5}` we *almost* shipped that fallback
-        # because nobody noticed during a frantic diagnostic loop.
-        # Fail-fast here so a missing CHANGELOG section is loud rather
-        # than a silently-degraded release.
-        run: |
-          $tag = '${{ github.event.release.tag_name }}'
-          $version = $tag -replace '^v',''
-          $escaped = [regex]::Escape($version)
-          $content = Get-Content CHANGELOG.md -Raw
-          $pattern = "(?ms)^## \[$escaped\]"
-          if (-not ([regex]::Match($content, $pattern).Success)) {
-            Write-Error "CHANGELOG.md has no section '## [$version]' matching the release tag. Add one before publishing the release. See docs/RELEASE-PROCESS.md."
-            exit 1
-          }
-          Write-Host "CHANGELOG.md has a section for $version — OK."
-
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v5
         with:
@@ -118,15 +97,41 @@ jobs:
 
       - name: Generate release notes from CHANGELOG.md
         shell: pwsh
+        # Resolution order:
+        #   1. If a per-version section '## [<version>]' exists, use it.
+        #   2. Otherwise, if '## [Unreleased]' has non-empty content,
+        #      use it and rewrite the heading to '## [<version>] — <today>'
+        #      so the release body reads naturally.
+        #   3. Otherwise, fall back to a generic "Release X. See
+        #      CHANGELOG.md for details." body.
+        # The pre-build CHANGELOG-matching gate that used to enforce (1)
+        # was removed in favour of this fallback so a maintainer can
+        # publish a release directly off [Unreleased] without burning a
+        # tag if they forget to rename the section first. See
+        # docs/RELEASE-PROCESS.md "Cutting a release".
         run: |
           $version = '${{ steps.version.outputs.version }}'
           $content = Get-Content CHANGELOG.md -Raw
-          $pattern = "(?ms)^## \[$version\].*?(?=^## \[|\z)"
-          $match = [regex]::Match($content, $pattern)
-          if ($match.Success) {
-            $body = $match.Value.Trim()
+
+          $versionPattern = "(?ms)^## \[$version\].*?(?=^## \[|\z)"
+          $versionMatch = [regex]::Match($content, $versionPattern)
+
+          if ($versionMatch.Success) {
+            $body = $versionMatch.Value.Trim()
+            Write-Host "Using '## [$version]' section from CHANGELOG.md."
           } else {
-            $body = "Release $version. See CHANGELOG.md for details."
+            $unreleasedPattern = "(?ms)^## \[Unreleased\](.*?)(?=^## \[|\z)"
+            $unreleasedMatch = [regex]::Match($content, $unreleasedPattern)
+            $unreleasedBody = if ($unreleasedMatch.Success) { $unreleasedMatch.Groups[1].Value.Trim() } else { "" }
+
+            if ($unreleasedBody.Length -gt 0) {
+              $today = (Get-Date -Format "yyyy-MM-dd")
+              $body = "## [$version] — $today`n`n$unreleasedBody"
+              Write-Host "Using [Unreleased] section from CHANGELOG.md (no per-version section found); rewrote heading to '## [$version] — $today' for the release body."
+            } else {
+              $body = "Release $version. See CHANGELOG.md for details."
+              Write-Warning "Neither '## [$version]' nor a non-empty '## [Unreleased]' section found in CHANGELOG.md; using generic fallback body."
+            }
           }
           $bannerLines = @(
             "> [!WARNING]",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **Release-time `CHANGELOG.md` matching gate relaxed.** The pre-build
+  step in `.github/workflows/release.yml` that failed the workflow
+  when no `## [<version>]` section existed has been removed.
+  `v0.0.1-preview.{16,17}` were burned by exactly that gate (publish a
+  release without remembering to rename the section first → workflow
+  fails → `release: published` won't refire for the same tag, so the
+  next attempt has to bump). The `Generate release notes from
+  CHANGELOG.md` step now resolves the body in this order: per-version
+  `## [<version>]` section if present → `## [Unreleased]` content
+  with the heading rewritten to `## [<version>] — <today>` for the
+  release body → generic `"Release X. See CHANGELOG.md for details."`
+  fallback (warned-on, not failed). Net effect: a maintainer can
+  publish a release directly off `[Unreleased]` without burning a
+  tag. `docs/RELEASE-PROCESS.md` "Cutting a release" updated to
+  describe both flows.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -72,11 +72,32 @@ that updates `CHANGELOG.md`.
 
 ### 2. Update the changelog and version
 
-Move the `## [Unreleased]` items into a new `## [X.Y.Z]` section in
-[`CHANGELOG.md`](../CHANGELOG.md) with today's date. Bump the
-`<Version>` property in `Directory.Build.props` (or the equivalent in
-each `.fsproj`) to match. Open a PR titled `release: vX.Y.Z`. Merge
-when CI is green.
+The release-notes step in `release.yml` resolves the body in this
+order:
+
+1. If [`CHANGELOG.md`](../CHANGELOG.md) has a `## [X.Y.Z]` section
+   matching the release tag, use it verbatim.
+2. Otherwise, if `## [Unreleased]` has non-empty content, use it as
+   the body — the workflow rewrites the heading to
+   `## [X.Y.Z] — <today>` so the final release reads naturally.
+3. Otherwise, fall back to a generic `"Release X.Y.Z. See
+   CHANGELOG.md for details."` body. This is the silent-degradation
+   path; we warn loudly in the workflow log when it's used.
+
+The lightest-touch flow is **(2)**: leave the bullets under
+`## [Unreleased]`, publish the release, and let the workflow promote
+them. After the release publishes, you can optionally open a small
+PR that renames `## [Unreleased]` to `## [X.Y.Z] — <date>` in the
+file itself and re-adds an empty `[Unreleased]` — that keeps
+`CHANGELOG.md` matching what the release page shows long-term. **(1)**
+is appropriate when you want a curated narrative committed to `main`
+before publishing (e.g. a stable `vX.Y.Z` release that benefits from
+review).
+
+Bump the `<Version>` property in `Directory.Build.props` (or the
+equivalent in each `.fsproj`) to match the release tag. If you went
+the (1) route, your PR title is `release: vX.Y.Z`; if you're using
+the (2) flow you don't need a separate changelog PR.
 
 ### 3. Publish the release
 
@@ -111,25 +132,23 @@ Triggered by the `release: published` event you just fired. Runs on
    an outdated `release.yml`.
 3. **Checkout** with default `ref` — release events set `GITHUB_REF`
    to `refs/tags/<tag_name>` so the source at the tag is checked out.
-4. **Validate `CHANGELOG.md` has a matching entry** — fails with a
-   clear error if no `## [<version>]` section exists. Without this
-   gate, the release-notes step further down silently falls back to a
-   generic "Release X. See CHANGELOG.md for details." body.
-5. **Setup .NET 9** via `actions/setup-dotnet@v5`.
-6. **Resolve version** — strips the leading `v` from
+4. **Setup .NET 9** via `actions/setup-dotnet@v5`.
+5. **Resolve version** — strips the leading `v` from
    `github.event.release.tag_name`, detects prerelease from the
    `-preview.N` / `-rc.N` suffix.
-7. `dotnet restore` / `dotnet build -c Release` / `dotnet test`.
-8. `dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish` (with `/p:Version=...`).
-9. **Install Velopack CLI** (`dotnet tool install -g vpk`).
-10. **`vpk pack`** — wraps `publish/` into a Velopack release at
-    `releases/`: `*Setup.exe`, full nupkg, `RELEASES`. (No
-    `*-delta.nupkg` on the first release; `releases.json` is not
-    produced by our `vpk pack` config.)
-11. **Generate release notes from `CHANGELOG.md`** — writes
-    `release-body.md` with the unsigned-preview banner prepended to
-    the matching `## [<version>]` section.
-12. **Update GitHub Release** via `softprops/action-gh-release@v3`:
+6. `dotnet restore` / `dotnet build -c Release` / `dotnet test`.
+7. `dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish` (with `/p:Version=...`).
+8. **Install Velopack CLI** (`dotnet tool install -g vpk`).
+9. **`vpk pack`** — wraps `publish/` into a Velopack release at
+   `releases/`: `*Setup.exe`, full nupkg, `RELEASES`. (No
+   `*-delta.nupkg` on the first release; `releases.json` is not
+   produced by our `vpk pack` config.)
+10. **Generate release notes from `CHANGELOG.md`** — writes
+    `release-body.md` by resolving the body via the order in step 2
+    above (per-version section → `[Unreleased]` content with rewritten
+    heading → generic fallback), then prepends the unsigned-preview
+    banner.
+11. **Update GitHub Release** via `softprops/action-gh-release@v3`:
     sets title to `pty-speak <version>`, replaces the auto-generated
     body with `release-body.md`, sets `prerelease` from the version
     resolution, and attaches the artifact files.


### PR DESCRIPTION
The pre-build 'Validate CHANGELOG.md has a matching entry' step in release.yml was added during the Stage 0 diagnostic loop to fail loud when the release-notes step would otherwise silently degrade to 'Release X. See CHANGELOG.md for details.' — but in practice it has caused exactly the problem it tried to prevent: v0.0.1-preview.{16,17} were burned at this gate (publish without renaming the section first => workflow fails => release: published can't refire for the same tag => next attempt has to bump). The gate's cost has clearly exceeded its benefit.

Replace the strict gate with a smarter release-notes resolution order:
  1. per-version '## [<version>]' section if present
  2. otherwise, '## [Unreleased]' content with the heading rewritten to '## [<version>] — <today>' for the release body
  3. otherwise, generic fallback (warned-on, not failed)

Net effect: a maintainer can publish a release directly off [Unreleased] without burning a tag. The (1) flow is still available for stable releases that benefit from a curated narrative committed to main beforehand.

- .github/workflows/release.yml: drop the validation step; replace the if/else in 'Generate release notes' with the three-way resolution above.
- docs/RELEASE-PROCESS.md: section '2. Update the changelog and version' rewritten to describe both flows; the workflow-step enumeration in '4. Wait for the release workflow' updated to reflect the removed step.
- CHANGELOG.md: new Changed bullet under [Unreleased] documenting the pipeline behaviour change.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      validation rows for the touched stage were run against NVDA, or
      a follow-up issue is filed if validation is deferred.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
