### PR TITLE
fix(ci): match Velopack's channel-suffixed manifest filenames in release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,39 @@ jobs:
         # fail_on_unmatched_files=false would silently upload nothing
         # and the release would ship without the file the auto-update
         # client expects. Fail the workflow loudly here instead.
-        # Required: *Setup.exe and *-full.nupkg. Delta nupkg, RELEASES,
-        # and releases.json are produced under known conditions but
-        # not on every release (e.g. delta needs a prior release to
-        # diff against), so they are not asserted here.
+        #
+        # Required artifacts (per Velopack's vpk pack docs):
+        #   * <id>-Setup.exe         — Windows installer
+        #   * <id>-<ver>-full.nupkg  — full update package
+        #   * releases.<channel>.json — releases index for auto-update
+        #   * assets.<channel>.json   — asset manifest used by deployment
+        # The channel suffix is Velopack's runtime identifier (we get
+        # "win" by default since we don't pass `--channel`); use a glob
+        # so this stays robust if we add channel routing later.
+        #
+        # Optional / not asserted:
+        #   * <id>-<ver>-delta.nupkg — only when a prior release exists
+        #     to diff against; v0.0.1-preview.18 (the first release
+        #     since CI was overhauled) had no prior release so no delta
+        #     was produced. Asserting it would fail the first release
+        #     after every channel change.
+        #   * RELEASES — legacy Squirrel-migration index; vpk produces
+        #     it for back-compat but new clients use releases.*.json.
+        #   * <id>-Portable.zip — opt-in flag we don't pass.
+        #
+        # Background: this gate was scoped to *Setup.exe + *-full.nupkg
+        # in PR #41, missing the manifest gap. v0.0.1-preview.18 shipped
+        # WITHOUT releases.win.json or assets.win.json because the
+        # softprops upload pattern was the literal `releases.json`
+        # (no channel) which didn't match Velopack's channel-suffixed
+        # output. Asserting them here closes the loop.
         run: |
-          $required = @('*Setup.exe', '*-full.nupkg')
+          $required = @(
+            '*Setup.exe',
+            '*-full.nupkg',
+            'releases.*.json',
+            'assets.*.json'
+          )
           $missing = @()
           foreach ($pattern in $required) {
             # Avoid the $matches automatic variable name — `Get-ChildItem`
@@ -120,7 +147,7 @@ jobs:
             }
           }
           if ($missing.Count -gt 0) {
-            Write-Error "Velopack pack did not produce required artifact(s) in releases/: $($missing -join ', '). Inspect the previous step's output and check whether vpk pack flags or output paths changed."
+            Write-Error "Velopack pack did not produce required artifact(s) in releases/: $($missing -join ', '). Inspect the previous step's `dir releases` output and check whether vpk pack flags or output paths changed (Velopack's channel-suffix convention is documented at https://docs.velopack.io/packaging/overview)."
             exit 1
           }
           Write-Host "Required Velopack artifacts present: $($required -join ', ')"
@@ -186,14 +213,24 @@ jobs:
           # fail_on_unmatched_files: false — vpk pack only produces a
           # *-delta.nupkg when there's a previous release to diff
           # against, so the delta pattern legitimately matches no files
-          # on the very first release. Required artifacts (Setup.exe,
-          # full nupkg, releases.json, RELEASES) are always produced
-          # by vpk pack; if any of them are missing, the prior vpk
-          # pack step would have failed already.
+          # on the very first release after a channel change. The
+          # earlier "Verify required Velopack artifacts exist" step
+          # asserts the non-optional patterns (*Setup.exe, *-full.nupkg,
+          # releases.*.json, assets.*.json) BEFORE this upload runs,
+          # so a silent skip here only ever drops genuinely-optional
+          # artifacts.
+          #
+          # File-naming notes (see https://docs.velopack.io/packaging/overview):
+          # vpk pack writes channel-suffixed manifests like
+          # releases.win.json / assets.win.json — the literal
+          # "releases.json" pattern used pre-fix didn't match those,
+          # which is why v0.0.1-preview.18 shipped without them. The
+          # globs below are channel-agnostic.
           fail_on_unmatched_files: false
           files: |
             releases/*Setup.exe
             releases/*-full.nupkg
             releases/*-delta.nupkg
-            releases/releases.json
+            releases/releases.*.json
+            releases/assets.*.json
             releases/RELEASES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`release.yml` now uploads Velopack's channel-suffixed manifest
+  files.** `v0.0.1-preview.18` shipped with only three release
+  assets (`*-full.nupkg`, `*-Setup.exe`, `RELEASES`) instead of the
+  five Velopack produces. Root cause: the `softprops/action-gh-release`
+  upload pattern was the literal `releases/releases.json`, but
+  Velopack outputs `releases.<channel>.json` (we get `releases.win.json`
+  for win-x64 packs since we don't pass `--channel`). With
+  `fail_on_unmatched_files: false` the literal pattern matched
+  nothing and the manifest was silently skipped — auto-update flows
+  would have broken for any user installing from the release.
+  Patterns updated to channel-agnostic globs:
+  `releases/releases.*.json` and `releases/assets.*.json`. The
+  artifact-existence gate added in PR #41 now also asserts both
+  manifests are present, so the next release fails loudly if
+  Velopack's naming changes again. `docs/RELEASE-PROCESS.md`
+  refreshed with the actual `vpk pack` output set per
+  Velopack's [packaging docs](https://docs.velopack.io/packaging/overview).
+
 ### Added
 
 - **Parser test coverage for SUB / OSC ST / DCS CAN / Unicode

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -140,20 +140,42 @@ Triggered by the `release: published` event you just fired. Runs on
 7. `dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish` (with `/p:Version=...`).
 8. **Install Velopack CLI** (`dotnet tool install -g vpk`).
 9. **`vpk pack`** — wraps `publish/` into a Velopack release at
-   `releases/`: `*Setup.exe`, full nupkg, `RELEASES`. (No
-   `*-delta.nupkg` on the first release; `releases.json` is not
-   produced by our `vpk pack` config.)
-10. **Generate release notes from `CHANGELOG.md`** — writes
+   `releases/`. Per Velopack's docs, the produced files are:
+    - `*-Setup.exe` (Windows installer)
+    - `*-<version>-full.nupkg` (full update package)
+    - `*-<version>-delta.nupkg` (delta — only when a prior release
+      exists for the same channel)
+    - `releases.<channel>.json` (releases index used by auto-update
+      clients to discover new versions)
+    - `assets.<channel>.json` (asset manifest used by Velopack
+      deployment commands)
+    - `RELEASES` (legacy Squirrel-migration index; produced for
+      back-compat — new clients use `releases.<channel>.json`)
+    The channel suffix is Velopack's runtime identifier. We don't
+    pass `--channel` so it defaults to `win` for win-x64 packs.
+10. **Verify required Velopack artifacts exist** — defense-in-depth
+    PowerShell step that asserts `*Setup.exe`, `*-full.nupkg`,
+    `releases.*.json`, and `assets.*.json` are all present in
+    `releases/`. Fails the workflow loudly if any are missing,
+    rather than letting the next softprops upload silently skip them
+    (the `v0.0.1-preview.18` release shipped without
+    `releases.win.json` or `assets.win.json` because the upload glob
+    was the literal `releases.json`; the gate exists so a future
+    Velopack rename or channel change doesn't repeat that failure).
+11. **Generate release notes from `CHANGELOG.md`** — writes
     `release-body.md` by resolving the body via the order in step 2
     above (per-version section → `[Unreleased]` content with rewritten
     heading → generic fallback), then prepends the unsigned-preview
     banner.
-11. **Update GitHub Release** via `softprops/action-gh-release@v3`:
+12. **Update GitHub Release** via `softprops/action-gh-release@v3`:
     sets title to `pty-speak <version>`, replaces the auto-generated
     body with `release-body.md`, sets `prerelease` from the version
     resolution, and attaches the artifact files.
     `fail_on_unmatched_files: false` so the optional `*-delta.nupkg`
-    and `releases.json` patterns don't fail the upload when absent.
+    pattern doesn't fail the upload when absent (first release after
+    a channel change has no delta to diff against). The other
+    patterns are asserted present by step 10 above, so the false
+    setting only ever drops genuinely-optional artifacts.
 
 ### 5. Smoke-test the release
 


### PR DESCRIPTION
## Summary

Fixes a silent release-pipeline gap: **`v0.0.1-preview.18` shipped without the Velopack auto-update manifests.**

Verified via GitHub Releases API — the release has 3 assets:
- `pty-speak-0.0.1-preview.18-full.nupkg` ✓
- `pty-speak-win-Setup.exe` ✓
- `RELEASES` ✓
- ❌ `releases.win.json` — **missing** (auto-update releases index)
- ❌ `assets.win.json` — **missing** (asset manifest used by deployment)

Root cause: the `softprops/action-gh-release` upload list used the literal pattern `releases/releases.json` (no channel), but per [Velopack's packaging docs](https://docs.velopack.io/packaging/overview) `vpk pack` writes channel-suffixed manifests like `releases.win.json` (we get the `win` suffix because we don't pass `--channel`). With `fail_on_unmatched_files: false` the literal pattern matched nothing and the manifest was silently skipped — auto-update flows would not have worked for any client installing from a release.

## Changes

1. **`release.yml` upload globs** — change `releases/releases.json` to `releases/releases.*.json`, add `releases/assets.*.json`.
2. **Artifact-existence gate** (added in PR #41) — now requires `releases.*.json` and `assets.*.json` in addition to `*Setup.exe` and `*-full.nupkg`. The next release fails loudly if Velopack's naming changes again rather than silently shipping incomplete assets.
3. **`docs/RELEASE-PROCESS.md`** — workflow-step list refreshed with the actual `vpk pack` output set; added the new "Verify required Velopack artifacts exist" step (which my edit to the gate just expanded).
4. **CHANGELOG** — entry under `[Unreleased]` / `Fixed`.

## Why this followed PR #41 instead of being part of it

The audit that drove PR #41 flagged this as P2 with a note that the agent "didn't verify against actual `vpk pack` output." During this session I followed up with the GitHub Releases MCP and confirmed the v0.0.1-preview.18 asset list directly — that's how I knew the manifest pattern was wrong. PR #41 already shipped the *general* artifact-existence gate (Setup.exe + full nupkg); this PR refines the gate based on the verified output set.

## Test plan

- [ ] `actionlint` green on the YAML changes
- [ ] Markdown link check green
- [ ] **Manual on next release** — when the maintainer publishes `v0.0.1-preview.19` (or whichever version comes next), confirm the GitHub release page lists 5 assets:
  - `pty-speak-<ver>-full.nupkg`
  - `pty-speak-win-Setup.exe`
  - `releases.win.json`
  - `assets.win.json`
  - `RELEASES`

  Plus optionally `pty-speak-<ver>-delta.nupkg` if a previous full nupkg exists for the same channel.
- [ ] If the artifact-existence gate fires unexpectedly on a future release, the error message points at `dir releases` output and Velopack's docs URL — easy to diagnose.

## Followups

1. **Issue #39 (conhost window)** — next on my list.
2. **Stage 4 proper** — UIA peer + FlaUI test.

## References

- [Velopack packaging overview](https://docs.velopack.io/packaging/overview) (output file list authoritative source)
- [velopack/velopack#90](https://github.com/velopack/velopack/issues/90) (`releases.{channel}.json` naming)
- v0.0.1-preview.18 release asset list (verified via `mcp__github__get_release_by_tag`)

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_