### PR TITLE
docs(contributing): document the literal-ESC-byte test-fixture convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,39 @@ empty `tests/Tests.Ui/` project reserves the path for FlaUI work.
   product stays screen-reader-agnostic, then confirm with a real screen
   reader.
 
+### Test fixtures: CSI / OSC / DCS sequences
+
+Existing tests in `VtParserTests.fs` and `ScreenTests.fs` embed a
+**literal 0x1B byte** (ESC) directly in the F# source. The byte
+is invisible in most editors but appears as `\033` under `od -c`.
+The test reads `feed screen (ascii "[5;3H")` to the eye, but the
+real bytes between `"` and `[` are `0x1B 0x5B`, so the parser
+recognizes CSI CUP. This is the pre-existing convention.
+
+**It is also a foot-gun.** Any edit that round-trips through plain
+text — including most agent edit tools, plain-text patches, and
+some web-editor copy-paste — silently strips the 0x1B byte. The
+test then literally reads `"[5;3H"` (no ESC), the parser emits
+five Print events, and the assertion fails (or worse, passes
+vacuously if it only checks something the Prints happen to
+satisfy). PR #38 burned one CI cycle on exactly this; the fix
+landed in `4c9c0d6`.
+
+For new test fixtures, prefer the explicit F# Unicode escape so
+the dependency on the parser's CSI handling is visible in source:
+
+```fsharp
+feed screen (ascii "\u001b[5;3H")           // CUP
+feed screen (ascii "\u001b[31m")            // SGR red
+feed screen (ascii "\u001b]0;Title\u0007")  // OSC 0; bell-terminated
+```
+
+Both forms compile to the same bytes at runtime; `\u001b` survives
+text-only edits. When touching a test that already uses the
+raw-byte form, leave it as-is rather than rewriting — but if a
+diff would land on that line for any other reason, take the
+opportunity to migrate it.
+
 CI runs `dotnet test` and `dotnet build -c Release` on `windows-latest`.
 Local pre-PR checklist:
 


### PR DESCRIPTION
## Summary

Documents the **literal-0x1B-byte** convention used by existing CSI/OSC/DCS test fixtures in `VtParserTests.fs` and `ScreenTests.fs`, calls out the foot-gun (plain-text edits silently strip the byte), and recommends the F# Unicode escape (``) as the durable form for new fixtures.

## Why

PR #38 burned one CI cycle on exactly this bug:
- I added a snapshot deep-copy test that fed `"[1;1HZ"` to the parser.
- The Edit tool sent plain text — no 0x1B byte — so the parser correctly emitted five Print events instead of CSI CUP.
- The cursor never moved to (0,0), `'Z'` printed somewhere else, and the assertion failed.
- Fix landed as `4c9c0d6` on PR #38 by injecting the 0x1B byte via a binary-safe Python edit.

The convention isn't documented anywhere, so the next agent (or human using a web editor) will hit the same trap. This PR adds the warning to `CONTRIBUTING.md` "Tests" → new "Test fixtures: CSI / OSC / DCS sequences" subsection.

## What this PR deliberately omits

- **No migration of existing fixtures.** Per the policy this PR establishes: leave the raw-byte form alone unless a diff already lands on the line. Sweeping migration would be a churn-y diff with no behavior change.
- **No new tests.** Documentation only.

## Test plan

- [ ] `dotnet build -c Release` clean (no source changes — should be a no-op)
- [ ] `dotnet test -c Release` green (same)
- [ ] Markdown link check passes (no new external links)
- [ ] Manual: render the section in GitHub's Markdown preview and confirm `` shows literally rather than as a control character

## Followups (separate PRs)

1. **Tests / CI / release audit** — broader cleanup pass before Stage 4 (in flight, will report back with findings).
2. **Conhost-second-window fix** — Issue #39, target before Stage 4 lands.
3. **Stage 4 proper** — UIA peer + FlaUI test, the actual NVDA-readable surface.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_