### PR TITLE
chore(scripts): add install-latest-preview.ps1 for low-friction preview iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/install-latest-preview.ps1` — one-command preview
+  installer for Windows.** Downloads the latest (or specified)
+  preview's `Setup.exe` from the GitHub Release assets, strips
+  the Mark-of-the-Web tag with `Unblock-File` so SmartScreen
+  doesn't prompt the unsigned-preview line on every iteration,
+  and runs the installer. Replaces the multi-step "open the
+  release page → navigate the asset list → click `Setup.exe`
+  → click 'More info' → click 'Run anyway'" flow that takes
+  several screen-reader steps per iteration with a single
+  command. Scoped to the iterative-smoke-testing workflow that
+  Stage 4+ NVDA verification needs; once Stage 11 ships
+  Velopack delta self-update via `Ctrl+Shift+U`, this script
+  becomes unnecessary for in-place updates. New `scripts/README.md`
+  documents the script and reserves the directory for future
+  utilities.
+
 ### Fixed
 
 - **`MainWindow` moves keyboard focus to `TerminalSurface` on

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ docs/                    Living developer documentation
 .github/
   workflows/             CI and release automation
   ISSUE_TEMPLATE/        Bug, feature, accessibility-issue templates
+scripts/                 Repo-local utility scripts (install helpers, etc.)
 src/                     F# / C# / WPF source (Stage 0 skeleton merged)
 tests/                   xUnit + FsCheck.Xunit + FlaUI placeholder
 ```
@@ -93,6 +94,7 @@ tests/                   xUnit + FsCheck.Xunit + FlaUI placeholder
 - **ConPTY platform notes:** [`docs/CONPTY-NOTES.md`](docs/CONPTY-NOTES.md)
 - **Session handoff (for picking up between Claude Code sessions):** [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md)
 - **Manual smoke-test matrix (every release):** [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+- **Install latest preview (PowerShell helper):** [`scripts/install-latest-preview.ps1`](scripts/install-latest-preview.ps1) — see [`scripts/README.md`](scripts/README.md)
 - **Security and trust model:** [`SECURITY.md`](SECURITY.md)
 - **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# scripts/
+
+Repo-local utility scripts. Each is documented at the top of its
+own file; this README is the index.
+
+## `install-latest-preview.ps1`
+
+PowerShell installer for the most recent (or specified) `pty-speak`
+preview release on Windows. Bypasses the SmartScreen prompt the
+unsigned-preview line currently triggers by stripping the
+Mark-of-the-Web from the downloaded installer.
+
+Use case: iterating on preview builds during Stage 4+ smoke
+testing. Replaces the multi-step "open release page → navigate to
+asset list → click `Setup.exe` → click 'More info' → click 'Run
+anyway' → wait for installer" flow with one command.
+
+```powershell
+# Latest release
+.\scripts\install-latest-preview.ps1
+
+# Specific tag
+.\scripts\install-latest-preview.ps1 -Tag v0.0.1-preview.22
+
+# Different fork
+.\scripts\install-latest-preview.ps1 -Repo someone/pty-speak-fork
+```
+
+The script prints each step (querying tag, downloading, unblocking,
+running) to stdout — NVDA users can follow along by ear.
+
+Once Stage 11 (auto-update via Velopack delta nupkgs) ships, this
+script becomes unnecessary for in-place updates: pressing
+`Ctrl+Shift+U` from inside the running app will fetch a
+~KB-sized delta and restart automatically.

--- a/scripts/install-latest-preview.ps1
+++ b/scripts/install-latest-preview.ps1
@@ -1,0 +1,80 @@
+# Downloads and installs a pty-speak preview release.
+#
+# Use case: iterating on Stage 4+ preview builds, where the
+# normal "open the GitHub Release page, navigate to the asset
+# list, find Setup.exe, click 'Run anyway' through SmartScreen"
+# flow is several screen-reader steps per iteration. This
+# script collapses that into one command and strips the
+# Mark-of-the-Web (MOTW) tag so SmartScreen doesn't prompt at
+# all.
+#
+# Examples:
+#   .\install-latest-preview.ps1
+#   .\install-latest-preview.ps1 -Tag v0.0.1-preview.22
+#
+# Notes:
+#   * `Unblock-File` removes the alternate data stream
+#     (Zone.Identifier) that Windows attaches to internet
+#     downloads. SmartScreen uses that stream to decide
+#     whether to prompt; once it's gone the unsigned
+#     installer launches without the "Windows protected your
+#     PC" dialog. (Windows Defender's reputation system can
+#     still prompt for genuinely-untrusted executables but
+#     in practice this script handles the unsigned-preview
+#     case cleanly.)
+#   * Velopack installers are per-user and write to
+#     `%LocalAppData%\pty-speak\`. No admin / UAC prompt is
+#     expected. If one appears, the installer is targeting
+#     `Program Files` — that'd be a packaging regression to
+#     file.
+#   * Once Stage 11 (auto-update) ships, this script becomes
+#     unnecessary for in-place updates: `Ctrl+Shift+U` from
+#     inside the running app will fetch a ~KB-sized delta
+#     and restart in ~2 seconds.
+
+[CmdletBinding()]
+param(
+    # Specific release tag to install (e.g. `v0.0.1-preview.22`).
+    # Omit to install the most recently published release.
+    [string]$Tag = "",
+
+    # Repository to pull from. Override only if you've forked.
+    [string]$Repo = "KyleKeane/pty-speak"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $Tag) {
+    Write-Host "Querying latest release tag for $Repo..."
+    $latest = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases?per_page=1"
+    if (-not $latest -or $latest.Count -eq 0) {
+        throw "No releases found for $Repo."
+    }
+    $Tag = $latest[0].tag_name
+}
+
+Write-Host "Tag: $Tag"
+
+$assetName = "pty-speak-win-Setup.exe"
+$url = "https://github.com/$Repo/releases/download/$Tag/$assetName"
+$path = Join-Path $env:TEMP $assetName
+
+Write-Host "Downloading $assetName to $path..."
+Invoke-WebRequest -Uri $url -OutFile $path
+
+if (-not (Test-Path $path)) {
+    throw "Download appeared to succeed but file is missing at $path."
+}
+
+$bytes = (Get-Item $path).Length
+if ($bytes -lt 50000000) {
+    Write-Warning "Setup.exe is only $bytes bytes (expected ~60-70 MB for a self-contained .NET 9 publish). The download may be truncated; consider re-running."
+}
+
+Write-Host "Removing Mark-of-the-Web so SmartScreen doesn't prompt..."
+Unblock-File $path
+
+Write-Host "Running installer..."
+Start-Process $path -Wait
+
+Write-Host "Done. Launch pty-speak from the Start menu."


### PR DESCRIPTION
## Summary

Maintainer feedback during Stage 4 NVDA smoke loops: each iterative preview install was several screen-reader steps (open release page → navigate asset list → activate `Setup.exe` → "More info" → "Run anyway" → wait), and SmartScreen prompts on every unsigned-preview install added friction on top of friction.

This adds `scripts/install-latest-preview.ps1`, a one-command PowerShell installer:

```powershell
.\scripts\install-latest-preview.ps1                      # Latest release
.\scripts\install-latest-preview.ps1 -Tag v0.0.1-preview.22  # Specific tag
```

What it does:

1. Queries `api.github.com/repos/KyleKeane/pty-speak/releases?per_page=1` for the latest tag (or uses `-Tag` if given).
2. Downloads `pty-speak-win-Setup.exe` to `%TEMP%`.
3. Validates the download is ≥ ~50 MB (catches truncation — a real self-contained .NET 9 publish is ~60–70 MB).
4. Calls `Unblock-File` to strip the Mark-of-the-Web alternate data stream. SmartScreen uses MOTW to decide whether to prompt; without it the unsigned preview installer runs without the "Windows protected your PC" dialog.
5. Runs the installer with `Start-Process -Wait` so the script blocks until install completes.

Each step prints a status line so NVDA users can follow along by ear. `$ErrorActionPreference = "Stop"` so download / file failures throw rather than silently producing a corrupt install.

Companion changes:
- New `scripts/README.md` as the index of repo-local utility scripts; reserves the directory for future tooling.
- `README.md` project layout gains a `scripts/` row; Quick links gets a pointer to the script and its README so future contributors don't miss it.
- CHANGELOG entry under `[Unreleased]` / Added.

## Forward note

Once Stage 11 (auto-update via Velopack delta nupkgs) ships, this script becomes unnecessary for in-place updates: pressing `Ctrl+Shift+U` from inside the running app will fetch a ~KB-sized delta and restart in ~2 seconds. The script is the bridge until that lands.

## Test plan

- [ ] CI passes (markdown link check, actionlint, build+test) — pure additive change, no behaviour impact.
- [ ] Maintainer runs the script on Windows once Stage 4 preview.22 is published. Pass conditions: NVDA reads "Querying...", "Downloading...", "Removing Mark-of-the-Web...", "Running installer...", "Done"; installer runs without SmartScreen prompt; pty-speak is launchable from Start menu afterwards.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_