### PR TITLE
feat(audit-cycle PR-B): pre-Stage-5 seams + Stage 6 spec ADR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,63 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Audit-cycle PR-B: pre-Stage-5 architectural seams +
+  Stage 6 spec ADR.** Two seams Stage 5+ contributors can
+  plug into without rebuilding the foundation:
+
+  1. **Parser-thread → UIA-peer notification channel.** New
+     `ScreenNotification` discriminated union in
+     `src/Terminal.Core/Types.fs` (`RowsChanged of int list
+     | ParserError of string`). `compose` in
+     `src/Terminal.App/Program.fs` constructs a bounded
+     `Channel<ScreenNotification>` (256 capacity, DropOldest)
+     and starts a consumer task that drains 1:1 onto the
+     existing `TerminalSurface.Announce` raise path
+     (PR #63). `startReaderLoop` now takes the channel
+     writer and publishes one `RowsChanged` per applied
+     event batch. Stage 5 inserts the coalescer (debounce
+     ~200ms, hash dedup, single notification per coalesced
+     batch) between the parser publish and the consumer
+     without changing the channel contract. Bonus: the
+     loop's previous `with | _ -> ()` exception swallow
+     becomes `ParserError` publish — closes the
+     cross-cutting "parser exceptions are silently
+     swallowed" gap from the audit. The "ConPTY child
+     failed to start" path also publishes `ParserError`
+     so users hear about it via NVDA rather than staring
+     at a silent terminal.
+
+  2. **`PreviewKeyDown` routing stub on `TerminalView`.**
+     New override in `src/Views/TerminalView.cs` plus a
+     public `AppReservedHotkeys` static list. The list
+     seeds with `Ctrl+Shift+U` (Stage 11 self-update,
+     shipped) and documents future entries as code comments
+     (`Ctrl+Shift+M` Stage 9, `Alt+Shift+R` Stage 10).
+     The override checks each reserved hotkey first and
+     leaves `e.Handled = false` so WPF's `InputBindings`
+     on the parent window can process the gesture before
+     any future PTY forwarding. No PTY forwarding happens
+     today — that's Stage 6 — but the seam is in place so
+     the contract is enforceable at review time when Stage
+     6 lands.
+
+  3. **`spec/tech-plan.md` §6 ADR amendment** (maintainer-
+     authorised; immutable-spec exception). Adds an "App-
+     reserved hotkey preservation contract" clause at the
+     top of Stage 6 making the contract normative: Stage 6's
+     keyboard layer MUST preserve every entry in
+     `TerminalView.AppReservedHotkeys` and MUST NOT mark
+     them `e.Handled = true`. The list and the spec clause
+     are co-equal sources of truth; new app-level hotkeys
+     append to both. Failure mode if violated is captured
+     in the spec text (silent loss of app-level hotkeys).
+
+  Companion PRs in the audit cycle: PR-A (docs truth-up,
+  shipped); PR-C (hygiene cleanup — MSAA delete +
+  InternalsVisibleTo + Stage 11 tests; queued).
+
 ### Changed
 
 - **Audit-cycle PR-A: documentation truth-up after Stage 4 +

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -378,6 +378,36 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 
 **Goal.** Typing into the WPF window sends correct VT byte sequences to the child. Arrow keys, Tab, Enter, Ctrl+C, Ctrl+L, Esc, function keys all work. NVDA shortcuts (anything with Insert/CapsLock) are NOT swallowed.
 
+> **App-reserved hotkey preservation contract** (ADR-style
+> amendment, audit-cycle PR-B 2026-05-01, maintainer-authorised
+> per the immutable-spec policy).
+>
+> Stage 6's keyboard layer MUST preserve every entry in the
+> `TerminalView.AppReservedHotkeys` list defined in
+> `src/Views/TerminalView.cs`. The list is the canonical source
+> of truth for app-level hotkeys; Stage 6's `PreviewKeyDown`
+> filter MUST NOT mark these key combinations
+> `e.Handled = true`, so WPF's `InputBindings` machinery on
+> the parent `MainWindow` processes them before any forwarding
+> to the PTY child.
+>
+> Initial entries (as of audit-cycle PR-B):
+>   - `Ctrl+Shift+U` — Stage 11 self-update (shipped, PR #63;
+>     bound in `setupAutoUpdateKeybinding` in
+>     `src/Terminal.App/Program.fs`).
+>
+> Future entries (declared as code comments today; activated
+> when their owning stage ships):
+>   - `Ctrl+Shift+M` — Stage 9 earcon mute toggle.
+>   - `Alt+Shift+R` — Stage 10 review-mode toggle.
+>
+> Failure mode if violated: app-level hotkeys silently stop
+> working — `Ctrl+Shift+U` no longer triggers self-update,
+> the user can no longer update the app from inside it
+> without going back to the install script. Catch this at
+> review time; reviewers must verify any Stage 6 keyboard-
+> filter PR honours the contract.
+
 ### 6.1 Capture model
 
 Use **two events** on the `TerminalView` ([Microsoft Learn: Input Overview](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/input-overview)):

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -34,16 +34,28 @@ module Program =
 
     /// Wire a freshly-spawned ConPtyHost into the screen + view. Spawns
     /// a single background task that pulls byte chunks off the host's
-    /// stdout channel, feeds them through the parser, and applies the
+    /// stdout channel, feeds them through the parser, applies the
     /// resulting VtEvents to the screen (on the WPF dispatcher thread
-    /// for Stage 3b — Stage 5 will move parser mutation onto a
-    /// dedicated thread with snapshot-on-render semantics).
+    /// for Stage 3b), and publishes a `RowsChanged` to the
+    /// notification channel so the UIA peer can `RaiseNotificationEvent`
+    /// for NVDA. Per the audit-cycle PR-B plan, this is the seam
+    /// Stage 5's coalescer plugs into: today every applied batch
+    /// produces one notification, and Stage 5 will insert a
+    /// debounce/dedup layer between this publish and the consumer
+    /// without changing the contract.
+    ///
+    /// Unexpected exceptions in the loop publish a `ParserError`
+    /// rather than being swallowed (closes the cross-cutting
+    /// "parser exceptions are silently swallowed" gap from the
+    /// audit). `OperationCanceledException` is still treated as
+    /// the normal shutdown path and not surfaced to the user.
     let private startReaderLoop
             (dispatcher: Dispatcher)
             (host: ConPtyHost)
             (parser: Parser)
             (screen: Screen)
             (view: TerminalView)
+            (notifications: System.Threading.Channels.ChannelWriter<ScreenNotification>)
             (ct: CancellationToken) : Task =
         Task.Run(fun () ->
             task {
@@ -60,10 +72,23 @@ module Program =
                                     dispatcher
                                         .InvokeAsync(Action(action))
                                         .Task
+                                // Stage 5 will refine "which rows
+                                // changed" once the coalescer lands;
+                                // for the seam we publish an empty
+                                // list (the consumer treats it as
+                                // "something changed, you decide what
+                                // to read"). A future revision can
+                                // compute the row-set from screen
+                                // sequence number deltas.
+                                let _ = notifications.TryWrite(RowsChanged [])
                                 ()
                 with
                 | :? OperationCanceledException -> ()
-                | _ -> ()
+                | ex ->
+                    let _ =
+                        notifications.TryWrite(
+                            ParserError(sprintf "Parser/reader loop: %s" ex.Message))
+                    ()
             } :> Task)
 
     /// Run the Velopack auto-update flow on a background task,
@@ -201,6 +226,60 @@ module Program =
         // user's first keypress.
         setupAutoUpdateKeybinding window
 
+        // Pre-Stage-5 seam (audit-cycle PR-B): bounded
+        // notification channel from the parser thread to the
+        // UIA peer. Today the consumer drains 1:1 onto
+        // `TerminalSurface.Announce`. Stage 5 will insert a
+        // coalescer between `startReaderLoop`'s publish and
+        // this consumer (debounce ~200ms, hash dedup, single
+        // notification per coalesced batch) without changing
+        // the channel's contract. The channel is bounded with
+        // DropOldest so a very fast parser can't grow the
+        // backlog without bound — rate-limiting at the source
+        // is Stage 5's job, but bounded-with-drop-oldest is
+        // the safe default for the seam.
+        let notificationChannel =
+            let opts =
+                System.Threading.Channels.BoundedChannelOptions(256,
+                    FullMode =
+                        System.Threading.Channels.BoundedChannelFullMode.DropOldest)
+            System.Threading.Channels.Channel.CreateBounded<ScreenNotification>(opts)
+
+        // Drain the channel onto the WPF dispatcher, calling
+        // `TerminalSurface.Announce` (which raises a UIA
+        // Notification event via the existing path PR #63
+        // wired for Stage 11). Each consumed notification
+        // produces one announcement.
+        let _ =
+            Task.Run(fun () ->
+                task {
+                    try
+                        let reader = notificationChannel.Reader
+                        let mutable keepGoing = true
+                        while keepGoing && not cts.Token.IsCancellationRequested do
+                            let! got = reader.WaitToReadAsync(cts.Token).AsTask()
+                            if not got then
+                                keepGoing <- false
+                            else
+                                let mutable peek = Unchecked.defaultof<ScreenNotification>
+                                while reader.TryRead(&peek) do
+                                    let msg =
+                                        match peek with
+                                        | RowsChanged _ ->
+                                            "Terminal output updated"
+                                        | ParserError s ->
+                                            sprintf "Terminal parser error: %s" s
+                                    let action () = window.TerminalSurface.Announce(msg)
+                                    let! _ =
+                                        window.Dispatcher
+                                            .InvokeAsync(Action(action))
+                                            .Task
+                                    ()
+                    with
+                    | :? OperationCanceledException -> ()
+                    | _ -> ()
+                } :> Task)
+
         let cfg : PtyConfig =
             { Cols = int16 ScreenCols
               Rows = int16 ScreenRows
@@ -214,9 +293,12 @@ module Program =
         window.Loaded.Add(fun _ ->
             match ConPtyHost.start cfg with
             | Error _ ->
-                // Stage 3b: silently ignore the failure for now —
-                // the empty terminal still renders. Stage 5 will add
-                // a UIA notification announcing the failure.
+                // Publish a ParserError so the user hears about
+                // ConPTY spawn failures via NVDA rather than
+                // staring at a silent empty terminal.
+                let _ =
+                    notificationChannel.Writer.TryWrite(
+                        ParserError "ConPTY child process failed to start.")
                 ()
             | Ok host ->
                 hostHandle <- Some host
@@ -227,11 +309,15 @@ module Program =
                         parser
                         screen
                         window.TerminalSurface
+                        notificationChannel.Writer
                         cts.Token
                 ())
 
         app.Exit.Add(fun _ ->
             try cts.Cancel() with _ -> ()
+            // Complete the writer so the consumer drain task
+            // exits cleanly when the channel runs dry.
+            try notificationChannel.Writer.TryComplete() |> ignore with _ -> ()
             match hostHandle with
             | Some h -> (h :> IDisposable).Dispose()
             | None -> ()

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -127,3 +127,30 @@ type Earcon =
 /// Accessibility markers / regions. Stage 6 expands this DU.
 type AccessibilityMarker =
     | Placeholder
+
+/// Notifications emitted by the parser/screen subsystem onto
+/// a `Channel<ScreenNotification>` consumed by the UIA peer
+/// for `RaiseNotificationEvent`. The audit-cycle PR-B added
+/// this DU as the **seam** Stage 5's coalescer plugs into:
+/// today every parser-applied batch produces one
+/// `RowsChanged`, and Stage 5 will insert a coalescer between
+/// the parser and this channel that batches / dedups /
+/// rate-limits without changing the channel's contract.
+///
+/// The companion `ParserError` case closes the cross-cutting
+/// "parser exceptions are silently swallowed" gap that the
+/// audit identified in `startReaderLoop`'s `with | _ -> ()`
+/// branch — instead of dropping unexpected exceptions, the
+/// reader publishes one and NVDA hears about it.
+type ScreenNotification =
+    /// Rows in the screen buffer changed since the last
+    /// notification. The list is the row indices that changed
+    /// in this batch (typically contiguous, but not required).
+    /// Stage 5's coalescer collapses many of these into one
+    /// before they reach the UIA peer.
+    | RowsChanged of int list
+    /// The parser / reader loop hit an unexpected exception
+    /// that would otherwise have been swallowed. Surfaced via
+    /// NVDA so the user knows something went wrong rather
+    /// than the terminal silently freezing.
+    | ParserError of string

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
+using System.Windows.Input;
 using System.Windows.Media;
 using Terminal.Accessibility;
 using Terminal.Core;
@@ -133,6 +134,79 @@ public class TerminalView : FrameworkElement
                 message,
                 "pty-speak.update");
         }
+    }
+
+    /// <summary>
+    /// App-reserved hotkey list. Stage 6 (keyboard input to PTY)
+    /// MUST preserve every entry here — its <c>PreviewKeyDown</c>
+    /// filter must NOT mark these key combinations
+    /// <c>e.Handled = true</c>, so WPF's <c>InputBindings</c>
+    /// machinery on the parent window processes them before any
+    /// forwarding to the PTY child. The corresponding clause in
+    /// <c>spec/tech-plan.md</c> §6 ("App-reserved hotkey
+    /// preservation contract") makes this contract normative.
+    ///
+    /// Each entry is documented with the stage that owns it and
+    /// the binding's command target. New app-level hotkeys
+    /// added in future stages append to this list AND the spec
+    /// §6 clause; the two are co-equal sources of truth.
+    /// </summary>
+    public static readonly (Key Key, ModifierKeys Modifiers, string Description)[]
+        AppReservedHotkeys =
+        [
+            // Stage 11 — Velopack auto-update (shipped, PR #63).
+            // Bound in `setupAutoUpdateKeybinding` in
+            // `src/Terminal.App/Program.fs`.
+            (Key.U, ModifierKeys.Control | ModifierKeys.Shift, "Stage 11 self-update"),
+
+            // Future entries (NOT yet bound; commented for
+            // forward-planning):
+            //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,
+            //    "Stage 9 earcon mute"),
+            //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,
+            //    "Stage 10 review-mode toggle"),
+        ];
+
+    /// <summary>
+    /// Pre-Stage-5 routing stub for keyboard input. Today this
+    /// override does nothing visible — Stage 6 (keyboard input
+    /// to PTY) will fill it in with the NVDA-modifier filter
+    /// and PTY-forwarding pipeline. The stub exists now to
+    /// guarantee that when Stage 6 lands, the
+    /// <see cref="AppReservedHotkeys"/> contract is honoured:
+    /// the override checks each reserved hotkey first and
+    /// leaves <c>e.Handled</c> alone for them, ensuring WPF's
+    /// <c>InputBindings</c> see them before any PTY forwarding.
+    ///
+    /// Until Stage 6 ships, no key forwarding happens at all
+    /// (the cmd.exe child receives no input) — that's the
+    /// pre-Stage-6 reality. NVDA review-cursor commands aren't
+    /// keyboard input to the PTY; they're handled by NVDA
+    /// itself and don't reach this method.
+    /// </summary>
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
+    {
+        base.OnPreviewKeyDown(e);
+
+        // App-reserved hotkey check: any match short-circuits
+        // and explicitly does NOT mark the event handled, so
+        // the parent Window's InputBindings can process the
+        // gesture and the corresponding command fires
+        // (Ctrl+Shift+U → runUpdateFlow today).
+        var pressedModifiers = Keyboard.Modifiers;
+        foreach (var (key, modifiers, _) in AppReservedHotkeys)
+        {
+            if (e.Key == key && pressedModifiers == modifiers)
+            {
+                // Explicitly leave Handled = false so
+                // InputBindings see this key combination.
+                return;
+            }
+        }
+
+        // No PTY forwarding until Stage 6 ships. Future Stage 6
+        // implementation must respect the reserved-hotkey
+        // contract (see spec/tech-plan.md §6).
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

PR-B of the audit cycle (per the maintainer-approved plan in `/root/.claude/plans/replicated-riding-sketch.md`). Two architectural seams Stage 5+ contributors plug into without rebuilding the foundation, plus the spec amendment that locks in the Stage 6 / Stage 11 keybinding contract.

## Seam 1 — parser-thread → UIA-peer notification channel

`src/Terminal.Core/Types.fs` gains `ScreenNotification` (`RowsChanged of int list | ParserError of string`).

`src/Terminal.App/Program.fs` `compose`:
- Constructs a bounded `Channel<ScreenNotification>` (256 capacity, DropOldest).
- Starts a consumer task that drains 1:1 onto the existing `TerminalSurface.Announce` raise path (PR #63), marshalling each item back to the WPF Dispatcher.
- Passes the writer to `startReaderLoop`.

`startReaderLoop`:
- Publishes `RowsChanged` per applied event batch.
- **Replaces `with | _ -> ()` with `ParserError` publish** — closes the cross-cutting "parser exceptions silently swallowed" finding from the audit. NVDA hears about it.
- ConPTY-spawn-failure path also publishes `ParserError`.

Stage 5's coalescer (debounce ~200ms, hash dedup, single notification per coalesced batch) inserts between the parser publish and the consumer drain **without changing the channel contract** — that's the seam this PR builds.

## Seam 2 — `PreviewKeyDown` routing stub on `TerminalView`

`src/Views/TerminalView.cs`:

- **`AppReservedHotkeys`**: `public static` array of `(Key, ModifierKeys, Description)`. Seeded with `(Ctrl+Shift+U, "Stage 11 self-update")`. Future entries documented as code comments awaiting their owning stage (`Ctrl+Shift+M` Stage 9, `Alt+Shift+R` Stage 10).
- **`OnPreviewKeyDown` override**: iterates `AppReservedHotkeys`; for any match returns without marking `e.Handled = true`. WPF's `InputBindings` on the parent Window then processes the gesture (today: `runUpdateFlow` for `Ctrl+Shift+U`).
- No PTY forwarding today — that's Stage 6's job. The seam exists so when Stage 6 lands, the contract is enforceable at review time.

## Spec ADR — `spec/tech-plan.md` §6

Maintainer-authorised exception to the immutable-spec policy. Adds an "App-reserved hotkey preservation contract" clause at the top of Stage 6 making the contract normative:

> Stage 6's keyboard layer MUST preserve every entry in the `TerminalView.AppReservedHotkeys` list. ... MUST NOT mark these key combinations `e.Handled = true`.

The list and the spec clause are co-equal sources of truth.

## Test plan

- [ ] CI passes (markdown link check, actionlint, build+test on windows-latest).
- [ ] Existing FlaUI tests still pass (Stage 4 + 11 verification chain unaffected).
- [ ] Manual smoke after merge + new preview cut: `Ctrl+Shift+U` self-update still works (the new PreviewKeyDown handler must NOT consume it). NVDA narrates "Terminal output updated" or "Terminal parser error: ..." periodically as the cmd.exe banner streams in.
- Tests for the new channel publish path are deliberately deferred to PR-C, which sets up the Program.fs factory-injection harness for `runUpdateFlow` testing.

## Cycle context

- PR-A (docs truth-up) — **merged**.
- PR-B (this) — pre-Stage-5 seams.
- PR-C (queued) — hygiene cleanup: MSAA delete + InternalsVisibleTo + Stage 11 `runUpdateFlow` tests.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_