### PR TITLE
feat: Ctrl+Shift+D launches process-cleanup diagnostic in separate PowerShell window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **`Ctrl+Shift+D` diagnostic-launcher hotkey.** Press
+  `Ctrl+Shift+D` from inside pty-speak to launch the bundled
+  process-cleanup diagnostic (`scripts/test-process-cleanup.ps1`)
+  in a separate PowerShell window. NVDA narrates "Diagnostic
+  launched in a separate PowerShell window. Switch to that
+  window to follow the test." The diagnostic auto-detects when
+  the user closes pty-speak (no Enter prompt), reports
+  PASS/FAIL plain-text output one-fact-per-line for screen-
+  reader audible follow-along, and runs both close paths
+  (Alt+F4 and X button). Added because Task Manager's
+  Processes-tab chevron-expand affordance is not screen-
+  reader-accessible, so the long-deferred Stage 4 process-
+  cleanup test could not be exercised by an NVDA-using
+  maintainer via the original Task Manager walkthrough.
+
+  The script is bundled into the Velopack install via
+  `Terminal.App.fsproj`'s `Content` include; the hotkey
+  resolves the script path via `AppContext.BaseDirectory`
+  so no install path is hardcoded. PowerShell is launched
+  with `-NoExit` so the window stays open after the test
+  completes; the user reads the output and closes that
+  window manually.
+
+  Future diagnostics (UIA peer health, ConPTY child status,
+  version dump) can be added as additional bundled scripts
+  reached either through the same hotkey via a sub-menu or
+  via additional reserved hotkeys following the
+  app-reserved-hotkey contract in `spec/tech-plan.md` §6.
+  The reserved-hotkey list is now: `Ctrl+Shift+U` (update),
+  `Ctrl+Shift+D` (diagnostic), `Ctrl+Shift+M` (Stage 9 mute,
+  reserved), `Alt+Shift+R` (Stage 10 review, reserved).
+
+  `SECURITY.md` row A-3 (pre-Stage-6 keyboard contract)
+  updated to reflect the new app-reserved hotkey.
+
 ### Security
 
 - **Security audit cycle SR-3: SECURITY.md audit response.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,8 @@ corresponding stage in [`spec/tech-plan.md`](spec/tech-plan.md).
 - **Pre-Stage-6 keyboard contract.** *(planned, Stage 6.)*
   `TerminalView.OnPreviewKeyDown` today is a stub that passes every
   non-reserved key through unfiltered; the only gestures captured at
-  the window level are app shortcuts (`Ctrl+Shift+U` for update). The
+  the window level are app shortcuts (`Ctrl+Shift+U` for update,
+  `Ctrl+Shift+D` for the process-cleanup diagnostic launcher). The
   child cmd.exe therefore does not currently receive typed input.
   Stage 6 introduces the NVDA-modifier filter and the actual PTY
   routing per [`spec/tech-plan.md`](spec/tech-plan.md) §6; row A-3
@@ -476,7 +477,7 @@ when those surfaces became code-bearing.
 | **Application surfaces** ||||||
 | A-1 | Jagged-snapshot `IndexOutOfRangeException` in word-boundary helpers | Medium (DoS in the screen-reader read path; today's `Screen.SnapshotRows` returns uniform rows, but `TerminalTextRange` constructor doesn't enforce uniformity) | `c >= rows.[r].Length` guards added inside `WordEndFrom`, `NextWordStart`, `PrevWordStart` in `TerminalAutomationPeer.fs` (audit-cycle SR-2, PR #77) | n/a | **shipped** |
 | A-2 | `Move(Character, count)` int32 underflow when `count = int.MinValue` | Medium (wrong-direction range mutation slips past the `max 0` clamp via wraparound) | `int64` widening before the `curIdx + count` add, applied to both `Move` and `MoveEndpointByUnit` Character arms (audit-cycle SR-2, PR #77) | n/a | **shipped** |
-| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the `Ctrl+Shift+U` app shortcut is captured) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6 | n/a | **planned (Stage 6)** |
+| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
 | **Update path (Stage 11)** ||||||
 | T-1 | Passive network observer of update flow | Low | TLS to GitHub | n/a (cost not justified) | **shipped** |
 | T-2 | Active MITM substituting update bytes | High | TLS + Velopack per-nupkg SHA hash in releases.win.json | + Ed25519 manifest signing (consistent forgery resistance) | **partial** (TLS+hash today; signing v0.1.0+) |

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -197,6 +197,71 @@ module Program =
                 ExecutedRoutedEventHandler(fun _ _ -> runUpdateFlow window)))
         |> ignore
 
+    /// Launch the bundled process-cleanup diagnostic script in a
+    /// separate PowerShell window. Triggered by `Ctrl+Shift+D` —
+    /// added because Task Manager's Processes-tab chevron-expand
+    /// affordance is not screen-reader-accessible, so a maintainer
+    /// running the deferred Stage 4 process-cleanup test on
+    /// NVDA cannot navigate the Task Manager UI to verify the
+    /// process tree by hand. The diagnostic script lives next to
+    /// `Terminal.App.exe` (bundled via `Terminal.App.fsproj`'s
+    /// `Content` include) and emits one-fact-per-line stdout that
+    /// NVDA reads aloud naturally.
+    ///
+    /// The PowerShell process is launched with `-NoExit` so the
+    /// spawned window stays open after the test completes; the
+    /// user reads the result, then closes that window manually.
+    /// This is intentional — auto-closing would lose the output.
+    ///
+    /// Future: more diagnostics (UIA peer health, ConPTY child
+    /// status, version dump) can be added as additional scripts
+    /// next to this one and routed through the same hotkey via
+    /// a sub-menu, OR added as their own hotkeys following the
+    /// app-reserved-hotkey contract in `spec/tech-plan.md` §6.
+    let private runDiagnostic (window: MainWindow) : unit =
+        let scriptPath =
+            System.IO.Path.Combine(
+                System.AppContext.BaseDirectory,
+                "test-process-cleanup.ps1")
+        if not (System.IO.File.Exists scriptPath) then
+            window.TerminalSurface.Announce(
+                sprintf
+                    "Diagnostic script not found at %s. Re-install pty-speak or report this as a packaging regression."
+                    scriptPath)
+        else
+            try
+                let psi = System.Diagnostics.ProcessStartInfo()
+                psi.FileName <- "powershell.exe"
+                psi.Arguments <-
+                    sprintf
+                        "-ExecutionPolicy Bypass -NoExit -File \"%s\""
+                        scriptPath
+                psi.UseShellExecute <- true
+                System.Diagnostics.Process.Start(psi) |> ignore
+                window.TerminalSurface.Announce(
+                    "Diagnostic launched in a separate PowerShell window. Switch to that window to follow the test.")
+            with ex ->
+                let safe = AnnounceSanitiser.sanitise ex.Message
+                window.TerminalSurface.Announce(
+                    sprintf "Could not launch diagnostic: %s" safe)
+
+    /// Wire `Ctrl+Shift+D` to trigger `runDiagnostic`. Same
+    /// pattern as `setupAutoUpdateKeybinding` above. Per the
+    /// app-reserved-hotkey contract, this gesture is in the
+    /// reserved list (Ctrl+Shift+U for update, Ctrl+Shift+D
+    /// for diagnostic, Ctrl+Shift+M for Stage 9 mute, Alt+Shift+R
+    /// for Stage 10 review mode) and Stage 6's keyboard layer
+    /// must continue to honour the priority order.
+    let private setupDiagnosticKeybinding (window: MainWindow) : unit =
+        let cmd = RoutedCommand("RunDiagnostic", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.D, ModifierKeys.Control ||| ModifierKeys.Shift)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
+            CommandBinding(
+                cmd,
+                ExecutedRoutedEventHandler(fun _ _ -> runDiagnostic window)))
+        |> ignore
+
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
     /// in here. For Stage 3b we just hold references to the long-lived
     /// pieces and ensure they're disposed on Application.Exit.
@@ -212,6 +277,11 @@ module Program =
         // window is loaded so the keybinding is live for the
         // user's first keypress.
         setupAutoUpdateKeybinding window
+
+        // Wire Ctrl+Shift+D to launch the bundled process-cleanup
+        // diagnostic script in a separate PowerShell window.
+        // Same install-before-window-load reasoning as above.
+        setupDiagnosticKeybinding window
 
         // Pre-Stage-5 seam (audit-cycle PR-B): bounded
         // notification channel from the parser thread to the

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -31,6 +31,22 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Bundle the process-cleanup diagnostic script next to the
+      Terminal.App.exe in the publish output. Velopack pack picks
+      it up automatically. The Ctrl+Shift+D hotkey in Program.fs
+      resolves the script via AppContext.BaseDirectory so the
+      install path doesn't need to be hardcoded. `<Link>` keeps
+      the file flat in the output directory rather than nesting
+      under `..\..\scripts\`.
+    -->
+    <Content Include="..\..\scripts\test-process-cleanup.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>test-process-cleanup.ps1</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Velopack" />
     <ProjectReference Include="..\Terminal.Core\Terminal.Core.fsproj" />


### PR DESCRIPTION
## Summary

Adds a window-level `Ctrl+Shift+D` keybinding that launches the bundled `scripts/test-process-cleanup.ps1` (shipped via #80) in a separate PowerShell window. NVDA narrates the launch event; the script's plain-text stdout (one fact per line) is read aloud naturally in the spawned window.

**Why now:** the Stage 4 process-cleanup test (long-deferred per `SESSION-HANDOFF.md` item 2) requires Task Manager navigation that isn't screen-reader-accessible. PR #80 shipped the PowerShell helper but the maintainer reported the install + copy-paste invocation path was too cumbersome by ear. A hotkey inside the running app makes the diagnostic one keypress away.

## Implementation

- **`Terminal.App.fsproj`** adds a `Content` include that copies the script next to `Terminal.App.exe` in the publish output. Velopack pack picks it up automatically.
- **`Program.fs`** adds `runDiagnostic` + `setupDiagnosticKeybinding`, mirroring the existing Stage 11 `setupAutoUpdateKeybinding` pattern. Resolves the script path via `AppContext.BaseDirectory`; launches PowerShell with `-ExecutionPolicy Bypass -NoExit -File` so the spawned window stays open after the test completes.
- **`compose()`** wires `setupDiagnosticKeybinding` alongside `setupAutoUpdateKeybinding`.
- Failure modes (missing script, `Process.Start` exception) announce a sanitised message via `AnnounceSanitiser` (SR-2 chokepoint) rather than crashing.

## Reserved-hotkey list updated

After this PR: `Ctrl+Shift+U` (update), `Ctrl+Shift+D` (diagnostic), `Ctrl+Shift+M` (Stage 9 mute, reserved), `Alt+Shift+R` (Stage 10 review, reserved). Stage 6's keyboard layer must continue to honour this list per the app-reserved-hotkey contract in `spec/tech-plan.md` §6.

`SECURITY.md` row A-3 updated to reflect the new app-reserved hotkey.

## Test plan

- [ ] CI green on Build and test (windows-latest)
- [ ] CI green on actionlint
- [ ] CI green on Markdown link check
- [ ] After merge, cut a new preview release. Install. Launch.
- [ ] Press `Ctrl+Shift+D`. Confirm NVDA reads "Diagnostic launched in a separate PowerShell window. Switch to that window to follow the test."
- [ ] Switch (Alt+Tab) to the spawned PowerShell window. Confirm NVDA reads the script's progress.
- [ ] Follow the script's two-pass test (Alt+F4 then X-button close). Confirm `OVERALL: PASS`.

## Future

Additional diagnostics (UIA peer health, ConPTY child status, version dump) can be added as more bundled scripts and reached either through the same hotkey via a sub-menu or via additional reserved hotkeys following the app-reserved-hotkey contract.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_