### PR TITLE
fix(release): walk back through burned tags when fetching prior nupkg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,23 +88,44 @@ jobs:
         # build ships full-only — auto-update clients fall back to
         # downloading the entire ~66 MB package every time.
         #
-        # Find the most recently published GitHub Release that isn't
-        # the one currently being released, download its
-        # `*-full.nupkg` into releases/, and let the next step pick it
-        # up. Skips silently if no prior release exists (first release
-        # on the channel) — that's not an error.
+        # Walk through GitHub Releases in published-descending order
+        # until we find one that has a `*-full.nupkg` asset, then
+        # download it. The walk-back skips "burned" releases: tags
+        # whose workflow run failed before producing artifacts, so
+        # the release exists on GitHub but has no nupkg attached.
+        # `v0.0.1-preview.{14, 23, 24}` were all burned this way at
+        # various points in this project's history; without the
+        # walk-back, the next release after a burned tag fails this
+        # step trying to download a nonexistent asset.
+        #
+        # Skips silently with a "no prior nupkg anywhere" message
+        # if no release in the history has the asset (legitimate
+        # first release on a channel).
         run: |
           New-Item -ItemType Directory -Force -Path releases | Out-Null
           $currentTag = '${{ github.event.release.tag_name }}'
-          $priorTag = gh release list --limit 100 --json tagName,publishedAt `
+          $candidates = gh release list --limit 100 --json tagName,publishedAt `
             | ConvertFrom-Json `
             | Where-Object { $_.tagName -ne $currentTag } `
-            | Sort-Object publishedAt -Descending `
-            | Select-Object -First 1 -ExpandProperty tagName
+            | Sort-Object publishedAt -Descending
+          $priorTag = $null
+          foreach ($candidate in $candidates) {
+            $tag = $candidate.tagName
+            Write-Host "Checking $tag for *-full.nupkg..."
+            $assets = gh release view $tag --json assets --jq '[.assets[].name]' 2>$null `
+              | ConvertFrom-Json
+            if ($assets -and ($assets | Where-Object { $_ -match '-full\.nupkg$' })) {
+              $priorTag = $tag
+              Write-Host "  Found *-full.nupkg in $tag."
+              break
+            } else {
+              Write-Host "  $tag has no *-full.nupkg (likely a burned tag); skipping."
+            }
+          }
           if (-not $priorTag) {
-            Write-Host 'No prior release found; vpk pack will produce a full nupkg only (no delta).'
+            Write-Host 'No prior release in history has a *-full.nupkg. vpk pack will produce a full nupkg only (no delta).'
           } else {
-            Write-Host "Prior release: $priorTag. Downloading *-full.nupkg into releases/ for delta generation."
+            Write-Host "Downloading *-full.nupkg from $priorTag for delta generation."
             gh release download $priorTag --pattern '*-full.nupkg' --dir releases --clobber
             Write-Host 'Prior nupkg present:'
             Get-ChildItem -Path releases -Filter '*-full.nupkg' | Format-Table Name, Length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release workflow walks back through burned tags when
+  fetching the prior `*-full.nupkg`.** `v0.0.1-preview.24`
+  failed at the "Fetch prior release nupkg" step because the
+  most recent prior release (`preview.23`) was a burned tag
+  whose own workflow had failed at the target-branch gate, so
+  no `*-full.nupkg` was ever uploaded to it. The original step
+  picked the most recent prior release by publishedAt and
+  blindly tried to download the asset — exit 1 from `gh
+  release download` when no matching assets existed propagated
+  to the workflow as a failure. Replaced with a walk-back loop
+  that iterates releases in descending order and uses
+  `gh release view --json assets` to find the most recent one
+  that actually has a `*-full.nupkg`. Falls through to the
+  existing "no prior nupkg, ship full-only" path if no release
+  in the history has the asset (legitimate first release on a
+  channel). Resolves the failure mode that
+  `v0.0.1-preview.{14, 23, 24}` all hit at different points;
+  combined with PR #64's documentation strengthening, makes
+  burned tags a recoverable rather than cascading failure.
+
 ### Changed
 
 - **`docs/RELEASE-PROCESS.md` step 3 rewritten with explicit


### PR DESCRIPTION
## Summary

`v0.0.1-preview.24` failed at the "Fetch prior release nupkg" step. Root cause: the workflow picked `preview.23` as the prior release (most recent by publishedAt), but `preview.23` was a burned tag — its own workflow had failed at the target-branch gate before producing any artifacts, so no `*-full.nupkg` was ever uploaded. `gh release download` exited 1 with "no assets to download" and the workflow propagated the failure.

This is the **third time** the broader "burned tag in the release history" pattern has bitten us (`preview.14`, `.23`, `.24`). PR #64 strengthened the docs around the cause (target-branch misconfiguration); this PR makes the workflow itself robust to burned tags.

## Fix

Replace the brittle "pick most recent prior release" logic with a walk-back loop that iterates releases in `publishedAt`-descending order and uses `gh release view --json assets` to find the most recent one that **actually has** a `*-full.nupkg` attached. Falls through to the existing "no prior nupkg, ship full-only" path if no release in history has the asset (legitimate first release on a channel).

Net effect: a burned tag in the release history no longer cascades into a failed delta build. preview.25 (the next release after this PR merges) will produce a delta against `preview.22` (the most recent shipped predecessor with a full nupkg), instead of failing trying to read from `preview.24`.

## Test plan

- [ ] CI passes (markdown link check, actionlint, build+test) — the change is in the release workflow, which doesn't run on PRs, so we can't directly exercise the fix in this PR's CI. Build+test passes verify nothing else broke.
- [ ] After merge, maintainer cuts `v0.0.1-preview.25`. Workflow log should show:
  - "Checking v0.0.1-preview.24 for *-full.nupkg... v0.0.1-preview.24 has no *-full.nupkg (likely a burned tag); skipping."
  - "Checking v0.0.1-preview.23 for *-full.nupkg... v0.0.1-preview.23 has no *-full.nupkg (likely a burned tag); skipping."
  - "Checking v0.0.1-preview.22 for *-full.nupkg... Found *-full.nupkg in v0.0.1-preview.22."
  - "Downloading *-full.nupkg from v0.0.1-preview.22 for delta generation."
- [ ] preview.25 release ships with a `*-delta.nupkg` (delta generated against preview.22).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_