### PR TITLE
docs: log diagnostic-launcher screen-reader-UX limitation as a deferred follow-up

### DIFF
--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -513,6 +513,18 @@ the app-reserved-hotkey contract in `spec/tech-plan.md` §6.
 | Release-notes launcher            | From running pty-speak, press `Ctrl+Shift+R`    | NVDA reads "Opened release notes in default browser: <url>"; default browser opens to the GitHub Releases page |
 | Release-notes URL is correct      | Inspect the browser's address bar               | URL is `https://github.com/KyleKeane/pty-speak/releases` (or whatever fork's `UpdateRepoUrl` was configured to) |
 
+**Known limitation (logged to `docs/SESSION-HANDOFF.md`
+item 6 for post-Stage-5/6 follow-up):** the spawned
+PowerShell window's stdout is **unreliably read by NVDA**.
+The script's plain-text output is correct, but conhost's
+UIA exposure isn't on par with pty-speak's own peer.
+Treat the on-screen output as the source of truth (review
+cursor in PowerShell works; sighted helper or
+copy-paste-into-NVDA-Speech-Viewer also works). The right
+fix is to run the diagnostic inside pty-speak itself once
+Stage 5 (streaming announcements) and Stage 6 (keyboard
+input) ship; see SESSION-HANDOFF item 6 for options.
+
 **Diagnostic decoder for the launcher hotkeys:**
 
 - **`Ctrl+Shift+D` silent, no PowerShell window** → Either the

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -237,6 +237,50 @@ disconnects mid-session.
       reference comment in `OnRender` deferring to Stage 5 is
       the lightweight handle.
 
+6. **Diagnostic-launcher UX needs a screen-reader-native
+   replacement (post-Stage-5/6).** PR #81 shipped
+   `Ctrl+Shift+D` to launch
+   `scripts/test-process-cleanup.ps1` in a separate
+   PowerShell window, with the working hypothesis that the
+   spawned conhost window would route the script's stdout
+   through Windows' default screen-reader path. Manual
+   verification on `v0.0.1-preview.27` (and the next preview
+   that picks up PR #82's script fix) found that **NVDA's
+   reading of the spawned PowerShell window is unreliable**
+   in practice — line-by-line stdout is the script's design
+   but conhost's UIA exposure isn't on par with pty-speak's
+   own `Document` + `Text` pattern peer.
+
+   The right replacement, suspected by the maintainer
+   during the manual test, is to run diagnostics **inside
+   pty-speak itself** rather than spawning a separate
+   process:
+
+   - **Once Stage 6 (keyboard input to PTY) ships:** the
+     user types `pwsh ./test-process-cleanup.ps1` (or
+     similar) directly into pty-speak's child shell. The
+     output flows through the screen and NVDA reads it
+     via the well-tested UIA peer.
+   - **Once Stage 5 (streaming announcements) ships:** the
+     output is also actively narrated as it streams in,
+     not just available via review cursor.
+   - **Optional architectural alternative** if multi-instance
+     launch becomes a desired feature: `Ctrl+Shift+D`
+     could launch a second pty-speak instance whose child
+     shell is the diagnostic, side-by-side with the
+     primary instance. Requires multi-instance plumbing
+     that isn't on the roadmap today.
+   - **Or:** rewrite the diagnostic as F# in
+     `Terminal.App.exe`, emitting announcements via the
+     existing `TerminalSurface.Announce` chokepoint. Most
+     accessible, but duplicates the logic.
+
+   `Ctrl+Shift+D` stays in place as a usable-but-imperfect
+   diagnostic until the above lands; the
+   `docs/ACCESSIBILITY-TESTING.md` "Diagnostic decoder for
+   the launcher hotkeys" subsection notes the limitation
+   so future runs aren't surprised.
+
 ## Working conventions on this repo
 
 The written rules live in [`CONTRIBUTING.md`](../CONTRIBUTING.md):


### PR DESCRIPTION
## Summary

Manual verification of `v0.0.1-preview.27` (and the next preview that picks up #82's script fix) showed:

- ✅ `Ctrl+Shift+R` opens the GitHub Releases page in the default browser — **PASS**
- ✅ `Ctrl+Shift+D` launches the bundled process-cleanup script — **PASS**

**But:** the working hypothesis behind PR #81 — that NVDA would reliably read the spawned PowerShell window's stdout — is **not borne out in practice**. NVDA's coverage of the spawned `conhost` window is unreliable; the script's plain-text output is correct but the screen reader doesn't surface it the way it does for pty-speak's own UIA Document / Text pattern peer.

## Logged for follow-up

The maintainer suspects (correctly) that the right fix is to run diagnostics **inside pty-speak itself** once Stages 5 and 6 ship. `docs/SESSION-HANDOFF.md` gains a new item 6 with three options enumerated:

1. **Stage 6 lands first → user types the diagnostic into pty-speak's own shell.** Cleanest. The output flows through pty-speak's own peer (well-tested with NVDA).
2. **Multi-instance launch** — `Ctrl+Shift+D` spawns a second pty-speak whose child shell runs the diagnostic. Requires multi-instance plumbing not currently on the roadmap.
3. **Reimplement the diagnostic in F#** emitting announcements via the existing `TerminalSurface.Announce` chokepoint. Most accessible; duplicates logic.

Until one of these lands, `Ctrl+Shift+D` stays in place as a usable-but-imperfect tool. `docs/ACCESSIBILITY-TESTING.md` gains a "Known limitation" callout in the launcher-hotkey section so future runs aren't surprised by the NVDA gap.

## Changes

- `docs/SESSION-HANDOFF.md` — new pending action item 6 with the limitation, the maintainer's intuition, and three architectural options.
- `docs/ACCESSIBILITY-TESTING.md` — "Known limitation" callout cross-linking item 6.

No code changes.

## Test plan

- [ ] CI green on actionlint
- [ ] CI green on Markdown link check
- [ ] CI green on Build and test (no F# touched)

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_