### PR TITLE
docs(smoke): reframe ACCESSIBILITY-TESTING.md as comprehensive manual smoke gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,12 @@ mark it N/A.
 - [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
       exclusive-mode acquisition added.
 - [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
-      validation rows for the touched stage were run against NVDA, or
-      a follow-up issue is filed if validation is deferred.
+      manual smoke-test rows for the touched stage were run against
+      NVDA on a clean Windows VM, or a follow-up issue is filed if
+      validation is deferred. **If this PR ships new user-visible
+      behaviour that CI cannot fully verify**, also add a row to the
+      matrix per the document's "Adding new manual tests" section
+      (procedure, expected outcome, diagnostic decoder bullet).
 
 ## Screenshots and screen-reader output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Comprehensive manual smoke-test matrix
+  (`docs/ACCESSIBILITY-TESTING.md` rewrite).** Reframes the
+  accessibility-only doc as the universal manual-validation gate
+  every release must pass. Three new always-run sections cover
+  artifact integrity (Velopack assets present, Setup.exe
+  non-zero, Authenticode status, hash matches) and launch /
+  process hygiene (single window, version in title, one-deep
+  process tree, clean shutdown, no orphan `cmd.exe`,
+  re-launch). Every per-stage table now has a "Diagnostic
+  decoder" subsection that maps each possible failure to the
+  likely-responsible subsystem — file paths and PR numbers
+  where applicable, so a FAIL goes from "something broke" to
+  "look at file X, PR Y" without further triage. New top-level
+  sections "Adding new manual tests" (criteria, required
+  fields, where in the matrix), "Sunset rules" (when a row
+  graduates to CI or gets deleted), and "Coverage that moved
+  to CI" (audit trail of the matrix's shrinking surface area
+  as automated assertions land). The Stage 4 section is
+  rewritten to reflect the actual ship architecture
+  (`AutomationPeer.GetPattern` override after the WM_GETOBJECT
+  pivot, not the original raw-provider plan), and notes that
+  PR #56's `tests/Tests.Ui/TextPatternTests.fs` now CI-pins
+  the producer side of the Text pattern. `docs/RELEASE-PROCESS.md`
+  step 5 was rewritten to defer to the comprehensive matrix
+  rather than carry its own minimal smoke list, and
+  `docs/SESSION-HANDOFF.md` item 3 (the visual install smoke
+  for the maintainer) now points at the matrix and tracks
+  Stage 4 NVDA verification alongside the existing single-window
+  check. The PR template's accessibility checklist gains an
+  "Adding new manual tests" reminder so PRs that ship
+  CI-unverifiable behaviour grow the matrix in the same change.
+  README's docs-index entry is updated to reflect the broader
+  scope.
+
 - **Stage 4 PR C — UIA Text pattern via `AutomationPeer.GetPattern`
   override + FlaUI verification test
   (`tests/Tests.Ui/TextPatternTests.fs`).** PR C started as a

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docs/                    Living developer documentation
   ROADMAP.md             Phased roadmap derived from spec/tech-plan.md
   BUILD.md               Build from source
   RELEASE-PROCESS.md     Cutting a Velopack release to GitHub Releases
-  ACCESSIBILITY-TESTING.md   NVDA / Narrator / JAWS validation matrix
+  ACCESSIBILITY-TESTING.md   Comprehensive manual smoke-test matrix (artifact integrity, process hygiene, NVDA, earcons, auto-update) with per-row diagnostic decoders
   CHECKPOINTS.md         Stable-baseline tags per shipped stage
   CONPTY-NOTES.md        Observed Windows ConPTY platform quirks
   SESSION-HANDOFF.md     Bridge between Claude Code coding sessions
@@ -92,7 +92,7 @@ tests/                   xUnit + FsCheck.Xunit + FlaUI placeholder
 - **Stable checkpoints (rollback guide):** [`docs/CHECKPOINTS.md`](docs/CHECKPOINTS.md)
 - **ConPTY platform notes:** [`docs/CONPTY-NOTES.md`](docs/CONPTY-NOTES.md)
 - **Session handoff (for picking up between Claude Code sessions):** [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md)
-- **Accessibility test matrix:** [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+- **Manual smoke-test matrix (every release):** [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
 - **Security and trust model:** [`SECURITY.md`](SECURITY.md)
 - **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1,9 +1,37 @@
-# Accessibility testing
+# Manual smoke-test matrix
 
-This is the manual validation matrix every release must pass. CI
-verifies behaviour at the UIA producer level; this document verifies
-behaviour at the screen-reader consumer level. The two are different
-enough that we cannot replace one with the other.
+This is the comprehensive manual validation gate every release must
+pass. CI verifies behaviour at the producer level (UIA peer
+construction, parser correctness, screen-buffer mutation, COM
+marshalling); this document verifies behaviour at the consumer level
+(what NVDA actually says, what the installer actually does, what
+happens to the user's process tree). The two are different enough
+that we cannot replace one with the other — see "Why this is manual"
+at the bottom for the longer rationale.
+
+The filename retains the historical
+`ACCESSIBILITY-TESTING.md` because accessibility testing is the bulk
+of the matrix, but the scope is **all manual checks every release
+must pass**: artifact integrity, process-launch hygiene, UIA, NVDA,
+earcons, auto-update.
+
+## How to use this document
+
+1. Cut the release per
+   [`docs/RELEASE-PROCESS.md`](RELEASE-PROCESS.md). Once the workflow
+   has produced the artifacts on a GitHub Release, walk this matrix
+   from top to bottom on a clean Windows VM.
+2. Run every section whose stage has shipped, plus every "always run"
+   section (artifact integrity, launch / process). Mark each row
+   PASS / FAIL / N/A.
+3. **If a row fails, consult the "Diagnostic decoder" paragraph that
+   follows that section.** Each decoder maps an observed failure to
+   the subsystem most likely to be responsible, so the next debugging
+   step is unambiguous.
+4. Open an issue for any FAIL with the row name in the title; attach
+   NVDA Event Tracker output for any speech-related failure.
+5. The release isn't promoted from prerelease to "latest" until every
+   required-stage row is PASS or N/A.
 
 ## Test environment
 
@@ -40,11 +68,79 @@ Planned reusable fixtures under `tests/fixtures/`:
 Once the developer-mode replay tool ships, replay these by piping
 into the terminal's stdin: `Terminal.App --replay tests/fixtures/...`.
 
+## Always-run sections (every release)
+
+These two sections run on every release regardless of stage, because
+they catch regressions in things that don't have a "stage" but break
+loudly when wrong.
+
+### Artifact integrity (run before installing)
+
+| Test                              | Procedure                                       | Expected                                                          |
+|-----------------------------------|-------------------------------------------------|-------------------------------------------------------------------|
+| All Velopack assets present       | Inspect the GitHub Release page                 | `*-Setup.exe`, `*-full.nupkg`, `releases.win.json`, `assets.win.json`, `RELEASES`. Delta-nupkg present iff this is not the first release on the channel. |
+| Setup.exe non-zero                | `(Get-Item .\pty-speak-Setup.exe).Length`       | `> 50000000` (≈ 50 MB) — a self-contained .NET 9 publish is around 60-70 MB. A truncated upload typically lands at a few KB. |
+| Authenticode signature status     | `Get-AuthenticodeSignature .\*Setup.exe \| Select Status, StatusMessage` | **For unsigned previews** (current `0.0.x-preview.N` line): `Status = NotSigned`. **For signed releases** (post-`v0.1.0`, once SignPath is re-enabled per `docs/RELEASE-PROCESS.md`): `Status = Valid`. |
+| Hash matches release attachment   | `Get-FileHash .\*Setup.exe -Algorithm SHA256`   | Hash matches the value in the GitHub Release body if one is published; this gate exists primarily for forensic-trace purposes (proving which build was used during smoke testing). |
+
+**Diagnostic decoder for artifact integrity:**
+
+- **Asset missing** → `release.yml` step 12 (the "Verify required
+  Velopack artifacts" gate added in PR #43) didn't fail when it
+  should have, OR the softprops upload silently dropped the file.
+  Check the workflow log for the run that produced this release;
+  inspect the `Velopack pack smoke artifact` upload step's file list.
+- **Setup.exe < 1 MB** → Velopack pack failed silently and produced
+  an empty installer. The `dotnet publish` step's `--self-contained`
+  flag may have been dropped.
+- **Authenticode `Valid` on a preview line** → Unexpected; the
+  unsigned-preview cutover may have regressed. Diff `release.yml`
+  against the documented unsigned config in `docs/RELEASE-PROCESS.md`.
+- **Authenticode `NotSigned` on a `v0.1.0+` release** → SignPath
+  integration regressed; the workflow needs `signpath/github-action-submit-signing-request@v1`
+  back per `docs/RELEASE-PROCESS.md` "Workflow changes when signing
+  returns".
+
+### Launch and process hygiene (run on every install)
+
+| Test                              | Procedure                                       | Expected                                                          |
+|-----------------------------------|-------------------------------------------------|-------------------------------------------------------------------|
+| Single window appears             | Run `Setup.exe`, then launch from Start menu    | **Exactly one** window (the WPF terminal surface). No empty parent console window behind it. |
+| Window title shows version        | Look at the window title bar                    | "pty-speak" plus the version number (matches the release tag).    |
+| Process tree is one-deep          | Open Task Manager → Details, sort by Image Name | Exactly one `Terminal.App.exe` AND one child `cmd.exe` (the ConPTY child). No leftover `conhost.exe` parent. |
+| Window closes cleanly             | Close the window via the X button               | Both `Terminal.App.exe` and the child `cmd.exe` exit within ~2 s. Task Manager shows neither image afterwards. |
+| Quit via Alt+F4 closes cleanly    | Press Alt+F4                                    | Same as above — clean exit, no orphans.                           |
+| Re-launch after exit              | Launch from Start menu again                    | New window opens cleanly. (Catches state-file corruption / single-instance regressions if those ship later.) |
+
+**Diagnostic decoder for launch and process hygiene:**
+
+- **Two windows appear, second is an empty console** → `OutputType`
+  regression in `src/Terminal.App/Terminal.App.fsproj`. Confirm it's
+  set to `WinExe`, not `Exe`. PR #44 fixed this; if it's recurred,
+  someone reverted the property or added `<DisableWinExeOutputInference>`.
+- **Two windows appear, second is also a WPF surface** → New
+  Application code path is creating a second window. Check
+  `src/Terminal.App/Program.fs` for added `MainWindow()` constructions.
+- **Title bar shows wrong version** → `Directory.Build.props`
+  `<Version>` not bumped, OR Velopack `--packVersion` mismatch.
+  Check the workflow run's "Resolve version" step output.
+- **No `cmd.exe` child** → ConPTY child failed to spawn. The Stage 3b
+  fallback path swallows this silently — check `src/Terminal.App/Program.fs`'s
+  `ConPtyHost.start` error branch and Event Viewer for child-process
+  errors.
+- **Orphan `cmd.exe` after window close** → ConPTY shutdown not
+  signalling the child. Check `App.Exit` cleanup in `Program.fs` and
+  `ConPtyHost.Dispose` / `ClosePseudoConsole` ordering.
+- **Window doesn't open at all** → WPF runtime crash on startup, OR
+  `MainWindow.SourceInitialized` handler crashed (PRs #54/55/56
+  added handlers there). Check Event Viewer → Application for a
+  .NET runtime exception trace.
+
 ## Stage validation matrix
 
 For every release, run the rows that correspond to stages already
-shipped. A row is **PASS** only if the screen reader behaviour matches
-the expected column verbatim.
+shipped. A row is **PASS** only if the screen reader / observed
+behaviour matches the expected column verbatim.
 
 ### Stage 0 — empty window (currently shipped: `v0.0.1-preview.15`)
 
@@ -53,6 +149,16 @@ the expected column verbatim.
 | Window opens                      | Launch app                                      | "pty-speak terminal, window" (from `AutomationProperties.Name`)  |
 | Window title                      | Press Insert+T                                  | NVDA announces "pty-speak"                                       |
 | Inspect.exe shows correct surface | Open Inspect.exe, hover over the window         | `AutomationId="pty-speak.MainWindow"`, `ControlType=Window`      |
+
+**Diagnostic decoder for Stage 0:**
+
+- **NVDA silent on focus** → `AutomationProperties.Name` removed
+  from `MainWindow.xaml`, OR the WPF UIA tree isn't being created
+  (check Inspect.exe — if Inspect can't see the window either, the
+  problem is below WPF).
+- **Wrong AutomationId in Inspect.exe** → `MainWindow.xaml`'s
+  `AutomationProperties.AutomationId` was changed; this is a
+  documented identity that downstream tooling (FlaUI tests) keys on.
 
 ### Stage 3b — first visible terminal surface (next preview)
 
@@ -67,36 +173,96 @@ the WPF `TextBlock`-equivalent output via its fallback diff path.
 | ANSI 16 colours render            | Run `dir /a` (cmd colourises filenames)         | Different file types render in different foreground colours      |
 | Window closes cleanly             | Close the window                                | Process exits; no orphan `cmd.exe` (verify via Task Manager)     |
 
-### Stage 4 — text exposure (split into 4a-shipped + Text-pattern-deferred)
+**Diagnostic decoder for Stage 3b:**
 
-PR #48 (Stage 4a, reduced scope) ships a UIA peer that exposes
-the terminal element with the right role and identity but
-**without the Text pattern**. The investigation that drove the
-reduced scope is in
-[`SESSION-HANDOFF.md`](SESSION-HANDOFF.md#stage-4-implementation-sketch);
-the short version is `AutomationPeer.GetPatternCore` is not
-reachable from any external assembly in the .NET 9 WPF reference
-assembly set, so the Text pattern needs a different exposure
-mechanism (likely `IRawElementProviderSimple` directly on
-`TerminalView`) tracked as a Stage 4 follow-up.
+- **No cmd.exe banner appears** → ConPTY spawn silently failed
+  (`Program.fs`'s `Ok host`/`Error _` branch swallows errors at
+  Stage 3b). Run the app from a console with `--debug` (once that
+  flag exists) or check Event Viewer for `CreatePseudoConsole`
+  errors.
+- **Banner appears but updates freeze** → Reader-loop task crashed.
+  The `try/with :? OperationCanceledException -> () | _ -> ()` in
+  `startReaderLoop` swallows everything; check Event Viewer for
+  unhandled task-scheduler exceptions.
+- **Visible flicker / tearing** → `Screen.Apply` mutating during
+  `OnRender`. Stage 4 substrate (`SnapshotRows`) was meant to
+  prevent this; verify `TerminalView.OnRender` reads `_screen`
+  inside the WPF dispatcher (Stage 5+ moves the parser off the
+  dispatcher and tearing becomes a real risk).
+- **No colour on `dir /a`** → SGR parser regression. Check the
+  `CSI m` branch in `Screen.fs`; `tests/Tests.Unit` covers most
+  SGR shapes — if those pass but visual output is monochrome, the
+  brush mapping in `TerminalView.cs` is suspect.
 
-**Testable after PR #48 (Stage 4a, reduced scope)**:
+### Stage 4 — UIA Document role + Text pattern (shipped through PR #56)
 
-| Test                              | Procedure                                       | Expected NVDA behaviour                                          |
+The Stage 4 architecture settled across four PRs:
+
+- **PR #48 (Stage 4a)** — `TerminalAutomationPeer` exposes Document
+  role, ClassName, Name, IsControlElement, IsContentElement.
+- **PR #54 (PR A)** — `WM_GETOBJECT` subclass hook (kept as a
+  legacy MSAA fallback path, not the primary route).
+- **PR #55 (PR B)** — `IRawElementProviderSimple` /
+  `TerminalRawProvider`, F# `TerminalTextProvider` /
+  `TerminalTextRange` over `Screen.SnapshotRows`.
+- **PR #56 (PR C)** — pivot to `AutomationPeer.GetPattern` override
+  (the public-virtual entry point that's reachable from external
+  assemblies, vs. `GetPatternCore` which isn't), plus a FlaUI
+  integration test pinning `DocumentRange.GetText`.
+
+The architectural finding from PR #56 is that UIA3 clients
+(NVDA, Inspect.exe, FlaUI.UIA3) dispatch `WM_GETOBJECT` with
+`UiaRootObjectId` (-25), not `OBJID_CLIENT` (-4); answering
+`UiaRootObjectId` with a simple provider breaks the UIA tree
+because UIA needs a fragment-root provider for navigation. The
+ship architecture overrides `GetPattern` on the existing peer
+instead, leaving WPF's UIA tree untouched and adding the Text
+pattern at the right element.
+
+| Test                              | Procedure                                       | Expected NVDA / UIA behaviour                                    |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
 | Window opens                      | Launch app                                      | "pty-speak, document"                                            |
-| Inspect.exe shows correct surface | Open Inspect.exe, hover over the terminal       | ControlType=Document, ClassName=`TerminalView`, Name=`Terminal`. Text pattern is **NOT** present at this stage — its absence is itself the gate that says "the Text-pattern follow-up still needs to land." |
-
-**Deferred to the Text-pattern follow-up PR**:
-
-| Test                              | Procedure                                       | Expected NVDA behaviour                                          |
-|-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| Review cursor reads current line  | NVDA+Numpad8                                    | NVDA reads the prompt line                                       |
+| Inspect.exe shows correct surface | Open Inspect.exe, hover over the terminal       | `ControlType=Document`, `ClassName="TerminalView"`, `Name="Terminal"` |
+| Inspect.exe shows Text pattern    | Inspect.exe → Patterns panel on the terminal    | Text pattern present; `DocumentRange.GetText(-1)` returns the screen contents |
+| Review cursor reads current line  | NVDA+Numpad8 over the terminal                  | NVDA reads the prompt line                                       |
 | Review cursor moves by line       | NVDA+Numpad7 / NVDA+Numpad9                     | NVDA reads previous / next line of the buffer                    |
 | Review cursor moves by word       | NVDA+Numpad4 / NVDA+Numpad6                     | NVDA reads previous / next word                                  |
 | Review cursor moves by character  | NVDA+Numpad1 / NVDA+Numpad3                     | NVDA reads previous / next character                             |
 | Empty line is announced           | Move review cursor to a blank row               | NVDA says "blank" — *not* the previous row, *not* silence        |
-| Inspect.exe shows Text pattern    | Open Inspect.exe, hover over the terminal       | Text pattern present; `DocumentRange.GetText(int.MaxValue)` returns non-empty cmd.exe output |
+
+**Diagnostic decoder for Stage 4:**
+
+- **Inspect.exe shows Document but NO Text pattern** → `GetPattern`
+  override regression on `TerminalAutomationPeer` (PR #56). Confirm
+  `src/Terminal.Accessibility/TerminalAutomationPeer.fs` still has
+  the `override _.GetPattern(patternInterface: PatternInterface)`
+  member returning the `textProvider` for `PatternInterface.Text`.
+- **Inspect.exe shows Document, Text pattern present, but
+  `DocumentRange.GetText(-1)` returns empty string** → Either
+  `TerminalView._screen` is null at query time (Stage 3b's
+  `compose` did not run before UIA queried, or the screen got
+  detached) OR `Screen.SnapshotRows` is returning an empty array.
+  CI's `tests/Tests.Ui/TextPatternTests.fs` asserts a length floor
+  of `30 × 120 + 29 = 3629`; if that test passes but manual smoke
+  fails, the runtime composition order is the suspect.
+- **NVDA silent on review-cursor commands** → Two possibilities:
+  (1) Text pattern is missing per the previous decoder; verify
+  with Inspect.exe first. (2) Text pattern is present and returns
+  text, but NVDA isn't binding to it — usually means the peer is
+  attached to the wrong WPF element (check `TerminalView.OnCreateAutomationPeer`),
+  or NVDA is in browse mode (press NVDA+Space to toggle).
+- **Inspect.exe crashes when hovering the terminal** → A
+  WM_GETOBJECT handler is misbehaving or returning a bad provider.
+  Most likely the raw-provider hook in `WindowSubclassNative.cs`
+  was re-enabled for `UiaRootObjectId` (-25) which is the failure
+  mode PR #56 found and reverted; confirm `OBJID_CLIENT` (-4) is
+  the only id matched.
+- **CI's `TextPatternTests` passes but manual NVDA reads stale
+  text** → `TerminalTextRange` is currently a snapshot at
+  capture time; future stages add stale-detection via
+  `Screen.SequenceNumber`. For now, this is expected behaviour,
+  not a regression — record it as N/A unless content is wildly
+  out of date.
 
 ### Stage 5 — streaming output
 
@@ -107,6 +273,23 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | Busy loop printing dots for 5 s   | Run a script that prints `.` 100×/s             | NVDA does not get stuck; speech queue drains within ~1 s of end  |
 | Cursor blink                      | Idle terminal with blinking cursor              | No announcements; only the cursor visibility flips               |
 | Notification event tracking       | Event Tracker add-on enabled                    | One Notification event per coalesced flush, with non-empty `displayString` |
+
+**Diagnostic decoder for Stage 5:**
+
+- **NVDA says "hello" multiple times** → Coalescing window in the
+  semantics layer is too short or absent; check Stage 5's
+  flush-coalescing logic against `spec/tech-plan.md` §5.
+- **NVDA frozen during busy-loop test** → Notification flooding;
+  the dedup-by-row-hash rule in the PR template's accessibility
+  checklist has been violated. Check Event Tracker for the
+  notification volume; if it's > 50/s the producer is unbounded.
+- **Cursor blink announces** → Cursor-visibility toggle is being
+  routed through a notification path. Should be a pure render
+  invalidation; check that Stage 5's blink handler doesn't call
+  `RaiseNotificationEvent`.
+- **Empty `displayString` in Event Tracker** → Notification text
+  not assembled correctly, or control characters slipped in
+  (PR-template rule "Control characters are stripped" violated).
 
 ### Stage 6 — keyboard input
 
@@ -119,6 +302,22 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | **NVDA shortcut still works**     | Press Insert+T                                  | NVDA announces the window title (proves we did not swallow Insert) |
 | **Caps Lock review still works**  | Press CapsLock+Numpad7                          | NVDA reads previous review line                                  |
 
+**Diagnostic decoder for Stage 6:**
+
+- **Insert+T does nothing** → `PreviewKeyDown` swallowed the
+  Insert key. The PR-template rule "No NVDA modifier keys are
+  swallowed" has been violated; the keyboard handler is intercepting
+  too broadly. Filter modifier keys explicitly.
+- **CapsLock+Numpad7 does nothing** → Same root cause as above
+  (CapsLock is the alternate NVDA modifier).
+- **Ctrl+C doesn't interrupt** → SIGINT not propagated to the
+  ConPTY child. Verify Ctrl+C handling in the keyboard layer
+  routes to the PTY's input stream rather than the WPF dispatcher.
+- **Tab completion shows no UIA notification** → Stage 6's
+  completion-detection wasn't shipped, or its OSC-133 / heuristic
+  detector regressed. Acceptable to mark N/A until Stage 6 ships
+  the heuristic.
+
 ### Stage 7 — Claude Code roundtrip
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
@@ -127,6 +326,22 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | Prompt → response                 | Type "Say hi", Enter                            | Claude responds; NVDA reads the response                         |
 | Spinner does not flood            | Trigger a long-thinking response                | Spinner is announced at most once or as a periodic earcon; NVDA never freezes |
 | Quitting cleanly                  | `/exit` or Ctrl+D                               | Process exits; NVDA announces it; terminal returns to host shell |
+
+**Diagnostic decoder for Stage 7:**
+
+- **NVDA frozen during spinner** → Spinner-row dedup is broken.
+  Check `tests/fixtures/claude-thinking.txt` replay through
+  Stage 5's coalescing path; if the unit tests pass, the
+  semantic-layer hashing is fine and the regression is in how
+  Stage 7's spinner detector classifies the row.
+- **Welcome screen silent** → Claude's TUI emits its first paint
+  in a way that bypasses our coalescing entry point. Compare against
+  Stage 5's `dir` test — if `dir` works but `claude` doesn't, the
+  difference is Claude's use of OSC sequences that our parser may
+  not be handling yet.
+- **`/exit` leaves orphaned `claude` process** → Same class as
+  Stage 3b's "orphan cmd.exe" — the ConPTY shutdown isn't
+  signalling the child correctly.
 
 ### Stage 8 — selection lists
 
@@ -138,6 +353,21 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | Enter confirms                    | Press Enter on selected item                    | List disappears; NVDA reads Claude's next output                 |
 | Inspect.exe shows tree            | Open Inspect.exe while the list is shown        | List + ListItem children with `IsSelected` set on the highlighted item |
 
+**Diagnostic decoder for Stage 8:**
+
+- **NVDA reads the visible text but not as a list** → Stage 8's
+  selection-list detector didn't recognise Claude's pattern. The
+  detector matches against `tests/fixtures/claude-selection-list.txt`;
+  if Claude updated its prompt rendering, the heuristic needs
+  retraining.
+- **`IsSelected` not set on highlighted item** → The detector
+  fired but the WPF UIA peer for the list isn't propagating the
+  selection. Check the `SelectionItemPattern` provider on the
+  list element's peer.
+- **Down arrow doesn't advance NVDA's announcement** → Selection
+  changed in Claude but the selection-changed UIA event wasn't
+  raised. Check `RaiseAutomationEvent(SelectionItemPatternIdentifiers.IsSelectedProperty)`.
+
 ### Stage 9 — earcons
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
@@ -148,6 +378,23 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | No NVDA TTS interference          | Earcon and NVDA speech overlap                  | Both audible; neither cuts the other                             |
 | Separate audio routing            | Set earcon device to second output              | Earcons play on chosen device, NVDA continues on default          |
 
+**Diagnostic decoder for Stage 9:**
+
+- **No earcon on red text** → Either Stage 9 isn't shipped, or
+  the SGR-to-earcon mapping regressed. Confirm the SGR red branch
+  is detected (Stage 5 visual smoke renders red — if THAT works
+  but the earcon doesn't, the binding from semantics → earcon is
+  the suspect).
+- **Earcon clips NVDA speech** → WASAPI exclusive mode acquired
+  somewhere (PR-template rule "no exclusive-mode acquisition").
+  Verify all WASAPI callers use `AudioClientShareMode.Shared`.
+- **Earcon outside specified frequency / duration band** → PR-template
+  rule "below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS" violated;
+  the earcon-generation code regressed.
+- **Mute toggle works once but not on next earcon** → Mute state
+  is transient (not persisted). Verify Stage 9's mute is a
+  process-global flag, not a per-event suppression.
+
 ### Stage 10 — review mode
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
@@ -156,6 +403,20 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | Quick-nav `e` to next error       | After `python -c "raise ValueError('boom')"`, press Alt+Shift+R then `e` | NVDA reads the red traceback line                |
 | Quick-nav `c` to next command     | After running several commands, press `c`       | NVDA reads the next command line                                 |
 | Exit review mode                  | Press Alt+Shift+R again                         | NVDA announces "Interactive mode"; keys go to PTY                |
+
+**Diagnostic decoder for Stage 10:**
+
+- **Alt+Shift+R does nothing** → Either the binding isn't
+  registered (Stage 10 not shipped, mark N/A) or the keyboard
+  layer is consuming it before review-mode sees it.
+- **`e` quick-nav lands on wrong line** → Error-line detector
+  uses red SGR; if `python -c "raise"` doesn't produce red on
+  the runner's terminal config, the test won't have a target.
+  Use a terminal-banner ANSI-coloured string explicitly to be
+  sure.
+- **Review mode doesn't release keyboard focus** → Mode toggle
+  doesn't restore the input router. Check Stage 10's mode-state
+  machine for a missing transition.
 
 ### Stage 11 — auto-update
 
@@ -167,19 +428,154 @@ mechanism (likely `IRawElementProviderSimple` directly on
 | Apply and restart                 | After download completes                        | App restarts within ~2 s, no UAC prompt, new version in title    |
 | Manifest signature verification   | Tamper with `releases.json` on a local mirror   | App refuses the update and announces the verification failure   |
 
+**Diagnostic decoder for Stage 11:**
+
+- **No update detected when one is published** → `releases.win.json`
+  glob mismatch (the failure mode PR #43 fixed). Confirm Velopack
+  CLI version matches CI's; check the channel suffix in the URL
+  the client is requesting.
+- **Update detected, download fails** → Ed25519 manifest
+  signature mismatch (once signing is on). For unsigned previews,
+  expected pass; for signed releases, the `MINISIGN_SECRET_KEY`
+  may have been rotated without re-signing the live release.
+- **UAC prompt on update** → Velopack is trying to write to a
+  location outside `%LocalAppData%`. Confirm the install path is
+  per-user; per-machine installs need elevated update flows.
+- **Restart loops or fails** → State file in `%LocalAppData%\pty-speak\`
+  may be corrupted across the version boundary. Stage 11 ships a
+  backwards-compat shim; if it regresses, the delta-update path
+  is the suspect.
+
 ## Recording results
 
 For each release tag:
 
-1. Copy this matrix into the PR that bumps the version.
-2. Mark each row PASS / FAIL / N/A.
-3. Attach the NVDA Event Tracker log for Stage 5 / 7 / 8 / 11 rows.
-4. The release workflow will not promote a draft to "latest" unless
+1. Copy this matrix into the PR that bumps the version (or into the
+   GitHub Release's "Smoke test results" comment thread if the
+   version-bump PR has already merged).
+2. Mark each row PASS / FAIL / N/A. Use FAIL only when the observed
+   behaviour disagrees with the "Expected" column; use N/A only when
+   the row's stage hasn't shipped yet OR the test fixture isn't
+   available for this run.
+3. Attach the NVDA Event Tracker log for Stage 5 / 7 / 8 / 11 rows
+   (or note "Event Tracker not installed" if running an abbreviated
+   smoke pass).
+4. **For each FAIL, paste the relevant decoder bullet** from the
+   stage's "Diagnostic decoder" subsection, noting which subsystem
+   you suspect. This turns every failure into a triaged issue
+   rather than a free-form "it didn't work" report.
+5. The release workflow will not promote a draft to "latest" unless
    every required-stage row is PASS or N/A.
 
-## When to add new rows
+## Adding new manual tests
 
-Any time we ship a stage, the rows for that stage become required and
-move into the "always run" portion of the matrix. Out-of-stage features
-(verbosity profiles, OSC 133 heuristics, compiler diagnostic
-interpreters) get their own rows in their own section as they ship.
+When new functionality ships and CI cannot fully verify the user-
+visible behaviour, that functionality needs a row in this matrix. A
+test belongs here when **at least one** of the following is true:
+
+- The behaviour is observable only through a screen reader (NVDA /
+  Narrator / JAWS) and the FlaUI integration tests can't simulate
+  what the screen reader does. (Most accessibility rows.)
+- The behaviour is observable only at the user's audio output
+  (earcons, TTS interaction). (Stage 9 rows.)
+- The behaviour involves the OS package layer (installer, signature,
+  process tree, auto-update). (Always-run sections + Stage 11.)
+- The behaviour requires a clean Windows VM and isn't reproducible
+  in the dev sandbox or CI runner (e.g. SmartScreen prompts,
+  per-user install paths).
+
+When a test does **not** belong here:
+
+- It can be expressed as an xUnit / FsCheck assertion against the
+  parser, the screen buffer, or the F# semantics types. (Those go
+  in `tests/Tests.Unit`.)
+- It can be expressed as a FlaUI assertion against the UIA tree.
+  (Those go in `tests/Tests.Ui`.)
+- It's covered by an existing row at a different stage that already
+  exercises the same code path.
+
+### Where in the matrix
+
+| Behaviour involves                                | Section                              |
+|---------------------------------------------------|--------------------------------------|
+| Installer / signature / file layout               | Always-run → Artifact integrity      |
+| Process tree, window lifecycle, OS visibility     | Always-run → Launch and process hygiene |
+| What NVDA / Narrator says or doesn't say          | Stage matrix → corresponding stage   |
+| Audio output (earcons, separate device)           | Stage matrix → Stage 9               |
+| Update download / apply                           | Stage matrix → Stage 11              |
+
+If a behaviour spans stages (e.g. Stage 4's Text pattern is exercised
+by every later stage's NVDA test), put the *primary* row in the stage
+that ships it, and reference it from later stages' decoders as a
+"first suspect" pointer.
+
+### Required fields per row
+
+Every row needs all four fields:
+
+| Field            | Purpose                                                                 |
+|------------------|-------------------------------------------------------------------------|
+| **Test**         | Short noun phrase identifying what's being checked. Stable across releases — issues will reference this name. |
+| **Procedure**    | Concrete keystrokes / commands. Reproducible in 30 seconds. If a fixture is needed, link to its location under `tests/fixtures/`. |
+| **Expected**     | Verbatim screen-reader output, observable file-system state, or visible UI behaviour. Avoid hedges like "approximately"; pin the wording. |
+| **Diagnostic**   | One bullet in the stage's "Diagnostic decoder" subsection mapping the failure to a likely subsystem. Without this, a FAIL is a triage burden; with it, a FAIL is a focused investigation. |
+
+The diagnostic should answer "if this fails, what file / commit /
+subsystem do I look at first?" — naming files and properties where
+practical, citing PR numbers when the row exists because of a
+specific past bug.
+
+### Sunset rules
+
+A row leaves this document when **either**:
+
+- The behaviour becomes verifiable via CI (FlaUI integration test,
+  semantic-layer unit test, or workflow assertion). Replace the row
+  with a bullet under "Coverage that moved to CI" at the bottom of
+  the relevant stage section, naming the test that now pins it.
+- The stage that introduced the row is removed from the roadmap.
+  Delete the row outright — the matrix is the *current* gate, not
+  a historical record. (`CHANGELOG.md` keeps the history.)
+
+Don't leave dead rows in place "just in case". They produce noise
+during smoke runs and erode the matrix's authority. If you're not
+sure whether to remove or keep a row, keep it for one release with
+a `(deprecation candidate)` suffix, then make the call at the next
+release based on whether it caught anything during that window.
+
+## Coverage that moved to CI
+
+This list documents tests that *used to* be in the manual matrix and
+are now pinned by an automated check. It's the audit trail for the
+matrix's shrinking surface area over time.
+
+- **Stage 4 → Inspect.exe shows Text pattern + non-empty
+  `DocumentRange.GetText`** is now pinned by
+  `tests/Tests.Ui/TextPatternTests.fs` (PR #56). The manual row
+  remains in the Stage 4 section because NVDA's review-cursor
+  behaviour over the same Text pattern requires manual NVDA, but
+  the producer side (pattern present + GetText returns a snapshot
+  with the expected length floor) is now CI-pinned.
+
+## Why this is manual
+
+CI tests run on a Windows runner with no logged-in interactive
+session, no audio hardware, no screen reader, no SmartScreen, no
+per-user install path that survives across runs. They can verify
+that producers emit the right UIA events, that the parser produces
+the right tokens, that the screen buffer mutates correctly, that
+the .NET assembly contains the right type with the right override.
+They cannot verify what the user actually hears or what the
+installer actually shows.
+
+The right model is: **CI catches regressions in the producers;
+manual smoke catches regressions in the consumer's experience.**
+The two surfaces don't overlap fully, and the parts that overlap
+(e.g. the Text pattern's existence on the UIA element) are the
+parts we *do* migrate to CI as soon as a stable assertion is
+available.
+
+A row that *could* be CI-tested but isn't yet is a follow-up issue,
+not a manual-matrix entry. The matrix is for the genuinely-manual
+checks: things that need a human, a screen reader, an audio output,
+or a real Windows shell.

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -200,26 +200,27 @@ Triggered by the `release: published` event you just fired. Runs on
 
 ### 5. Smoke-test the release
 
-On a clean VM:
+The comprehensive manual smoke-test gate lives in
+[`docs/ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md). Walk
+that document top-to-bottom on a clean Windows VM:
 
-1. Download `pty-speak-Setup.exe` from the new release.
-2. Confirm the build is **unsigned** (this is currently expected):
-   ```powershell
-   Get-AuthenticodeSignature .\pty-speak-Setup.exe |
-     Select-Object Status, StatusMessage
-   ```
-   `Status` is `NotSigned`; `StatusMessage` confirms no signature.
-   SmartScreen will prompt; choose "More info → Run anyway" or use
-   `Unblock-File` first.
-3. Run the installer. For the historic Stage 0 preview the window
-   was empty; for previews built from `main` at Stage 3b+ the window
-   shows live `cmd.exe` output. Confirm no errors and that the
-   window titled "pty-speak" opens.
-4. Launch the app from the Start menu; confirm the same window opens
-   from the installed location (`%LocalAppData%\pty-speak\current\`).
-5. Once Stage 11 lands, trigger the auto-update path from a previously
-   installed older version (`Ctrl+Shift+U`); confirm the delta
-   downloads and the relaunch happens within ~2 seconds.
+1. Run the **always-run** sections (Artifact integrity, Launch and
+   process hygiene) for every release regardless of stage.
+2. Run the **stage matrix** rows for every stage that's shipped at
+   this release tag. (E.g. for a release built from `main` after
+   PR #56 merged, that's Stage 0 + Stage 3b + Stage 4.)
+3. For each FAIL, paste the relevant decoder bullet from the
+   document into the GitHub Issue you open.
+4. The release is not promoted from prerelease to "latest" until
+   every required-stage row is PASS or N/A.
+
+The smoke-test document captures (a) the procedure for every test,
+(b) the expected outcome verbatim, and (c) a "Diagnostic decoder"
+that maps each possible failure to the likely-responsible subsystem,
+so a failure goes from "something broke" to "look at file X, PR Y,
+subsystem Z" without further investigation. New manual tests are
+added per the "Adding new manual tests" section of that document
+whenever a shipped behaviour can't be CI-verified.
 
 ### 6. Announce
 

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -51,24 +51,33 @@ disconnects mid-session.
    programmatically check PR status, merge PRs, or post issue
    comments — falls back to asking the maintainer.
 
-3. **Visual install smoke of `v0.0.1-preview.19` on Windows.**
-   `v0.0.1-preview.19` was published 2026-04-28 and shipped all
-   five Velopack assets correctly (full nupkg, Setup.exe,
-   `releases.win.json`, `assets.win.json`, `RELEASES`) plus the
-   two GitHub-auto source archives — 7 visible in the release
-   UI, validating the manifest fix from PR #43. The
-   single-window fix from PR #44 still needs an actual Windows
-   install to confirm. Steps:
-   1. Download `pty-speak-win-Setup.exe` from
-      <https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.19>.
-   2. Run the installer (SmartScreen will warn — expected for
-      unsigned previews).
-   3. Launch from Start menu.
-   4. **Pass condition**: only one window appears (the WPF
-      surface). No empty console window behind it.
-   If a second window does appear, reopen [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39)
-   with details — the WinExe fix may not have taken effect, or
-   there's a different cause we haven't surfaced yet.
+3. **Run the full manual smoke matrix on the latest preview.**
+   The comprehensive gate lives in
+   [`docs/ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md);
+   walk the always-run sections (Artifact integrity + Launch and
+   process hygiene) plus every shipped-stage row for whichever
+   preview is current. Track FAILs as GitHub issues, pasting the
+   relevant decoder bullet into the issue body so triage is
+   focused.
+
+   Specific items still pending verification on the most recent
+   previews:
+
+   - The single-window fix from PR #44 (`OutputType=WinExe`)
+     needs a clean Windows install to confirm. Pass condition is
+     the matrix's "Single window appears" row in the
+     Launch-and-process-hygiene section.
+   - The Stage 4 Text-pattern surface (PRs #54 / #55 / #56)
+     needs an NVDA review-cursor walk on a real terminal. Pass
+     conditions are the Stage-4 "Review cursor reads current
+     line" / "Review cursor moves by line" rows.
+
+   If the single-window check fails, reopen
+   [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39).
+   For Stage-4 NVDA failures, file a fresh issue — the chain is
+   new and a regression there is most likely a `GetPattern`
+   override regression on `TerminalAutomationPeer`, per the
+   Stage-4 diagnostic decoder.
 
 4. **Small CI / release timing optimisation pass** (low priority,
    pure cleanup). Current CI per-PR job times are reasonable but


### PR DESCRIPTION
## Summary

Maintainer feedback after installing `v0.0.1-preview.20`: each release needs **one comprehensive list** of manual checks CI can't do, with explicit diagnostic guidance for every failure mode and a documented process for growing the matrix as new functionality ships.

Restructures `docs/ACCESSIBILITY-TESTING.md` (filename retained because 12 other docs link to it) so it is now the universal manual-validation gate.

### What's new in the matrix

- **Two always-run sections** at the top, run on every release regardless of stage:
  - **Artifact integrity** (5 rows): all Velopack assets present, Setup.exe non-zero, Authenticode status matches release line, SHA256 forensic trace.
  - **Launch and process hygiene** (6 rows): single window (catches `OutputType` regression from PR #44), version in title, one-deep process tree, clean shutdown, Alt+F4 cleanup, re-launch after exit.

- **Diagnostic decoder for every stage**: each table now has a paragraph that maps every possible failure to the likely-responsible subsystem — file paths and PR numbers where applicable, so a FAIL goes from "something broke" to "look at file X, PR Y, subsystem Z" without further triage.

- **Stage 4 rewritten end-to-end** to reflect the actual ship architecture (`AutomationPeer.GetPattern` override after the WM_GETOBJECT pivot in PR #56), with a note that `TextPatternTests.fs` now CI-pins the producer side of the Text pattern.

- **Four new top-level sections:**
  - "Adding new manual tests" — criteria for manual vs CI placement, where each kind of test goes, the four required fields per row.
  - "Sunset rules" — when rows graduate to CI or get deleted, explicit "don't leave dead rows" rule.
  - "Coverage that moved to CI" — audit trail of the matrix's shrinking surface area.
  - "Why this is manual" — rationale: CI catches producers, manual catches consumer experience.

- **"Recording results" expanded**: each FAIL must paste the matching decoder bullet into the issue, so triage starts already focused.

### Companion updates

- `docs/RELEASE-PROCESS.md` step 5 rewritten to defer to the comprehensive matrix instead of duplicating a five-bullet smoke list that aged out of sync.
- `docs/SESSION-HANDOFF.md` item 3 (visual-install-smoke pending action) now points at the matrix and tracks both the single-window check (PR #44) and the Stage 4 NVDA verification (PRs #54/55/56) as specific pass/fail conditions.
- `.github/PULL_REQUEST_TEMPLATE.md` accessibility checklist gains an "Adding new manual tests" prompt — any PR that ships CI-unverifiable behaviour grows the matrix in the same change rather than deferring to a follow-up.
- `README.md` docs-index entry updated to reflect the broader scope.

### The diagnostic-decoder pattern

This is the core of the change. A manual test that says only "expected X, got Y" produces free-form "doesn't work" issues; a manual test that says "expected X, got Y, and if so look at file Z, PR W, subsystem K first" produces actionable triage. The decoders were drafted by walking the existing rows and asking "what would I look at first if this row failed today?" — answers came from this session's CI-iteration history (PR #44's `OutputType`, PR #56's `GetPattern` override, PR #43's Velopack manifest globs) and from the architecture as documented in CONTRIBUTING.md and the PR template's checklist.

## Test plan

- [ ] Markdown link check passes (the new content has only internal `docs/` and PR-number links).
- [ ] Cross-reference walk: every link from the matrix to RELEASE-PROCESS / SESSION-HANDOFF / PR template resolves bidirectionally.
- [ ] Diagnostic decoder bullets reference real files (`src/Terminal.App/Terminal.App.fsproj`, `src/Terminal.Accessibility/TerminalAutomationPeer.fs`, etc.) — spot-check a sample.
- [ ] No dead manual rows: every row in the current matrix corresponds to behaviour shippable today (or marked clearly as Stage 5+ / planned).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_