### PR TITLE
feat: Ctrl+Shift+R opens GitHub Releases page; propagate hotkey docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,37 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **`Ctrl+Shift+R` release-notes browser hotkey.** Press
+  `Ctrl+Shift+R` (mnemonic: **R**eleases) from inside pty-speak
+  to open the GitHub Releases page for the configured
+  `UpdateRepoUrl` (today
+  `https://github.com/KyleKeane/pty-speak/releases`) in the
+  user's default web browser. NVDA narrates "Opened release
+  notes in default browser: <url>". Useful as a one-keypress
+  answer to "what changed in this version?" without leaving
+  pty-speak. The browser's own accessibility surface handles
+  the release-notes navigation; pty-speak just hands the URL
+  to the OS shell. URL is derived from `UpdateRepoUrl` so a
+  fork / self-hosted variant only needs to update one
+  constant (Phase 2's TOML config will make `UpdateRepoUrl`
+  user-configurable per `SECURITY.md` row C-1; this hotkey
+  inherits whatever the user configures).
+
+  Note on the `Ctrl+Shift+R` vs `Alt+Shift+R` (Stage 10
+  review-mode toggle, reserved) mnemonic overlap: WPF treats
+  the two as distinct `KeyGesture`s (different modifier
+  sets), so there is no actual keypress conflict. The R-vs-R
+  mnemonic similarity is the only cost; the maintainer chose
+  Ctrl+Shift+R explicitly for the "R for Releases" parallel.
+
+  The reserved-hotkey list now reads: `Ctrl+Shift+U` (update),
+  `Ctrl+Shift+D` (diagnostic), `Ctrl+Shift+R` (release notes),
+  `Ctrl+Shift+M` (Stage 9 mute, reserved), `Alt+Shift+R`
+  (Stage 10 review, reserved). `SECURITY.md` row A-3 +
+  "What we defend against" bullet updated to reflect; the
+  reserved-hotkey list in `docs/USER-SETTINGS.md` Keybindings
+  section also updated.
+
 - **`Ctrl+Shift+D` diagnostic-launcher hotkey.** Press
   `Ctrl+Shift+D` from inside pty-speak to launch the bundled
   process-cleanup diagnostic (`scripts/test-process-cleanup.ps1`)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ Once Stage 11 (Velopack auto-update) lands, the GA flow is:
 4. Self-update from inside the app with `Ctrl+Shift+U` (this checks GitHub
    Releases and applies the delta in ~2 seconds).
 
+### App-reserved hotkeys (currently shipped)
+
+These are captured by pty-speak at the window level before any future
+Stage-6 keyboard layer routes input to the child shell. Stage 6 will
+preserve this list per the app-reserved-hotkey contract in
+[`spec/tech-plan.md`](spec/tech-plan.md) §6.
+
+- **`Ctrl+Shift+U`** — self-update via Velopack (Stage 11). Checks
+  GitHub Releases and applies the delta in ~2 seconds.
+- **`Ctrl+Shift+D`** — launch the bundled process-cleanup diagnostic
+  in a separate PowerShell window. Verifies that closing pty-speak
+  via Alt+F4 or the X button leaves no orphan `Terminal.App.exe` /
+  ConPTY child processes. Output is plain text NVDA reads aloud
+  naturally.
+- **`Ctrl+Shift+R`** — open the GitHub Releases page in your default
+  browser. One-keypress answer to "what changed in this version?"
+  before deciding whether to update.
+
+Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute toggle),
+`Alt+Shift+R` (Stage 10 review-mode toggle).
+
 The historical Stage 0 preview installer opens an empty window. Once
 the next preview is cut from the current `main`, the installer launches
 `cmd.exe` under ConPTY and renders its output in the window — input

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,7 +69,8 @@ corresponding stage in [`spec/tech-plan.md`](spec/tech-plan.md).
   `TerminalView.OnPreviewKeyDown` today is a stub that passes every
   non-reserved key through unfiltered; the only gestures captured at
   the window level are app shortcuts (`Ctrl+Shift+U` for update,
-  `Ctrl+Shift+D` for the process-cleanup diagnostic launcher). The
+  `Ctrl+Shift+D` for the process-cleanup diagnostic launcher,
+  `Ctrl+Shift+R` for the release-notes browser launcher). The
   child cmd.exe therefore does not currently receive typed input.
   Stage 6 introduces the NVDA-modifier filter and the actual PTY
   routing per [`spec/tech-plan.md`](spec/tech-plan.md) §6; row A-3
@@ -477,7 +478,7 @@ when those surfaces became code-bearing.
 | **Application surfaces** ||||||
 | A-1 | Jagged-snapshot `IndexOutOfRangeException` in word-boundary helpers | Medium (DoS in the screen-reader read path; today's `Screen.SnapshotRows` returns uniform rows, but `TerminalTextRange` constructor doesn't enforce uniformity) | `c >= rows.[r].Length` guards added inside `WordEndFrom`, `NextWordStart`, `PrevWordStart` in `TerminalAutomationPeer.fs` (audit-cycle SR-2, PR #77) | n/a | **shipped** |
 | A-2 | `Move(Character, count)` int32 underflow when `count = int.MinValue` | Medium (wrong-direction range mutation slips past the `max 0` clamp via wraparound) | `int64` widening before the `curIdx + count` add, applied to both `Move` and `MoveEndpointByUnit` Character arms (audit-cycle SR-2, PR #77) | n/a | **shipped** |
-| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
+| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher, `Ctrl+Shift+R` for release-notes browser launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
 | **Update path (Stage 11)** ||||||
 | T-1 | Passive network observer of update flow | Low | TLS to GitHub | n/a (cost not justified) | **shipped** |
 | T-2 | Active MITM substituting update bytes | High | TLS + Velopack per-nupkg SHA hash in releases.win.json | + Ed25519 manifest signing (consistent forgery resistance) | **partial** (TLS+hash today; signing v0.1.0+) |

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -498,6 +498,43 @@ pattern at the right element.
   backwards-compat shim; if it regresses, the delta-update path
   is the suspect.
 
+### App-reserved hotkey launchers (run on every release that bundles them)
+
+Two diagnostic / convenience hotkeys ride alongside the auto-update
+keybinding. They aren't tied to a specific stage but were added in
+the post-Stage-11 audit-cycle work to make manual NVDA-side testing
+easier. Stage 6's keyboard layer must continue to honour these per
+the app-reserved-hotkey contract in `spec/tech-plan.md` §6.
+
+| Test                              | Procedure                                       | Expected behaviour                                               |
+|-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
+| Diagnostic launcher               | From running pty-speak, press `Ctrl+Shift+D`    | NVDA reads "Diagnostic launched in a separate PowerShell window. Switch to that window to follow the test."; PowerShell window opens; bundled `test-process-cleanup.ps1` runs; on Alt+Tab to that window NVDA reads its plain-text progress |
+| Diagnostic two-pass               | After the launcher: follow the script's prompts | Pass 1 (Alt+F4 close) and Pass 2 (X-button close, with `Alt+Space`/`Enter` keyboard-equivalent) both report PASS; final summary line `OVERALL: PASS` |
+| Release-notes launcher            | From running pty-speak, press `Ctrl+Shift+R`    | NVDA reads "Opened release notes in default browser: <url>"; default browser opens to the GitHub Releases page |
+| Release-notes URL is correct      | Inspect the browser's address bar               | URL is `https://github.com/KyleKeane/pty-speak/releases` (or whatever fork's `UpdateRepoUrl` was configured to) |
+
+**Diagnostic decoder for the launcher hotkeys:**
+
+- **`Ctrl+Shift+D` silent, no PowerShell window** → Either the
+  `setupDiagnosticKeybinding` wiring regressed in `Program.fs`, OR
+  the bundled `test-process-cleanup.ps1` is missing from the
+  install. Check `%LocalAppData%\pty-speak\current\` for the
+  script file; if missing, the `Content` include in
+  `Terminal.App.fsproj` regressed (which Velopack pack picks up).
+- **`Ctrl+Shift+D` opens PowerShell but the script bails immediately
+  with "pty-speak already running, abort"** → PR #82's fix
+  regressed; the script's `Run-Pass` should detect-and-reuse, not
+  abort.
+- **`Ctrl+Shift+R` silent, no browser** → Either the
+  `setupReleasesKeybinding` wiring regressed, OR the user has no
+  default browser handler registered for `https:` URLs (rare on
+  Windows). NVDA should announce a sanitised exception message in
+  the second case.
+- **`Ctrl+Shift+R` opens the wrong URL** → `UpdateRepoUrl` constant
+  in `Program.fs` was changed without updating the release-notes
+  flow. The two share the same constant by design (single source
+  of truth for the repo URL).
+
 ## Recording results
 
 For each release tag:

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -263,11 +263,27 @@ defaults; they shouldn't be the only options.
 
 ### Current state
 
-Two app-level keybindings shipped today:
+Four app-level keybindings shipped today:
 
 - **`Ctrl+Shift+U`** — Velopack auto-update (Stage 11, PR #63).
   Wired in `setupAutoUpdateKeybinding` in
   `src/Terminal.App/Program.fs`.
+- **`Ctrl+Shift+D`** — process-cleanup diagnostic launcher
+  (PR #81). Spawns `scripts/test-process-cleanup.ps1` (bundled
+  next to `Terminal.App.exe`) in a separate PowerShell window
+  so the screen-reader user can audibly verify ConPTY child
+  cleanup on app close — added because Task Manager's
+  Processes-tab chevron-expand affordance isn't NVDA-accessible.
+  Wired in `setupDiagnosticKeybinding`.
+- **`Ctrl+Shift+R`** — release-notes browser launcher (PR #83).
+  Opens the GitHub Releases page (`UpdateRepoUrl` +
+  `/releases`) in the user's default web browser. Useful as
+  a one-keypress answer to "what changed in this version?"
+  before deciding whether to press `Ctrl+Shift+U`. Wired in
+  `setupReleasesKeybinding`. Note: `Ctrl+Shift+R` and
+  `Alt+Shift+R` (Stage 10 review-mode toggle, reserved) are
+  distinct WPF gestures — different modifier sets — so there
+  is no actual keypress conflict, only a mnemonic similarity.
 - (planned) **`Ctrl+Shift+M`** — earcon mute toggle (Stage 9).
 - (planned) **`Alt+Shift+R`** — review-mode toggle (Stage 10).
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -249,9 +249,10 @@ module Program =
     /// pattern as `setupAutoUpdateKeybinding` above. Per the
     /// app-reserved-hotkey contract, this gesture is in the
     /// reserved list (Ctrl+Shift+U for update, Ctrl+Shift+D
-    /// for diagnostic, Ctrl+Shift+M for Stage 9 mute, Alt+Shift+R
-    /// for Stage 10 review mode) and Stage 6's keyboard layer
-    /// must continue to honour the priority order.
+    /// for diagnostic, Ctrl+Shift+R for release notes,
+    /// Ctrl+Shift+M for Stage 9 mute, Alt+Shift+R for Stage 10
+    /// review mode) and Stage 6's keyboard layer must continue
+    /// to honour the priority order.
     let private setupDiagnosticKeybinding (window: MainWindow) : unit =
         let cmd = RoutedCommand("RunDiagnostic", typeof<MainWindow>)
         let gesture = KeyGesture(Key.D, ModifierKeys.Control ||| ModifierKeys.Shift)
@@ -260,6 +261,53 @@ module Program =
             CommandBinding(
                 cmd,
                 ExecutedRoutedEventHandler(fun _ _ -> runDiagnostic window)))
+        |> ignore
+
+    /// Open the GitHub Releases page for this repository in the
+    /// user's default web browser. Triggered by `Ctrl+Shift+R`
+    /// (mnemonic: **R**eleases). Useful as a one-keypress answer
+    /// to "what changed in this version?" without leaving
+    /// pty-speak — the screen reader can navigate the rendered
+    /// release notes in the browser, which has its own
+    /// well-tested accessibility surface.
+    ///
+    /// `Ctrl+Shift+R` and `Alt+Shift+R` (Stage 10 review-mode
+    /// toggle, reserved) are different gestures — different
+    /// modifier sets — so WPF treats them as distinct
+    /// `KeyGesture`s. The mnemonic overlap (both R) is the only
+    /// cost; the maintainer chose Ctrl+Shift+R explicitly for
+    /// the "R for Releases" parallel.
+    ///
+    /// The URL is derived from `UpdateRepoUrl` (the same
+    /// constant the Velopack auto-update flow uses) so a fork
+    /// or a self-hosted variant only needs to update one
+    /// constant. Phase 2's TOML config will make `UpdateRepoUrl`
+    /// user-configurable per `SECURITY.md` row C-1; this hotkey
+    /// inherits whatever the user configures.
+    let private runOpenReleases (window: MainWindow) : unit =
+        let url = UpdateRepoUrl + "/releases"
+        try
+            let psi = System.Diagnostics.ProcessStartInfo()
+            psi.FileName <- url
+            psi.UseShellExecute <- true
+            System.Diagnostics.Process.Start(psi) |> ignore
+            window.TerminalSurface.Announce(
+                sprintf "Opened release notes in default browser: %s" url)
+        with ex ->
+            let safe = AnnounceSanitiser.sanitise ex.Message
+            window.TerminalSurface.Announce(
+                sprintf "Could not open release notes: %s" safe)
+
+    /// Wire `Ctrl+Shift+R` to trigger `runOpenReleases`. Same
+    /// pattern as the other reserved hotkeys above.
+    let private setupReleasesKeybinding (window: MainWindow) : unit =
+        let cmd = RoutedCommand("OpenReleases", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.R, ModifierKeys.Control ||| ModifierKeys.Shift)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
+            CommandBinding(
+                cmd,
+                ExecutedRoutedEventHandler(fun _ _ -> runOpenReleases window)))
         |> ignore
 
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
@@ -282,6 +330,10 @@ module Program =
         // diagnostic script in a separate PowerShell window.
         // Same install-before-window-load reasoning as above.
         setupDiagnosticKeybinding window
+
+        // Wire Ctrl+Shift+R to open the GitHub Releases page in
+        // the user's default browser.
+        setupReleasesKeybinding window
 
         // Pre-Stage-5 seam (audit-cycle PR-B): bounded
         // notification channel from the parser thread to the


### PR DESCRIPTION
## Summary

Adds a window-level `Ctrl+Shift+R` keybinding (mnemonic: **R**eleases) that opens the GitHub Releases page (`UpdateRepoUrl` + `/releases`) in the user's default web browser. NVDA narrates the URL as it launches; the browser's own accessibility surface handles the release-notes navigation thereafter.

Useful as a one-keypress answer to *"what changed in this version?"* without leaving pty-speak. Complements `Ctrl+Shift+U` (which checks for and applies updates) by giving the user a way to read release notes BEFORE deciding to update.

**Note on `Ctrl+Shift+R` vs `Alt+Shift+R`** (Stage 10 review-mode toggle, reserved): WPF treats them as distinct `KeyGesture`s — different modifier sets — so there is no actual keypress conflict; only mnemonic overlap. Maintainer chose R explicitly for the "R for Releases" parallel.

## Implementation

- `Program.fs` adds `runOpenReleases` + `setupReleasesKeybinding`, mirroring `setupAutoUpdateKeybinding` / `setupDiagnosticKeybinding`. Uses `ProcessStartInfo` with `UseShellExecute=true` so the URL routes to the OS-default browser handler.
- `compose()` wires `setupReleasesKeybinding` alongside the other reserved-hotkey setups.
- URL derived from `UpdateRepoUrl` so forks / self-hosted variants only update one constant (Phase 2 TOML config will make this user-configurable per `SECURITY.md` row C-1).
- Failure modes (no browser, `Process.Start` exception) announce a sanitised message via `AnnounceSanitiser` (SR-2 chokepoint).

## Documentation propagation

This PR also closes the gap where PR #81's `Ctrl+Shift+D` was only mentioned in CHANGELOG and SECURITY.md but not in user-facing docs:

- **`README.md`** gains a new "App-reserved hotkeys (currently shipped)" subsection under Install enumerating `Ctrl+Shift+U` / `D` / `R` with one-line descriptions.
- **`docs/USER-SETTINGS.md`** Keybindings section enumerates all four shipped hotkeys (was just `Ctrl+Shift+U`) plus the two reserved for Stages 9 / 10.
- **`docs/ACCESSIBILITY-TESTING.md`** gains a new test-table section for the launcher hotkeys with PASS/FAIL rows for both `Ctrl+Shift+D` and `Ctrl+Shift+R`, including a diagnostic decoder for typical regressions.
- **`SECURITY.md`** row A-3 + "What we defend against" bullet updated to reflect `Ctrl+Shift+R` alongside U and D.
- **`CHANGELOG.md`** captures both the feature and the docs sweep.

## Reserved-hotkey list

After this PR: `Ctrl+Shift+U` (update), `Ctrl+Shift+D` (diagnostic), `Ctrl+Shift+R` (release notes), `Ctrl+Shift+M` (Stage 9 mute, reserved), `Alt+Shift+R` (Stage 10 review, reserved). Stage 6's keyboard layer must continue to honour this list per the app-reserved-hotkey contract in `spec/tech-plan.md` §6.

## Test plan

- [ ] CI green on Build and test (windows-latest)
- [ ] CI green on actionlint
- [ ] CI green on Markdown link check
- [ ] After merge, cut a new preview release.
- [ ] From a running pty-speak: press `Ctrl+Shift+R`. Confirm NVDA reads "Opened release notes in default browser: https://github.com/KyleKeane/pty-speak/releases" and the browser opens to that URL.
- [ ] Confirm `Alt+Shift+R` (when Stage 10 ships in the future) does NOT collide with this hotkey at the WPF level.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh