### PR TITLE
fix(stage-4): implement Text-pattern Line + Character navigation (preview.20 NVDA review-cursor fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,56 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stage 4 Text-pattern navigation: NVDA's review cursor can
+  now read the terminal buffer.** `v0.0.1-preview.20` install
+  smoke established that PR #56's Text-pattern surface was
+  reachable but unusable: NVDA's "read current line" returned
+  "blank" and prev/next-line did nothing. Root cause was that
+  `TerminalTextRange`'s `ExpandToEnclosingUnit`, `Move`,
+  `MoveEndpointByUnit`, and `MoveEndpointByRange` were all
+  no-op stubs from PR #56's "navigation deferred to PR D"
+  scope. Without them NVDA's review cursor couldn't delimit a
+  line: `ExpandToEnclosingUnit(Line)` was silently dropped,
+  leaving the range collapsed at start with empty `GetText`
+  output. Implementation in this commit:
+
+  - `TerminalTextRange` now tracks mutable `(startRow,
+    startCol, endRow, endCol)` endpoints (the UIA contract
+    requires the void-returning navigation methods to mutate
+    in place).
+  - `ExpandToEnclosingUnit` handles `Character`, `Document`,
+    and `Line` (other unit types degrade to `Line` until a
+    terminal-output tokenizer arrives).
+  - `Move`, `MoveEndpointByUnit`, `MoveEndpointByRange`
+    implement UIA's contract including endpoint-collision
+    handling (range collapses to the moved point if endpoints
+    cross).
+  - `CompareEndpoints` returns the lexicographic ordering
+    over `(row, col)` positions.
+  - `GetText` uses the range endpoints (was returning the
+    entire snapshot regardless of range).
+  - `DocumentRange` constructs a half-open `[(0,0), (rows, 0))`
+    range matching UIA's standard endpoint convention.
+
+  `tests/Tests.Ui/TextPatternTests.fs` gains a navigation
+  regression test that asserts `ExpandToEnclosingUnit(Line)`
+  bounds the range length below the full-document size, and
+  `Move(Line, 1)` preserves the Line shape — the two
+  invariants whose violation produced the preview.20
+  failure mode.
+
+- **Removed `MainWindow.xaml`'s
+  `AutomationProperties.HelpText`.** Preview.20 NVDA smoke
+  heard "Screen-reader-native Windows terminal. Stage 3b:
+  bytes from a child shell are parsed and rendered; UIA
+  exposure lands in Stage 4." read after the role
+  announcement on every focus. That string was useful as
+  developer documentation while the project was bootstrapping
+  but is verbose chatter for the user. The window's name and
+  Document role are sufficient.
+
 ### Added
 
 - **Comprehensive manual smoke-test matrix

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -100,49 +100,182 @@ module SnapshotText =
                     sb.Append(row.[c].Ch.ToString()) |> ignore
             sb.ToString()
 
-/// UIA `ITextRangeProvider` over an immutable row snapshot.
+/// UIA `ITextRangeProvider` over an immutable row snapshot
+/// with mutable `(row, col)` endpoints.
 ///
-/// Stage 4 (this PR) ships only `GetText`, `Clone`, and
-/// `Compare` with real behaviour — those three are what NVDA
-/// calls during initial document read-out. Navigation
-/// (`Move`, `MoveEndpointByUnit`), endpoint manipulation,
-/// selection, and attribute queries are stubbed to satisfy the
-/// interface so UIA marshalling doesn't fault, but they don't
-/// influence what NVDA reads in this PR. PR C (the FlaUI
-/// Text-pattern integration test) verifies that `GetText`
-/// returns the expected snapshot under a real UIA client; the
-/// stubbed methods are exercised in later stages when caret
-/// movement / SGR exposure work begins.
+/// The range covers cells in `[Start, End)` half-open, where
+/// each endpoint is a `(row, col)` position with `col` in
+/// `[0, cols]` — `col == cols` is the legal "end of row"
+/// position equivalent to `(row + 1, 0)` for `row < rows - 1`.
 ///
-/// `Sequence` records the `Screen.SequenceNumber` at capture
-/// time so a future stale-detection check can compare against
-/// the current screen state. Stage 4 doesn't use it yet — the
-/// snapshot is materialised once per UIA query and discarded —
-/// but storing it now keeps the range structure aligned with
-/// the substrate that Screen.fs already exposes.
-type TerminalTextRange(sequence: int64, rows: Cell[][]) =
+/// Endpoints are *mutable* because UIA's `ITextRangeProvider`
+/// surface mutates ranges in place (`ExpandToEnclosingUnit`,
+/// `Move`, `MoveEndpointByUnit`, `MoveEndpointByRange`,
+/// `Select` are all `void` — they are required to alter the
+/// receiver, not return a new range). The original PR-C
+/// implementation kept the range immutable and stubbed every
+/// mutating method as a no-op; that broke NVDA's review
+/// cursor (preview.20 smoke: read-current-line returned
+/// "blank" because NVDA's `ExpandToEnclosingUnit(Line)` was
+/// silently dropped, leaving the range collapsed at start
+/// with no text to read).
+type TerminalTextRange(
+        sequence: int64,
+        rows: Cell[][],
+        cols: int,
+        initialStartRow: int,
+        initialStartCol: int,
+        initialEndRow: int,
+        initialEndCol: int) =
+
+    let mutable startRow = initialStartRow
+    let mutable startCol = initialStartCol
+    let mutable endRow = initialEndRow
+    let mutable endCol = initialEndCol
+
+    /// Number of rows in the snapshot. `rows.Length` for non-empty
+    /// snapshots; 0 for the early-startup empty range.
+    let rowCount = rows.Length
 
     member _.Sequence = sequence
     member _.Rows = rows
+    member _.Cols = cols
+    member _.StartRow = startRow
+    member _.StartCol = startCol
+    member _.EndRow = endRow
+    member _.EndCol = endCol
+    member _.RowCount = rowCount
+
+    /// Compare two positions; returns -1 / 0 / 1 like
+    /// `compare` on tuples but inlined so the hot path
+    /// doesn't allocate.
+    static member private ComparePos
+            (aRow: int, aCol: int, bRow: int, bCol: int) : int =
+        if aRow < bRow then -1
+        elif aRow > bRow then 1
+        elif aCol < bCol then -1
+        elif aCol > bCol then 1
+        else 0
+
+    /// Clamp a position to the valid range `[0, rows] × [0, cols]`,
+    /// where `(rows, 0)` is the legal one-past-end position.
+    static member private ClampPos
+            (rowCount: int, cols: int, r: int, c: int) : int * int =
+        let r = max 0 (min rowCount r)
+        let c =
+            if r = rowCount then 0
+            else max 0 (min cols c)
+        (r, c)
+
+    /// Render `[start, end)` of `rows` into a string using
+    /// `\n` between rows, matching `SnapshotText.render`'s
+    /// row-join rule. Cells beyond `cols` (impossible for
+    /// well-formed snapshots, but defensive against jagged
+    /// arrays) are skipped.
+    static member private GetTextInRange
+            (rows: Cell[][]) (cols: int)
+            (sr: int) (sc: int) (er: int) (ec: int) : string =
+        let sb = StringBuilder()
+        let mutable r = sr
+        while r <= er && r < rows.Length do
+            let firstCol = if r = sr then sc else 0
+            let lastColExclusive =
+                if r = er then ec
+                else cols
+            let row = rows.[r]
+            let mutable c = firstCol
+            while c < lastColExclusive && c < row.Length do
+                sb.Append(row.[c].Ch.ToString()) |> ignore
+                c <- c + 1
+            if r < er then
+                sb.Append('\n') |> ignore
+            r <- r + 1
+        sb.ToString()
 
     interface ITextRangeProvider with
 
         member _.Clone() =
-            TerminalTextRange(sequence, rows) :> ITextRangeProvider
+            TerminalTextRange(
+                sequence, rows, cols,
+                startRow, startCol, endRow, endCol)
+            :> ITextRangeProvider
 
         member _.Compare(other: ITextRangeProvider) : bool =
-            // Two ranges are equal when they wrap the same
-            // snapshot identity. Reference equality is enough
-            // for Stage 4 because each `DocumentRange` call
-            // returns a freshly captured snapshot — clones
-            // share the underlying `rows` reference.
+            // Two ranges compare equal when they wrap the same
+            // snapshot AND have identical endpoints. Endpoint
+            // equality matters because NVDA clones a range,
+            // navigates the clone, then asks "did anything
+            // happen?" — without endpoint comparison every
+            // clone would be reported as "same as original."
             match other with
             | :? TerminalTextRange as r ->
                 obj.ReferenceEquals(r.Rows, rows)
+                && r.StartRow = startRow && r.StartCol = startCol
+                && r.EndRow = endRow && r.EndCol = endCol
             | _ -> false
 
-        member _.CompareEndpoints(_: TextPatternRangeEndpoint, _: ITextRangeProvider, _: TextPatternRangeEndpoint) = 0
-        member _.ExpandToEnclosingUnit(_: TextUnit) = ()
+        member _.CompareEndpoints
+                (thisEndpoint, otherProvider, otherEndpoint) =
+            let (thisR, thisC) =
+                if thisEndpoint = TextPatternRangeEndpoint.Start
+                then (startRow, startCol)
+                else (endRow, endCol)
+            match otherProvider with
+            | :? TerminalTextRange as r ->
+                let (otherR, otherC) =
+                    if otherEndpoint = TextPatternRangeEndpoint.Start
+                    then (r.StartRow, r.StartCol)
+                    else (r.EndRow, r.EndCol)
+                TerminalTextRange.ComparePos(thisR, thisC, otherR, otherC)
+            | _ -> 0
+
+        member _.ExpandToEnclosingUnit(unit: TextUnit) =
+            // Reshape the range to enclose the unit at `Start`.
+            // For Line we pick the row of `Start` and span the
+            // whole row plus the implicit row separator (so
+            // GetText returns the row's cells). Word /
+            // Paragraph / Page degrade to Line for now — Stage
+            // 4 ships line + character navigation; word
+            // semantics arrive later when we have a tokenizer
+            // for terminal output (prompt vs command vs result
+            // is the heuristic).
+            match unit with
+            | TextUnit.Character ->
+                // 1-cell range starting at the current Start.
+                let (sr, sc) =
+                    TerminalTextRange.ClampPos(rowCount, cols, startRow, startCol)
+                let (er, ec) =
+                    if sc + 1 <= cols then (sr, sc + 1)
+                    elif sr + 1 < rowCount then (sr + 1, 0)
+                    else (rowCount, 0)
+                startRow <- sr
+                startCol <- sc
+                endRow <- er
+                endCol <- ec
+            | TextUnit.Document ->
+                startRow <- 0
+                startCol <- 0
+                endRow <- rowCount
+                endCol <- 0
+            | _ ->
+                // Line / Word / Paragraph / Page → enclose the
+                // row at Start.
+                let (sr, _) =
+                    TerminalTextRange.ClampPos(rowCount, cols, startRow, startCol)
+                if rowCount = 0 then
+                    startRow <- 0
+                    startCol <- 0
+                    endRow <- 0
+                    endCol <- 0
+                else
+                    startRow <- sr
+                    startCol <- 0
+                    if sr + 1 < rowCount then
+                        endRow <- sr + 1
+                        endCol <- 0
+                    else
+                        endRow <- sr
+                        endCol <- cols
         member _.FindAttribute(_: int, _: obj, _: bool) =
             Unchecked.defaultof<ITextRangeProvider>
         member _.FindText(_: string, _: bool, _: bool) =
@@ -157,15 +290,128 @@ type TerminalTextRange(sequence: int64, rows: Cell[][]) =
         member _.GetEnclosingElement() = Unchecked.defaultof<IRawElementProviderSimple>
 
         member _.GetText(maxLength: int) =
-            let rendered = SnapshotText.render rows
+            let rendered =
+                TerminalTextRange.GetTextInRange
+                    rows cols startRow startCol endRow endCol
             if maxLength < 0 || maxLength >= rendered.Length then
                 rendered
             else
                 rendered.Substring(0, maxLength)
 
-        member _.Move(_: TextUnit, _: int) = 0
-        member _.MoveEndpointByUnit(_: TextPatternRangeEndpoint, _: TextUnit, _: int) = 0
-        member _.MoveEndpointByRange(_: TextPatternRangeEndpoint, _: ITextRangeProvider, _: TextPatternRangeEndpoint) = ()
+        member this.Move(unit: TextUnit, count: int) =
+            // Per UIA contract, `Move` translates the entire
+            // range by `count` units, preserving the unit
+            // shape. We collapse to start, move that endpoint,
+            // then expand back to the unit. Returns the
+            // number of units actually moved (clamped at
+            // document boundaries).
+            if rowCount = 0 || count = 0 then 0
+            else
+                match unit with
+                | TextUnit.Character ->
+                    let stepsRequested = count
+                    let totalCells = rowCount * cols
+                    // Position-as-cell-index: r*cols + c
+                    let curIdx =
+                        (max 0 (min (rowCount - 1) startRow)) * cols
+                        + (max 0 (min cols startCol))
+                    let targetIdx = max 0 (min totalCells (curIdx + stepsRequested))
+                    let actualMoved = targetIdx - curIdx
+                    let nr = targetIdx / cols
+                    let nc = targetIdx % cols
+                    startRow <- nr
+                    startCol <- nc
+                    // 1-cell range
+                    let (er, ec) =
+                        if nc + 1 <= cols then (nr, nc + 1)
+                        elif nr + 1 < rowCount then (nr + 1, 0)
+                        else (rowCount, 0)
+                    endRow <- er
+                    endCol <- ec
+                    actualMoved
+                | _ ->
+                    // Line / Word / Paragraph / Page → line.
+                    let curRow = max 0 (min (rowCount - 1) startRow)
+                    let target = max 0 (min (rowCount - 1) (curRow + count))
+                    let actualMoved = target - curRow
+                    startRow <- target
+                    startCol <- 0
+                    if target + 1 < rowCount then
+                        endRow <- target + 1
+                        endCol <- 0
+                    else
+                        endRow <- target
+                        endCol <- cols
+                    actualMoved
+
+        member _.MoveEndpointByUnit
+                (endpoint: TextPatternRangeEndpoint,
+                 unit: TextUnit,
+                 count: int) =
+            // Move only one endpoint by `count` units, keeping
+            // the other fixed. If the endpoints cross, UIA's
+            // contract is to also pull the other endpoint to
+            // match (the range collapses to the moved point).
+            if rowCount = 0 || count = 0 then 0
+            else
+                let isStart = endpoint = TextPatternRangeEndpoint.Start
+                let (curR, curC) =
+                    if isStart then (startRow, startCol) else (endRow, endCol)
+                let (newR, newC, actualMoved) =
+                    match unit with
+                    | TextUnit.Character ->
+                        let totalCells = rowCount * cols
+                        let curIdx =
+                            (max 0 (min (rowCount - 1) curR)) * cols
+                            + (max 0 (min cols curC))
+                        let targetIdx = max 0 (min totalCells (curIdx + count))
+                        let moved = targetIdx - curIdx
+                        let nr = targetIdx / cols
+                        let nc = targetIdx % cols
+                        (nr, nc, moved)
+                    | _ ->
+                        let target = max 0 (min rowCount (curR + count))
+                        let moved = target - curR
+                        // Line endpoints land at column 0
+                        // (start of next line) for Line units.
+                        (target, 0, moved)
+                if isStart then
+                    startRow <- newR
+                    startCol <- newC
+                    if TerminalTextRange.ComparePos(startRow, startCol, endRow, endCol) > 0 then
+                        endRow <- startRow
+                        endCol <- startCol
+                else
+                    endRow <- newR
+                    endCol <- newC
+                    if TerminalTextRange.ComparePos(startRow, startCol, endRow, endCol) > 0 then
+                        startRow <- endRow
+                        startCol <- endCol
+                actualMoved
+
+        member _.MoveEndpointByRange
+                (thisEndpoint: TextPatternRangeEndpoint,
+                 otherProvider: ITextRangeProvider,
+                 otherEndpoint: TextPatternRangeEndpoint) =
+            match otherProvider with
+            | :? TerminalTextRange as r ->
+                let (otherR, otherC) =
+                    if otherEndpoint = TextPatternRangeEndpoint.Start
+                    then (r.StartRow, r.StartCol)
+                    else (r.EndRow, r.EndCol)
+                if thisEndpoint = TextPatternRangeEndpoint.Start then
+                    startRow <- otherR
+                    startCol <- otherC
+                    if TerminalTextRange.ComparePos(startRow, startCol, endRow, endCol) > 0 then
+                        endRow <- startRow
+                        endCol <- startCol
+                else
+                    endRow <- otherR
+                    endCol <- otherC
+                    if TerminalTextRange.ComparePos(startRow, startCol, endRow, endCol) > 0 then
+                        startRow <- endRow
+                        startCol <- endCol
+            | _ -> ()
         member _.Select() = ()
         member _.AddToSelection() = ()
         member _.RemoveFromSelection() = ()
@@ -190,10 +436,19 @@ type TerminalTextProvider(screenSource: Func<Screen | null>) =
     member private _.CaptureFullRange() : ITextRangeProvider =
         match screenSource.Invoke() with
         | null ->
-            TerminalTextRange(0L, Array.empty<Cell[]>) :> ITextRangeProvider
+            TerminalTextRange(
+                0L, Array.empty<Cell[]>, 0,
+                0, 0, 0, 0)
+            :> ITextRangeProvider
         | screen ->
             let seqNum, rows = screen.SnapshotRows(0, screen.Rows)
-            TerminalTextRange(seqNum, rows) :> ITextRangeProvider
+            // Document range: start = (0, 0), end = (rows, 0)
+            // i.e. one-past-last-row, matching UIA's
+            // half-open range convention.
+            TerminalTextRange(
+                seqNum, rows, screen.Cols,
+                0, 0, rows.Length, 0)
+            :> ITextRangeProvider
 
     interface ITextProvider with
 

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -7,8 +7,7 @@
         Width="800"
         Background="Black"
         AutomationProperties.Name="pty-speak terminal"
-        AutomationProperties.AutomationId="pty-speak.MainWindow"
-        AutomationProperties.HelpText="Screen-reader-native Windows terminal. Stage 3b: bytes from a child shell are parsed and rendered; UIA exposure lands in Stage 4.">
+        AutomationProperties.AutomationId="pty-speak.MainWindow">
     <Grid>
         <views:TerminalView x:Name="TerminalSurface" x:FieldModifier="public" />
     </Grid>

--- a/tests/Tests.Ui/TextPatternTests.fs
+++ b/tests/Tests.Ui/TextPatternTests.fs
@@ -179,3 +179,81 @@ let ``UIA Text pattern is reachable and DocumentRange.GetText reflects the scree
     Assert.Contains("\n", text)
 
     app.Close() |> ignore
+
+/// Stage 4 navigation regression test (post-PR-#56).
+///
+/// Preview.20 install smoke established that a working
+/// Text-pattern producer is necessary but not sufficient
+/// for NVDA: the review cursor needs functional
+/// `ExpandToEnclosingUnit` + `Move` to delimit and traverse
+/// lines. PR #56's no-op stubs satisfied the interface but
+/// silently dropped NVDA's navigation calls, leaving the
+/// range collapsed at start (read-current-line returned
+/// "blank"). This test pins that working line navigation
+/// stays working.
+///
+/// What's asserted:
+///   1. After `ExpandToEnclosingUnit(Line)` on the document
+///      range, `GetText` length is bounded above by ~`cols`
+///      (one row plus one row-separator newline at most).
+///      This catches the no-op-stub regression — without
+///      navigation the range stays at full-document length
+///      (3629).
+///   2. After `Move(Line, 1)` the range stays Line-shaped
+///      (same length bound), confirming Move preserves the
+///      unit shape rather than e.g. collapsing the range.
+///
+/// What's deliberately not asserted:
+///   * Specific cell content — cmd.exe banner timing isn't
+///     deterministic across Windows runners.
+///   * Word / Paragraph navigation — Stage 4 ships Line +
+///     Character only; later stages add tokenized units.
+[<Fact>]
+let ``Text-pattern range navigation can pin to a single line and advance`` () =
+    let exePath = locateTerminalAppExe ()
+    use app = Application.Launch(exePath)
+    use automation = new UIA3Automation()
+    let mainWindow =
+        match app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0)) with
+        | null -> failwith "Main window did not appear within 10 seconds."
+        | mw -> mw
+
+    let textPattern =
+        match findTextPattern mainWindow with
+        | None -> failwith "Text pattern not found in the UIA tree."
+        | Some tp -> tp
+
+    let docRange = textPattern.DocumentRange
+    let docLength = docRange.GetText(-1).Length
+
+    // After Line expansion the range should cover at most
+    // one row plus one row-separator. `Program.compose`
+    // sets cols=120; the upper bound 200 leaves slack for
+    // implementation choices around the trailing newline
+    // without admitting "full document" (3629).
+    let lineRange = docRange.Clone()
+    lineRange.ExpandToEnclosingUnit(FlaUI.Core.Definitions.TextUnit.Line)
+    let lineText = lineRange.GetText(-1)
+    let firstLineLength = lineText.Length
+    Assert.True(
+        firstLineLength > 0 && firstLineLength <= 200,
+        sprintf
+            "Expected Line-expanded range length in (0, 200]; got %d. If %d == %d, ExpandToEnclosingUnit(Line) regressed to a no-op (Stage 4's preview.20 failure mode)."
+            firstLineLength
+            firstLineLength
+            docLength)
+
+    // Move to next line should preserve Line shape.
+    let moved = lineRange.Move(FlaUI.Core.Definitions.TextUnit.Line, 1)
+    Assert.True(
+        moved >= 0,
+        sprintf "Expected Move(Line, 1) to return non-negative count; got %d" moved)
+    let secondLineLength = lineRange.GetText(-1).Length
+    Assert.True(
+        secondLineLength > 0 && secondLineLength <= 200,
+        sprintf
+            "Expected post-Move Line range length in (0, 200]; got %d. Move regressed if this matches the document length (%d)."
+            secondLineLength
+            docLength)
+
+    app.Close() |> ignore


### PR DESCRIPTION
## Summary

Fixes the Stage 4 Text-pattern regression that `v0.0.1-preview.20` install smoke surfaced: NVDA's "read current line" returns "blank" and prev/next-line do nothing, even though Inspect.exe sees the Document role and the Text pattern is reachable.

### Root cause

PR #56 shipped `TerminalTextRange` with `ExpandToEnclosingUnit`, `Move`, `MoveEndpointByUnit`, and `MoveEndpointByRange` as no-op stubs (the PR scope said "navigation deferred to PR D"). NVDA's review cursor calls these to delimit "the current line"; with all of them as no-ops the range stays collapsed-at-start, so `GetText` returns an empty string and NVDA reads "blank."

### Fix

`TerminalTextRange` now tracks **mutable** `(startRow, startCol, endRow, endCol)` endpoints (UIA's void-returning navigation methods are required by the contract to mutate in place, not return a new range), and:

- `ExpandToEnclosingUnit` handles `Character`, `Document`, and `Line` (other unit types degrade to `Line` until a terminal-output tokenizer arrives in a later stage).
- `Move`, `MoveEndpointByUnit`, and `MoveEndpointByRange` implement UIA's contract including the endpoint-collision rule (range collapses to the moved point if endpoints cross).
- `CompareEndpoints` returns the lexicographic ordering over `(row, col)` positions.
- `GetText` uses the range endpoints (was returning the entire snapshot regardless of range).
- `DocumentRange` constructs a half-open `[(0, 0), (rows, 0))` range matching UIA's standard endpoint convention.

### Bonus fix (small, related)

Removes `MainWindow.xaml`'s `AutomationProperties.HelpText`. Preview.20 smoke heard "Screen-reader-native Windows terminal. Stage 3b: bytes from a child shell..." after every role announcement — verbose developer documentation that doesn't help the user. The window's name and role are sufficient.

### Regression test

`tests/Tests.Ui/TextPatternTests.fs` gains `Text-pattern range navigation can pin to a single line and advance` which asserts the two structural invariants whose violation produced the preview.20 failure: `ExpandToEnclosingUnit(Line)` bounds GetText length below the full-document size, and `Move(Line, 1)` preserves the Line shape. Specific cell content isn't asserted (cmd.exe banner timing isn't deterministic).

## Test plan

- [ ] CI build + test passes on `windows-latest`.
- [ ] Existing `TextPatternTests` (DocumentRange length floor) still passes — verifies the GetText extraction handles the document range correctly.
- [ ] New navigation test passes — pins the regression class.
- [ ] Existing `AutomationPeerTests` and `WindowSubclassTests` still pass — verifies no regression on the peer-tree path.
- [ ] After merge: maintainer reruns the manual smoke matrix Stage 4 rows on the next preview build (NVDA "read current line", prev/next line, character/word navigation).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_