### PR TITLE
chore(audit-cycle PR-E): cache ~/.dotnet/tools across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,24 @@ jobs:
         # restore step doesn't produce.
         run: dotnet publish src/Terminal.App/Terminal.App.fsproj --configuration Release --runtime win-x64 --self-contained true --output publish
 
+      - name: Cache Velopack CLI (vpk) global install
+        # Audit-cycle PR-E. Caches `~/.dotnet/tools` so the
+        # Velopack CLI doesn't re-download (~10s saved) on
+        # every run. Cache key is statically versioned (`v1`)
+        # rather than tied to a specific vpk version because
+        # `dotnet tool install -g vpk` (no --version) installs
+        # latest — the cache lives until vpk has a release we
+        # actually want to pull, at which point bump v1 → v2.
+        # PATH already includes ~/.dotnet/tools (setup-dotnet
+        # puts it there) so cached or fresh, `vpk` is callable.
+        id: cache-vpk
+        uses: actions/cache@v5
+        with:
+          path: ~/.dotnet/tools
+          key: ${{ runner.os }}-dotnet-tools-vpk-v1
+
       - name: Install Velopack CLI (vpk)
+        if: steps.cache-vpk.outputs.cache-hit != 'true'
         run: dotnet tool install -g vpk
 
       - name: Velopack pack smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,21 @@ jobs:
       - name: Publish (self-contained win-x64)
         run: dotnet publish src/Terminal.App/Terminal.App.fsproj -c Release -r win-x64 --self-contained -o publish /p:Version=${{ steps.version.outputs.version }}
 
+      - name: Cache Velopack CLI global install
+        # Audit-cycle PR-E. Mirrors the cache strategy in
+        # ci.yml's build job: caches `~/.dotnet/tools` so vpk
+        # doesn't re-download on every release run. The cache
+        # is shared across both workflows by using the same
+        # key. Bump v1 → v2 when we want to force-pull a new
+        # vpk version.
+        id: cache-vpk
+        uses: actions/cache@v5
+        with:
+          path: ~/.dotnet/tools
+          key: ${{ runner.os }}-dotnet-tools-vpk-v1
+
       - name: Install Velopack CLI
+        if: steps.cache-vpk.outputs.cache-hit != 'true'
         run: dotnet tool install -g vpk
 
       - name: Fetch prior release full nupkg for delta generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,33 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **Audit-cycle PR-E: cache `~/.dotnet/tools` across CI
+  runs.** Both `.github/workflows/ci.yml` (Build and test
+  job) and `.github/workflows/release.yml` (release-pack
+  job) now cache the global dotnet tools directory before
+  `dotnet tool install -g vpk`. The install step gates on
+  `cache-hit != 'true'` so a cached run skips the install
+  entirely. Saves ~10s per CI run. Cache key is statically
+  versioned (`v1`); bump to `v2` when a new vpk version is
+  wanted (the cache key change forces a fresh install,
+  which pulls latest from NuGet, then re-caches).
+
+  Two other CI optimisations from SESSION-HANDOFF item 3
+  investigated and **deferred**: merging the two
+  `gaurav-nelson/github-action-markdown-link-check` steps
+  into one invocation (the action doesn't support both
+  `folder-path` and `file-path`; combining would either
+  drop the `spec/` exclusion or require enumerating 14
+  files explicitly that would drift); release.yml audit
+  for vpk-pack input cache (per-build artefacts have no
+  cache opportunity) and gh-download 5xx retry (no flakes
+  observed yet, defer until a flake happens). Both
+  trade-offs are documented in `docs/SESSION-HANDOFF.md`
+  item 3 so a future contributor doesn't redo the
+  investigation.
+
 ### Added
 
 - **Audit-cycle PR-D: deferred-test burn-down.** Closes the

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -116,33 +116,43 @@ disconnects mid-session.
    override regression on `TerminalAutomationPeer` per
    the Stage-4 diagnostic decoder.
 
-3. **Small CI / release timing optimisation pass** (low priority,
-   pure cleanup). Current CI per-PR job times are reasonable but
-   not tight: actionlint ~12 s, markdown link check ~56 s,
-   Build+test (windows-latest) ~2 min. Candidate trims that don't
-   compromise the utility of any check:
+3. **CI / release timing optimisation — partial completion.**
+   Audit-cycle PR-E shipped the highest-leverage optimisation:
+   `~/.dotnet/tools` is now cached across CI runs in both
+   `ci.yml` and `release.yml`, so `dotnet tool install -g vpk`
+   no longer re-downloads (~10s saved per run). Cache key is
+   statically versioned; bump `v1 → v2` in the cache key
+   when a new vpk version is wanted.
 
-   - Merge the two sequential `gaurav-nelson/github-action-markdown-link-check`
-     steps in `markdown-link-check` into one invocation that
-     covers both `docs/` and the root markdown files. Saves one
-     Node container start (~15–20 s) without changing what's
-     checked.
-   - Cache the `dotnet tool install -g vpk` step in the build
-     job (the Velopack CLI is stable across runs). Today it
-     re-downloads on every CI run; ~10 s saved with a global
-     tools cache or by pinning vpk into a `dotnet-tools.json`
-     manifest restored under `~/.nuget/packages` cache.
-   - Audit `.github/workflows/release.yml` for the same kinds of
-     wins (e.g. is the `vpk pack` step's input directory
-     restored from cache? Does the prior-release nupkg fetch
-     from PR #45 retry on transient `gh` 5xx?).
+   Two candidate trims investigated and DEFERRED (low-value
+   relative to restructuring cost):
 
-   Constraint: do not weaken any check's effectiveness. Keep
-   `continue-on-error: true` on the link checks (they're
-   advisory by design); keep `--locked-mode` once NuGet lock
-   files land (item 5); keep the Velopack pack smoke step
-   (it's the only thing that catches packaging regressions
-   before release day).
+   - **Merge two `gaurav-nelson/github-action-markdown-link-check`
+     steps into one invocation.** The action takes either
+     `folder-path` OR `file-path` (not both), so combining
+     would require enumerating all 14 markdown files
+     explicitly OR scanning the whole repo (which would
+     break the deliberate `spec/` exclusion documented in
+     the workflow comments). Savings: ~15-20s. Cost:
+     either ugly file enumeration that drifts from reality
+     as docs are added, or losing the `spec/`-immutable
+     URLs exclusion. Not worth it; revisit if the action
+     gains a multi-folder option.
+
+   - **Audit `release.yml` for similar wins** (vpk pack
+     input cache, gh release-download retry on transient
+     5xx). The vpk-pack input is per-build artefacts (no
+     cache opportunity). The gh-fetch retry would help
+     on transient flakes but hasn't actually flaked in any
+     of our release runs to date — defer until a flake
+     happens. PR-E added a doc note in this file rather
+     than guess-coding for a non-issue.
+
+   Constraint preserved: `continue-on-error: true` on
+   link checks (advisory by design), Velopack pack smoke
+   step (catches packaging regressions before release
+   day), `--locked-mode` once NuGet lock files land
+   (item 4) all unchanged.
 
 4. **Enable NuGet lock files (deferred from PR #41).** The
    investigation in PR #41 settled on enabling


### PR DESCRIPTION
## Summary

Burn-down PR E for the audit cycle. Closes SESSION-HANDOFF.md item 3 (CI / release timing optimisation). The cleanup pattern: ship the highest-leverage optimisation, document the deferred candidates with rationale so the next contributor doesn't redo the investigation.

## What ships

Both `.github/workflows/ci.yml` (Build and test job) and `.github/workflows/release.yml` (release-pack job) gain an `actions/cache@v5` step before `dotnet tool install -g vpk`. The install gates on `cache-hit != 'true'` so cached runs skip the install entirely.

- Cache path: `~/.dotnet/tools`
- Cache key: `${{ runner.os }}-dotnet-tools-vpk-v1` (statically versioned; bump v1 → v2 in BOTH workflows when a new vpk version is wanted)
- Saves: **~10s per CI run** after the first cache populate

`PATH` is unaffected (setup-dotnet always adds `~/.dotnet/tools` to PATH).

## Investigated and deferred (with rationale)

Two other CI candidates from SESSION-HANDOFF item 3 investigated and rejected as not worth the restructuring cost:

1. **Merging the two `gaurav-nelson/github-action-markdown-link-check` steps.** The action doesn't support both `folder-path` and `file-path`. Combining would require either enumerating all 14 markdown files (drifts as docs are added) or scanning the whole repo (breaks the deliberate `spec/` exclusion). Savings ~15-20s; not worth losing the `spec/` exclusion that's intentionally documented in the workflow comments.

2. **Deeper `release.yml` audit (vpk-pack input cache, gh release-download 5xx retry).** The vpk-pack input is per-build artifacts (no cache opportunity). The gh-fetch 5xx retry would help on transient flakes but no flakes have been observed in any release run. Defer until a real flake happens.

Both rationales are documented in `docs/SESSION-HANDOFF.md` item 3 so a future contributor doesn't redo the investigation.

## Test plan

- [ ] CI passes (markdown link check, actionlint, build+test). The first run after merge populates the cache; the second run uses it.
- [ ] Time the build+test job before vs after — should drop by ~10s once the cache is hit on the second run.
- [ ] Existing manual + automated smoke unaffected — vpk binary itself is identical, just installed-once-cached.

## Cycle status

Audit cycle complete after this PR merges:

| PR | Concern | Status |
|---|---|---|
| #71 PR-A | docs truth-up | merged |
| #72 PR-B | pre-Stage-5 seams + spec ADR | merged |
| #73 PR-C | hygiene cleanup | merged |
| #74 PR-D | deferred-test burn-down | merged |
| this PR-E | CI timing optimisation | this PR |

All open queued items after this are maintainer-only (push baseline tags, Test 8 manual smoke, NuGet lock files).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_