### PR TITLE
security(sr-1): parser bounds against malicious input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,60 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Security
+
+- **Security audit cycle SR-1: parser bounds against malicious
+  input.** Closes three HIGH/MEDIUM findings from the
+  comprehensive code-level security audit. All three are
+  ANSI-bomb-class DoS protections — they don't change
+  behaviour for legitimate input, just cap the parser-state
+  accumulators so an adversarially-shaped byte stream
+  can't allocate without bound or wrap into negative
+  values.
+
+  - **`currentParam` int32 clamp at 65535** (alacritty / vte
+    parity). Input like `\x1b[999999999999999999m` previously
+    overflowed int32 to a negative SGR param; now it clamps.
+    Applied at both CSI and DCS digit-accumulation sites in
+    `src/Terminal.Parser/StateMachine.fs`.
+
+  - **`MAX_DCS_RAW = 4096` cap** on DCS payload emission.
+    `DcsPassthrough` now tracks `dcsTotalLen` and stops
+    emitting `DcsPut` events past the cap (DCS Hook + Unhook
+    pair still fires, so the framing stays intact). Matches
+    the ANSI-bomb resistance pattern Sixel / ReGIS terminal
+    emulators use.
+
+  - **OSC overflow transitions to `OscIgnore`.** Previously
+    the parser silently truncated OSC payloads at
+    `MAX_OSC_RAW = 1024` but stayed in `OscString`, where an
+    embedded `\x1B` in dropped bytes could be misread as ST
+    and desynchronise the state machine. New `OscIgnore`
+    sub-state mirrors the existing `DcsIgnore` pattern:
+    consumes bytes until ST/BEL terminator, then dispatches
+    an empty `OscDispatch`.
+
+  - **`Screen.csiDispatch` catch-all comment** documents that
+    response-generating sequences (DSR, DA1/2/3, DECRQM,
+    DECRQSS, CPR, title/font reports) are deliberately
+    dropped per `SECURITY.md` row TC-1. Reviewers are
+    instructed to block any PR that adds a handler in this
+    match without a matching `SECURITY.md` update.
+
+  Four new tests in `tests/Tests.Unit/VtParserTests.fs` pin
+  each contract: SGR param clamp returns non-negative;
+  8 KiB DCS payload produces ≤ 4096 `DcsPut` events with
+  Hook+Unhook intact; 8 KiB OSC payload dispatches once
+  with empty params; parser returns to `Ground` after OSC
+  overflow + terminator.
+
+  Companion PRs in this audit cycle (queued):
+  SR-2 (accessibility hardening: jagged-array bounds,
+  control-char `AnnounceSanitiser`, `Move` overflow guard);
+  SR-3 (`SECURITY.md` audit response: 6 new inventory rows
+  + cross-references). The full plan is in
+  `/root/.claude/plans/replicated-riding-sketch.md`.
+
 ### Changed
 
 - **Audit-cycle PR-E: cache `~/.dotnet/tools` across CI

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -197,7 +197,21 @@ type Screen(rows: int, cols: int) =
         | 'J' -> eraseDisplay p0Default0
         | 'K' -> eraseLine p0Default0
         | 'm' -> applySgr parms
-        | _ -> ()  // Unsupported CSI final — silently ignored
+        | _ ->
+            // Audit-cycle SR-1: this catch-all is intentional and
+            // SECURITY-CRITICAL. It silently drops final bytes
+            // for the response-generating sequences listed in
+            // SECURITY.md row TC-1 (DSR `n`, DA1/2/3 `c`, CPR
+            // built on DSR, DECRQM `$p`, DECRQSS `$q`, title
+            // report `21 t`, font-size report). Re-enabling any
+            // of these (writing back through the PTY, building
+            // a response packet, etc.) re-opens the CVE class
+            // covering CVE-2003-0063, CVE-2022-45872,
+            // CVE-2024-50349/52005. Reviewers MUST block any PR
+            // that adds a handler in this match without a
+            // matching SECURITY.md update describing the new
+            // mitigation strategy.
+            ()
 
     member _.Rows = rows
     member _.Cols = cols

--- a/src/Terminal.Parser/StateMachine.fs
+++ b/src/Terminal.Parser/StateMachine.fs
@@ -21,16 +21,26 @@ type VtState =
     | DcsPassthrough
     | DcsIgnore
     | OscString
+    | OscIgnore
     | SosPmApcString
 
 /// alacritty/vte caps copied verbatim. Anything beyond these limits is
 /// silently dropped — the alternative (allocating without bound for an
 /// adversarial input stream) is a memory-DoS surface.
+///
+/// Audit-cycle SR-1 added `MAX_DCS_RAW` (4096, alacritty parity for the
+/// Hook→Unhook DCS payload window) and `MAX_PARAM_VALUE` (65535,
+/// alacritty / vte parity to keep `currentParam` from overflowing
+/// int32 under inputs like `\x1b[999999999999999999m`). The
+/// SECURITY.md `Application surfaces` section row A-1 references
+/// these constants.
 module internal Limits =
     let MAX_INTERMEDIATES = 2
     let MAX_OSC_PARAMS = 16
     let MAX_OSC_RAW = 1024
+    let MAX_DCS_RAW = 4096
     let MAX_PARAMS = 16
+    let MAX_PARAM_VALUE = 65535
 
 /// Stateful single-byte-at-a-time parser. Encapsulates Williams'
 /// state machine plus a small UTF-8 decoder for `Print` events.
@@ -54,6 +64,13 @@ type StateMachine() =
     let intermediates = ResizeArray<byte>()
     let oscParams = ResizeArray<ResizeArray<byte>>()
     let mutable oscTotalLen = 0
+    /// Audit-cycle SR-1: tracks total bytes emitted in the current
+    /// DCS Hook→Unhook window so the parser stops emitting `DcsPut`
+    /// events past `Limits.MAX_DCS_RAW`. The DCS dispatch pair
+    /// (`DcsHook` / `DcsUnhook`) still fires; only the per-byte
+    /// stream is bounded. Reset on `DcsHook` dispatch.
+    /// See SECURITY.md A-1.
+    let mutable dcsTotalLen = 0
     let mutable privateMarker: char option = None
 
     // Small UTF-8 decoder. We intentionally avoid System.Text.Encoding
@@ -263,7 +280,16 @@ type StateMachine() =
         | CsiParam ->
             if b >= 0x30uy && b <= 0x39uy then
                 if currentParam < 0 then currentParam <- 0
-                currentParam <- currentParam * 10 + int (b - 0x30uy)
+                // Audit-cycle SR-1: clamp at MAX_PARAM_VALUE
+                // (65535, alacritty / vte parity) so input
+                // like `\x1b[999999999999999999m` can't
+                // overflow int32 to a negative value and
+                // mistrigger an SGR / cursor handler. See
+                // SECURITY.md A-1 (Application surfaces).
+                if currentParam < Limits.MAX_PARAM_VALUE then
+                    currentParam <- currentParam * 10 + int (b - 0x30uy)
+                    if currentParam > Limits.MAX_PARAM_VALUE then
+                        currentParam <- Limits.MAX_PARAM_VALUE
                 None
             elif b = 0x3Buy then
                 pushParam ()
@@ -341,6 +367,31 @@ type StateMachine() =
                 None
             else
                 oscAppend b
+                // Audit-cycle SR-1: once the payload cap fires,
+                // transition to OscIgnore so the parser stops
+                // accumulating but stays in a deterministic
+                // state. An embedded 0x1B in dropped bytes
+                // could otherwise be misread as ST and
+                // desynchronise the state machine. See
+                // SECURITY.md A-1.
+                if oscTotalLen >= Limits.MAX_OSC_RAW then
+                    state <- OscIgnore
+                None
+        | OscIgnore ->
+            // SR-1: consume bytes until terminator. Then dispatch
+            // an empty OscDispatch so downstream consumers still
+            // see the OSC framing (just without payload).
+            if b = 0x07uy then
+                state <- Ground
+                Some(OscDispatch([||], true))
+            elif b = 0x1Buy then
+                state <- Escape
+                resetSequence ()
+                Some(OscDispatch([||], false))
+            elif b = 0x18uy || b = 0x1Auy then
+                state <- Ground
+                Some(Execute b)
+            else
                 None
         | DcsEntry ->
             if b >= 0x30uy && b <= 0x39uy then
@@ -360,6 +411,7 @@ type StateMachine() =
                 let p = snapshotParams ()
                 let i = snapshotIntermediates ()
                 state <- DcsPassthrough
+                dcsTotalLen <- 0  // SR-1: reset DCS payload counter on Hook
                 Some(DcsHook(p, i, char b))
             elif b = 0x18uy || b = 0x1Auy then
                 state <- Ground
@@ -370,7 +422,16 @@ type StateMachine() =
         | DcsParam ->
             if b >= 0x30uy && b <= 0x39uy then
                 if currentParam < 0 then currentParam <- 0
-                currentParam <- currentParam * 10 + int (b - 0x30uy)
+                // Audit-cycle SR-1: clamp at MAX_PARAM_VALUE
+                // (65535, alacritty / vte parity) so input
+                // like `\x1b[999999999999999999m` can't
+                // overflow int32 to a negative value and
+                // mistrigger an SGR / cursor handler. See
+                // SECURITY.md A-1 (Application surfaces).
+                if currentParam < Limits.MAX_PARAM_VALUE then
+                    currentParam <- currentParam * 10 + int (b - 0x30uy)
+                    if currentParam > Limits.MAX_PARAM_VALUE then
+                        currentParam <- Limits.MAX_PARAM_VALUE
                 None
             elif b = 0x3Buy then
                 pushParam ()
@@ -389,6 +450,7 @@ type StateMachine() =
                 let p = snapshotParams ()
                 let i = snapshotIntermediates ()
                 state <- DcsPassthrough
+                dcsTotalLen <- 0  // SR-1: reset DCS payload counter on Hook
                 Some(DcsHook(p, i, char b))
             elif b = 0x18uy || b = 0x1Auy then
                 state <- Ground
@@ -404,6 +466,7 @@ type StateMachine() =
                 let p = snapshotParams ()
                 let i = snapshotIntermediates ()
                 state <- DcsPassthrough
+                dcsTotalLen <- 0  // SR-1: reset DCS payload counter on Hook
                 Some(DcsHook(p, i, char b))
             elif b = 0x18uy || b = 0x1Auy then
                 state <- Ground
@@ -422,7 +485,18 @@ type StateMachine() =
             elif b = 0x7Fuy then
                 None
             else
-                Some(DcsPut b)
+                // SR-1: bound DCS payload at MAX_DCS_RAW (4 KiB,
+                // alacritty parity). Beyond the cap, byte
+                // accounting still runs but no event emits, so
+                // a child sending GBs of DCS doesn't allocate
+                // GBs of `DcsPut` records. The Hook/Unhook
+                // dispatch pair still fires unchanged.
+                // See SECURITY.md A-1.
+                if dcsTotalLen < Limits.MAX_DCS_RAW then
+                    dcsTotalLen <- dcsTotalLen + 1
+                    Some(DcsPut b)
+                else
+                    None
         | DcsIgnore ->
             if b = 0x1Buy then
                 state <- Escape

--- a/tests/Tests.Unit/VtParserTests.fs
+++ b/tests/Tests.Unit/VtParserTests.fs
@@ -284,3 +284,86 @@ let ``valid Unicode scalars round-trip through UTF-8 as a single Print``
         (match events.[0] with
          | Print decoded -> decoded = r
          | _ -> false)
+
+// ---------------------------------------------------------------------
+// SR-1 (audit-cycle security hardening): bounds against malicious or
+// adversarially-shaped input. Each test pins a contract enforced by
+// changes in `Terminal.Parser/StateMachine.fs` and
+// `Terminal.Core/Screen.fs`. See SECURITY.md row A-1 for the surface.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CSI param accumulator clamps int32 overflow at MAX_PARAM_VALUE`` () =
+    // SR-1: `\x1b[999999999999999999m` previously overflowed int32 to a
+    // negative value. Now it clamps at 65535 and an SGR dispatch
+    // fires with a non-negative param. The exact value is
+    // implementation detail (clamped or 0); the contract is
+    // never-negative.
+    let events = parse (ascii "\x1b[999999999999999999m")
+    let dispatched =
+        events
+        |> Array.choose (function
+            | CsiDispatch(parms, _, 'm', _) -> Some parms
+            | _ -> None)
+        |> Array.tryHead
+    match dispatched with
+    | None -> failwith "expected an SGR (CSI m) dispatch"
+    | Some parms ->
+        Assert.True(parms.Length >= 1)
+        Assert.True(parms.[0] >= 0, sprintf "param[0]=%d, should not be negative" parms.[0])
+        Assert.True(parms.[0] <= 65535, sprintf "param[0]=%d, should be clamped at 65535" parms.[0])
+
+[<Fact>]
+let ``DCS payload caps at MAX_DCS_RAW; DcsHook + DcsUnhook still fire`` () =
+    // SR-1: 8 KiB of DCS payload should produce DcsHook then ≤ 4096
+    // DcsPut events then DcsUnhook on ESC \. The cap protects
+    // against ANSI-bomb DoS while preserving DCS framing.
+    let header = ascii "\x1bP1$q"  // DCS hook (DECRQSS shape)
+    let payload = Array.create 8192 (byte 'x')
+    let terminator = ascii "\x1b\\"
+    let bytes = Array.concat [ header; payload; terminator ]
+    let events = parse bytes
+    let hookCount = events |> Array.filter (function DcsHook _ -> true | _ -> false) |> Array.length
+    let putCount = events |> Array.filter (function DcsPut _ -> true | _ -> false) |> Array.length
+    let unhookCount = events |> Array.filter (function DcsUnhook -> true | _ -> false) |> Array.length
+    Assert.Equal(1, hookCount)
+    Assert.Equal(1, unhookCount)
+    Assert.True(putCount <= 4096, sprintf "DcsPut count = %d, should be capped at 4096" putCount)
+    Assert.True(putCount > 0, "expected at least some DcsPut emit")
+
+[<Fact>]
+let ``OSC overflow transitions to OscIgnore and dispatches empty payload`` () =
+    // SR-1: 8 KiB of OSC payload should produce exactly one
+    // OscDispatch on BEL — empty payload because the parser
+    // transitions to OscIgnore once MAX_OSC_RAW (1024 bytes) is
+    // hit. Parser ends in Ground (verified by feeding a Print
+    // after the BEL and seeing it emit).
+    let header = ascii "\x1b]0;"  // OSC start, set window title
+    let payload = Array.create 8192 (byte 'x')
+    let terminator = [| 0x07uy |]  // BEL
+    let bytes = Array.concat [ header; payload; terminator ]
+    let events = parse bytes
+    let oscDispatches =
+        events
+        |> Array.choose (function OscDispatch(parms, bel) -> Some(parms, bel) | _ -> None)
+    Assert.Equal(1, oscDispatches.Length)
+    let parms, bellTerminated = oscDispatches.[0]
+    Assert.True(bellTerminated)
+    // Empty payload: after overflow we don't carry forward the
+    // partially-collected bytes. (Pinned: NEVER carry the
+    // truncated payload — that's the desync risk SR-1 closed.)
+    let nonEmptyParam = parms |> Array.exists (fun p -> p.Length > 0)
+    Assert.False(nonEmptyParam, "OSC overflow should dispatch with empty params")
+
+[<Fact>]
+let ``OSC overflow leaves parser in Ground after terminator`` () =
+    // After overflow + BEL terminator, feeding a Print byte should
+    // produce a Print event — confirms parser is back in Ground.
+    let header = ascii "\x1b]0;"
+    let payload = Array.create 4096 (byte 'x')
+    let terminator = [| 0x07uy |]  // BEL
+    let after = ascii "Z"
+    let bytes = Array.concat [ header; payload; terminator; after ]
+    let events = parse bytes
+    let lastPrint = events |> Array.tryFindBack (function Print _ -> true | _ -> false)
+    Assert.Equal(Some (Print(rune 'Z')), lastPrint)


### PR DESCRIPTION
## Summary

SR-1 of the security-audit cycle. Closes three HIGH/MEDIUM parser findings: ANSI-bomb-class DoS protections that cap the parser-state accumulators against adversarially-shaped input. Behaviour is unchanged for legitimate input; just bounded for malicious input.

Per the maintainer-approved plan at `/root/.claude/plans/replicated-riding-sketch.md`.

## Changes

### `currentParam` int32 clamp (Parser/2.1, **HIGH**)
Input like `\x1b[999999999999999999m` previously overflowed `int32` in the digit-accumulation arithmetic to a negative SGR param, which `applySgrOne` and other consumers would mistreat. Now clamps at `MAX_PARAM_VALUE = 65535` (alacritty/vte parity). Applied at both CSI and DCS digit-accumulation sites in `StateMachine.fs`.

### `MAX_DCS_RAW = 4096` cap (Parser/2.3, **HIGH**)
`DcsPassthrough` previously emitted one `DcsPut` event per byte without bound — a child sending GBs of DCS payload allocated GBs of event records. New `dcsTotalLen` counter resets on each `DcsHook` (3 sites); per-byte emit gates on `dcsTotalLen < MAX_DCS_RAW`. Hook/Unhook framing pair fires unchanged. Matches alacritty's per-Hook→Unhook window cap.

### OSC overflow → `OscIgnore` (Parser/2.2, **MEDIUM**)
Previously the parser silently truncated OSC payloads at `MAX_OSC_RAW = 1024` but stayed in `OscString` — an embedded `0x1B` in dropped bytes could be misread as ST and desynchronise the state machine. New `OscIgnore` sub-state mirrors the existing `DcsIgnore` pattern: consumes bytes until ST/BEL terminator, then dispatches an empty `OscDispatch`.

### `Screen.csiDispatch` catch-all comment (Code-as-doc, **MEDIUM**)
The `| _ -> ()` arm in `csiDispatch` previously had a one-line comment. This drop is **intentional and SECURITY-CRITICAL** per `SECURITY.md` row TC-1: re-enabling any of the response-generating sequences (DSR, DA1/2/3, DECRQM, DECRQSS, CPR, title/font reports) re-opens CVE-2003-0063, CVE-2022-45872, CVE-2024-50349/52005. New multi-line comment names the affected sequences and instructs reviewers.

## Tests

Four new tests in `tests/Tests.Unit/VtParserTests.fs`:
1. CSI param accumulator clamps int32 overflow at `MAX_PARAM_VALUE`; never negative.
2. 8 KiB DCS payload produces 1 `DcsHook` + ≤ 4096 `DcsPut` + 1 `DcsUnhook`.
3. 8 KiB OSC payload dispatches once with empty params on BEL.
4. Parser returns to `Ground` after OSC overflow + terminator.

The 60+ existing parser tests (including FsCheck properties on chunked feed equivalence and CAN return-to-Ground) still pass — these are additive bounds, not behavioural changes.

## Test plan

- [ ] CI passes (build+test on windows-latest, actionlint, markdown link check).
- [ ] No regression in `cmd.exe` banner rendering or `dir` output (legitimate VT sequences don't hit the new caps).
- [ ] Existing manual smoke matrix Stages 0/3b/4/11 unaffected.

## Cycle context

- SR-1 (this) — parser hardening.
- SR-2 (queued) — accessibility hardening (jagged-array bounds + `AnnounceSanitiser` + `Move` overflow guard).
- SR-3 (queued) — `SECURITY.md` audit response with 6 new inventory rows.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_