### PR TITLE
chore: parser param-push fix (#42) + delta nupkg generation in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,39 @@ jobs:
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
 
+      - name: Fetch prior release full nupkg for delta generation
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Velopack's `vpk pack` only generates a *-delta.nupkg when a
+        # prior *-full.nupkg for the same packId exists in --outputDir
+        # at pack time. CI starts from a fresh runner each release, so
+        # without this step the releases/ directory is empty and every
+        # build ships full-only — auto-update clients fall back to
+        # downloading the entire ~66 MB package every time.
+        #
+        # Find the most recently published GitHub Release that isn't
+        # the one currently being released, download its
+        # `*-full.nupkg` into releases/, and let the next step pick it
+        # up. Skips silently if no prior release exists (first release
+        # on the channel) — that's not an error.
+        run: |
+          New-Item -ItemType Directory -Force -Path releases | Out-Null
+          $currentTag = '${{ github.event.release.tag_name }}'
+          $priorTag = gh release list --limit 100 --json tagName,publishedAt `
+            | ConvertFrom-Json `
+            | Where-Object { $_.tagName -ne $currentTag } `
+            | Sort-Object publishedAt -Descending `
+            | Select-Object -First 1 -ExpandProperty tagName
+          if (-not $priorTag) {
+            Write-Host 'No prior release found; vpk pack will produce a full nupkg only (no delta).'
+          } else {
+            Write-Host "Prior release: $priorTag. Downloading *-full.nupkg into releases/ for delta generation."
+            gh release download $priorTag --pattern '*-full.nupkg' --dir releases --clobber
+            Write-Host 'Prior nupkg present:'
+            Get-ChildItem -Path releases -Filter '*-full.nupkg' | Format-Table Name, Length
+          }
+
       - name: Pack with Velopack
         shell: pwsh
         run: |
@@ -94,6 +127,36 @@ jobs:
         run: |
           echo "Velopack pack completed for tag ${{ github.event.release.tag_name }}"
           dir releases
+
+      - name: Remove prior-release artifacts staged for delta generation
+        shell: pwsh
+        # The "Fetch prior release full nupkg for delta generation"
+        # step earlier dropped the previous version's *-full.nupkg
+        # into releases/ so vpk pack could diff against it. vpk pack
+        # leaves it there. softprops/action-gh-release would then
+        # upload it as a duplicate asset on the current release.
+        # Remove versioned nupkgs that don't match the current
+        # version. Non-versioned files (Setup.exe, RELEASES,
+        # releases.<channel>.json, assets.<channel>.json) are
+        # overwritten by vpk pack so don't need cleanup.
+        run: |
+          $ver = '${{ steps.version.outputs.version }}'
+          $fullPattern  = "*-$ver-full.nupkg"
+          $deltaPattern = "*-$ver-delta.nupkg"
+          $stale = Get-ChildItem -Path releases -File `
+            | Where-Object {
+                ($_.Name -like '*-full.nupkg' -and $_.Name -notlike $fullPattern) -or
+                ($_.Name -like '*-delta.nupkg' -and $_.Name -notlike $deltaPattern)
+              }
+          if ($stale) {
+            Write-Host 'Removing stale prior-version nupkgs:'
+            $stale | Format-Table Name, Length
+            $stale | Remove-Item -Force
+          } else {
+            Write-Host 'No stale prior-version nupkgs to remove.'
+          }
+          Write-Host 'releases/ after cleanup:'
+          Get-ChildItem -Path releases | Format-Table Name, Length
 
       - name: Verify required Velopack artifacts exist
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Fixed
 
+- **Parser preserves the in-flight digit param across the
+  Param → Intermediate transition (closes
+  [Issue #42](https://github.com/KyleKeane/pty-speak/issues/42)).**
+  `StateMachine.fs`'s `CsiParam → CsiIntermediate` and
+  `DcsParam → DcsIntermediate` edges previously called
+  `collectIntermediate` without first calling `pushParam`, so
+  inputs like `\x1b[1$q` (CSI param + intermediate) or
+  `\x1bP1$q...` (DECRQSS-shape DCS) emitted dispatch events
+  with `parms = [||]` instead of `[|1|]`. Both edges now push
+  the in-flight digit before transitioning, matching Williams'
+  canonical `param;collect` action and alacritty/vte. The
+  `CAN inside DCS passthrough emits DcsUnhook` test was
+  re-augmented with the `$` byte (which used to be deliberately
+  removed in #41 to dodge this bug); a new
+  `CSI with param + intermediate preserves the in-flight digit`
+  test pins the parallel CSI invariant so a future regression
+  in either edge fails loudly.
+- **CI release workflow now fetches the prior release `*-full.nupkg`
+  before `vpk pack`, so deltas are produced for every non-first
+  release.** `v0.0.1-preview.18` and `v0.0.1-preview.19` both
+  shipped full-only — Velopack only generates a `*-delta.nupkg`
+  when a prior `*-full.nupkg` exists in `--outputDir` at pack
+  time, and CI starts from a fresh runner each release. New
+  step uses `gh release list` + `gh release download
+  --pattern '*-full.nupkg'` to drop the previous release's full
+  package into `releases/` before `vpk pack`. A subsequent
+  cleanup step removes the prior nupkg before the softprops
+  upload so it doesn't get re-attached to the current release as
+  a duplicate. First release on a channel (no prior to diff
+  against) is handled silently — `gh release list` returns
+  empty and the step logs and skips. Auto-update clients on
+  the next release will fetch ~KB-sized delta packages instead
+  of ~66 MB full nupkgs. `docs/RELEASE-PROCESS.md` updated to
+  describe both new steps and the renumbered downstream steps.
 - **`Terminal.App.exe` no longer allocates a console window at
   startup.** `Terminal.App.fsproj` previously set
   `OutputType=Exe` + `DisableWinExeOutputInference=true`, which

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -139,7 +139,18 @@ Triggered by the `release: published` event you just fired. Runs on
 6. `dotnet restore` / `dotnet build -c Release` / `dotnet test`.
 7. `dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish` (with `/p:Version=...`).
 8. **Install Velopack CLI** (`dotnet tool install -g vpk`).
-9. **`vpk pack`** — wraps `publish/` into a Velopack release at
+9. **Fetch prior release `*-full.nupkg`** — uses `gh release list`
+   to find the most recently published GitHub Release (excluding
+   the one being released right now), then `gh release download
+   --pattern '*-full.nupkg' --dir releases`. Velopack's `vpk
+   pack` only generates a `*-delta.nupkg` if a prior `*-full.nupkg`
+   for the same packId already lives in `--outputDir`; without
+   this step every CI run starts from an empty `releases/` and
+   ships full-only packages, so auto-update clients re-download
+   the whole ~66 MB on every update. Skips silently when no
+   prior release exists (first release on a channel) — that's
+   not an error.
+10. **`vpk pack`** — wraps `publish/` into a Velopack release at
    `releases/`. Per Velopack's docs, the produced files are:
     - `*-Setup.exe` (Windows installer)
     - `*-<version>-full.nupkg` (full update package)
@@ -153,7 +164,17 @@ Triggered by the `release: published` event you just fired. Runs on
       back-compat — new clients use `releases.<channel>.json`)
     The channel suffix is Velopack's runtime identifier. We don't
     pass `--channel` so it defaults to `win` for win-x64 packs.
-10. **Verify required Velopack artifacts exist** — defense-in-depth
+11. **Remove prior-release artifacts staged for delta generation** —
+    PowerShell step that deletes any `*-<ver>-full.nupkg` /
+    `*-<ver>-delta.nupkg` in `releases/` whose `<ver>` doesn't
+    match the current release version. The fetch step in step 9
+    drops the previous version's `*-full.nupkg` into `releases/`
+    so vpk pack can diff against it; vpk leaves it there after
+    packing, and without this cleanup softprops would upload it
+    as a duplicate asset on the current release. Non-versioned
+    files (Setup.exe, RELEASES, manifests) are overwritten by
+    vpk pack so don't need cleanup.
+12. **Verify required Velopack artifacts exist** — defense-in-depth
     PowerShell step that asserts `*Setup.exe`, `*-full.nupkg`,
     `releases.*.json`, and `assets.*.json` are all present in
     `releases/`. Fails the workflow loudly if any are missing,
@@ -162,20 +183,20 @@ Triggered by the `release: published` event you just fired. Runs on
     `releases.win.json` or `assets.win.json` because the upload glob
     was the literal `releases.json`; the gate exists so a future
     Velopack rename or channel change doesn't repeat that failure).
-11. **Generate release notes from `CHANGELOG.md`** — writes
+13. **Generate release notes from `CHANGELOG.md`** — writes
     `release-body.md` by resolving the body via the order in step 2
     above (per-version section → `[Unreleased]` content with rewritten
     heading → generic fallback), then prepends the unsigned-preview
     banner.
-12. **Update GitHub Release** via `softprops/action-gh-release@v3`:
+14. **Update GitHub Release** via `softprops/action-gh-release@v3`:
     sets title to `pty-speak <version>`, replaces the auto-generated
     body with `release-body.md`, sets `prerelease` from the version
     resolution, and attaches the artifact files.
     `fail_on_unmatched_files: false` so the optional `*-delta.nupkg`
-    pattern doesn't fail the upload when absent (first release after
-    a channel change has no delta to diff against). The other
-    patterns are asserted present by step 10 above, so the false
-    setting only ever drops genuinely-optional artifacts.
+    pattern doesn't fail the upload when no prior release exists
+    on the channel (first release after a channel change). The
+    other patterns are asserted present by step 12 above, so the
+    false setting only ever drops genuinely-optional artifacts.
 
 ### 5. Smoke-test the release
 

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -51,21 +51,24 @@ disconnects mid-session.
    programmatically check PR status, merge PRs, or post issue
    comments — falls back to asking the maintainer.
 
-3. **Cut `v0.0.1-preview.19` to revalidate Stage 3b after the
-   pre-Stage-4 fixes.** Two regressions affecting the last
-   release ([Issue #39](https://github.com/KyleKeane/pty-speak/issues/39)
-   conhost window, and the Velopack-manifest upload gap) merged
-   to `main` after `v0.0.1-preview.18` shipped. A fresh preview
-   confirms both:
-   - **Single window on launch** — only the WPF surface, no empty
-     conhost behind it. Fixed in PR #44 (`OutputType=WinExe`).
-   - **Five release assets attached** — `*-full.nupkg`,
-     `*-Setup.exe`, `releases.win.json`, `assets.win.json`,
-     `RELEASES`. The new artifact-existence gate added in PR #41
-     and refined in PR #43 will fail the workflow loudly if any
-     are missing; if it stays green, the manifest fix is also
-     verified. Auto-update flows now have what they need.
-   Procedure in [`docs/RELEASE-PROCESS.md`](RELEASE-PROCESS.md).
+3. **Visual install smoke of `v0.0.1-preview.19` on Windows.**
+   `v0.0.1-preview.19` was published 2026-04-28 and shipped all
+   five Velopack assets correctly (full nupkg, Setup.exe,
+   `releases.win.json`, `assets.win.json`, `RELEASES`) plus the
+   two GitHub-auto source archives — 7 visible in the release
+   UI, validating the manifest fix from PR #43. The
+   single-window fix from PR #44 still needs an actual Windows
+   install to confirm. Steps:
+   1. Download `pty-speak-win-Setup.exe` from
+      <https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.19>.
+   2. Run the installer (SmartScreen will warn — expected for
+      unsigned previews).
+   3. Launch from Start menu.
+   4. **Pass condition**: only one window appears (the WPF
+      surface). No empty console window behind it.
+   If a second window does appear, reopen [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39)
+   with details — the WinExe fix may not have taken effect, or
+   there's a different cause we haven't surfaced yet.
 
 4. **Enable NuGet lock files (deferred from PR #41).** The
    investigation in PR #41 settled on enabling

--- a/src/Terminal.Parser/StateMachine.fs
+++ b/src/Terminal.Parser/StateMachine.fs
@@ -269,6 +269,14 @@ type StateMachine() =
                 pushParam ()
                 None
             elif b >= 0x20uy && b <= 0x2Fuy then
+                // Commit the in-flight digit before transitioning to
+                // CsiIntermediate. Without this `pushParam ()`, an
+                // input like `\x1b[1$q` would lose the `1` because
+                // the dispatch in CsiIntermediate snapshots
+                // `parameters` directly without pushing first
+                // (Williams' canonical table runs `param;collect`
+                // on this edge, alacritty/vte runs the same).
+                pushParam ()
                 collectIntermediate b
                 state <- CsiIntermediate
                 None
@@ -368,6 +376,11 @@ type StateMachine() =
                 pushParam ()
                 None
             elif b >= 0x20uy && b <= 0x2Fuy then
+                // Same fix as CsiParam → CsiIntermediate: commit the
+                // in-flight digit before transitioning so a DCS like
+                // `\x1bP1$q` (DECRQSS-shape) keeps its `1` param.
+                // Tracked under #42 before the fix.
+                pushParam ()
                 collectIntermediate b
                 state <- DcsIntermediate
                 None

--- a/tests/Tests.Unit/VtParserTests.fs
+++ b/tests/Tests.Unit/VtParserTests.fs
@@ -167,22 +167,19 @@ let ``OSC: ST-terminated sequence emits OscDispatch with bellTerminated=false`` 
 
 [<Fact>]
 let ``CAN inside DCS passthrough emits DcsUnhook and returns to Ground`` () =
-    // ESC P 1 q (one-param DCS, no intermediate), then payload bytes
-    // 'Z' 'Z' 'Z', then CAN. DcsPassthrough on CAN emits DcsUnhook
-    // (NOT Execute — that asymmetry with CSI is deliberate; see
-    // StateMachine.fs).
-    //
-    // The test deliberately omits the `$` intermediate byte that a
-    // real DECRQSS would carry. Adding `$` between '1' and 'q' would
-    // exercise the DcsParam → DcsIntermediate transition, where the
-    // parser drops the in-flight digit param (no `pushParam ()` on
-    // that edge in StateMachine.fs:370-373); the result is parms=[||]
-    // instead of [|1|]. That's arguably a parser bug, but this test
-    // is about CAN-in-DCS, not param-pushing semantics — keep the
-    // input simple.
+    // ESC P 1 $ q (DECRQSS-shape: one-param DCS with intermediate),
+    // then payload bytes 'Z' 'Z' 'Z', then CAN. Two invariants
+    // exercised at once:
+    //   1. DcsParam → DcsIntermediate transition pushes the in-flight
+    //      digit (was Issue #42; fixed in this PR by adding pushParam
+    //      to that edge in StateMachine.fs). parms must be [|1|], not
+    //      [||] as it was pre-fix.
+    //   2. DcsPassthrough on CAN emits DcsUnhook (NOT Execute —
+    //      asymmetry with CSI's CAN-during-CSI is deliberate; see
+    //      StateMachine.fs).
     let parser = Parser.create ()
     let events = Parser.feedArray parser [|
-        0x1Buy; byte 'P'; byte '1'; byte 'q'
+        0x1Buy; byte 'P'; byte '1'; byte '$'; byte 'q'
         byte 'Z'; byte 'Z'; byte 'Z'
         0x18uy
     |]
@@ -190,7 +187,7 @@ let ``CAN inside DCS passthrough emits DcsUnhook and returns to Ground`` () =
     match events.[0] with
     | DcsHook(parms, intermediates, finalByte) ->
         Assert.Equal<int[]>([| 1 |], parms)
-        Assert.Equal<byte[]>([||], intermediates)
+        Assert.Equal<byte[]>([| 0x24uy |], intermediates)
         Assert.Equal('q', finalByte)
     | other -> Assert.Fail(sprintf "Expected DcsHook, got %A" other)
     Assert.Equal(DcsPut 0x5Auy, events.[1])
@@ -198,6 +195,25 @@ let ``CAN inside DCS passthrough emits DcsUnhook and returns to Ground`` () =
     Assert.Equal(DcsPut 0x5Auy, events.[3])
     Assert.Equal(DcsUnhook, events.[4])
     Assert.Equal(Ground, parser.State)
+
+[<Fact>]
+let ``CSI with param + intermediate preserves the in-flight digit`` () =
+    // CSI 1 $ q is the DECRQSS counterpart for SGR queries. The
+    // parallel transition CsiParam → CsiIntermediate had the same
+    // missing-pushParam bug as DcsParam → DcsIntermediate (Issue #42).
+    // Pinning both with this test means a regression in either edge
+    // breaks loudly.
+    let events = parse [|
+        0x1Buy; byte '['; byte '1'; byte '$'; byte 'q'
+    |]
+    Assert.Equal(1, events.Length)
+    match events.[0] with
+    | CsiDispatch(parms, intermediates, finalByte, priv) ->
+        Assert.Equal<int[]>([| 1 |], parms)
+        Assert.Equal<byte[]>([| 0x24uy |], intermediates)
+        Assert.Equal('q', finalByte)
+        Assert.Equal<char option>(None, priv)
+    | other -> Assert.Fail(sprintf "Expected CsiDispatch, got %A" other)
 
 [<Fact>]
 let ``UTF-8: multi-byte scalar emits a single Print`` () =


### PR DESCRIPTION
## Summary

Bundles two cleanups before Stage 4 so we don't ship Stage 4 on top of known gaps:

### 1. Parser param-push fix (closes #42)

`CsiParam → CsiIntermediate` and `DcsParam → DcsIntermediate` previously called `collectIntermediate` without first calling `pushParam`, so inputs like `\x1b[1$q` (CSI param + intermediate) or `\x1bP1$q…` (DECRQSS-shape DCS) emitted dispatch events with `parms = [||]` instead of `[|1|]`.

- Added `pushParam ()` to both edges, matching Williams' canonical `param;collect` action and alacritty/vte's table.
- **Re-augmented** the existing DCS-CAN test with the `$` byte (which had been removed in #41 specifically to dodge this bug — comment was a placeholder for "fix this later").
- **New test** `CSI with param + intermediate preserves the in-flight digit` for the parallel CSI invariant. Now both edges have explicit pin tests.

### 2. Delta nupkg generation in CI (no issue filed; flagged earlier this session)

`v0.0.1-preview.18` and `v0.0.1-preview.19` both shipped full-only — Velopack only generates a `*-delta.nupkg` when a prior `*-full.nupkg` lives in `--outputDir` at pack time, and CI starts from a fresh runner each release.

- **New step "Fetch prior release full nupkg for delta generation"** before `vpk pack`. Uses `gh release list --json` + `gh release download --pattern '*-full.nupkg'` to find the most recently published GitHub Release (excluding the one being released right now) and stage its full nupkg in `releases/`.
- **First release on a channel is handled silently** — `gh release list` returns an empty filter result and the step logs "No prior release found".
- **New step "Remove prior-release artifacts staged for delta generation"** after pack and before the artifact-existence gate. Velopack leaves the prior nupkg in `releases/` after packing; without cleanup, softprops would upload it as a duplicate asset on the current release. The cleanup keeps only `*-<current-version>-full.nupkg` and `*-<current-version>-delta.nupkg`; non-versioned files (Setup.exe, RELEASES, manifests) are overwritten by `vpk pack` so don't need cleanup.
- **Net win**: auto-update clients on the next release will fetch ~KB-sized deltas instead of full ~66 MB packages.

### 3. SESSION-HANDOFF and RELEASE-PROCESS refreshes

- `SESSION-HANDOFF.md` action item #3 reframed: "cut `v0.0.1-preview.19`" (done) → "visual install smoke of preview.19 on Windows" (still pending). Spells out the four-step verify procedure and the pass condition.
- `RELEASE-PROCESS.md` workflow-step list updated: 12 steps → 14 steps (two new ones with the renumbered downstream peers).

## Test plan

- [ ] `dotnet build -c Release` clean on `windows-latest`
- [ ] `dotnet test -c Release` green — should be **47 tests** (was 46; 1 new CSI-with-intermediate test, the DCS-CAN test is now augmented but remains 1 test)
- [ ] `actionlint` green on the new YAML (uses standard `gh` CLI + PowerShell pipelines)
- [ ] **Manual on next release** (`v0.0.1-preview.20` or whichever): release should now ship **6 Velopack assets** instead of 5:
  - `pty-speak-<ver>-full.nupkg`
  - `pty-speak-<ver>-delta.nupkg` ← **NEW**
  - `pty-speak-win-Setup.exe`
  - `releases.win.json`
  - `assets.win.json`
  - `RELEASES`

  Plus the two GitHub auto-generated source archives = 8 visible in the UI.

## Risks evaluated

- **`gh release list` failing in CI**: it's preinstalled on `windows-latest` and uses `GH_TOKEN` from the workflow's `secrets.GITHUB_TOKEN`. The release workflow already has `permissions: contents: write` (line 12) which is what `gh` needs to read releases. No new permission required.
- **Cleanup step over-aggressively deletes**: the filter is `-like '*-full.nupkg'` AND `-notlike '*-<currentVersion>-full.nupkg'`, so non-`-full.nupkg` files are untouched. Manually traced for `v0.0.1-preview.20`: only `pty-speak-0.0.1-preview.19-full.nupkg` (the prior) gets removed.
- **Delta vs. full version mismatch**: Velopack picks the highest-versioned prior nupkg as the delta source. If the previous release is somehow newer than the current (downgrade), Velopack handles that internally — not our problem to encode.
- **Parser fix downstream effects**: `Screen.Apply` already handles CSI events correctly regardless of param count; the only downstream change is that DECRQSS-style sequences now arrive with their params populated. That's a strict improvement; nothing in the current `Screen.Apply` would regress.

## Followups / nothing else open

This was the last cleanup pass per the maintainer's "clean footing for Stage 4" request. After this lands:
- Issue #39 ✅ closed by #44.
- Issue #42 ✅ closed by this PR.
- Visual smoke for #44 — pending maintainer's Windows install (tracked in SESSION-HANDOFF action item #3).
- Pending baseline tags + lock files — maintainer-side actions, tracked.
- **Stage 4 (UIA exposure) is the next PR.**

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_