### PR TITLE
test(audit-cycle PR-D): deferred-test burn-down (UpdateMessages + word-boundary helpers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,63 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Audit-cycle PR-D: deferred-test burn-down.** Closes the
+  largest test-coverage gap identified by the audit
+  (SESSION-HANDOFF.md item 6) and validates that PR-C's
+  `InternalsVisibleTo("PtySpeak.Tests.Unit")` wiring works
+  end-to-end. Two new test files in `tests/Tests.Unit/`:
+
+  - **`UpdateMessagesTests.fs`** — six unit tests for the
+    Stage 11 update-failure announcement mapping. PR-D
+    extracted the exception-to-message logic from
+    `runUpdateFlow`'s catch block into a pure function
+    `Terminal.Core.UpdateMessages.announcementForException :
+    exn -> string` so the regression class that matters
+    most (the user-visible NVDA announcement per failure
+    class) is testable without standing up an
+    `IUpdateManager` adapter to mock Velopack's concrete
+    type. Tests cover all four branches
+    (`HttpRequestException` → network message,
+    `TaskCanceledException` → timeout message,
+    `IOException` → disk message, catch-all → generic),
+    plus two defensive ordering tests that fail loudly if
+    a refactor accidentally moves the catch-all above the
+    specific branches.
+
+  - **`WordBoundaryTests.fs`** — fourteen unit tests for
+    `TerminalTextRange`'s word-boundary helpers
+    (`IsWordSeparator`, `WordEndFrom`, `NextWordStart`,
+    `PrevWordStart`). PR-D changed the four helpers from
+    `static member private` to `static member internal`
+    so Tests.Unit can reach them via PR-C's
+    `InternalsVisibleTo` declaration. The tests pin the
+    "whitespace-only word boundaries (paths read as one
+    word)" policy that PR #68 shipped — anyone tightening
+    `IsWordSeparator` to include punctuation will fail
+    these tests and have to update them deliberately.
+
+  Companion changes: `src/Terminal.App/Program.fs`
+  `runUpdateFlow` now calls
+  `UpdateMessages.announcementForException` instead of
+  inlining the match (no behaviour change, just relocation
+  for testability). `tests/Tests.Unit/Tests.Unit.fsproj`
+  gains `UseWPF=true` and a ProjectReference to
+  `Terminal.Accessibility` (needed to resolve the WPF
+  reference set transitively when reaching internal
+  helpers in that assembly).
+
+### Changed
+
+- **Audit-cycle PR-D: SESSION-HANDOFF.md cleanup.** Item 2
+  (Re-enable the GitHub MCP server) removed as obsolete —
+  the MCP has been working reliably for the last ~14 PRs
+  in this session, the original "occasionally disconnects
+  mid-session" concern has not recurred. Items 3-5
+  renumbered to 2-4. Item 6 (Stage 11 `runUpdateFlow`
+  test coverage) removed as shipped via this PR.
+
 ### Removed
 
 - **Audit-cycle PR-C: deleted dead-code MSAA fallback path

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -48,12 +48,7 @@ disconnects mid-session.
    3a-screen-model, 3b-wpf-rendering}`. Tags don't trigger any
    workflow; they're rollback handles only.
 
-2. **Re-enable the GitHub MCP server** in the next Claude Code thread
-   if it's not auto-reconnected. Without it the agent can't
-   programmatically check PR status, merge PRs, or post issue
-   comments — falls back to asking the maintainer.
-
-3. **Stage 4 + Stage 11 NVDA verification — complete except
+2. **Stage 4 + Stage 11 NVDA verification — complete except
    for one process-cleanup row.** The maintainer ran the
    relevant rows of
    [`docs/ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md)
@@ -121,7 +116,7 @@ disconnects mid-session.
    override regression on `TerminalAutomationPeer` per
    the Stage-4 diagnostic decoder.
 
-4. **Small CI / release timing optimisation pass** (low priority,
+3. **Small CI / release timing optimisation pass** (low priority,
    pure cleanup). Current CI per-PR job times are reasonable but
    not tight: actionlint ~12 s, markdown link check ~56 s,
    Build+test (windows-latest) ~2 min. Candidate trims that don't
@@ -149,7 +144,7 @@ disconnects mid-session.
    (it's the only thing that catches packaging regressions
    before release day).
 
-5. **Enable NuGet lock files (deferred from PR #41).** The
+4. **Enable NuGet lock files (deferred from PR #41).** The
    investigation in PR #41 settled on enabling
    `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>`
    in `Directory.Build.props` so `dotnet restore` writes a
@@ -171,43 +166,6 @@ disconnects mid-session.
    The `**/packages.lock.json` glob already in `ci.yml`'s cache
    key picks up the lock files automatically once they exist —
    no separate cache-key change needed.
-
-6. **Stage 11 `runUpdateFlow` test coverage** (deferred from
-   audit-cycle PR-C). The audit identified
-   `src/Terminal.App/Program.fs:runUpdateFlow` (~80 lines,
-   three exception branches) as the largest untested surface
-   in the codebase. PR-C scoped this out because the cheapest
-   test approach needs an `IUpdateManager` adapter wrapping
-   Velopack's concrete `UpdateManager` class so tests can
-   inject a fake — that's adapter scaffold large enough to
-   warrant its own focused PR. Recommended approach when
-   landing this:
-
-   - Define `IUpdateManager` in
-     `src/Terminal.App/Program.fs` (or a sibling F# file)
-     mirroring the methods used (`IsInstalled`,
-     `CheckForUpdatesAsync`, `DownloadUpdatesAsync`,
-     `ApplyUpdatesAndRestart`).
-   - Wrap Velopack's concrete `UpdateManager` in a
-     `VelopackUpdateManager : IUpdateManager` adapter.
-   - `runUpdateFlow` takes a factory (or the
-     `IUpdateManager` directly) so tests inject a fake.
-   - Tests in a new
-     `tests/Tests.Unit/UpdateFlowTests.fs` cover:
-     `HttpRequestException` → "cannot reach GitHub Releases";
-     `TaskCanceledException` → "Update check timed out";
-     `IOException` → "Update could not be written to disk";
-     repeat keypress while in-flight → dedup announcement.
-   - **Alternative (simpler)**: extract the
-     exception-to-message mapping into a pure function
-     `announcementForUpdateException : exn -> string` and
-     test that directly without mocking UpdateManager. This
-     covers the regression class that matters most (the
-     user-facing message for each exception class) without
-     the adapter scaffold cost. Either approach is
-     acceptable; pick based on whether other tests will
-     also need an `IUpdateManager` adapter (e.g. if Stage
-     11 grows new flows).
 
 ## Working conventions on this repo
 

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -218,7 +218,7 @@ type internal TerminalTextRange(
     /// single word, matching how most terminal users mentally
     /// parse paths and prompts. A future stage with a real
     /// SGR-aware tokenizer can refine this.
-    static member private IsWordSeparator(cell: Cell) : bool =
+    static member internal IsWordSeparator(cell: Cell) : bool =
         let n = cell.Ch.Value
         n = int ' ' || n = int '\t'
 
@@ -230,7 +230,7 @@ type internal TerminalTextRange(
     /// practice cmd.exe's output rarely produces wrap-words
     /// because cmd.exe's own rendering already breaks at
     /// row boundaries.
-    static member private WordEndFrom
+    static member internal WordEndFrom
             (rows: Cell[][]) (cols: int)
             (r: int) (c: int) : int * int =
         let mutable r = r
@@ -254,7 +254,7 @@ type internal TerminalTextRange(
     /// the first non-separator cell after that run. Returns
     /// `(rowCount, 0)` (one past the document) if no
     /// further word exists.
-    static member private NextWordStart
+    static member internal NextWordStart
             (rows: Cell[][]) (cols: int)
             (r: int) (c: int) : int * int =
         let mutable r = r
@@ -298,7 +298,7 @@ type internal TerminalTextRange(
     /// cells until either the cell BEFORE us is a separator
     /// or we hit `(0, 0)`. Returns `(0, 0)` if no earlier word
     /// boundary exists.
-    static member private PrevWordStart
+    static member internal PrevWordStart
             (rows: Cell[][]) (cols: int)
             (r: int) (c: int) : int * int =
         let mutable r = r

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -152,42 +152,22 @@ module Program =
                                 do! mgr.DownloadUpdatesAsync(updateInfo, progress)
                                 announce "Restarting to apply update..."
                                 mgr.ApplyUpdatesAndRestart(updateInfo)
-                    with
-                    | :? System.Net.Http.HttpRequestException as ex ->
-                        // Network-layer failure: DNS resolution,
-                        // connection refused, TLS handshake, etc.
-                        // The most common case offline; surface it
-                        // explicitly so the user knows it's
-                        // recoverable by reconnecting rather than
-                        // a permanent app-state issue.
-                        announce
-                            (sprintf
-                                "Update check failed: cannot reach GitHub Releases. Check your internet connection. (%s)"
-                                ex.Message)
-                    | :? TaskCanceledException ->
-                        // Includes both explicit cancellation
-                        // and HTTP timeouts. Velopack uses
-                        // CancellationToken under the hood; a
-                        // dropped connection mid-download lands
-                        // here.
-                        announce
-                            "Update check timed out. Check your internet connection and try Ctrl+Shift+U again."
-                    | :? System.IO.IOException as ex ->
-                        // Disk-side failure during download or
-                        // applying the patch — typically
-                        // permission denied or out of disk.
-                        announce
-                            (sprintf
-                                "Update could not be written to disk: %s. Free up space or check folder permissions in %%LocalAppData%%\\pty-speak\\."
-                                ex.Message)
-                    | ex ->
-                        // Catch-all for the genuinely unexpected.
-                        // Specific Velopack exception types
-                        // (SignatureMismatch when signing returns,
-                        // etc.) can be split out as their failure
-                        // modes become observable.
-                        announce
-                            (sprintf "Update failed: %s" ex.Message)
+                    with ex ->
+                        // Audit-cycle PR-D extracted the
+                        // exception → user-message mapping into
+                        // the pure `UpdateMessages.announcementForException`
+                        // function in Terminal.Core so the
+                        // four cases (HttpRequestException →
+                        // network message, TaskCanceledException →
+                        // timeout message, IOException → disk
+                        // message, catch-all → generic message)
+                        // are unit-testable without mocking
+                        // Velopack's UpdateManager. New Velopack
+                        // exception types (e.g. SignatureMismatch
+                        // when signing returns) get added as
+                        // discrete branches in that module; this
+                        // call site doesn't change.
+                        announce (UpdateMessages.announcementForException ex)
 
                     updateInProgress <- false
                 }

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="Screen.fs" />
+    <Compile Include="UpdateMessages.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Terminal.Core/UpdateMessages.fs
+++ b/src/Terminal.Core/UpdateMessages.fs
@@ -1,0 +1,56 @@
+namespace Terminal.Core
+
+open System
+open System.Net.Http
+open System.Threading.Tasks
+
+/// User-facing announcement messages for Stage 11's
+/// `runUpdateFlow` exception handler. Extracted from
+/// `src/Terminal.App/Program.fs` (audit-cycle PR-D) so the
+/// regression-class that matters most — the user-visible
+/// message NVDA narrates when an update fails — is
+/// unit-testable without standing up a Velopack mock.
+///
+/// Pure function. Takes the exception, returns the string.
+/// `runUpdateFlow`'s catch block calls this and pipes the
+/// result to `TerminalView.Announce`.
+module UpdateMessages =
+
+    /// Map an exception from the update flow to the
+    /// announcement string NVDA reads. The four cases
+    /// match what PR #66 introduced as structured handling:
+    ///
+    ///   * `HttpRequestException` — the most common case
+    ///     (network unreachable, DNS failure, TLS handshake,
+    ///     captive-portal Wi-Fi). Includes the inner message
+    ///     so the user can distinguish "no internet" from
+    ///     "GitHub is down."
+    ///   * `TaskCanceledException` — HTTP timeout or
+    ///     mid-download drop. Bare message; no `ex.Message`
+    ///     because the framework's text isn't user-friendly.
+    ///   * `IOException` — disk-side failure during download
+    ///     or apply. Includes inner message + a hint to free
+    ///     space or check `%LocalAppData%\pty-speak\`
+    ///     permissions.
+    ///   * Catch-all — anything else. Generic "Update
+    ///     failed" + the inner message so the user has a
+    ///     thread to pull on if they file an issue.
+    ///
+    /// New Velopack exception types (e.g. `SignatureMismatch`
+    /// once signing returns) get added here as discrete
+    /// branches before the catch-all when their failure mode
+    /// becomes observable.
+    let announcementForException (ex: exn) : string =
+        match ex with
+        | :? HttpRequestException ->
+            sprintf
+                "Update check failed: cannot reach GitHub Releases. Check your internet connection. (%s)"
+                ex.Message
+        | :? TaskCanceledException ->
+            "Update check timed out. Check your internet connection and try Ctrl+Shift+U again."
+        | :? System.IO.IOException ->
+            sprintf
+                "Update could not be written to disk: %s. Free up space or check folder permissions in %%LocalAppData%%\\pty-speak\\."
+                ex.Message
+        | _ ->
+            sprintf "Update failed: %s" ex.Message

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -7,6 +7,15 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <!--
+      Audit-cycle PR-D added Terminal.Accessibility (which has
+      UseWPF=true) as a project ref so we can unit-test its
+      `internal` word-boundary helpers. UseWPF here ensures
+      the WPF reference set resolves; tests don't directly
+      construct WPF types, but the F# compiler still needs
+      the references when it loads the dependency graph.
+    -->
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +23,8 @@
     <Compile Include="ConPtyHostTests.fs" />
     <Compile Include="VtParserTests.fs" />
     <Compile Include="ScreenTests.fs" />
+    <Compile Include="UpdateMessagesTests.fs" />
+    <Compile Include="WordBoundaryTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -30,6 +41,14 @@
     <ProjectReference Include="..\..\src\Terminal.Core\Terminal.Core.fsproj" />
     <ProjectReference Include="..\..\src\Terminal.Pty\Terminal.Pty.fsproj" />
     <ProjectReference Include="..\..\src\Terminal.Parser\Terminal.Parser.fsproj" />
+    <!--
+      Audit-cycle PR-D added Terminal.Accessibility so
+      WordBoundaryTests can reach `TerminalTextRange`'s
+      static internal helpers via the
+      `[<assembly: InternalsVisibleTo("PtySpeak.Tests.Unit")>]`
+      declaration PR-C added to Terminal.Accessibility.
+    -->
+    <ProjectReference Include="..\..\src\Terminal.Accessibility\Terminal.Accessibility.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.Unit/UpdateMessagesTests.fs
+++ b/tests/Tests.Unit/UpdateMessagesTests.fs
@@ -1,0 +1,77 @@
+module PtySpeak.Tests.Unit.UpdateMessagesTests
+
+open System
+open System.Net.Http
+open System.Threading.Tasks
+open Xunit
+open Terminal.Core
+
+/// Tests for `Terminal.Core.UpdateMessages.announcementForException`,
+/// the pure function PR-D extracted from `runUpdateFlow`'s catch
+/// block (audit-cycle follow-up; SESSION-HANDOFF.md item 6).
+/// The function maps an exception to the NVDA announcement
+/// string; these tests pin the contract per failure class so a
+/// future refactor that accidentally collapses the branches
+/// (or returns the wrong message for a class) fails CI loudly.
+
+[<Fact>]
+let ``HttpRequestException produces network-failure announcement with inner message`` () =
+    let inner = "Could not resolve host 'github.com'"
+    let ex = HttpRequestException(inner)
+    let msg = UpdateMessages.announcementForException ex
+    Assert.Contains("cannot reach GitHub Releases", msg)
+    Assert.Contains("Check your internet connection", msg)
+    Assert.Contains(inner, msg)
+
+[<Fact>]
+let ``TaskCanceledException produces timeout announcement without inner message`` () =
+    let ex = TaskCanceledException()
+    let msg = UpdateMessages.announcementForException ex
+    Assert.Contains("Update check timed out", msg)
+    Assert.Contains("Ctrl+Shift+U", msg)
+
+[<Fact>]
+let ``IOException produces disk-failure announcement with inner message and path hint`` () =
+    let inner = "The process cannot access the file because it is being used by another process."
+    let ex = System.IO.IOException(inner)
+    let msg = UpdateMessages.announcementForException ex
+    Assert.Contains("could not be written to disk", msg)
+    Assert.Contains(inner, msg)
+    // The path hint mentions %LocalAppData%\pty-speak\ — a
+    // user with NVDA can't see the path but it gives
+    // sighted helpers something to navigate to.
+    Assert.Contains("LocalAppData", msg)
+    Assert.Contains("pty-speak", msg)
+
+[<Fact>]
+let ``Generic exception falls through to catch-all with inner message`` () =
+    // Pick an exception type the function doesn't have a
+    // specific branch for. ArgumentException is unlikely to
+    // come from Velopack's update flow but exercises the
+    // catch-all branch.
+    let inner = "Unexpected internal state"
+    let ex = ArgumentException(inner)
+    let msg = UpdateMessages.announcementForException ex
+    Assert.StartsWith("Update failed:", msg)
+    Assert.Contains(inner, msg)
+
+[<Fact>]
+let ``HttpRequestException is matched specifically, not by the catch-all`` () =
+    // Defensive — if a refactor reorders the match arms and
+    // the catch-all moves above HttpRequestException, this
+    // test fails because the catch-all message starts with
+    // "Update failed:" but the HTTP-specific message starts
+    // with "Update check failed:".
+    let ex = HttpRequestException("test")
+    let msg = UpdateMessages.announcementForException ex
+    Assert.False(
+        msg.StartsWith("Update failed:"),
+        "HttpRequestException landed on the catch-all branch, not the specific one. Match-arm ordering regressed.")
+
+[<Fact>]
+let ``IOException is matched specifically, not by the catch-all`` () =
+    let ex = System.IO.IOException("test")
+    let msg = UpdateMessages.announcementForException ex
+    Assert.False(
+        msg.StartsWith("Update failed:"),
+        "IOException landed on the catch-all branch, not the specific one. Match-arm ordering regressed.")

--- a/tests/Tests.Unit/WordBoundaryTests.fs
+++ b/tests/Tests.Unit/WordBoundaryTests.fs
@@ -1,0 +1,164 @@
+module PtySpeak.Tests.Unit.WordBoundaryTests
+
+open System.Text
+open Xunit
+open Terminal.Core
+open Terminal.Accessibility
+
+/// Tests for `TerminalTextRange`'s word-boundary helpers
+/// (`IsWordSeparator`, `WordEndFrom`, `NextWordStart`,
+/// `PrevWordStart`). The audit-cycle's PR-D made these
+/// `static member internal` (were `static member private`)
+/// so Tests.Unit can reach them via the
+/// `InternalsVisibleTo("PtySpeak.Tests.Unit")` declaration
+/// PR-C added to Terminal.Accessibility.
+///
+/// These tests also serve as the validation that the
+/// InternalsVisibleTo wiring from PR-C is working
+/// end-to-end — if the test project can't resolve the
+/// internal helpers, it'd be a build failure, not a runtime
+/// fail, so the CI build step is the gate.
+
+let private mkCell (c: char) : Cell =
+    { Ch = Rune(int c); Attrs = SgrAttrs.defaults }
+
+/// Build a single-row Cell[][] padded with blanks to
+/// `cols` width. Convenient for testing word-boundary
+/// behaviour on representative terminal-output strings.
+let private mkRows (s: string) (cols: int) : Cell[][] =
+    let row = Array.init cols (fun i ->
+        if i < s.Length then mkCell s.[i] else Cell.blank)
+    [| row |]
+
+// ---------- IsWordSeparator ----------
+
+[<Fact>]
+let ``IsWordSeparator true for space`` () =
+    Assert.True(TerminalTextRange.IsWordSeparator(mkCell ' '))
+
+[<Fact>]
+let ``IsWordSeparator true for tab`` () =
+    Assert.True(TerminalTextRange.IsWordSeparator(mkCell '\t'))
+
+[<Fact>]
+let ``IsWordSeparator false for letter`` () =
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell 'a'))
+
+[<Fact>]
+let ``IsWordSeparator false for digit`` () =
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '7'))
+
+[<Fact>]
+let ``IsWordSeparator false for punctuation (path-as-word policy)`` () =
+    // Whitespace-only word boundaries: punctuation stays
+    // INSIDE the word so paths like `C:\Users\test>` read
+    // as one word for fast NVDA navigation. If this changes,
+    // docs/USER-SETTINGS.md "Word boundaries" needs to flip
+    // too.
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '.'))
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '\\'))
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell ':'))
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '-'))
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '_'))
+    Assert.False(TerminalTextRange.IsWordSeparator(mkCell '/'))
+
+// ---------- NextWordStart ----------
+
+[<Fact>]
+let ``NextWordStart from word interior advances to next word`` () =
+    let rows = mkRows "hello world test" 30
+    // Starting at column 2 ("ll" of hello"), should advance
+    // through the rest of "hello", skip the space, land on
+    // "w" of "world" at column 6.
+    let (r, c) = TerminalTextRange.NextWordStart rows 30 0 2
+    Assert.Equal(0, r)
+    Assert.Equal(6, c)
+
+[<Fact>]
+let ``NextWordStart from word start advances past current word`` () =
+    let rows = mkRows "hello world" 20
+    // Starting at column 0 ("h" of hello), advances to
+    // "w" of "world" at column 6.
+    let (r, c) = TerminalTextRange.NextWordStart rows 20 0 0
+    Assert.Equal(0, r)
+    Assert.Equal(6, c)
+
+[<Fact>]
+let ``NextWordStart from separator skips run and finds next word`` () =
+    let rows = mkRows "a   bcd" 20
+    // Starting at column 1 (the first space), should skip
+    // to "b" at column 4.
+    let (r, c) = TerminalTextRange.NextWordStart rows 20 0 1
+    Assert.Equal(0, r)
+    Assert.Equal(4, c)
+
+[<Fact>]
+let ``NextWordStart returns past-end when no more words`` () =
+    let rows = mkRows "a" 20
+    let (r, _) = TerminalTextRange.NextWordStart rows 20 0 0
+    // Single-row buffer, single word. Past the end means
+    // r >= rows.Length. With cols=20 the row is "a" + 19
+    // spaces; from inside "a" we walk through "a" then
+    // through the space run, then run off the end of the
+    // single row (r=1, which is past rows.Length=1).
+    Assert.True(r >= rows.Length, sprintf "Expected r >= %d (past document end); got r=%d" rows.Length r)
+
+// ---------- WordEndFrom ----------
+
+[<Fact>]
+let ``WordEndFrom on a word position returns one-past-last`` () =
+    let rows = mkRows "hello world" 20
+    // Starting at column 0 (start of "hello"), end is at
+    // column 5 (the space). One-past-the-last-cell-of-the-word.
+    let (r, c) = TerminalTextRange.WordEndFrom rows 20 0 0
+    Assert.Equal(0, r)
+    Assert.Equal(5, c)
+
+[<Fact>]
+let ``WordEndFrom on a separator returns same position (zero-width)`` () =
+    let rows = mkRows "a b" 20
+    // Starting at the space (col 1) returns the same
+    // position immediately because we're on a separator.
+    let (r, c) = TerminalTextRange.WordEndFrom rows 20 0 1
+    Assert.Equal(0, r)
+    Assert.Equal(1, c)
+
+[<Fact>]
+let ``WordEndFrom on a path-as-word treats punctuation as inside`` () =
+    let path = "C:\\Users\\test>"
+    let rows = mkRows path 30
+    // The whole path reads as one word — the first
+    // separator is at column len(path) (the trailing
+    // padding-blank).
+    let (r, c) = TerminalTextRange.WordEndFrom rows 30 0 0
+    Assert.Equal(0, r)
+    Assert.Equal(path.Length, c)
+
+// ---------- PrevWordStart ----------
+
+[<Fact>]
+let ``PrevWordStart from second word returns first word start`` () =
+    let rows = mkRows "hello world" 20
+    // Starting at column 6 ("w" of world), going back
+    // should land on column 0 ("h" of hello).
+    let (r, c) = TerminalTextRange.PrevWordStart rows 20 0 6
+    Assert.Equal(0, r)
+    Assert.Equal(0, c)
+
+[<Fact>]
+let ``PrevWordStart from origin returns origin`` () =
+    let rows = mkRows "hello" 20
+    // (0, 0) is the document origin; can't go back further.
+    let (r, c) = TerminalTextRange.PrevWordStart rows 20 0 0
+    Assert.Equal(0, r)
+    Assert.Equal(0, c)
+
+[<Fact>]
+let ``PrevWordStart from inside a word returns that word's start`` () =
+    let rows = mkRows "  hello world" 30
+    // Starting at column 5 (inside "hello", which begins
+    // at column 2 after the two leading spaces), going
+    // back lands on column 2.
+    let (r, c) = TerminalTextRange.PrevWordStart rows 30 0 5
+    Assert.Equal(0, r)
+    Assert.Equal(2, c)


### PR DESCRIPTION
## Summary

Burn-down PR D for the audit cycle (per the cleanup plan the maintainer approved). Closes SESSION-HANDOFF.md item 6 (Stage 11 `runUpdateFlow` test coverage) and validates that PR-C's `InternalsVisibleTo("PtySpeak.Tests.Unit")` wiring works end-to-end.

## What's added

**`src/Terminal.Core/UpdateMessages.fs`** (new): pure `announcementForException : exn -> string` extracted from `runUpdateFlow`'s catch block. Lives in Terminal.Core (no WPF / Velopack deps) so it's trivially unit-testable.

**`src/Terminal.App/Program.fs`**: catch block replaces the inline match with a call to the extracted function. No behaviour change.

**`src/Terminal.Accessibility/TerminalAutomationPeer.fs`**: four word-boundary helpers (`IsWordSeparator`, `WordEndFrom`, `NextWordStart`, `PrevWordStart`) changed from `static member private` to `static member internal` so Tests.Unit can reach them.

**`tests/Tests.Unit/UpdateMessagesTests.fs`** (new, 6 tests): pin all four announcement branches + two defensive ordering tests that catch a refactor accidentally moving the catch-all above the specific arms.

**`tests/Tests.Unit/WordBoundaryTests.fs`** (new, 14 tests): pin the whitespace-only word-boundary policy from PR #68. Anyone tightening `IsWordSeparator` to include punctuation will fail these tests and have to update them deliberately.

**`tests/Tests.Unit/Tests.Unit.fsproj`**: adds `UseWPF=true` and a ProjectReference to `Terminal.Accessibility`.

## SESSION-HANDOFF cleanup (bundled)

- Item 2 (GitHub MCP reconnection) **removed** — obsolete; MCP has worked reliably for the last ~14 PRs in this session.
- Items 3-5 **renumbered** to 2-4.
- Item 6 (Stage 11 tests) **removed** — shipped here.

After this PR + PR-E (queued, CI timing), the only open queued items are the four maintainer-only ones (baseline tags, Test 8 manual smoke, CI timing addressed by PR-E, NuGet lock files).

## Test plan

- [ ] CI passes — the 6 + 14 new unit tests run on `windows-latest`.
- [ ] Existing tests still pass (no regression in `ScreenTests`, `VtParserTests`, `ConPtyHostTests`, `SmokeTests`, `AutomationPeerTests`, `TextPatternTests`).
- [ ] `runUpdateFlow` still announces the right message for each exception type — runtime behaviour unchanged because the catch block now delegates to the extracted function.
- [ ] If you cut a fresh preview after this merges, `Ctrl+Shift+U` self-update still produces the structured failure messages from PR #66 / `docs/UPDATE-FAILURES.md`.

## Cycle context

- Audit-cycle PR-A (#71), PR-B (#72), PR-C (#73) — **merged**.
- This (PR-D) closes the test-coverage follow-up.
- PR-E (CI timing) is the last cleanup; queued.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_