### PR TITLE
feat(core): Screen.SequenceNumber + Screen.SnapshotRows (Stage 4 substrate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,40 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Stage 4 substrate — `Screen.SequenceNumber` + `Screen.SnapshotRows`
+  in `Terminal.Core`.** `Screen` now exposes a monotonic
+  `SequenceNumber: int64` (incremented on every `Apply`) and a
+  `SnapshotRows(startRow, count): int64 * Cell[][]` method that
+  atomically captures an immutable copy of the requested rows
+  paired with the sequence number at capture time. Both `Apply` and
+  `SnapshotRows` serialize on a private gate object, which is the
+  boundary between the WPF Dispatcher (where the parser feeds
+  events) and the UIA RPC thread (where Stage 4's
+  `ITextRangeProvider` will read snapshots from). This is the
+  thread-safety primitive that spec §4.3's snapshot-on-construction
+  rule depends on; landing it ahead of the UIA peer keeps the
+  Stage 4 PR focused on the peer + provider implementation.
+  `tests/Tests.Unit/ScreenTests.fs` covers fresh-screen baseline,
+  per-event sequence increments, deep-copy independence, sequence-
+  pairing, argument validation, the `count = 0` degenerate, and a
+  concurrent producer / snapshot stress test.
+
 ### Changed
 
+- **`docs/SESSION-HANDOFF.md` brought up to date.** Replaced the
+  out-of-date "in-flight branch" / "last shipped release" rows: the
+  `chore/session-handoff-and-final-audit` audit, the `preview.18`
+  CHANGELOG, and the relaxed CHANGELOG-matching gate (PRs #35-#37)
+  all merged on 2026-04-28; `v0.0.1-preview.18` is now the last
+  shipped preview. Recorded the maintainer-reported Stage-3b
+  finding that a separate `cmd.exe` console-host window appears
+  behind the WPF window on launch, and tracked the conhost
+  defect under "Pending action items" as orthogonal to Stage 4.
+  Updated the Stage 4 sketch to reference the new
+  `Screen.SnapshotRows` / `Screen.SequenceNumber` primitives so the
+  snapshot rule is implementable without further substrate work.
 - **Release-time `CHANGELOG.md` matching gate relaxed.** The pre-build
   step in `.github/workflows/release.yml` that failed the workflow
   when no `## [<version>]` section existed has been removed.

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -20,16 +20,17 @@ A new session should read this **first**, then
 | | |
 |---|---|
 | **Last merged stage** | Stage 3b (WPF `TerminalView` + end-to-end `ConPtyHost → Parser → Screen → TerminalView`) |
-| **Last shipped release** | [`v0.0.1-preview.15`](https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.15) — Stage 0 (empty-window installer, NVDA-validated) |
-| **Released since** | Nothing. Stages 1, 2, 3a, 3b are on `main` but not yet shipped as a preview. The Stage-3b installer is the next natural smoke target. |
-| **In-flight branch** | `chore/session-handoff-and-final-audit` — documentation audit + spec rewrite + extraction of working conventions into CONTRIBUTING. **Must be reviewed and merged before any Stage 4 work**, otherwise Stage 4 lands on top of an unreviewed audit branch and the histories tangle. See `CHANGELOG.md` `[Unreleased]` for the bullet-by-bullet scope. |
-| **Next stage** | **Stage 4** — UIA exposure (first NVDA milestone). See sketch below. |
+| **Last shipped release** | [`v0.0.1-preview.18`](https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.18) — first preview cut from Stage 3b state. Maintainer has installed the build and confirmed `cmd.exe` runs under ConPTY end-to-end. (`preview.16` and `.17` were burned by the `## [<version>]` CHANGELOG-matching gate before #37 relaxed it; both retag the same `db44d6d` commit and were never shipped artifacts.) |
+| **Stage-3b smoke status** | **Known issue:** the maintainer reports a separate `cmd.exe` console host window appears behind the pty-speak WPF window on launch. ConPTY children should not allocate their own conhost — points at a `STARTUPINFOEX` / `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` defect in `Terminal.Pty/PseudoConsole.fs` or `ConPtyHost.fs`. Tracked separately from Stage 4; doesn't block UIA work. |
+| **In-flight branch** | None. The pre-Stage-4 audit (PR #35), `preview.18` CHANGELOG (PR #36), and the relaxed CHANGELOG-matching gate (PR #37) all merged in sequence on 2026-04-28. |
+| **Next stage** | **Stage 4** — UIA exposure (first NVDA milestone). See sketch below. The Stage-4-prep PR (this PR) lands `Screen.SequenceNumber` + `Screen.SnapshotRows` so the UIA peer's `ITextRangeProvider` can capture immutable row state across the UIA RPC thread without tearing. |
 
 The end-to-end pipeline is wired: launching the app spawns `cmd.exe`
 under ConPTY, parses its output, applies VtEvents to a 30×120
 `Screen`, and renders the buffer in a custom WPF `FrameworkElement`.
-Visual smoke on Windows is **pending** — the maintainer hasn't
-installed the post-Stage-3 build yet.
+The maintainer has installed `v0.0.1-preview.18` and confirmed text
+appears in the WPF window; the conhost-second-window finding above
+is the only outstanding Stage-3b regression.
 
 ## Pending action items (maintainer)
 
@@ -38,30 +39,26 @@ GitHub-website access. They've accumulated because the development
 sandbox can't push tags and the GitHub MCP server occasionally
 disconnects mid-session.
 
-1. **Review and merge the audit branch
-   `chore/session-handoff-and-final-audit`.** It carries the
-   documentation audit, the spec rewrite, and the
-   SESSION-HANDOFF→CONTRIBUTING extraction described in the
-   `CHANGELOG.md` `[Unreleased]` section. **Do this before starting
-   Stage 4** so Stage 4 doesn't sit on top of an unreviewed audit
-   stack. If a PR isn't already open, create one at
-   `https://github.com/KyleKeane/pty-speak/pull/new/chore/session-handoff-and-final-audit`.
+1. **Push the five pending baseline tags.** Exact commands are in
+   [`docs/CHECKPOINTS.md`](CHECKPOINTS.md#pending-checkpoint-tags):
+   `baseline/stage-{0-ci-release, 1-conpty-hello-world, 2-vt-parser,
+   3a-screen-model, 3b-wpf-rendering}`. Tags don't trigger any
+   workflow; they're rollback handles only.
 
-2. **Push the four pending baseline tags.** Exact commands are in
-   [`docs/CHECKPOINTS.md`](CHECKPOINTS.md#pending-checkpoint-tags).
-   Tags don't trigger any workflow; they're rollback handles only.
-
-3. **Optional: cut a `v0.0.1-preview.16` release.** Validates Stage 3b
-   visually (cmd.exe text appearing in the WPF window) and gives you
-   an installer to run NVDA against. Procedure in
-   [`docs/RELEASE-PROCESS.md`](RELEASE-PROCESS.md#cutting-a-release);
-   make sure to add a `## [0.0.1-preview.16]` section to
-   `CHANGELOG.md` first or the new release-time gate will refuse it.
-
-4. **Re-enable the GitHub MCP server** in the next Claude Code thread
+2. **Re-enable the GitHub MCP server** in the next Claude Code thread
    if it's not auto-reconnected. Without it the agent can't
    programmatically check PR status, merge PRs, or post issue
    comments — falls back to asking the maintainer.
+
+3. **Investigate the Stage-3b conhost-second-window finding.** When
+   the maintainer launched `v0.0.1-preview.18` they observed a
+   separate `cmd.exe` console host window appearing behind the
+   pty-speak WPF window. Under ConPTY the child shell should
+   inherit the pseudo-console; a separate conhost suggests
+   `STARTUPINFOEX.cb` or the `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`
+   attachment isn't taking effect. Likely sites:
+   `src/Terminal.Pty/PseudoConsole.fs` and `src/Terminal.Pty/Native.fs`.
+   Tracked as its own concern; orthogonal to Stage 4 UIA work.
 
 ## Working conventions on this repo
 
@@ -191,10 +188,13 @@ reference to the `Screen` — pass it via `TerminalView.SetScreen`
 **Snapshot rule**: UIA calls into the provider on a different thread
 from the WPF Dispatcher. Mutating the buffer while UIA reads = crash
 (see `Terminal.Accessibility` design notes in `spec/overview.md`).
-For Stage 4 the simplest approach is: every `ITextRangeProvider`
-holds an immutable copy of the rows it spans, taken at construction.
-A buffer-modify counter (sequence number) lets the peer invalidate
-stale ranges.
+The Stage-4-prep PR landed the substrate for this:
+`Screen.SnapshotRows(startRow, count)` returns `(int64 * Cell[][])`
+under the same lock as `Screen.Apply`, and `Screen.SequenceNumber`
+exposes the monotonic counter. Each `ITextRangeProvider` constructor
+should take a `(sequence, snapshot)` tuple and compare against
+`screen.SequenceNumber` later to detect staleness. No additional
+locking is required in `Terminal.Accessibility`.
 
 **Testing without NVDA**:
 - **FlaUI** integration tests in `tests/Tests.Ui/` (currently

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -20,6 +20,18 @@ open System.Text
 ///   * CSI K — erase line (modes 0/1/2).
 ///   * CSI m — SGR for the basic 16 ANSI colours plus 0/1/3/4/7/22/23/24/27.
 ///
+/// Stage 4 substrate (no UIA peer yet):
+///   * `SequenceNumber` increments on every Apply call. Stage 4's
+///     `ITextRangeProvider` reads it together with `SnapshotRows`
+///     to detect stale ranges across UIA RPC threads. The counter
+///     bumps for non-mutating events too (e.g. `DcsPut`); that's
+///     intentional — staleness "the buffer might have changed" is
+///     conservative and safe.
+///   * `SnapshotRows(start, count)` returns an immutable copy of
+///     the requested rows plus the sequence number at the moment
+///     of capture, taken under the same gate as Apply so callers
+///     never observe a torn buffer.
+///
 /// Deliberately *not* covered yet (later stages refine):
 ///   * 256-colour and truecolor SGR (38;5;n, 38;2;r;g;b) — needs a
 ///     parser that splits sub-parameters by `;` vs `:`.
@@ -36,6 +48,13 @@ type Screen(rows: int, cols: int) =
     let cells: Cell[,] = Array2D.create rows cols Cell.blank
     let cursor: Cursor = Cursor.create ()
     let mutable currentAttrs: SgrAttrs = SgrAttrs.defaults
+
+    // Mutation gate. Apply takes this lock; SnapshotRows takes it to
+    // capture (sequence, rows) atomically. Stage 3b feeds Apply on the
+    // WPF dispatcher; Stage 4's UIA peer reads snapshots from the UIA
+    // RPC thread, so the lock is the boundary between them.
+    let gate = obj ()
+    let mutable sequenceNumber: int64 = 0L
 
     let clamp lo hi v = max lo (min hi v)
 
@@ -193,20 +212,46 @@ type Screen(rows: int, cols: int) =
     /// Read-only access to a cell. (row, col) are 0-indexed.
     member _.GetCell(row: int, col: int) : Cell = cells.[row, col]
 
+    /// Monotonic counter incremented on every Apply. Stage 4 ranges
+    /// store this at construction; if it has changed when the range
+    /// is later queried, the range is known to be stale. Reads under
+    /// the same lock as Apply / SnapshotRows so that 64-bit loads
+    /// can't tear on architectures without atomic int64 reads.
+    member _.SequenceNumber : int64 = lock gate (fun () -> sequenceNumber)
+
+    /// Atomically capture an immutable copy of `count` rows starting
+    /// at `startRow`, paired with the sequence number at capture
+    /// time. Each returned row is a fresh `Cell[]` of length `Cols`;
+    /// callers may retain it indefinitely.
+    member _.SnapshotRows(startRow: int, count: int) : int64 * Cell[][] =
+        if startRow < 0 || startRow >= rows then
+            invalidArg "startRow" (sprintf "startRow must be in [0, %d); got %d" rows startRow)
+        if count < 0 then
+            invalidArg "count" (sprintf "count must be non-negative; got %d" count)
+        if startRow + count > rows then
+            invalidArg "count" (sprintf "startRow + count must be <= %d; got %d + %d" rows startRow count)
+        lock gate (fun () ->
+            let snapshot = Array.init count (fun i ->
+                let r = startRow + i
+                Array.init cols (fun c -> cells.[r, c]))
+            sequenceNumber, snapshot)
+
     /// Apply a single VT event to the buffer. Stage 3a covers the
     /// minimum needed to render cmd.exe-style output; unsupported
     /// sequences are silently no-ops so the parser can continue
     /// streaming without exceptions.
     member _.Apply(event: VtEvent) =
-        match event with
-        | Print rune -> printRune rune
-        | Execute b -> executeC0 b
-        | CsiDispatch(parms, _, finalByte, _priv) ->
-            // Private-marker sequences (DECSET ?h/?l) are ignored
-            // in Stage 3a; alt-screen and friends arrive later.
-            csiDispatch parms finalByte
-        | EscDispatch _
-        | OscDispatch _
-        | DcsHook _
-        | DcsPut _
-        | DcsUnhook -> ()  // Not yet handled — Stage 4+
+        lock gate (fun () ->
+            sequenceNumber <- sequenceNumber + 1L
+            match event with
+            | Print rune -> printRune rune
+            | Execute b -> executeC0 b
+            | CsiDispatch(parms, _, finalByte, _priv) ->
+                // Private-marker sequences (DECSET ?h/?l) are ignored
+                // in Stage 3a; alt-screen and friends arrive later.
+                csiDispatch parms finalByte
+            | EscDispatch _
+            | OscDispatch _
+            | DcsHook _
+            | DcsPut _
+            | DcsUnhook -> ())  // Not yet handled — Stage 4+

--- a/tests/Tests.Unit/ScreenTests.fs
+++ b/tests/Tests.Unit/ScreenTests.fs
@@ -197,3 +197,95 @@ let ``CSI m with no params is equivalent to CSI 0m`` () =
     feed screen (ascii "[1mA[mB")
     Assert.True(screen.GetCell(0, 0).Attrs.Bold)
     Assert.False(screen.GetCell(0, 1).Attrs.Bold)
+
+// ---------------------------------------------------------------------
+// Stage 4 substrate: SequenceNumber + SnapshotRows
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``fresh screen has SequenceNumber 0`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    Assert.Equal(0L, screen.SequenceNumber)
+
+[<Fact>]
+let ``Apply increments SequenceNumber once per event`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let parser = Parser.create ()
+    let events = Parser.feedArray parser (ascii "abc")
+    let before = screen.SequenceNumber
+    for e in events do screen.Apply(e)
+    Assert.Equal(before + int64 events.Length, screen.SequenceNumber)
+
+[<Fact>]
+let ``SnapshotRows returns an immutable copy of the requested rows`` () =
+    let screen = Screen(rows = 3, cols = 4)
+    feed screen (ascii "ab\ncd")
+    let _seq, rows = screen.SnapshotRows(0, 2)
+    Assert.Equal(2, rows.Length)
+    Assert.Equal(4, rows.[0].Length)
+    Assert.Equal('a', rows.[0].[0].Ch.ToString().[0])
+    Assert.Equal('b', rows.[0].[1].Ch.ToString().[0])
+
+    // Mutating the screen after the snapshot must not affect the
+    // returned rows — the snapshot is a deep copy.
+    feed screen (ascii "[1;1HZ")
+    Assert.Equal('Z', screen.GetCell(0, 0).Ch.ToString().[0])
+    Assert.Equal('a', rows.[0].[0].Ch.ToString().[0])
+
+[<Fact>]
+let ``SnapshotRows pairs the snapshot with the sequence number at capture time`` () =
+    let screen = Screen(rows = 2, cols = 3)
+    feed screen (ascii "ab")
+    let seq1, _ = screen.SnapshotRows(0, screen.Rows)
+    feed screen (ascii "c")
+    let seq2, _ = screen.SnapshotRows(0, screen.Rows)
+    Assert.True(seq2 > seq1, sprintf "expected %d > %d" seq2 seq1)
+
+[<Fact>]
+let ``SnapshotRows rejects out-of-range arguments`` () =
+    let screen = Screen(rows = 3, cols = 3)
+    Assert.Throws<System.ArgumentException>(fun () ->
+        screen.SnapshotRows(-1, 1) |> ignore) |> ignore
+    Assert.Throws<System.ArgumentException>(fun () ->
+        screen.SnapshotRows(0, -1) |> ignore) |> ignore
+    Assert.Throws<System.ArgumentException>(fun () ->
+        screen.SnapshotRows(0, 4) |> ignore) |> ignore
+    Assert.Throws<System.ArgumentException>(fun () ->
+        screen.SnapshotRows(2, 2) |> ignore) |> ignore
+
+[<Fact>]
+let ``SnapshotRows with count=0 returns an empty array without affecting the sequence`` () =
+    let screen = Screen(rows = 3, cols = 3)
+    feed screen (ascii "ab")
+    let before = screen.SequenceNumber
+    let _seq, rows = screen.SnapshotRows(1, 0)
+    Assert.Empty(rows)
+    Assert.Equal(before, screen.SequenceNumber)
+
+[<Fact>]
+let ``concurrent snapshots and applies never tear`` () =
+    // Producer thread feeds bytes through the parser and applies
+    // them; the test thread continuously snapshots rows. Snapshots
+    // must be well-shaped and SequenceNumber monotonic — the lock
+    // around Apply / SnapshotRows is what guarantees both.
+    let screen = Screen(rows = 4, cols = 8)
+    let parser = Parser.create ()
+    let producer = System.Threading.Tasks.Task.Run(fun () ->
+        let payload = ascii "Hello World!\n"
+        for _ in 1 .. 1000 do
+            let events = Parser.feedArray parser payload
+            for e in events do screen.Apply(e))
+    // At least one snapshot before the producer's exit so the test
+    // can't degenerate to zero iterations on a fast machine.
+    let firstSeq, firstRows = screen.SnapshotRows(0, screen.Rows)
+    Assert.Equal(4, firstRows.Length)
+    let mutable lastSeq = firstSeq
+    while not producer.IsCompleted do
+        let seq, rows = screen.SnapshotRows(0, screen.Rows)
+        Assert.True(seq >= lastSeq, sprintf "sequence regressed: %d < %d" seq lastSeq)
+        lastSeq <- seq
+        Assert.Equal(4, rows.Length)
+        for r in rows do Assert.Equal(8, r.Length)
+    producer.Wait()
+    let finalSeq, _ = screen.SnapshotRows(0, screen.Rows)
+    Assert.True(finalSeq >= lastSeq)

--- a/tests/Tests.Unit/ScreenTests.fs
+++ b/tests/Tests.Unit/ScreenTests.fs
@@ -227,8 +227,11 @@ let ``SnapshotRows returns an immutable copy of the requested rows`` () =
     Assert.Equal('b', rows.[0].[1].Ch.ToString().[0])
 
     // Mutating the screen after the snapshot must not affect the
-    // returned rows — the snapshot is a deep copy.
-    feed screen (ascii "[1;1HZ")
+    // returned rows — the snapshot is a deep copy. The
+    // ESC (0x1B) byte before the [ is what makes the parser
+    // recognize CSI; without it "[1;1H" parses as five Print
+    // events and the cursor never returns to (0,0).
+    feed screen (ascii "[1;1HZ")
     Assert.Equal('Z', screen.GetCell(0, 0).Ch.ToString().[0])
     Assert.Equal('a', rows.[0].[0].Ch.ToString().[0])
 


### PR DESCRIPTION
## Summary

- **`Screen.SequenceNumber: int64`** — monotonic counter bumped on every `Apply` call.
- **`Screen.SnapshotRows(startRow, count): int64 * Cell[][]`** — atomic `(sequence, deep-copy of rows)` tuple, taken under the same private lock as `Apply` so callers across threads never observe a torn buffer.
- **`docs/SESSION-HANDOFF.md`** brought up to date for post-#37 `main` (last shipped is `preview.18`, audit branch merged, conhost-second-window finding recorded as a separate concern).
- **CHANGELOG `[Unreleased]`** entry added.

## Why this lands ahead of the Stage 4 PR

`spec/tech-plan.md` §4.3 (the snapshot rule) requires every `ITextRangeProvider` to hold an immutable copy of the rows it spans, captured at construction, with a sequence number to detect staleness. The UIA RPC thread is not the WPF Dispatcher — anything reading `cells` directly will eventually crash on a half-written row.

Landing the snapshot/sequence primitive on its own keeps the Stage 4 PR focused on the actual UIA work (`TerminalAutomationPeer.fs` + `TerminalTextProvider.fs` + the FlaUI test fixture). Per CONTRIBUTING's "one concern per PR" rule.

## Threading model

```
WPF Dispatcher                                  UIA RPC thread (Stage 4)
  │                                                       │
  └── Screen.Apply(event)  ─── lock(gate) ───  Screen.SnapshotRows(start, count)
                  │                                       │
                  ▼                                       ▼
       sequenceNumber += 1                    return (sequenceNumber, deep-copy)
       mutate cells / cursor / SGR
```

Both `Apply` and `SnapshotRows` serialize on the same private gate object. `SequenceNumber` reads under the same lock so 64-bit loads can't tear on architectures without atomic int64 reads.

## What this PR deliberately omits

- **No `OnCreateAutomationPeer` override yet on `TerminalView`.** That's Stage 4 proper.
- **No `Terminal.Accessibility` content.** Still `Placeholder.fs`; gets replaced in the Stage 4 PR.
- **No FlaUI package reference in `Tests.Ui.fsproj`.** Added when the UIA tests land.

## Test plan

- [x] `tests/Tests.Unit/ScreenTests.fs` — new tests:
  - [x] fresh screen has `SequenceNumber = 0`
  - [x] `Apply` increments `SequenceNumber` once per event
  - [x] `SnapshotRows` returns an immutable deep copy (mutating the screen after the snapshot doesn't affect the returned rows)
  - [x] `(sequence, snapshot)` pair captured atomically — a later snapshot has a strictly larger sequence after intervening `Apply`s
  - [x] argument validation rejects `startRow < 0`, `count < 0`, and `startRow + count > rows`
  - [x] `count = 0` returns an empty array without bumping the sequence
  - [x] concurrent producer/snapshot stress test: 1000 iterations, sequence non-decreasing, no torn snapshots
- [ ] Existing `ScreenTests` still green (no behavior change to `Apply` other than the sequence bump and the lock; all existing fixtures are single-threaded)
- [ ] `dotnet build -c Release` clean on `windows-latest`
- [ ] `dotnet test -c Release` green on `windows-latest`
- [ ] Manual NVDA smoke is **N/A** — no user-visible behavior change in this PR

## Followups (separate PRs)

1. **Stage 4 proper** — `TerminalAutomationPeer.fs` + `TerminalTextProvider.fs` + `OnCreateAutomationPeer` hook in `TerminalView.cs` + FlaUI integration test in `Tests.Ui`. The snapshot rule from this PR is the linchpin.
2. **Conhost-second-window investigation** — Stage-3b smoke test surfaced a stray `cmd.exe` console host window appearing behind the WPF window on launch. Likely a `STARTUPINFOEX.cb` or `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` defect in `src/Terminal.Pty/PseudoConsole.fs` / `Native.fs`. Orthogonal to Stage 4.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_