### PR TITLE
feat(ui): version suffix in window title + structured update-failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,46 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Window title and accessibility name now include the running
+  version.** `MainWindow.xaml.cs` reads
+  `AssemblyInformationalVersionAttribute` (which carries the
+  prerelease tag like `0.0.1-preview.26` because
+  `System.Version` doesn't) and sets `Title = "pty-speak {version}"`
+  + `AutomationProperties.Name = "pty-speak terminal {version}"`.
+  NVDA+T now reads the version, so users can audibly confirm
+  which build they're running — particularly important after
+  Stage 11's `Ctrl+Shift+U` self-update so the post-restart
+  announcement reflects the new version. Strips any
+  `+commit-sha` deterministic-build trailer from the
+  announcement to keep it clean. Closes the
+  "version-suffix-missing" follow-up logged in
+  `docs/SESSION-HANDOFF.md`.
+
 ### Fixed
+
+- **Update-failure announcements pattern-match on common
+  exception types instead of a single generic catch.**
+  `runUpdateFlow`'s `with` block now branches on:
+  - `HttpRequestException` → "Update check failed: cannot
+    reach GitHub Releases. Check your internet connection.
+    (...)" — the offline case, the most common failure for
+    end users on flaky connections.
+  - `TaskCanceledException` → "Update check timed out. Check
+    your internet connection and try Ctrl+Shift+U again." —
+    timeouts and dropped-mid-download.
+  - `IOException` → "Update could not be written to disk: ...
+    Free up space or check folder permissions in
+    %%LocalAppData%%\\pty-speak\\." — disk-side failures
+    during download or patch application.
+  - Catch-all for unexpected exceptions remains as
+    "Update failed: ...".
+  Replaces the single generic "Update failed: <ex.Message>"
+  that PR #63 shipped with a "later stage can pattern-match"
+  TODO comment. The user's offline-failure question on
+  preview.25 install made this concrete enough to
+  implement now.
 
 - **Release workflow walks back through burned tags when
   fetching the prior `*-full.nupkg`.** `v0.0.1-preview.24`

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -127,18 +127,42 @@ module Program =
                                 do! mgr.DownloadUpdatesAsync(updateInfo, progress)
                                 announce "Restarting to apply update..."
                                 mgr.ApplyUpdatesAndRestart(updateInfo)
-                    with ex ->
-                        // Distinct announcements per failure
-                        // class would need structured matching
-                        // on Velopack exceptions; for Stage 11
-                        // the simple "update failed: <reason>"
-                        // is enough for NVDA to surface the
-                        // problem audibly. A later stage can
-                        // pattern-match on specific Velopack
-                        // exception types (NetworkUnavailable,
-                        // SignatureMismatch, etc.) and
-                        // announce differently.
-                        announce (sprintf "Update failed: %s" ex.Message)
+                    with
+                    | :? System.Net.Http.HttpRequestException as ex ->
+                        // Network-layer failure: DNS resolution,
+                        // connection refused, TLS handshake, etc.
+                        // The most common case offline; surface it
+                        // explicitly so the user knows it's
+                        // recoverable by reconnecting rather than
+                        // a permanent app-state issue.
+                        announce
+                            (sprintf
+                                "Update check failed: cannot reach GitHub Releases. Check your internet connection. (%s)"
+                                ex.Message)
+                    | :? TaskCanceledException ->
+                        // Includes both explicit cancellation
+                        // and HTTP timeouts. Velopack uses
+                        // CancellationToken under the hood; a
+                        // dropped connection mid-download lands
+                        // here.
+                        announce
+                            "Update check timed out. Check your internet connection and try Ctrl+Shift+U again."
+                    | :? System.IO.IOException as ex ->
+                        // Disk-side failure during download or
+                        // applying the patch — typically
+                        // permission denied or out of disk.
+                        announce
+                            (sprintf
+                                "Update could not be written to disk: %s. Free up space or check folder permissions in %%LocalAppData%%\\pty-speak\\."
+                                ex.Message)
+                    | ex ->
+                        // Catch-all for the genuinely unexpected.
+                        // Specific Velopack exception types
+                        // (SignatureMismatch when signing returns,
+                        // etc.) can be split out as their failure
+                        // modes become observable.
+                        announce
+                            (sprintf "Update failed: %s" ex.Message)
 
                     updateInProgress <- false
                 }

--- a/src/Views/MainWindow.xaml.cs
+++ b/src/Views/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Interop;
 
 namespace PtySpeak.Views;
@@ -8,6 +10,37 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        // Inject the running assembly's informational version into
+        // both the visible Title and the AutomationProperties.Name
+        // (the latter is what NVDA reads on focus / NVDA+T). Lets
+        // the user audibly confirm which version is running —
+        // important after Stage 11's Ctrl+Shift+U self-update so
+        // the post-restart announcement reflects the new version.
+        //
+        // Uses `AssemblyInformationalVersionAttribute` rather than
+        // `Assembly.GetName().Version` because the System.Version
+        // type doesn't carry prerelease suffixes ("0.0.1-preview.26"
+        // is not a valid System.Version; it parses as 0.0.1.0).
+        // The release workflow's `dotnet publish /p:Version=...`
+        // step injects the InformationalVersion at build time from
+        // the GitHub release tag, so installed builds carry the
+        // exact version string the user can match against the
+        // GitHub Release page.
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            // Strip any "+commit-sha" suffix the build pipeline
+            // adds (SourceLink / deterministic build trailer);
+            // it's noise for the user's audible announcement.
+            var plusIdx = version.IndexOf('+');
+            if (plusIdx > 0) version = version.Substring(0, plusIdx);
+
+            Title = $"pty-speak {version}";
+            AutomationProperties.SetName(this, $"pty-speak terminal {version}");
+        }
 
         // Install the WM_GETOBJECT subclass hook as soon as the
         // HWND exists. SourceInitialized fires after CreateWindow


### PR DESCRIPTION
## Summary

Bundles two small Stage-11 follow-ups directly addressing observations from the preview.25 install smoke:

1. **Version suffix in window title and accessibility name** (closes the deferred `docs/SESSION-HANDOFF.md` follow-up).
2. **Structured pattern-matching on update-failure exception types** (directly answers the maintainer's question "is there a good failure mode if the app cannot connect to the Internet?").

## Change 1 — Version in title

`MainWindow.xaml.cs` reads `AssemblyInformationalVersionAttribute` (which carries prerelease tags like `0.0.1-preview.26` — `System.Version` doesn't) and sets:

```
Title = "pty-speak 0.0.1-preview.26"
AutomationProperties.Name = "pty-speak terminal 0.0.1-preview.26"
```

NVDA+T now reads the version, so you can audibly confirm which build is running. Particularly important after Stage 11's `Ctrl+Shift+U` self-update — the post-restart "pty-speak terminal {version}, document" announcement now reflects the new version, giving you a tangible signal the update flipped successfully.

Strips any `+commit-sha` deterministic-build trailer from the announcement to keep the audible string clean.

## Change 2 — Better update-failure messages

Replaces PR #63's single generic catch with branches for the failure modes most likely to surface for end users:

| Exception type | NVDA announcement |
|---|---|
| `HttpRequestException` | "Update check failed: cannot reach GitHub Releases. Check your internet connection. (...)" |
| `TaskCanceledException` | "Update check timed out. Check your internet connection and try Ctrl+Shift+U again." |
| `IOException` | "Update could not be written to disk: .... Free up space or check folder permissions in %LocalAppData%\\pty-speak\\." |
| Anything else | "Update failed: ..." (unchanged) |

Specific Velopack exception types (e.g. `SignatureMismatch` once signing returns before v0.1.0) can be split out as their failure modes become observable.

## Test plan

- [ ] CI build + test passes on `windows-latest`.
- [ ] After merge: cut `v0.0.1-preview.26`. From inside running preview.25, press `Ctrl+Shift+U`. Expected:
  - Pre-update: NVDA+T reads "pty-speak terminal 0.0.1-preview.25"
  - Update flow announces phases as before
  - Post-restart: NVDA+T reads "pty-speak terminal 0.0.1-preview.26" — audible confirmation of update success.
- [ ] Offline test: disconnect network, press `Ctrl+Shift+U`. Expected: "Update check failed: cannot reach GitHub Releases. Check your internet connection. (...)" — not raw .NET exception text.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_