### PR TITLE
spike: probe F# implementation of IRawElementProviderSimple (Issue #49 foundation #3)

### DIFF
--- a/src/Terminal.Accessibility/RawProviderSpike.fs
+++ b/src/Terminal.Accessibility/RawProviderSpike.fs
@@ -1,0 +1,44 @@
+namespace Terminal.Accessibility
+
+open System.Windows.Automation.Peers
+open System.Windows.Automation.Provider
+
+/// Foundation spike #3 (last of three before committing to
+/// Issue #49 option 1) — confirms F# can implement
+/// `System.Windows.Automation.Provider.IRawElementProviderSimple`
+/// as cleanly as it implemented `ITextProvider` /
+/// `ITextRangeProvider` in PR #47. This is the interface the
+/// option-1 Text-pattern implementation will host.
+///
+/// The four interface members:
+///   * `ProviderOptions` (property)
+///   * `GetPatternProvider(int)` (method, returns the pattern
+///     provider for a given UIA pattern ID, null if not supported)
+///   * `GetPropertyValue(int)` (method, returns the value of a
+///     UIA property, null if not supported)
+///   * `HostRawElementProvider` (property, returns the WPF host
+///     provider so UIA can hand off non-pattern queries to the
+///     standard tree)
+///
+/// All members are stubs; the goal is the compile pass alone.
+/// F#'s override resolution and explicit-interface implementation
+/// machinery decide whether this works at type-definition time,
+/// so no runtime / instantiation needed.
+///
+/// Discard policy: throwaway diagnostic infrastructure. If CI
+/// passes, F# can host the interface and the option-1
+/// implementation PR can begin. The follow-up PR deletes this
+/// file. If CI fails, the failure mode tells us what's
+/// incompatible before any of the WM_GETOBJECT plumbing is
+/// written.
+
+type internal RawProviderSpike() =
+    interface IRawElementProviderSimple with
+        member _.ProviderOptions =
+            ProviderOptions.ServerSideProvider
+        member _.GetPatternProvider(_: int) =
+            Unchecked.defaultof<obj>
+        member _.GetPropertyValue(_: int) =
+            Unchecked.defaultof<obj>
+        member _.HostRawElementProvider =
+            Unchecked.defaultof<IRawElementProviderSimple>

--- a/src/Terminal.Accessibility/Terminal.Accessibility.fsproj
+++ b/src/Terminal.Accessibility/Terminal.Accessibility.fsproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Compile Include="TerminalAutomationPeer.fs" />
+    <Compile Include="RawProviderSpike.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Foundation spike #3 of 3 — the last unknown before committing to [Issue #49](https://github.com/KyleKeane/pty-speak/issues/49)'s option 1 implementation. Confirms F# can implement `IRawElementProviderSimple` as cleanly as it implemented `ITextProvider` / `ITextRangeProvider` in PR #47.

## Why this spike

The architectural commitment is to have `TerminalView` (or a sibling raw provider) implement `IRawElementProviderSimple` and host the Text pattern through `GetPatternProvider(int patternId)`. PR #47 already confirmed F# handles `ITextProvider` + `ITextRangeProvider` interface implementations cleanly — but `IRawElementProviderSimple` is a different (smaller) interface in the same namespace, and it's worth verifying with a focused 4-member compile probe rather than discovering an issue mid-implementation.

## What this PR adds

`src/Terminal.Accessibility/RawProviderSpike.fs` — a 4-member stub class implementing the interface:
- `ProviderOptions` (property) → `ProviderOptions.ServerSideProvider`
- `GetPatternProvider(int)` → `Unchecked.defaultof<obj>`
- `GetPropertyValue(int)` → `Unchecked.defaultof<obj>`
- `HostRawElementProvider` (property) → `Unchecked.defaultof<IRawElementProviderSimple>`

F#'s explicit-interface implementation machinery decides at type-definition time whether the interface is implementable. CI's compile pass alone is the test — no UI thread, no runtime, no instantiation needed.

## Test plan

- [ ] CI's `Build and test (windows-latest)` is the entire test surface
- [ ] `actionlint` and markdown link check stay green (no workflow / docs touched)

## Outcomes

| CI outcome | What it means | Next step |
|---|---|---|
| **Green** | F# hosts the interface cleanly. All three foundation spikes done. Option-1 implementation PR can begin with full architectural information. | Architecturally commit to option 1; open implementation PR (likely 200-400 lines: WM_GETOBJECT P/Invoke + raw provider + revival of the `TerminalTextProvider` / `TerminalTextRange` types from the deleted PR #48 attempt). |
| **Red** | Some F# / `IRawElementProviderSimple` interop quirk we don't know about yet. Failure mode names what's different. | Patch surgically; or, if structural, document the finding and pivot the architectural plan once more. |

Discard policy: this file is throwaway. The follow-up PR (option-1 implementation OR a different pivot) deletes it.

## Status of the foundation arc after this PR

| # | Spike | PR | Outcome |
|---|---|---|---|
| 1 | FlaUI integration-test infrastructure | #51 | ✅ green |
| 2 | Reflection visibility test for `GetPatternCore` | #52 | ✅ ruled option 3 out |
| 3 | F# `IRawElementProviderSimple` compile probe | this PR | pending |

After this lands (or the pivot it surfaces), no remaining unknowns; option 1 is committed and the implementation PR begins.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_