### PR TITLE
feat(stage-4.5): alt-screen 1049 back-buffer (PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,77 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 4.5 PR-B: alt-screen 1049 back-buffer.** Closes the
+  last latent gap in the Claude Code rendering substrate.
+  Claude's Ink reconciler — and many other modern TUIs (`less`,
+  `vim`, `fzf`, `git log` pager, npm install's progress bars)
+  — sends `\x1b[?1049h` on startup to enter the alternate
+  screen and `\x1b[?1049l` on exit. Without alt-screen support,
+  the primary buffer's scrollback would get corrupted on every
+  alt-screen TUI launch; with it, the primary content is
+  preserved untouched and the screen reader can navigate
+  whichever buffer is active at the moment.
+
+  Implementation:
+
+  - `Screen` now holds two `Cell[,]` buffers (`primaryBuffer`,
+    `altBuffer`) and a `mutable activeBuffer` field that
+    points at one of them. Every cell read / write site
+    (`printRune`, `executeC0` for BS/HT/LF/CR, `eraseDisplay`,
+    `eraseLine`, `csiDispatch` cursor moves, `SnapshotRows`,
+    `GetCell`) was migrated from `cells.[r, c]` to
+    `activeBuffer.[r, c]` in one mechanical rename.
+
+  - `csiPrivateDispatch` (added by PR-A) now handles
+    `?1049h` → `enterAltScreen ()` and `?1049l` →
+    `exitAltScreen ()`. Both functions are idempotent: a
+    repeated `?1049h` while already in alt-screen is a
+    no-op; a repeated `?1049l` while already on primary is
+    a no-op.
+
+  - **Save/restore semantics match xterm `?1049`**: on enter,
+    the cursor row / col / SGR attrs are captured into a
+    `savedPrimary: (int * int * SgrAttrs) option` field;
+    `activeBuffer` is repointed at `altBuffer`; the alt
+    buffer is cleared (xterm convention — alt-screen always
+    starts blank); cursor moves to (0, 0) with default
+    attrs. On exit, the saved state is restored and
+    `activeBuffer` is repointed at `primaryBuffer`. Primary
+    cells are *never copied* — they sit unchanged in
+    `primaryBuffer` because nothing wrote to them during
+    the alt session.
+
+  - **`Modes.AltScreen` flag** flips with the swap so future
+    consumers (UIA peer announcing buffer changes, Stage 5
+    coalescer needing flush barriers, etc.) can read it.
+
+  - **`SequenceNumber` bumps on `?1049h/l`** as a side
+    effect of every `Apply` call. Stage 5's coalescer
+    should treat alt-screen toggles as a hard
+    invalidation barrier — flush the debounce window,
+    then resume — because the row content can change
+    wholesale between buffers and a debounce window
+    straddling a swap would mis-attribute rows. The PR-B
+    test `SequenceNumber bumps on ?1049h and ?1049l` pins
+    the contract for Stage 5's author to read.
+
+  9 new tests in `tests/Tests.Unit/ScreenTests.fs` exercise:
+  the AltScreen flag toggle; primary content preservation
+  across alt-screen entry/exit; alt-buffer reset on every
+  entry; cursor + attrs reset on enter and restore on
+  exit; idempotency of double-enter and double-exit;
+  `SnapshotRows` returning alt content during alt mode and
+  primary content after exit; and the `SequenceNumber`
+  bump on toggle.
+
+  **Stage 4.5 cycle complete with this PR**: the substrate
+  is in place for Stage 7 to actually run Claude Code. Next
+  is Stage 5 (streaming output notifications) — the
+  coalescer plugs into the `ScreenNotification` channel
+  seam shipped in audit-cycle PR-B and uses the `Modes`
+  bits + `SequenceNumber` bumps that Stage 4.5 PR-A and
+  PR-B established.
+
 - **Stage 4.5 PR-A: VT mode coverage + SGR table fills.**
   Closes the latent gap where the parser correctly emits
   events that `Screen.fs` silently dropped at its `_ -> ()`

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -19,10 +19,10 @@ A new session should read this **first**, then
 
 | | |
 |---|---|
-| **Last merged stages** | **Stage 4** (UIA Document + Text pattern + Line/Character/Word navigation + focus-into-TerminalSurface fix, PRs #54-#56, #59, #60, #68) and **Stage 11** (Velopack auto-update via `Ctrl+Shift+U`, PRs #63, #66). Both **NVDA-verified working** on a clean Windows 11 install — Stage 4 on `v0.0.1-preview.22` and `.26`, Stage 11 via a successful `preview.25 → preview.26` self-update. **Security-audit cycle SR-1/SR-2/SR-3** (PRs #76, #77, #78) merged after that, closing every HIGH-severity finding from the comprehensive code-level audit. |
-| **Last shipped release** | `v0.0.1-preview.26` (or whichever preview the maintainer last cut — release cadence is ad-hoc during the unsigned-preview line). The auto-update path replaces the `scripts/install-latest-preview.ps1` bridge for in-place updates; the script is now **deprecated for in-place updates** but remains useful for fresh installs and dev-environment workflows. The next preview cut will pick up the SR-1/SR-2/SR-3 hardening + the Stage 4.5 substrate work once that ships. |
-| **In-flight branch** | None. SR-1/SR-2/SR-3 audit cycle merged. The 2026-05-01 strategic stage review (`/root/.claude/plans/replicated-riding-sketch.md`) committed the maintainer to a separate **Stage 4.5 — Claude Code rendering substrate** stage between Stages 4 and 5. Process-cleanup test (the only Stage 4 row not yet exercised) is now a recurring acceptance check — see "Pending action items" item 2 below. |
-| **Next stage** | **Stage 4.5 — Claude Code rendering substrate.** Closes the latent gap where the parser correctly emits VT events that `Screen.fs` silently drops at its `_ -> ()` catch-all arms: alt-screen 1049 (DECSET `?1049h/l`), cursor visibility (DECTCEM `?25h/l`), DECSC/DECRC cursor save/restore (`ESC 7`/`ESC 8`), 256-colour SGR (`38;5;n`), and truecolor SGR (`38;2;r;g;b`). Adds a new `TerminalModes` record in `Types.fs` to centralise mode bits (alt-screen, cursor-visible, DECCKM, bracketed-paste, focus-reporting) so Stages 5/6/7 don't smear them across files. Without 4.5, Stage 7's Claude Code roundtrip will fail because Claude sends `?1049h` + `?25l` + truecolor on startup. After 4.5, **Stage 5 — Streaming output notifications** (Channel-based coalescer with 200ms debounce + frame-hash + per-row hash dedup; the frame-hash layer is a Stage 5 design refinement from the strategic review to compose with Claude Ink's full-frame redraws). |
+| **Last merged stages** | **Stage 4** (UIA Document + Text pattern + Line/Character/Word navigation + focus-into-TerminalSurface fix, PRs #54-#56, #59, #60, #68), **Stage 11** (Velopack auto-update via `Ctrl+Shift+U`, PRs #63, #66), **Security-audit cycle SR-1/SR-2/SR-3** (PRs #76, #77, #78), and **Stage 4.5 — Claude Code rendering substrate** (PR-A #85 mode coverage + SGR walker + DECTCEM + DECSC/DECRC + OSC 52 chokepoint, PR-B alt-screen 1049 back-buffer). Stage 4 + 11 NVDA-verified on `v0.0.1-preview.26`; Stage 4.5 verified by xUnit (27 new tests across PR-A + PR-B); manual NVDA verification on the next preview cut is the acceptance gate. |
+| **Last shipped release** | `v0.0.1-preview.26` (or whichever preview the maintainer last cut — release cadence is ad-hoc during the unsigned-preview line). The auto-update path replaces the `scripts/install-latest-preview.ps1` bridge for in-place updates; the script is now **deprecated for in-place updates** but remains useful for fresh installs and dev-environment workflows. The next preview cut picks up the SR-1/SR-2/SR-3 hardening + the Stage 4.5 substrate work (PR-A + PR-B). |
+| **In-flight branch** | None. Stage 4.5 PR-A and PR-B merged. The 2026-05-01 strategic stage review (`/root/.claude/plans/replicated-riding-sketch.md`) sequenced Stage 5 next. Process-cleanup test (the deferred Stage 4 row) is the recurring acceptance check tracked in "Pending action items" item 2; should re-run after the post-Stage-4.5 preview cut. |
+| **Next stage** | **Stage 5 — Streaming output notifications.** First stage where the user gets passive narration as terminal output streams in, rather than active review-cursor exploration. Validation: NVDA reads `dir` line-by-line; spinner-class redraws don't flood NVDA's speech queue; busy loops printing dots don't get NVDA stuck. Substrate: the `Screen.SequenceNumber` + `Screen.SnapshotRows` primitives (PR #38), the parser→UIA notification channel seam (audit-cycle PR-B), Stage 11's existing `TerminalView.Announce` raise path (PR #63), and Stage 4.5's `TerminalModes` + alt-screen flush-barrier semantics (PRs #85 + Stage 4.5 PR-B). Stage 5 plugs the coalescer between the parser and the channel: per-row hash dedup PLUS a frame-hash layer (added per the strategic review §C to compose with Claude Ink's full-frame redraws — without it, every row hash changes per redraw and per-row dedup never fires) PLUS a 200ms debounce. Alt-screen toggle is a hard flush barrier per the Stage 4.5 PR-B test contract. The seams are in place; only the coalescing logic is new. |
 
 The end-to-end pipeline now reaches the auto-update boundary:
 launching the app spawns `cmd.exe` under ConPTY, parses its
@@ -32,10 +32,11 @@ via UIA Document role + Text pattern with working Line / Word /
 Character / Document review-cursor navigation, and self-updates
 to subsequent previews via `Ctrl+Shift+U` with NVDA progress
 narration plus an audible version-flip on restart. Stage 4.5
-is the immediate next cycle (close the latent VT gaps so Stage
-7 can actually render Claude Code), and Stage 5 is the first
-stage where output starts narrating itself instead of waiting
-for the user to navigate to it.
+shipped in two PRs (mode coverage + alt-screen back-buffer);
+the Screen layer now applies DECTCEM, DECSC/DECRC, 256/truecolor
+SGR, alt-screen 1049, and the OSC 52 SECURITY-CRITICAL silent
+drop. Stage 5 is the first stage where output starts narrating
+itself instead of waiting for the user to navigate to it.
 
 ## Pending action items (maintainer)
 

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -67,8 +67,24 @@ type Screen(rows: int, cols: int) =
         if rows <= 0 then invalidArg "rows" "rows must be positive"
         if cols <= 0 then invalidArg "cols" "cols must be positive"
 
-    // Row-major grid. Row 0 is the top of the screen.
-    let cells: Cell[,] = Array2D.create rows cols Cell.blank
+    // Stage 4.5 PR-B: alt-screen 1049 back-buffer.
+    // Two row-major grids (primary + alt). All cell reads /
+    // writes go through `activeBuffer`, which is one of the
+    // two depending on alt-screen state. Primary content is
+    // preserved by *reference* during alt-screen sessions —
+    // we never copy primary on enter. On exit we just stop
+    // pointing at alt; primary is unchanged because nothing
+    // wrote to it during the alt-screen session.
+    //
+    // `savedPrimary` captures the cursor + SGR state that the
+    // primary buffer was in at the moment of `?1049h`, so
+    // `?1049l` can restore them. The xterm convention is that
+    // `?1049` saves/restores cursor + attrs as part of the
+    // buffer swap (it's a DECSC-equivalent baked in).
+    let primaryBuffer: Cell[,] = Array2D.create rows cols Cell.blank
+    let altBuffer: Cell[,] = Array2D.create rows cols Cell.blank
+    let mutable activeBuffer: Cell[,] = primaryBuffer
+    let mutable savedPrimary: (int * int * SgrAttrs) option = None
     let cursor: Cursor = Cursor.create ()
     let mutable currentAttrs: SgrAttrs = SgrAttrs.defaults
 
@@ -91,9 +107,9 @@ type Screen(rows: int, cols: int) =
         // Move every row up by one; bottom row becomes blank.
         for r in 0 .. rows - 2 do
             for c in 0 .. cols - 1 do
-                cells.[r, c] <- cells.[r + 1, c]
+                activeBuffer.[r, c] <- activeBuffer.[r + 1, c]
         for c in 0 .. cols - 1 do
-            cells.[rows - 1, c] <- Cell.blank
+            activeBuffer.[rows - 1, c] <- Cell.blank
 
     let advanceRow () =
         if cursor.Row < rows - 1 then
@@ -103,7 +119,7 @@ type Screen(rows: int, cols: int) =
 
     let writeAt (r: int) (c: int) (cell: Cell) =
         if r >= 0 && r < rows && c >= 0 && c < cols then
-            cells.[r, c] <- cell
+            activeBuffer.[r, c] <- cell
 
     let printRune (rune: Rune) =
         if cursor.Col >= cols then
@@ -139,32 +155,32 @@ type Screen(rows: int, cols: int) =
             // Clear from cursor to end of current line, then clear
             // following rows.
             for c in cursor.Col .. cols - 1 do
-                cells.[cursor.Row, c] <- Cell.blank
+                activeBuffer.[cursor.Row, c] <- Cell.blank
             for r in cursor.Row + 1 .. rows - 1 do
                 for c in 0 .. cols - 1 do
-                    cells.[r, c] <- Cell.blank
+                    activeBuffer.[r, c] <- Cell.blank
         | 1 ->
             for r in 0 .. cursor.Row - 1 do
                 for c in 0 .. cols - 1 do
-                    cells.[r, c] <- Cell.blank
+                    activeBuffer.[r, c] <- Cell.blank
             for c in 0 .. cursor.Col do
-                if c < cols then cells.[cursor.Row, c] <- Cell.blank
+                if c < cols then activeBuffer.[cursor.Row, c] <- Cell.blank
         | _ ->
             for r in 0 .. rows - 1 do
                 for c in 0 .. cols - 1 do
-                    cells.[r, c] <- Cell.blank
+                    activeBuffer.[r, c] <- Cell.blank
 
     let eraseLine (mode: int) =
         match mode with
         | 0 ->
             for c in cursor.Col .. cols - 1 do
-                cells.[cursor.Row, c] <- Cell.blank
+                activeBuffer.[cursor.Row, c] <- Cell.blank
         | 1 ->
             for c in 0 .. cursor.Col do
-                if c < cols then cells.[cursor.Row, c] <- Cell.blank
+                if c < cols then activeBuffer.[cursor.Row, c] <- Cell.blank
         | _ ->
             for c in 0 .. cols - 1 do
-                cells.[cursor.Row, c] <- Cell.blank
+                activeBuffer.[cursor.Row, c] <- Cell.blank
 
     /// Apply a single SGR parameter to currentAttrs.
     let applySgrOne (n: int) =
@@ -240,6 +256,56 @@ type Screen(rows: int, cols: int) =
                     walk (i + 1)
             walk 0
 
+    /// Switch the active buffer from primary to alt and reset
+    /// alt-screen state (cleared buffer, cursor at origin,
+    /// default attrs). Called when DECSET `?1049h` arrives.
+    /// Idempotent: if alt-screen is already active, this is a
+    /// no-op.
+    ///
+    /// Save semantics match xterm's `?1049`: the cursor
+    /// position and SGR attrs of the primary buffer at the
+    /// moment of swap are captured into `savedPrimary` so
+    /// `?1049l` can restore them. The primary buffer's *cells*
+    /// are not copied — they stay in `primaryBuffer` because
+    /// nothing writes to it during the alt session.
+    let enterAltScreen () =
+        if not modes.AltScreen then
+            savedPrimary <- Some (cursor.Row, cursor.Col, currentAttrs)
+            // Clear alt buffer (xterm convention: alt-screen
+            // starts blank).
+            for r in 0 .. rows - 1 do
+                for c in 0 .. cols - 1 do
+                    altBuffer.[r, c] <- Cell.blank
+            activeBuffer <- altBuffer
+            cursor.Row <- 0
+            cursor.Col <- 0
+            currentAttrs <- SgrAttrs.defaults
+            modes.AltScreen <- true
+
+    /// Switch the active buffer back to primary and restore
+    /// the cursor + SGR attrs that were saved on enter. Called
+    /// when DECSET `?1049l` arrives. Idempotent: if alt-screen
+    /// is not active, this is a no-op.
+    ///
+    /// Defensive: if `savedPrimary` is somehow `None` while
+    /// `modes.AltScreen` is `true` (shouldn't happen — they
+    /// flip atomically — but guard anyway), fall back to
+    /// (0, 0) with default attrs rather than crash.
+    let exitAltScreen () =
+        if modes.AltScreen then
+            match savedPrimary with
+            | Some (savedRow, savedCol, savedAttrs) ->
+                cursor.Row <- savedRow
+                cursor.Col <- savedCol
+                currentAttrs <- savedAttrs
+            | None ->
+                cursor.Row <- 0
+                cursor.Col <- 0
+                currentAttrs <- SgrAttrs.defaults
+            savedPrimary <- None
+            activeBuffer <- primaryBuffer
+            modes.AltScreen <- false
+
     /// CSI private-marker dispatch: handles sequences emitted
     /// when the parser sees a `?` private byte (DECSET / DECRESET
     /// for terminal modes). Stage 4.5 PR-A wires DECTCEM (`?25h/l`,
@@ -256,8 +322,8 @@ type Screen(rows: int, cols: int) =
         match finalByte, n with
         | 'h', 25 -> modes.CursorVisible <- true
         | 'l', 25 -> modes.CursorVisible <- false
-        // PR-B will add: | 'h', 1049 -> enterAltScreen ()
-        //                | 'l', 1049 -> exitAltScreen ()
+        | 'h', 1049 -> enterAltScreen ()
+        | 'l', 1049 -> exitAltScreen ()
         // Stage 6 will add: ?1 (DECCKM), ?2004 (bracketed paste),
         //                   ?1004 (focus reporting)
         | _ -> ()
@@ -352,7 +418,7 @@ type Screen(rows: int, cols: int) =
     member _.Modes = modes
 
     /// Read-only access to a cell. (row, col) are 0-indexed.
-    member _.GetCell(row: int, col: int) : Cell = cells.[row, col]
+    member _.GetCell(row: int, col: int) : Cell = activeBuffer.[row, col]
 
     /// Monotonic counter incremented on every Apply. Stage 4 ranges
     /// store this at construction; if it has changed when the range
@@ -375,7 +441,7 @@ type Screen(rows: int, cols: int) =
         lock gate (fun () ->
             let snapshot = Array.init count (fun i ->
                 let r = startRow + i
-                Array.init cols (fun c -> cells.[r, c]))
+                Array.init cols (fun c -> activeBuffer.[r, c]))
             sequenceNumber, snapshot)
 
     /// Apply a single VT event to the buffer. Stage 3a covers the

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -92,7 +92,7 @@ type Screen(rows: int, cols: int) =
     // DECCKM, bracketed paste, focus reporting). Centralised
     // here so Stage 5/6/7 don't smear them across files. PR-B
     // wires `AltScreen`; Stage 6 wires the keyboard-side bits.
-    let mutable modes: TerminalModes = TerminalModes.defaults
+    let mutable modes: TerminalModes = TerminalModes.create ()
 
     // Mutation gate. Apply takes this lock; SnapshotRows takes it to
     // capture (sequence, rows) atomically. Stage 3b feeds Apply on the

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -105,9 +105,21 @@ type TerminalModes =
       mutable FocusReporting: bool }
 
 module TerminalModes =
-    /// Default mode set: alt-screen off, cursor visible, every
-    /// other bit at its DECSET-default-reset value.
-    let defaults : TerminalModes =
+    /// Fresh `TerminalModes` instance with the default mode set:
+    /// alt-screen off, cursor visible, every other bit at its
+    /// DECSET-default-reset value.
+    ///
+    /// **Must be a `unit -> TerminalModes` factory, NOT a
+    /// `let defaults : TerminalModes = { ... }` static value.**
+    /// `TerminalModes` is a regular record (reference semantics),
+    /// so a static `let` binding would return the SAME instance
+    /// to every caller — and mutations from one `Screen` instance
+    /// would leak into every other `Screen`. The static-value
+    /// pattern is safe for `SgrAttrs.defaults` and `Cell.blank`
+    /// because those are `[<Struct>]` (value semantics, copied
+    /// on assignment), but for `TerminalModes` we need a fresh
+    /// instance per construction. This mirrors `Cursor.create ()`.
+    let create () : TerminalModes =
         { AltScreen = false
           CursorVisible = true
           DECCKM = false

--- a/tests/Tests.Unit/ScreenTests.fs
+++ b/tests/Tests.Unit/ScreenTests.fs
@@ -482,3 +482,140 @@ let ``OSC 52 sequence increments SequenceNumber but does not mutate cells`` () =
     // Cells unchanged.
     for c in 0 .. snap0.[0].Length - 1 do
         Assert.Equal(snap0.[0].[c], snap1.[0].[c])
+
+// ---------------------------------------------------------------------
+// Stage 4.5 PR-B — alt-screen 1049 back-buffer
+// ---------------------------------------------------------------------
+//
+// Tests for DECSET ?1049h/l. Pointer-swap semantics: alt-screen
+// is its own buffer; primary content is preserved by reference
+// (no copy), so exiting alt-screen surfaces the unchanged
+// primary buffer. Cursor + SGR attrs are saved on enter and
+// restored on exit (xterm `?1049` is a buffer swap + DECSC
+// rolled into one).
+
+[<Fact>]
+let ``alt-screen toggle flips Modes.AltScreen flag`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    Assert.False(screen.Modes.AltScreen)
+    feed screen (ascii "\x1b[?1049h")
+    Assert.True(screen.Modes.AltScreen)
+    feed screen (ascii "\x1b[?1049l")
+    Assert.False(screen.Modes.AltScreen)
+
+[<Fact>]
+let ``alt-screen entry preserves primary content (pointer-swap, no copy)`` () =
+    let screen = Screen(rows = 3, cols = 8)
+    feed screen (ascii "primary!")
+    Assert.Equal("primary!", rowText screen 0)
+    // Enter alt-screen and write something completely
+    // different on it.
+    feed screen (ascii "\x1b[?1049h")
+    feed screen (ascii "ALTSCRN!")
+    Assert.Equal("ALTSCRN!", rowText screen 0)
+    // Exit alt-screen — primary should be untouched because
+    // nothing wrote to it during the alt session.
+    feed screen (ascii "\x1b[?1049l")
+    Assert.Equal("primary!", rowText screen 0)
+
+[<Fact>]
+let ``alt-screen entry clears the alt buffer`` () =
+    // Alt buffer starts blank on every enter; if we enter,
+    // write, exit, and re-enter, the alt buffer should be
+    // blank on the second entry (xterm convention).
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1049h")
+    feed screen (ascii "first")
+    Assert.Equal("first", rowText screen 0)
+    feed screen (ascii "\x1b[?1049l")
+    feed screen (ascii "\x1b[?1049h")
+    // Second entry should clear the alt buffer.
+    Assert.Equal("     ", rowText screen 0)
+
+[<Fact>]
+let ``alt-screen entry resets cursor to (0, 0) with default attrs`` () =
+    let screen = Screen(rows = 3, cols = 10)
+    // Set up non-trivial primary state: bold attr + cursor at (1, 5).
+    feed screen (ascii "\x1b[1m\x1b[2;6H")
+    Assert.True(screen.CurrentAttrs.Bold)
+    Assert.Equal(1, screen.Cursor.Row)
+    Assert.Equal(5, screen.Cursor.Col)
+    feed screen (ascii "\x1b[?1049h")
+    // On enter: cursor at (0, 0), default attrs.
+    Assert.Equal(0, screen.Cursor.Row)
+    Assert.Equal(0, screen.Cursor.Col)
+    Assert.False(screen.CurrentAttrs.Bold)
+
+[<Fact>]
+let ``alt-screen exit restores cursor + SGR attrs from primary`` () =
+    let screen = Screen(rows = 3, cols = 10)
+    feed screen (ascii "\x1b[1m\x1b[2;6H")  // bold + (1, 5)
+    feed screen (ascii "\x1b[?1049h")
+    // Mess with state inside alt-screen.
+    feed screen (ascii "\x1b[3;1H\x1b[3m")  // (2, 0) + italic
+    feed screen (ascii "\x1b[?1049l")
+    // Exit: cursor and bold attrs restored from primary.
+    Assert.Equal(1, screen.Cursor.Row)
+    Assert.Equal(5, screen.Cursor.Col)
+    Assert.True(screen.CurrentAttrs.Bold)
+    Assert.False(screen.CurrentAttrs.Italic)
+
+[<Fact>]
+let ``alt-screen entry is idempotent (?1049h while already in alt is a no-op)`` () =
+    let screen = Screen(rows = 3, cols = 10)
+    feed screen (ascii "primary")
+    feed screen (ascii "\x1b[?1049h")
+    feed screen (ascii "altone")
+    Assert.Equal("altone    ", rowText screen 0)
+    // Second ?1049h must not clear the alt buffer (the
+    // already-in-alt branch short-circuits before the clear
+    // loop).
+    feed screen (ascii "\x1b[?1049h")
+    Assert.Equal("altone    ", rowText screen 0)
+
+[<Fact>]
+let ``alt-screen exit is idempotent (?1049l while not in alt is a no-op)`` () =
+    let screen = Screen(rows = 3, cols = 10)
+    feed screen (ascii "primary")
+    Assert.False(screen.Modes.AltScreen)
+    feed screen (ascii "\x1b[?1049l")
+    Assert.False(screen.Modes.AltScreen)
+    // Primary content unchanged.
+    Assert.Equal("primary   ", rowText screen 0)
+
+[<Fact>]
+let ``SnapshotRows during alt-screen returns alt content; post-exit returns primary`` () =
+    let screen = Screen(rows = 1, cols = 8)
+    feed screen (ascii "primary!")
+    feed screen (ascii "\x1b[?1049h")
+    feed screen (ascii "altscrn!")
+    let _, snapDuring = screen.SnapshotRows(0, 1)
+    let cellChars =
+        snapDuring.[0]
+        |> Array.map (fun c -> c.Ch.ToString())
+        |> String.concat ""
+    Assert.Equal("altscrn!", cellChars)
+    feed screen (ascii "\x1b[?1049l")
+    let _, snapAfter = screen.SnapshotRows(0, 1)
+    let cellCharsAfter =
+        snapAfter.[0]
+        |> Array.map (fun c -> c.Ch.ToString())
+        |> String.concat ""
+    Assert.Equal("primary!", cellCharsAfter)
+
+[<Fact>]
+let ``SequenceNumber bumps on ?1049h and ?1049l`` () =
+    // Stage 5's coalescer must treat alt-screen toggles as
+    // flush barriers — the row content can change wholesale
+    // between primary and alt, so a debounce window
+    // straddling a swap would mis-attribute rows. The bump is
+    // automatic because Apply unconditionally bumps for every
+    // event; this test pins the contract.
+    let screen = Screen(rows = 1, cols = 5)
+    let seq0 = screen.SequenceNumber
+    feed screen (ascii "\x1b[?1049h")
+    let seq1 = screen.SequenceNumber
+    Assert.True(seq1 > seq0)
+    feed screen (ascii "\x1b[?1049l")
+    let seq2 = screen.SequenceNumber
+    Assert.True(seq2 > seq1)


### PR DESCRIPTION
## Summary

Stage 4.5 PR-B: closes the last latent gap in the Claude Code rendering substrate by adding alt-screen 1049 back-buffer support. Claude's Ink reconciler — and many other modern TUIs (`less`, `vim`, `fzf`, `git log` pager, `npm install`'s progress bars) — sends `\x1b[?1049h` on startup to enter the alternate screen and `\x1b[?1049l` on exit. Without alt-screen support, the primary buffer's scrollback would get corrupted on every alt-screen TUI launch.

PR-A (#85) shipped the substrate (TerminalModes record + private-CSI dispatch + ESC dispatch + SGR walker + OSC 52 chokepoint). PR-B plugs alt-screen into that substrate.

## Implementation

- **Two `Cell[,]` buffers + active-buffer pointer.** `Screen` now holds `primaryBuffer`, `altBuffer`, and `mutable activeBuffer` (which points at one of them). Every cell read / write site (`printRune`, `executeC0`, `eraseDisplay`, `eraseLine`, `csiDispatch` cursor moves, `SnapshotRows`, `GetCell`) was migrated from `cells.[r, c]` to `activeBuffer.[r, c]` in one mechanical rename.
- **`enterAltScreen` / `exitAltScreen`** functions wired into the `csiPrivateDispatch` arms `'h', 1049` and `'l', 1049` (PR-A's stub).
- **Save/restore semantics match xterm `?1049`**: on enter, cursor row/col/SGR attrs are captured into `savedPrimary: (int * int * SgrAttrs) option`; `activeBuffer` repoints at `altBuffer`; alt buffer cleared (xterm convention); cursor → `(0, 0)` + default attrs. On exit: saved state restored, `activeBuffer` repoints at `primaryBuffer`. **Primary cells never copied** — they sit unchanged in `primaryBuffer` because nothing wrote to them during the alt session.
- **Both functions idempotent**: double-enter is a no-op; double-exit is a no-op.
- **`Modes.AltScreen` flag** flips with the swap.

## Stage 5 contract (flush barriers)

`SequenceNumber` bumps on `?1049h/l` as a side effect of every `Apply` call. Stage 5's coalescer **must** treat alt-screen toggles as a hard flush barrier — the row content can change wholesale between buffers and a debounce window straddling a swap would mis-attribute rows. The new test `SequenceNumber bumps on ?1049h and ?1049l` pins the contract.

## Tests

9 new tests in `tests/Tests.Unit/ScreenTests.fs`:

- AltScreen flag toggle
- Primary content preserved across alt-screen entry/exit
- Alt buffer cleared on every entry (re-entering doesn't surface stale content)
- Cursor + attrs reset on enter (0, 0 + defaults)
- Cursor + attrs restored on exit (from `savedPrimary`)
- Idempotent double-enter
- Idempotent double-exit
- `SnapshotRows` returns alt content during alt mode; primary content after exit
- `SequenceNumber` bumps on toggle (Stage 5 flush-barrier contract)

## Docs

- `CHANGELOG.md` `[Unreleased]` → Added: long Stage 4.5 PR-B entry
- `docs/SESSION-HANDOFF.md` "Where we left off": Stage 4.5 shipped (PR-A + PR-B), Stage 5 next with the frame-hash refinement + alt-screen flush-barrier notes for the coalescer author

## Stage 4.5 cycle complete with this PR

After merge, the substrate is in place for Stage 7 to actually run Claude Code. Next: Stage 5 (streaming output notifications).

## Test plan

- [ ] CI green on Build and test (windows-latest)
- [ ] CI green on actionlint
- [ ] CI green on Markdown link check
- [ ] After merge, cut a new preview release. Self-update via `Ctrl+Shift+U`.
- [ ] Manual smoke: in `cmd.exe`, run `more SECURITY.md` (or any pager that uses alt-screen). Text scrolls in the alt buffer. Exit `more`. Prompt is back unchanged.
- [ ] NVDA sanity: review cursor on alt-screen content reads the alt buffer; after exit, review cursor reads the primary buffer.
- [ ] Run `Ctrl+Shift+D` diagnostic to verify no process-lifecycle regression.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_