### PR TITLE
docs(roadmap): re-prioritise Stage 11 (auto-update) to land next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **Stage 11 (Velopack auto-update) re-prioritised to land
+  immediately after Stage 4, ahead of Stages 5-10.** The original
+  ordering put Stage 11 last because auto-update is feature
+  completeness rather than core functionality. Stage 4's manual
+  NVDA verification cycle made the recurring cost of install
+  friction visible — each iterative preview is download →
+  SmartScreen prompts → install, several screen-reader steps per
+  loop. Stage 11 has no architectural dependency on Stages 5-10
+  (`UpdateManager` is independent of streaming notifications,
+  keyboard input routing, list detection, earcons, and review
+  mode), so moving it forward amortises the friction across all
+  remaining stages. `docs/ROADMAP.md`'s Phase 1 table now lists
+  Stage 11 as "next" with a "Stage ordering" subsection capturing
+  the rationale; `docs/SESSION-HANDOFF.md` "Where we left off"
+  and a new "Stage 11 implementation sketch" replace the old
+  Stage 4 next-pointer (Stage 4 is fully merged on `main` as of
+  PR #60); `spec/tech-plan.md` §11 gains an implementation-order
+  note at the top (the spec content itself is unchanged — only
+  the order of execution shifts). The standalone
+  `scripts/install-latest-preview.ps1` (PR #61) is the bridge
+  until Stage 11 lands and is documented as deprecated for
+  in-place updates once it does.
+
 ### Added
 
 - **`scripts/install-latest-preview.ps1` — one-command preview

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,14 +38,14 @@ for ANSI color/style changes.*
 | 1     | ConPTY hello world                     | `dir` bytes returned from cmd.exe via PTY       | merged on `main` |
 | 2     | VT500 parser                           | Golden tests + FsCheck never-throws property    | merged on `main` |
 | 3     | Screen model + WPF rendering           | `cmd` runs visibly inside the WPF window        | merged on `main` (split as 3a + 3b — see [`docs/CHECKPOINTS.md`](CHECKPOINTS.md)) |
-| 4     | First UIA provider (text exposure)     | NVDA review cursor reads the buffer             | next — split into spike + 4a/4b/4c per [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md#stage-4-implementation-sketch) |
+| 4     | First UIA provider (text exposure)     | NVDA review cursor reads the buffer             | merged on `main` (PRs #54-#56, #59, #60); awaiting external NVDA verification on the preview that bundles them |
+| 11    | Velopack auto-update                   | `Ctrl+Shift+U` updates from GitHub Releases     | **next** (re-prioritised — see "Stage ordering" note below) |
 | 5     | Streaming output notifications         | NVDA reads `dir` line by line; spinner doesn't flood | pending |
 | 6     | Keyboard input to PTY                  | PowerShell, vim, Ctrl+C all work; NVDA keys still work | pending |
 | 7     | Run Claude Code end-to-end             | Roundtrip prompt → response, NVDA reads it      | pending |
 | 8     | Interactive list detection + UIA list  | Selection prompt announced as listbox           | pending |
 | 9     | Earcons (NAudio) + color announcement  | Red plays alarm; Ctrl+Shift+M mutes             | pending |
 | 10    | Review mode + structured navigation    | `e` jumps to next error in scrollback           | pending |
-| 11    | Velopack auto-update                   | `Ctrl+Shift+U` updates from GitHub Releases     | pending |
 
 A stage in CI green and an internal test pass earns a `vX.Y.Z-preview.N`
 prerelease. A stage with a successful external NVDA validation pass
@@ -53,6 +53,31 @@ earns a non-prerelease tag.
 
 For the canonical list of stable rollback points (one per shipped
 stage), see [`docs/CHECKPOINTS.md`](CHECKPOINTS.md).
+
+### Stage ordering
+
+The original ordering put Stage 11 (Velopack auto-update) last because
+auto-update is feature-completeness rather than core functionality.
+After Stage 4's manual-NVDA verification cycle made the install
+friction's recurring cost visible (each iterative preview is
+download → SmartScreen prompts → install, several screen-reader
+steps per loop), Stage 11 was re-prioritised to land **next** —
+ahead of Stages 5-10. The justification:
+
+- Stage 11 has **no architectural dependency** on Stages 5-10. It's
+  Velopack's `UpdateManager` API + a `KeyBinding` on the Window's
+  `InputBindings`; both are independent of streaming notifications,
+  keyboard input routing, list detection, earcons, or review mode.
+- Every subsequent stage will need its own NVDA verification loop,
+  and each loop pays the install-friction tax under the current
+  flow. Shipping Stage 11 first amortises that cost across all
+  remaining stages.
+- The standalone `scripts/install-latest-preview.ps1` (PR #61) is
+  the bridge until Stage 11 lands; once it does, that script is
+  deprecated for in-place updates.
+
+Stage 4's verification can complete in parallel with Stage 11
+shipping — they don't block each other.
 
 ## Phase 2 — accessibility depth (v0.2.0 onward)
 

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -19,19 +19,19 @@ A new session should read this **first**, then
 
 | | |
 |---|---|
-| **Last merged stage** | Stage 3b (WPF `TerminalView` + end-to-end `ConPtyHost → Parser → Screen → TerminalView`) |
-| **Last shipped release** | [`v0.0.1-preview.18`](https://github.com/KyleKeane/pty-speak/releases/tag/v0.0.1-preview.18) — first preview cut from Stage 3b state. Maintainer has installed the build and confirmed `cmd.exe` runs under ConPTY end-to-end. (`preview.16` and `.17` were burned by the `## [<version>]` CHANGELOG-matching gate before #37 relaxed it; both retag the same `db44d6d` commit and were never shipped artifacts.) |
-| **Stage-3b smoke status** | Resolved on `main` pending visual reverification on the next preview. The "second window" the maintainer saw on `v0.0.1-preview.18` was the parent `Terminal.App.exe` itself (the `OutputType=Exe` setting put it in the Windows console subsystem, so Windows allocated a conhost at startup before any of our code ran). The ConPTY child setup checked out clean against Microsoft's canonical sample — none of the four hypotheses originally listed in [Issue #39](https://github.com/KyleKeane/pty-speak/issues/39) was the actual cause. Fix landed in PR #44 (`OutputType=WinExe`); next preview release is the smoke target. |
-| **In-flight branch** | None. Pre-Stage-4 fixes (#41 test/CI hygiene, #43 Velopack manifest globs, #44 WPF subsystem) and docs (#40 ESC-byte convention) all merged. |
-| **Next stage** | **Stage 4** — UIA exposure (first NVDA milestone). Substrate (`Screen.SequenceNumber` + `Screen.SnapshotRows`) shipped in PR #38; threading boundary is in place; `tests/Tests.Ui/` is reserved for FlaUI integration tests that this stage adds. See sketch below. |
+| **Last merged stage** | Stage 4 — UIA exposure: `TerminalAutomationPeer` Document role + Text pattern via `AutomationPeer.GetPattern` override + Line/Character review-cursor navigation + `MainWindow.Loaded` focuses `TerminalSurface` (PRs #54-#56, #59, #60). |
+| **Last shipped release** | `v0.0.1-preview.22` (the build the maintainer is testing now). Earlier preview.21 install smoke surfaced the focus-on-Window bug fixed in PR #60; preview.22 is the verification target. |
+| **In-flight branch** | None. Stage 4 fully merged on `main`; Stage-4 NVDA verification is happening on preview.22 in parallel with Stage-11 prep. |
+| **Next stage** | **Stage 11 (re-prioritised) — Velopack auto-update.** The original ordering put Stage 11 last, but Stage 4's NVDA verification cycle made the install friction's recurring cost visible (each iterative preview is download → SmartScreen prompts → install, several screen-reader steps per loop). Stage 11 has no architectural dependency on Stages 5-10, so it's been moved forward to amortise the install-friction tax across all remaining stages. See `docs/ROADMAP.md` "Stage ordering" for the rationale; the implementation sketch is the existing `spec/tech-plan.md` §11. The standalone `scripts/install-latest-preview.ps1` (PR #61) is the bridge until Stage 11 lands. |
 
-The end-to-end pipeline is wired: launching the app spawns `cmd.exe`
-under ConPTY, parses its output, applies VtEvents to a 30×120
-`Screen`, and renders the buffer in a custom WPF `FrameworkElement`.
-The maintainer has installed `v0.0.1-preview.18` and confirmed text
-appears in the WPF window. The `OutputType=Exe` defect that produced
-the empty parent-process console is fixed on `main`; visual smoke
-on a fresh preview will confirm a single window at launch.
+The end-to-end pipeline is wired through Stage 4: launching the app
+spawns `cmd.exe` under ConPTY, parses its output, applies VtEvents
+to a 30×120 `Screen`, renders the buffer in a custom WPF
+`FrameworkElement`, and exposes that buffer to NVDA via UIA Document
+role + Text pattern with working Line / Character / Document review-
+cursor navigation. The maintainer has installed `v0.0.1-preview.22`
+and is running the manual smoke matrix Stage-4 rows in parallel
+with Stage-11 implementation prep.
 
 ## Pending action items (maintainer)
 
@@ -221,7 +221,85 @@ all validation happens in CI on `windows-latest`. Implications:
   aware of this and will say "try smaller actions" if a long write
   hangs.
 
-## Stage 4 implementation sketch
+## Stage 11 implementation sketch (next)
+
+Stage 11 was re-prioritised to land next — see "Where we left off"
+and `docs/ROADMAP.md` "Stage ordering" for the rationale.
+`spec/tech-plan.md` §11 has the full spec; this sketch is the
+pre-digested implementation plan.
+
+**Goal:** `Ctrl+Shift+U` from inside the running app downloads the
+next preview's delta nupkg and restarts within ~2 seconds, with
+NVDA progress announcements throughout. Replaces the standalone
+`scripts/install-latest-preview.ps1` for in-place updates.
+
+**Implementation outline:**
+
+1. Add `Velopack` NuGet reference to `Terminal.App.fsproj`
+   (already in scope per `spec/tech-plan.md` §0; the reference may
+   already be transitive through the Velopack tooling, verify
+   first).
+
+2. In `Terminal.App/Program.fs`, replace the existing bare
+   `VelopackApp.Build().Run()` with the full update protocol:
+   - `VelopackApp.Build().Run()` stays first (must run before any
+     WPF type loads — Velopack issue #195).
+   - After WPF startup, construct `UpdateManager` pointing at the
+     GitHub Releases source for our channel.
+   - On `Ctrl+Shift+U`, kick a background task that calls
+     `CheckForUpdatesAsync` → `DownloadUpdatesAsync` (with progress
+     callback) → `ApplyUpdatesAndRestart`.
+
+3. Wire the keybinding via `MainWindow.xaml`'s `InputBindings`
+   (a `KeyBinding` with `Modifiers="Control+Shift"` and `Key="U"`).
+   Or in code-behind on `MainWindow.xaml.cs`. The keybinding must
+   not pass through to the PTY (Stage 6's input pipeline isn't
+   shipped yet but design for forward compat).
+
+4. NVDA progress announcements: each phase ("Checking for
+   updates", "Downloading X.Y.Z", "X% downloaded", "Restarting")
+   raises a UIA Notification event with `displayString` set. The
+   Stage 4 `TerminalAutomationPeer` is the natural raise point —
+   it's already focused per PR #60.
+
+5. Failure surfaces (no update available, network failure,
+   signature mismatch once signing returns): each becomes a
+   distinct NVDA announcement, never a silent failure. Use
+   structured error matching on Velopack's exceptions, not
+   string contains.
+
+6. FlaUI integration test in `tests/Tests.Ui/`: launch the app,
+   send Ctrl+Shift+U via UIA `IInvokeProvider` or keyboard
+   simulation, assert the Notification event fires. Don't
+   assert actual download/restart in CI (that needs a real
+   GitHub release to exist) — file as a manual smoke row.
+
+7. Manual smoke matrix row in `docs/ACCESSIBILITY-TESTING.md`
+   Stage 11 section already exists; the diagnostic decoder I
+   added in PR #58 covers the failure modes.
+
+**Pitfalls already captured in `spec/tech-plan.md` §11.5:**
+- Don't request elevation (Velopack discussion #8 — manifest must
+  be `asInvoker`).
+- `VelopackApp.Build().Run()` MUST be first, or you get the
+  endless restart loop from Velopack issue #195.
+- Test installer flow on a clean VM (the Stage-4 manual matrix
+  installer pass already does this).
+
+**Scope discipline:** Stage 11 is one PR. If during implementation
+we discover Velopack's API needs more glue than expected, that's
+a sign to spike first (the same Stage-4 spike-then-PR pattern
+that worked for PRs #51-#56). Don't combine Stage 11 with Stage 5
+or any other stage.
+
+## Stage 4 implementation sketch (shipped — retained as reference)
+
+> **Status:** all of Stage 4 has merged on `main` as of PR #60.
+> The sketch below is the pre-digested execution plan that drove
+> PRs #54-#56 + #59 + #60; it's preserved as reference for the
+> architectural reasoning (especially the WM_GETOBJECT vs
+> AutomationPeer.GetPattern pivot in PR #56) but is no longer the
+> active plan.
 
 `spec/tech-plan.md` §4 has the full spec; the spec is immutable per
 the documentation policy. This sketch is the pre-digested

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -637,6 +637,22 @@ When focus reaches an item, build a snapshot range, raise `RaiseAutomationEvent(
 
 ## Stage 11 — Velopack auto-update
 
+> **Implementation order note (post-Stage-4):** Stage 11 was
+> originally listed last because auto-update is feature
+> completeness, not core functionality. It has been re-prioritised
+> to land **immediately after Stage 4** rather than after Stages
+> 5-10. Stage 4's NVDA verification cycle made the recurring cost
+> of manual install friction visible (each iterative preview is
+> several screen-reader steps to navigate the release page,
+> dismiss SmartScreen, run the installer). Stage 11 has no
+> architectural dependency on Stages 5-10 — the `UpdateManager`
+> API is independent of streaming notifications, keyboard input
+> routing, list detection, earcons, or review mode — so moving
+> it forward amortises the install-friction tax across all
+> subsequent stages without compromising the design. The spec
+> below is unchanged; only the order of execution has shifted.
+> See `docs/ROADMAP.md` "Stage ordering" for the rationale.
+
 **Goal.** Ship to GitHub Releases. User presses `Ctrl+Shift+U`; app checks for updates; reports progress audibly via UIA LiveRegion; restarts on apply.
 
 ### 11.1 Velopack from F#


### PR DESCRIPTION
## Summary

Maintainer feedback during Stage 4 NVDA verification: install friction (download → SmartScreen prompts → install on every iterative preview) is a meaningful tax on verification throughput, and that tax compounds across every subsequent stage's manual smoke pass.

Stage 11 (Velopack auto-update) was originally listed last because auto-update is feature completeness rather than core functionality. But Stage 11 has **no architectural dependency** on Stages 5–10:

- Velopack `UpdateManager` API is independent of streaming notifications (Stage 5), keyboard input routing (Stage 6), list detection (Stage 8), earcons (Stage 9), or review mode (Stage 10).
- The `Ctrl+Shift+U` keybinding goes through WPF Window `InputBindings`, not the future Stage 6 keyboard pipeline.
- NVDA progress announcements use the existing `TerminalAutomationPeer`'s notification raise path — already in place from Stage 4.

Moving Stage 11 forward amortises install friction across all remaining stages without compromising the design. Stage 4's NVDA verification can complete in parallel with Stage 11 shipping — they don't block each other.

## What this PR changes (docs only)

- `docs/ROADMAP.md` Phase 1 table reorders Stage 11 to the row immediately after Stage 4, marks Stage 11 as "next", marks Stage 4 as "merged on main, awaiting external NVDA verification". New "Stage ordering" subsection captures the rationale.
- `docs/SESSION-HANDOFF.md` "Where we left off" replaces the Stage-3b/Stage-4 next-pointer with a Stage-11-next pointer that records preview.22 as the verification target. New "Stage 11 implementation sketch" section above the Stage 4 sketch (which is now annotated as shipped/reference).
- `spec/tech-plan.md` §11 gets an implementation-order note at the top. The spec content itself is unchanged per the immutable-spec policy — only the order of execution shifts, which the maintainer explicitly authorised.
- `CHANGELOG.md` entry under `[Unreleased]` / Changed describes the reorder and references the bridge script (PR #61) as the interim until Stage 11 ships.

No source code changes. The actual Stage 11 implementation follows in a subsequent PR; this is just the priority and documentation alignment.

## Test plan

- [ ] CI passes (markdown link check, actionlint, build+test) — pure docs change, no behaviour impact.
- [ ] Cross-references resolve: ROADMAP's "Stage ordering" → SESSION-HANDOFF's "Stage 11 implementation sketch" → spec/tech-plan.md §11 implementation-order note.
- [ ] No dead Stage-4 references in the "next stage" / current-priority pointers (Stage 4 is now annotated as merged-on-main).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_