### PR TITLE
spike: reflection probe of FrameworkElementAutomationPeer.GetPatternCore (Issue #49)

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -347,8 +347,19 @@ NVDA can't read the buffer contents. Investigation status:
       compiled cleanly.
   Tracked in [Issue #49](https://github.com/KyleKeane/pty-speak/issues/49).
 
-- **Option 3 (last resort): reflection-based override
-  registration.** Not pursuing unless option 1 also fails.
+- **Option 3 ruled out (PR #52 reflection probe).** The runtime
+  metadata strips `GetPatternCore` the same way the public
+  reference assembly does — a reflection probe via
+  `BindingFlags.Instance | NonPublic | Public | FlattenHierarchy`
+  on `FrameworkElementAutomationPeer` finds zero matches for
+  `GetPatternCore`. Sanity baseline (`GetClassNameCore` IS
+  findable via the same probe) confirms the test infrastructure
+  isn't the cause. Reflection-based binding is therefore not a
+  viable architectural path. The probe is preserved as a
+  regression sentinel in
+  `tests/Tests.Ui/AutomationPeerReflectionTests.fs`; if a future
+  .NET update exposes `GetPatternCore` in runtime metadata,
+  the sentinel test fails and we know to re-evaluate.
 
 The reduced PR #48 peer that ships the Document role + identity
 stays; the IRawElementProviderSimple path adds Text on top

--- a/tests/Tests.Ui/AutomationPeerReflectionTests.fs
+++ b/tests/Tests.Ui/AutomationPeerReflectionTests.fs
@@ -120,7 +120,7 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
                         m.Name
                         parameters
                         m.ReturnType.FullName
-                        m.DeclaringType.Assembly.GetName().Name)
+                        (m.DeclaringType.Assembly.GetName().Name))
             output.WriteLine(
                 sprintf
                     "GetPatternCore IS findable via reflection (%d match%s). The runtime metadata has the method even though the public reference assembly strips it. Reflection-based binding is viable as a Text-pattern exposure path; option 1 (raw IRawElementProviderSimple) and option 3 (reflection hook) are both architecturally available."

--- a/tests/Tests.Ui/AutomationPeerReflectionTests.fs
+++ b/tests/Tests.Ui/AutomationPeerReflectionTests.fs
@@ -7,20 +7,22 @@ open Xunit
 open Xunit.Abstractions
 
 /// Narrow a `Type | null` to a string. `MethodInfo.DeclaringType`
-/// returns nullable per docs (dynamic methods can have no
-/// declaring type), and F# 9's nullability checker rightly
-/// rejects direct member access on the nullable. The helper
-/// returns a marker for the null case so the diagnostic output
-/// stays informative without crashing.
+/// is `Type | null` per .NET 9 docs (dynamic methods can have no
+/// declaring type), AND `Type.FullName` / `AssemblyName.Name` are
+/// each `string | null` (open generics; unnamed assemblies). Both
+/// nullables are handled here so the diagnostic stays informative
+/// across all the nullable layers without a nested match cascade.
 let private declaringTypeName (m: MemberInfo) : string =
-    match m.DeclaringType with
-    | null -> "<no declaring type>"
-    | dt -> dt.FullName
+    m.DeclaringType
+    |> Option.ofObj
+    |> Option.bind (fun dt -> Option.ofObj dt.FullName)
+    |> Option.defaultValue "<no declaring type>"
 
 let private declaringAssemblyName (m: MemberInfo) : string =
-    match m.DeclaringType with
-    | null -> "<no declaring type>"
-    | dt -> dt.Assembly.GetName().Name
+    m.DeclaringType
+    |> Option.ofObj
+    |> Option.bind (fun dt -> Option.ofObj (dt.Assembly.GetName().Name))
+    |> Option.defaultValue "<no declaring type>"
 
 /// Spike #2 from the Stage 4 follow-up plan: probe whether
 /// `FrameworkElementAutomationPeer.GetPatternCore` is reachable

--- a/tests/Tests.Ui/AutomationPeerReflectionTests.fs
+++ b/tests/Tests.Ui/AutomationPeerReflectionTests.fs
@@ -1,9 +1,26 @@
 module PtySpeak.Tests.Ui.AutomationPeerReflectionTests
 
+open System
 open System.Reflection
 open System.Windows.Automation.Peers
 open Xunit
 open Xunit.Abstractions
+
+/// Narrow a `Type | null` to a string. `MethodInfo.DeclaringType`
+/// returns nullable per docs (dynamic methods can have no
+/// declaring type), and F# 9's nullability checker rightly
+/// rejects direct member access on the nullable. The helper
+/// returns a marker for the null case so the diagnostic output
+/// stays informative without crashing.
+let private declaringTypeName (m: MemberInfo) : string =
+    match m.DeclaringType with
+    | null -> "<no declaring type>"
+    | dt -> dt.FullName
+
+let private declaringAssemblyName (m: MemberInfo) : string =
+    match m.DeclaringType with
+    | null -> "<no declaring type>"
+    | dt -> dt.Assembly.GetName().Name
 
 /// Spike #2 from the Stage 4 follow-up plan: probe whether
 /// `FrameworkElementAutomationPeer.GetPatternCore` is reachable
@@ -63,7 +80,7 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
                     (if found.IsPublic then "public " else "")
                     (if found.IsFamily then "protected " else "")
                     (if found.IsAssembly then "internal " else "")
-                    found.DeclaringType.FullName
+                    (declaringTypeName found)
                     found.ReturnType.FullName)
 
     /// The actual question. Probes for `GetPatternCore` on
@@ -116,11 +133,11 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
                         "Found: %s %s %s.%s(%s) -> %s [DeclaringType assembly: %s]"
                         access
                         modifiers
-                        m.DeclaringType.FullName
+                        (declaringTypeName m)
                         m.Name
                         parameters
                         m.ReturnType.FullName
-                        (m.DeclaringType.Assembly.GetName().Name))
+                        (declaringAssemblyName m))
             output.WriteLine(
                 sprintf
                     "GetPatternCore IS findable via reflection (%d match%s). The runtime metadata has the method even though the public reference assembly strips it. Reflection-based binding is viable as a Text-pattern exposure path; option 1 (raw IRawElementProviderSimple) and option 3 (reflection hook) are both architecturally available."

--- a/tests/Tests.Ui/AutomationPeerReflectionTests.fs
+++ b/tests/Tests.Ui/AutomationPeerReflectionTests.fs
@@ -1,0 +1,128 @@
+module PtySpeak.Tests.Ui.AutomationPeerReflectionTests
+
+open System.Reflection
+open System.Windows.Automation.Peers
+open Xunit
+open Xunit.Abstractions
+
+/// Spike #2 from the Stage 4 follow-up plan: probe whether
+/// `FrameworkElementAutomationPeer.GetPatternCore` is reachable
+/// via reflection at runtime, even though it's not reachable at
+/// compile time from a subclass override (CS0117 / FS0855 from
+/// PRs #47, #48, #50).
+///
+/// Two possible outcomes, each with clear architectural
+/// implications for Issue #49's Text-pattern exposure:
+///
+///   * Method found → the runtime metadata for
+///     `FrameworkElementAutomationPeer` has `GetPatternCore`;
+///     only the public reference assembly we compile against
+///     strips it. Reflection-based binding (option 3 from
+///     Issue #49) becomes a real-if-brittle path: load the
+///     method via reflection, install our pattern map, dispatch
+///     `GetPattern` calls through it. Brittle because runtime
+///     metadata could change in a future .NET update; viable
+///     because the same is true for any reflection-based
+///     interop and Microsoft's own peers use the method at
+///     runtime.
+///
+///   * Method NOT found → the runtime hides the method too,
+///     not just the ref assembly. Reflection-based binding is
+///     not viable; pattern exposure HAS to go through a
+///     non-AutomationPeer mechanism (raw
+///     `IRawElementProviderSimple` via `WM_GETOBJECT` hook).
+///
+/// The test always prints its findings via ITestOutputHelper
+/// regardless of pass/fail so the merged PR captures the
+/// diagnostic in CI logs that future readers can consult.
+
+type AutomationPeerReflectionTests(output: ITestOutputHelper) =
+
+    /// Sanity check: a method we KNOW is reachable via
+    /// reflection (the spike PR #47 successfully overrode it)
+    /// should also be findable. If THIS fails, the test
+    /// infrastructure itself is wrong, not our specific probe.
+    [<Fact>]
+    member _.``GetClassNameCore is findable via reflection (sanity baseline)`` () =
+        let t = typeof<FrameworkElementAutomationPeer>
+        let flags =
+            BindingFlags.Instance
+            ||| BindingFlags.NonPublic
+            ||| BindingFlags.Public
+        let m = t.GetMethod("GetClassNameCore", flags)
+        match m with
+        | null ->
+            output.WriteLine(
+                "Sanity baseline FAILED: GetClassNameCore not found via reflection.")
+            Assert.Fail(
+                "Reflection sanity baseline failed — GetClassNameCore should always be findable.")
+        | found ->
+            output.WriteLine(
+                sprintf
+                    "Sanity baseline PASSED: GetClassNameCore is %s%s%s, declared on %s, returns %s."
+                    (if found.IsPublic then "public " else "")
+                    (if found.IsFamily then "protected " else "")
+                    (if found.IsAssembly then "internal " else "")
+                    found.DeclaringType.FullName
+                    found.ReturnType.FullName)
+
+    /// The actual question. Probes for `GetPatternCore` on
+    /// `FrameworkElementAutomationPeer` and its base types using
+    /// `BindingFlags.FlattenHierarchy` so an inherited method
+    /// counts.
+    [<Fact>]
+    member _.``GetPatternCore reflection probe (the architectural question)`` () =
+        let t = typeof<FrameworkElementAutomationPeer>
+        let flags =
+            BindingFlags.Instance
+            ||| BindingFlags.NonPublic
+            ||| BindingFlags.Public
+            ||| BindingFlags.FlattenHierarchy
+
+        // Use GetMethods (plural) to find ALL methods named
+        // GetPatternCore including ones inherited from
+        // UIElementAutomationPeer / AutomationPeer.
+        let candidates =
+            t.GetMethods(flags)
+            |> Array.filter (fun m -> m.Name = "GetPatternCore")
+
+        if candidates.Length = 0 then
+            output.WriteLine(
+                "GetPatternCore is NOT findable via reflection on FrameworkElementAutomationPeer (or its bases). The runtime metadata strips it the same way the public reference assembly does. Reflection-based binding is not viable; option 1 (raw IRawElementProviderSimple via WM_GETOBJECT) is the only remaining Text-pattern exposure path.")
+            Assert.Fail(
+                "GetPatternCore not findable via reflection — see test output for architectural implication.")
+        else
+            for m in candidates do
+                let access =
+                    if m.IsPublic then "public"
+                    elif m.IsFamily then "protected"
+                    elif m.IsFamilyOrAssembly then "protected internal"
+                    elif m.IsFamilyAndAssembly then "private protected"
+                    elif m.IsAssembly then "internal"
+                    elif m.IsPrivate then "private"
+                    else "(unknown access)"
+                let modifiers =
+                    [ if m.IsAbstract then yield "abstract"
+                      if m.IsVirtual then yield "virtual"
+                      if m.IsFinal then yield "sealed" ]
+                    |> String.concat " "
+                let parameters =
+                    m.GetParameters()
+                    |> Array.map (fun p ->
+                        sprintf "%s %s" p.ParameterType.Name p.Name)
+                    |> String.concat ", "
+                output.WriteLine(
+                    sprintf
+                        "Found: %s %s %s.%s(%s) -> %s [DeclaringType assembly: %s]"
+                        access
+                        modifiers
+                        m.DeclaringType.FullName
+                        m.Name
+                        parameters
+                        m.ReturnType.FullName
+                        m.DeclaringType.Assembly.GetName().Name)
+            output.WriteLine(
+                sprintf
+                    "GetPatternCore IS findable via reflection (%d match%s). The runtime metadata has the method even though the public reference assembly strips it. Reflection-based binding is viable as a Text-pattern exposure path; option 1 (raw IRawElementProviderSimple) and option 3 (reflection hook) are both architecturally available."
+                    candidates.Length
+                    (if candidates.Length = 1 then "" else "es"))

--- a/tests/Tests.Ui/AutomationPeerReflectionTests.fs
+++ b/tests/Tests.Ui/AutomationPeerReflectionTests.fs
@@ -85,12 +85,22 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
                     (declaringTypeName found)
                     found.ReturnType.FullName)
 
-    /// The actual question. Probes for `GetPatternCore` on
-    /// `FrameworkElementAutomationPeer` and its base types using
-    /// `BindingFlags.FlattenHierarchy` so an inherited method
-    /// counts.
+    /// PR #52's CI run gave the architectural answer:
+    /// `GetPatternCore` is NOT reachable via runtime reflection
+    /// either. The runtime metadata strips it the same way the
+    /// public reference assembly does (proven by the same
+    /// reflection probe finding `GetClassNameCore` cleanly above).
+    ///
+    /// This test now asserts that finding as a SENTINEL — if a
+    /// future .NET update exposes `GetPatternCore` in runtime
+    /// metadata, this test fails and we know to re-evaluate the
+    /// architectural commitment to option 1 (raw
+    /// `IRawElementProviderSimple` via `WM_GETOBJECT`) over
+    /// option 3 (reflection-based binding) from
+    /// [Issue #49](https://github.com/KyleKeane/pty-speak/issues/49).
+    /// Until then, option 3 is decisively ruled out.
     [<Fact>]
-    member _.``GetPatternCore reflection probe (the architectural question)`` () =
+    member _.``GetPatternCore is unreachable via runtime reflection (sentinel for Issue 49 architectural decision)`` () =
         let t = typeof<FrameworkElementAutomationPeer>
         let flags =
             BindingFlags.Instance
@@ -107,9 +117,7 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
 
         if candidates.Length = 0 then
             output.WriteLine(
-                "GetPatternCore is NOT findable via reflection on FrameworkElementAutomationPeer (or its bases). The runtime metadata strips it the same way the public reference assembly does. Reflection-based binding is not viable; option 1 (raw IRawElementProviderSimple via WM_GETOBJECT) is the only remaining Text-pattern exposure path.")
-            Assert.Fail(
-                "GetPatternCore not findable via reflection — see test output for architectural implication.")
+                "Confirmed: GetPatternCore is NOT findable via reflection on FrameworkElementAutomationPeer (or its bases). Matches PR #52's original finding; option 1 (raw IRawElementProviderSimple via WM_GETOBJECT) remains the committed Text-pattern exposure path. Issue #49 option 3 stays ruled out.")
         else
             for m in candidates do
                 let access =
@@ -142,6 +150,11 @@ type AutomationPeerReflectionTests(output: ITestOutputHelper) =
                         (declaringAssemblyName m))
             output.WriteLine(
                 sprintf
-                    "GetPatternCore IS findable via reflection (%d match%s). The runtime metadata has the method even though the public reference assembly strips it. Reflection-based binding is viable as a Text-pattern exposure path; option 1 (raw IRawElementProviderSimple) and option 3 (reflection hook) are both architecturally available."
+                    "REGRESSION: GetPatternCore is now findable via reflection (%d match%s). The runtime metadata exposes the method that PR #52 confirmed was hidden in this .NET version. Re-evaluate Issue #49: option 3 (reflection-based binding) may now be viable; the architectural commitment to option 1 may need revisiting."
                     candidates.Length
                     (if candidates.Length = 1 then "" else "es"))
+
+        // Sentinel: assert the architectural reality. If this ever
+        // becomes non-empty, the test fails and the ABOVE diagnostic
+        // names what changed.
+        Assert.Empty(candidates)

--- a/tests/Tests.Ui/Tests.Ui.fsproj
+++ b/tests/Tests.Ui/Tests.Ui.fsproj
@@ -7,11 +7,20 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!--
+      UseWPF brings in PresentationCore / PresentationFramework
+      so the AutomationPeerReflectionTests can reference
+      `System.Windows.Automation.Peers.FrameworkElementAutomationPeer`
+      directly via `typeof<>`. FlaUI alone doesn't pull these in
+      because it's UI-framework-agnostic at the UIA layer.
+    -->
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="Placeholder.fs" />
     <Compile Include="AutomationPeerTests.fs" />
+    <Compile Include="AutomationPeerReflectionTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Foundation spike #2 of 3 (after PR #51's FlaUI infrastructure). Settles whether `FrameworkElementAutomationPeer.GetPatternCore` is in the **runtime** metadata, even though we know it's stripped from the **public reference assembly** we compile against (proven by CS0117 / FS0855 in PRs #47, #48, #50).

The answer determines which Text-pattern exposure paths from [Issue #49](https://github.com/KyleKeane/pty-speak/issues/49) are architecturally available.

## What this PR adds

`tests/Tests.Ui/AutomationPeerReflectionTests.fs` — two tests:

1. **Sanity baseline.** Probes `GetClassNameCore` (a method PR #47 successfully overrode, so we know it's reachable). If this fails, the test infrastructure itself is wrong, not our specific probe.
2. **The architectural question.** Probes `GetPatternCore` with `BindingFlags.FlattenHierarchy` so an inherited method on `UIElementAutomationPeer` or `AutomationPeer` counts.

Both tests use `ITestOutputHelper` so the diagnostic — full method signature, declaring type, access modifiers, declaring assembly — prints in CI logs regardless of pass/fail. Whoever picks up the Text-pattern work can `gh run view` the merged commit and see the actual signature info without re-running anything.

`Tests.Ui.fsproj` gets `<UseWPF>true</UseWPF>` so the test can reference `FrameworkElementAutomationPeer` directly via `typeof<>`. FlaUI alone doesn't pull WPF in because it's UI-framework-agnostic at the UIA layer.

## Outcomes

| Outcome | What it means | Implication for #49 |
|---|---|---|
| **Test passes (method found)** | The runtime metadata has `GetPatternCore`; only the public reference assembly strips it. | Reflection-based binding (option 3) becomes a viable-if-brittle Text-pattern exposure path. Both option 1 (raw `IRawElementProviderSimple`) and option 3 are available; we choose based on cost/quality, not architectural feasibility. |
| **Test fails (method NOT found)** | The runtime hides it too. | Reflection-based binding is not viable. Option 1 is the only path. Option 3 gets struck from #49. |

Either outcome is useful information — the test was designed to be diagnostic, not pass/fail in the usual sense. (For CI hygiene the test will report Pass when the method is found, since "found" matches the test name's positive framing.)

## Test plan

- [ ] `dotnet build -c Release` clean — same surface as PR #51 plus reflection code.
- [ ] `dotnet test -c Release` — both reflection tests run; CI output shows the diagnostic regardless of pass/fail.
- [ ] FlaUI integration test from PR #51 still passes (no changes affecting it).

## Followups

After this lands:
3. **F# `IRawElementProviderSimple` compile spike** — small, last of the three foundation pieces.
4. **Architectural commitment for Text-pattern.** Choose option 1 (raw provider) or, if this PR's reflection probe finds the method, weigh option 3 (reflection hook) against it with full information.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_