### PR TITLE
fix(app): switch Terminal.App to WinExe to drop the parent console window (closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Fixed
 
+- **`Terminal.App.exe` no longer allocates a console window at
+  startup.** `Terminal.App.fsproj` previously set
+  `OutputType=Exe` + `DisableWinExeOutputInference=true`, which
+  forced the produced executable into the Windows console
+  subsystem; Windows allocated a conhost for the parent process
+  before any of our code ran, and that empty console window
+  appeared behind the WPF window on every launch
+  ([Issue #39](https://github.com/KyleKeane/pty-speak/issues/39)).
+  Investigation ruled out the four ConPTY-side hypotheses
+  originally listed (`STARTUPINFOEX.cb`, attribute attachment,
+  `STARTF_USESTDHANDLES`, `CREATE_NEW_CONSOLE`) — the ConPTY
+  setup matches Microsoft's canonical sample exactly. Switched
+  the executable to `OutputType=WinExe` (Windows GUI subsystem,
+  matching what the WPF SDK would auto-infer) and dropped the
+  `DisableWinExeOutputInference` opt-out. No source changes
+  needed; `grep` confirms zero `Console.WriteLine`/`printfn`
+  calls in `src/`, so nothing was relying on an attached
+  console. Visual smoke verification needs a Windows install of
+  the next preview release.
 - **`release.yml` now uploads Velopack's channel-suffixed manifest
   files.** `v0.0.1-preview.18` shipped with only three release
   assets (`*-full.nupkg`, `*-Setup.exe`, `RELEASES`) instead of the

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -21,16 +21,17 @@ A new session should read this **first**, then
 |---|---|
 | **Last merged stage** | Stage 3b (WPF `TerminalView` + end-to-end `ConPtyHost → Parser → Screen → TerminalView`) |
 | **Last shipped release** | [`v0.0.1-preview.18`](https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.18) — first preview cut from Stage 3b state. Maintainer has installed the build and confirmed `cmd.exe` runs under ConPTY end-to-end. (`preview.16` and `.17` were burned by the `## [<version>]` CHANGELOG-matching gate before #37 relaxed it; both retag the same `db44d6d` commit and were never shipped artifacts.) |
-| **Stage-3b smoke status** | **Known issue:** the maintainer reports a separate `cmd.exe` console host window appears behind the pty-speak WPF window on launch. ConPTY children should not allocate their own conhost — points at a `STARTUPINFOEX` / `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` defect in `Terminal.Pty/PseudoConsole.fs` or `ConPtyHost.fs`. Tracked separately from Stage 4; doesn't block UIA work. |
-| **In-flight branch** | None. The pre-Stage-4 audit (PR #35), `preview.18` CHANGELOG (PR #36), and the relaxed CHANGELOG-matching gate (PR #37) all merged in sequence on 2026-04-28. |
-| **Next stage** | **Stage 4** — UIA exposure (first NVDA milestone). See sketch below. The Stage-4-prep PR (this PR) lands `Screen.SequenceNumber` + `Screen.SnapshotRows` so the UIA peer's `ITextRangeProvider` can capture immutable row state across the UIA RPC thread without tearing. |
+| **Stage-3b smoke status** | Resolved on `main` pending visual reverification on the next preview. The "second window" the maintainer saw on `v0.0.1-preview.18` was the parent `Terminal.App.exe` itself (the `OutputType=Exe` setting put it in the Windows console subsystem, so Windows allocated a conhost at startup before any of our code ran). The ConPTY child setup checked out clean against Microsoft's canonical sample — none of the four hypotheses originally listed in [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39) was the actual cause. Fix landed in PR #44 (`OutputType=WinExe`); next preview release is the smoke target. |
+| **In-flight branch** | None. Pre-Stage-4 fixes (#41 test/CI hygiene, #43 Velopack manifest globs, #44 WPF subsystem) and docs (#40 ESC-byte convention) all merged. |
+| **Next stage** | **Stage 4** — UIA exposure (first NVDA milestone). Substrate (`Screen.SequenceNumber` + `Screen.SnapshotRows`) shipped in PR #38; threading boundary is in place; `tests/Tests.Ui/` is reserved for FlaUI integration tests that this stage adds. See sketch below. |
 
 The end-to-end pipeline is wired: launching the app spawns `cmd.exe`
 under ConPTY, parses its output, applies VtEvents to a 30×120
 `Screen`, and renders the buffer in a custom WPF `FrameworkElement`.
 The maintainer has installed `v0.0.1-preview.18` and confirmed text
-appears in the WPF window; the conhost-second-window finding above
-is the only outstanding Stage-3b regression.
+appears in the WPF window. The `OutputType=Exe` defect that produced
+the empty parent-process console is fixed on `main`; visual smoke
+on a fresh preview will confirm a single window at launch.
 
 ## Pending action items (maintainer)
 
@@ -50,16 +51,21 @@ disconnects mid-session.
    programmatically check PR status, merge PRs, or post issue
    comments — falls back to asking the maintainer.
 
-3. **Investigate the Stage-3b conhost-second-window finding.** When
-   the maintainer launched `v0.0.1-preview.18` they observed a
-   separate `cmd.exe` console host window appearing behind the
-   pty-speak WPF window. Under ConPTY the child shell should
-   inherit the pseudo-console; a separate conhost suggests
-   `STARTUPINFOEX.cb` or the `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`
-   attachment isn't taking effect. Likely sites:
-   `src/Terminal.Pty/PseudoConsole.fs` and `src/Terminal.Pty/Native.fs`.
-   Tracked as its own concern; orthogonal to Stage 4 UIA work.
-   Tracked: [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39).
+3. **Cut `v0.0.1-preview.19` to revalidate Stage 3b after the
+   pre-Stage-4 fixes.** Two regressions affecting the last
+   release ([Issue #39](https://github.com/KyleKeane/pty-speak/issues/39)
+   conhost window, and the Velopack-manifest upload gap) merged
+   to `main` after `v0.0.1-preview.18` shipped. A fresh preview
+   confirms both:
+   - **Single window on launch** — only the WPF surface, no empty
+     conhost behind it. Fixed in PR #44 (`OutputType=WinExe`).
+   - **Five release assets attached** — `*-full.nupkg`,
+     `*-Setup.exe`, `releases.win.json`, `assets.win.json`,
+     `RELEASES`. The new artifact-existence gate added in PR #41
+     and refined in PR #43 will fail the workflow loudly if any
+     are missing; if it stays green, the manifest fix is also
+     verified. Auto-update flows now have what they need.
+   Procedure in [`docs/RELEASE-PROCESS.md`](RELEASE-PROCESS.md).
 
 4. **Enable NuGet lock files (deferred from PR #41).** The
    investigation in PR #41 settled on enabling

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -2,8 +2,25 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
-    <OutputType>Exe</OutputType>
-    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+    <!--
+      WinExe puts the produced executable into the Windows GUI
+      subsystem so Windows does NOT allocate a conhost window for
+      Terminal.App.exe at startup. Stage 0 originally shipped with
+      OutputType=Exe + DisableWinExeOutputInference=true, which
+      forced the console subsystem and made an empty console window
+      appear behind the WPF window on every launch (Issue #39).
+      Microsoft.NET.Sdk.WindowsDesktop's auto-inference would set
+      WinExe automatically when UseWPF=true, but we set it
+      explicitly so the choice is auditable in the project file
+      rather than buried in SDK behavior.
+
+      Don't add Console.WriteLine / printfn calls and expect to see
+      output — there is no attached console with WinExe. Diagnostics
+      should go through `System.Diagnostics.Debug.WriteLine` (visible
+      in DebugView / the VS Output window) or a structured logger
+      once one is introduced.
+    -->
+    <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <RootNamespace>PtySpeak.App</RootNamespace>
     <AssemblyName>Terminal.App</AssemblyName>


### PR DESCRIPTION
Closes #39.

## Summary

Switches `Terminal.App.fsproj` from `OutputType=Exe` (console subsystem) to `OutputType=WinExe` (Windows GUI subsystem) and removes the now-unnecessary `DisableWinExeOutputInference=true` opt-out. With `UseWPF=true`, this is what Microsoft.NET.Sdk.WindowsDesktop would auto-infer; we set it explicitly so the choice is auditable in the project file rather than buried in SDK inference rules.

## Why

The maintainer's smoke test of `v0.0.1-preview.18` reported a separate `cmd.exe`-style window appearing behind the WPF window. Investigation in [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39) ruled out all four ConPTY-side hypotheses I originally listed:

| Hypothesis | Code site | Status |
|---|---|---|
| `STARTUPINFOEX.cb` wrong | `PseudoConsole.fs:177` (`Marshal.SizeOf<STARTUPINFOEX>()`) | ✓ correct |
| `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` not attached | `PseudoConsole.fs:157-164` | ✓ correct |
| `STARTF_USESTDHANDLES` set | `PseudoConsole.fs:188` (`dwFlags = 0u`) | ✓ not set |
| `CREATE_NEW_CONSOLE` / `CREATE_NEW_PROCESS_GROUP` set | `PseudoConsole.fs:209` (only `EXTENDED_STARTUPINFO_PRESENT`) | ✓ not set |

The ConPTY setup matches Microsoft's [canonical pseudo-console sample](https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session). The cmd.exe child genuinely should not be spawning its own conhost.

The actual cause is on the **parent app** side: `OutputType=Exe` puts the executable into the console subsystem, so Windows allocates a conhost for `Terminal.App.exe` at startup — before any of our code runs. That empty console window is what's appearing alongside the WPF window. The combination has been in place since the first Stage 0 commit (`2adb23e`); there's no surviving comment explaining why, and best guess is a defensive holdover from an earlier Stage 0 build issue that's no longer relevant.

## Risks evaluated

- **Console output during normal run**: `grep -rn 'Console\.\|printfn\|printf\|System.Console' src/` finds **zero** matches. No output to lose.
- **Velopack installer events** (`--squirrel-install`, `--squirrel-uninstall`): `VelopackApp.Run()` uses GUI dialogs for user-facing events and silent execution for post-install hooks. No console-only path.
- **Build / publish flow**: `dotnet publish ... -r win-x64 --self-contained` works identically for `WinExe` and `Exe`. `vpk pack --mainExe Terminal.App.exe` is unaffected.
- **F# `[<EntryPoint>]` convention**: works the same for `WinExe`.

## Test plan

- [ ] `dotnet build -c Release` clean on `windows-latest` (the only test surface this PR's CI can hit)
- [ ] `dotnet test -c Release` green
- [ ] `actionlint` green
- [ ] **Manual visual smoke (needs a Windows machine)**: cut `v0.0.1-preview.19` after this lands; install via `pty-speak-Setup.exe`; confirm only one window appears at launch (the WPF surface) — no adjacent empty conhost. The companion fix from PR #43 means the auto-update manifests will also be correctly attached to that release, so this is the natural smoke target for both pre-Stage-4 fixes at once.

## What this PR deliberately omits

- **No source changes.** The fix is configuration-only.
- **No console-fallback shim.** Per the in-fsproj comment I added: future contributors should use `System.Diagnostics.Debug.WriteLine` (visible in DebugView / VS Output) instead of `Console.WriteLine` once they need diagnostic output, or wire up a structured logger.

## Followups

After this and #43 land, Stage 4 (UIA exposure) is unblocked.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_