### PR TITLE
spike: FlaUI integration-test infrastructure (foundation for Text-pattern verification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **FlaUI integration test infrastructure
+  (`tests/Tests.Ui/AutomationPeerTests.fs`).** First UIA test in
+  the project: launches `Terminal.App.exe` from the build
+  output, attaches via `UIA3Automation`, finds the `TerminalView`
+  descendant by `ClassName`, and asserts `ControlType=Document`
+  and `Name="Terminal"`. `Tests.Ui.fsproj` gains
+  `FlaUI.Core` / `FlaUI.UIA3` package references and a
+  `ReferenceOutputAssembly="false"` ProjectReference to
+  `Terminal.App` so MSBuild builds the app before the test runs
+  without linking its outputs into the test bin. The test is
+  scoped to validate that PR #48's reduced-scope peer actually
+  works at runtime (the `TerminalView` element is reachable via
+  UIA with the expected role and identity) and to give any
+  future Text-pattern attempt an automated verification harness
+  before merging. This is the foundation piece that any further
+  Stage 4 work — raw `IRawElementProviderSimple` provider,
+  reflection-based binding, or anything else — needs in place.
+
 - **Stage 4a (reduced scope) — UIA Document role + identity.**
   `TerminalView` now exposes a `TerminalAutomationPeer` via
   `OnCreateAutomationPeer`. UIA clients (NVDA, Inspect.exe) find

--- a/tests/Tests.Ui/AutomationPeerTests.fs
+++ b/tests/Tests.Ui/AutomationPeerTests.fs
@@ -1,0 +1,69 @@
+module PtySpeak.Tests.Ui.AutomationPeerTests
+
+open System
+open System.IO
+open System.Threading
+open Xunit
+open FlaUI.Core
+open FlaUI.UIA3
+
+/// Locate the Terminal.App.exe build output. CI's `dotnet build`
+/// before `dotnet test` builds every project in the solution, so by
+/// the time this test runs the exe is present at the expected path.
+/// `<ProjectReference ReferenceOutputAssembly="false">` in the
+/// fsproj guarantees the build-order dependency without linking the
+/// app's outputs into the test bin directory.
+///
+/// Directory layout:
+///   <repo>/tests/Tests.Ui/bin/Release/net9.0-windows/   ← AppContext.BaseDirectory
+///   <repo>/src/Terminal.App/bin/Release/net9.0-windows/Terminal.App.exe
+let private locateTerminalAppExe () : string =
+    let testDir = AppContext.BaseDirectory
+    // Five `..` segments to get from net9.0-windows back up to <repo>.
+    let repoRoot =
+        Path.GetFullPath(
+            Path.Combine(testDir, "..", "..", "..", "..", ".."))
+    let exePath =
+        Path.Combine(
+            repoRoot,
+            "src", "Terminal.App", "bin", "Release", "net9.0-windows",
+            "Terminal.App.exe")
+    if not (File.Exists exePath) then
+        failwithf
+            "Terminal.App.exe not found at %s. Expected MSBuild to have built it before tests run."
+            exePath
+    exePath
+
+/// Stage 4 FlaUI infrastructure spike — the minimum-viable
+/// integration test that:
+///   1. launches Terminal.App.exe
+///   2. attaches via UIA3
+///   3. finds the TerminalView element by the ClassName the
+///      TerminalAutomationPeer (PR #48) sets explicitly
+///   4. asserts the element's ControlType is Document and Name is
+///      "Terminal"
+/// If this passes on CI, the FlaUI test infrastructure is real
+/// and we have a verification harness any future Text-pattern
+/// implementation can build on. If it fails — for desktop-session
+/// reasons, P/Invoke quirks, or anything else — the failure mode
+/// itself is the diagnostic.
+[<Fact>]
+let ``TerminalView is exposed as a UIA Document with the correct ClassName and Name`` () =
+    let exePath = locateTerminalAppExe ()
+    use app = Application.Launch(exePath)
+
+    use automation = new UIA3Automation()
+    let mainWindow = app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0))
+    Assert.NotNull(mainWindow)
+
+    let cf = automation.ConditionFactory
+    let terminalView =
+        mainWindow.FindFirstDescendant(cf.ByClassName("TerminalView"))
+    Assert.NotNull(terminalView)
+
+    Assert.Equal(
+        FlaUI.Core.Definitions.ControlType.Document,
+        terminalView.ControlType)
+    Assert.Equal("Terminal", terminalView.Name)
+
+    app.Close() |> ignore

--- a/tests/Tests.Ui/AutomationPeerTests.fs
+++ b/tests/Tests.Ui/AutomationPeerTests.fs
@@ -53,13 +53,24 @@ let ``TerminalView is exposed as a UIA Document with the correct ClassName and N
     use app = Application.Launch(exePath)
 
     use automation = new UIA3Automation()
-    let mainWindow = app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0))
-    Assert.NotNull(mainWindow)
+    let mainWindow =
+        // FlaUI declares GetMainWindow's return as
+        // `AutomationElement | null`; F# 9's Nullable=enable rightly
+        // refuses to let us call methods on it without an explicit
+        // null check. Pattern-match for null AND give a useful
+        // failure message in one step — beats Assert.NotNull both
+        // for nullability narrowing and for diagnostic value.
+        match app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0)) with
+        | null ->
+            failwith "Main window did not appear within 10 seconds. Possible causes: Velopack startup hang, WPF subsystem misconfiguration, or runner desktop session not available."
+        | mw -> mw
 
     let cf = automation.ConditionFactory
     let terminalView =
-        mainWindow.FindFirstDescendant(cf.ByClassName("TerminalView"))
-    Assert.NotNull(terminalView)
+        match mainWindow.FindFirstDescendant(cf.ByClassName("TerminalView")) with
+        | null ->
+            failwith "TerminalView descendant not found in the UIA tree. PR #48's TerminalAutomationPeer should set ClassName=TerminalView via GetClassNameCore; check that OnCreateAutomationPeer is still wired and the peer is reaching the tree."
+        | tv -> tv
 
     Assert.Equal(
         FlaUI.Core.Definitions.ControlType.Document,

--- a/tests/Tests.Ui/Tests.Ui.fsproj
+++ b/tests/Tests.Ui/Tests.Ui.fsproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="Placeholder.fs" />
+    <Compile Include="AutomationPeerTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -22,6 +23,21 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FlaUI.Core" />
+    <PackageReference Include="FlaUI.UIA3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Force build-order dependency on Terminal.App so the exe
+      exists at AutomationPeerTests' expected path when `dotnet
+      test` runs. ReferenceOutputAssembly=false avoids linking
+      the app's outputs into the test bin (the test launches the
+      app as a separate process).
+    -->
+    <ProjectReference
+        Include="..\..\src\Terminal.App\Terminal.App.fsproj"
+        ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

First FlaUI integration test in the project. Establishes the test infrastructure that any future Text-pattern exposure work needs to verify against (Issue #49 follow-up).

## What this PR adds

- **`tests/Tests.Ui/AutomationPeerTests.fs`** — single test that:
  1. Locates `Terminal.App.exe` from the Release build output by walking up from `AppContext.BaseDirectory` to the repo root.
  2. Launches the app via `FlaUI.Core.Application.Launch`.
  3. Attaches via `UIA3Automation`.
  4. Waits 10 seconds for the main window.
  5. Finds the `TerminalView` descendant by `ClassName`.
  6. Asserts `ControlType=Document` and `Name="Terminal"` — the properties PR #48's reduced-scope `TerminalAutomationPeer` sets explicitly.
  7. Closes the app cleanly via FlaUI's `IDisposable` handling.

- **`tests/Tests.Ui/Tests.Ui.fsproj`** — adds `FlaUI.Core` / `FlaUI.UIA3` PackageReferences (both already pinned at 5.0.0 in `Directory.Packages.props` since Stage 0) and a `ReferenceOutputAssembly="false"` ProjectReference to `Terminal.App` so MSBuild builds the app before the test runs without linking its outputs into the test bin.

- **CHANGELOG entry** under `[Unreleased]` / `Added`.

## Why this comes before any Text-pattern implementation

After [Issue #49](https://github.com/KyleKeane/pty-speak/issues/49)'s investigation foreclosed the AutomationPeer override path, the remaining options for exposing the Text pattern are substantial work — raw `IRawElementProviderSimple` via a `WM_GETOBJECT` hook, reflection-based binding, etc. None of those are worth committing to without a way to *verify* what UIA clients actually see at runtime. This PR is that verification harness.

If this PR's CI goes green, every future Text-pattern attempt has a concrete pass/fail signal before merging. If it fails, we learn early that FlaUI on `windows-latest` has issues we need to address before any of the bigger work is worth attempting.

## Risks I'm trying to surface

1. **FlaUI on GitHub Actions `windows-latest`.** The runner has an interactive desktop session by default but this is the first time the project actually exercises it. If the desktop session isn't available to the test process, the test will fail at `app.GetMainWindow` with a timeout.
2. **Process startup timing.** Velopack's `VelopackApp.Build().Run()` runs at app startup; for normal launches with no Velopack-specific args it's a no-op, but if it does anything unexpected the test's 10-second window-wait gives it room.
3. **Path resolution.** The five `..` segments from `AppContext.BaseDirectory` to repo root assume the standard `bin/Release/net9.0-windows/` output structure. If MSBuild lays things out differently, the test fails fast at `locateTerminalAppExe` with a clear message.
4. **F# / FlaUI interop.** FlaUI is C#-style API. F# calls C# methods directly; the spike file is small enough that any F# syntax issue surfaces immediately.

Each risk has a clear failure mode in the test harness — none can fail silently.

## Outcomes

| CI outcome | What it means | Next step |
|---|---|---|
| **Green** | Foundation works. PR #48's peer is reachable from a real UIA client at runtime. Verification harness is real. | Move to next spike: reflection visibility test for `GetPatternCore` runtime metadata. |
| **Red** | Failure mode identifies what's wrong (`locateTerminalAppExe` failwith / `GetMainWindow` timeout / element not found / wrong properties). Each tells us something specific. | Diagnose, patch, re-run — much cheaper than diagnosing the same issue mid-Text-pattern work. |

## Followups

After this lands, in order:
1. Reflection visibility test for `GetPatternCore` runtime metadata (settles whether reflection-based binding is viable).
2. F# `IRawElementProviderSimple` compile spike (tiny, but worth confirming).
3. Architectural commitment for Text-pattern exposure with full information.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_