### PR TITLE
chore(hygiene): keybinding count fix + branch-cleanup convention + bulk-cleanup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **Repo-hygiene cleanup (post-Stage-4.5 sweep).** Two
+  small documentation fixes, a future-proofing convention
+  added to `CONTRIBUTING.md`, and a one-time cleanup
+  script for the maintainer to run on their workstation:
+
+  - `docs/USER-SETTINGS.md` Keybindings section: corrected
+    "Four app-level keybindings shipped today" to "Three"
+    (the bullet list correctly enumerates three shipped
+    `Ctrl+Shift+U/D/R` plus two reserved `Ctrl+Shift+M`,
+    `Alt+Shift+R`; the prose count was off by one).
+
+  - `CONTRIBUTING.md` Branching and pull requests: new
+    bullet documenting the post-merge convention to
+    delete the source branch (both remote and local).
+    The repo had accumulated 75+ stale post-merge
+    branches over the project's history; the codified
+    convention prevents recurrence.
+
+  - `scripts/cleanup-stale-branches.sh`: bundled
+    maintainer-side script that deletes the 77 accumulated
+    stale post-merge branches in one go. The agent
+    sandbox cannot delete remote refs (proxy returns
+    HTTP 403 on `git push --delete`), so this is a
+    one-time maintainer action. Idempotent
+    (`git ls-remote --exit-code` check skips branches
+    that have already been deleted). The script can be
+    deleted from the repo after the one-time cleanup
+    finishes.
+
+  - `docs/SESSION-HANDOFF.md` "Pending action items"
+    item 7 tracks the cleanup-script run as a
+    maintainer-side action.
+
+  No code paths touched.
+
 ### Added
 
 - **Stage 4.5 PR-B: alt-screen 1049 back-buffer.** Closes the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,15 @@ See [`docs/BUILD.md`](docs/BUILD.md) for build instructions.
   (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`).
   All PRs to date have been squashed; the merge commit subject becomes
   the canonical history line.
+- **Delete the source branch after the squash-merge lands** (both
+  remote and local). The squashed commit on `main` is the canonical
+  reference; the branch is redundant after merge and accumulates as
+  visual noise in `git branch -a`. GitHub's "Delete branch" button
+  on the merged PR page does the remote half in one click; locally,
+  `git fetch --prune origin` + `git branch -d <name>` finishes the
+  job. Without this discipline the repo accumulates dozens of stale
+  refs over time (the post-Stage-4.5 hygiene sweep removed 75+ such
+  branches in one go).
 - **One concern per PR.** When tempted to bundle two improvements,
   split them. Past frustrations on this repo trace back to oversized
   PRs with multiple moving parts; small focused PRs review faster and

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -282,6 +282,38 @@ disconnects mid-session.
    the launcher hotkeys" subsection notes the limitation
    so future runs aren't surprised.
 
+7. **One-time bulk-delete of 77 stale post-merge branches
+   on `origin/`.** The post-Stage-4.5 hygiene audit
+   identified 77 remote branches whose work has been
+   squash-merged into `main` (every branch's PR has
+   either `merged_at` or a `closed` state per the GitHub
+   API). They've accumulated because the
+   delete-branch-after-merge convention wasn't codified
+   until PR #87 added it to CONTRIBUTING.md.
+
+   The agent sandbox cannot delete remote branches
+   (proxy returns HTTP 403 on `git push --delete`), so
+   this is a maintainer-side action. The full deletion
+   list is bundled as
+   `scripts/cleanup-stale-branches.sh` (shipped via
+   PR #87). To execute:
+
+   ```bash
+   bash scripts/cleanup-stale-branches.sh
+   ```
+
+   Runs from any workstation with normal git push
+   permissions. ~30 sec end to end. Idempotent (skips
+   branches that have already been deleted via
+   `ls-remote --exit-code` check). After it completes,
+   `origin/` should have ~3 branches: `main`, the
+   active hygiene PR's branch (if not yet merged), and
+   any in-flight new work.
+
+   The script can be deleted from the repo after the
+   one-time cleanup finishes; future branch hygiene is
+   covered by the per-PR convention in CONTRIBUTING.md.
+
 ## Working conventions on this repo
 
 The written rules live in [`CONTRIBUTING.md`](../CONTRIBUTING.md):

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -263,7 +263,8 @@ defaults; they shouldn't be the only options.
 
 ### Current state
 
-Four app-level keybindings shipped today:
+Three app-level keybindings shipped today (plus two reserved
+for future stages — listed inline below):
 
 - **`Ctrl+Shift+U`** — Velopack auto-update (Stage 11, PR #63).
   Wired in `setupAutoUpdateKeybinding` in

--- a/scripts/cleanup-stale-branches.sh
+++ b/scripts/cleanup-stale-branches.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# One-time bulk-delete of stale post-merge branches on `origin/`.
+#
+# The post-Stage-4.5 hygiene audit (2026-05-02) identified 77 remote
+# branches whose work has been squash-merged into `main` over the
+# project's history. They accumulated because the
+# delete-branch-after-merge convention wasn't codified until PR #87
+# added it to `CONTRIBUTING.md`.
+#
+# Each branch listed below has a corresponding closed-or-merged PR;
+# the squashed commit on `main` is the canonical reference. The
+# `git ls-remote --exit-code` check makes this idempotent — branches
+# that have already been deleted are silently skipped, so re-running
+# the script after a partial run is safe.
+#
+# Skipped intentionally:
+#   - `main` (obvious)
+#   - `chore/hygiene-keybinding-count-and-branch-convention` — the
+#     active PR #87 branch that ships THIS script. Once #87 merges,
+#     it can be added to a follow-up cleanup if desired (or simply
+#     deleted via the GitHub UI's "Delete branch" button on the
+#     merged PR page).
+#
+# Run from any workstation with normal git push permissions:
+#
+#     bash scripts/cleanup-stale-branches.sh
+#
+# After it completes, this script file itself can be deleted (it's a
+# one-time cleanup). Future branch hygiene is covered by the
+# per-PR convention in CONTRIBUTING.md.
+
+set -e
+cd "$(git rev-parse --show-toplevel)"
+git fetch --prune origin
+
+BRANCHES=(
+    chore/add-diagnostic-workflow
+    chore/audit-hygiene
+    chore/bump-action-gh-release-v3
+    chore/bump-changelog-to-preview-2
+    chore/bump-changelog-to-preview-3
+    chore/bump-upload-artifact-v7
+    chore/changelog-preview-18
+    chore/checkpoints-pending-tags
+    chore/ci-hygiene-actionlint-and-release-gates
+    chore/ci-timing-optimisation
+    chore/document-checkpoints
+    chore/drop-release-env-and-bump-changelog
+    chore/finalize-release-pipeline-docs
+    chore/install-latest-preview-script
+    chore/process-cleanup-test-script
+    chore/relax-changelog-gate
+    chore/release-bisect-add-notes-step
+    chore/release-bisect-pack-only
+    chore/release-conditional-delta-pattern
+    chore/release-drop-optional-delta-pattern
+    chore/release-fix-heredoc-indentation
+    chore/release-restore-build-pipeline
+    chore/release-restore-publish-pack-upload
+    chore/release-restore-softprops-upload
+    chore/release-restore-windows-runner
+    chore/release-trigger-on-release-event
+    chore/remove-diagnose-workflow
+    chore/session-handoff-and-final-audit
+    chore/stage-1-audit-and-conpty-notes
+    chore/stage-4-prep-snapshot-and-handoff
+    chore/strip-release-to-minimum
+    chore/test-and-ci-cleanup-pre-stage-4
+    ci/fix-velopack-manifest-globs
+    claude/create-project-docs-xVA6n
+    docs/audit-truth-up
+    docs/comprehensive-manual-smoke-tests
+    docs/contributing-esc-byte-convention
+    docs/diagnostic-ux-deferred-followup
+    docs/move-stage-11-forward
+    docs/post-audit-handoff-update
+    docs/release-process-target-branch-guidance
+    docs/security-comprehensive-threat-model
+    docs/session-handoff-ci-timing-reminder
+    docs/session-handoff-stage-4-and-11-verified
+    docs/stage-4-three-pr-plan
+    docs/user-settings-catalog-and-configurability-principle
+    feat/diagnostic-hotkey-ctrl-shift-d
+    feat/pre-stage-5-seams
+    feat/release-notes-hotkey-ctrl-shift-n
+    feat/stage-11-velopack-self-update
+    feat/stage-4-text-flaui-test
+    feat/stage-4-text-raw-provider
+    feat/stage-4.5a-mode-coverage
+    feat/stage-4.5b-alt-screen
+    feat/stage-4a-minimal-uia-surface
+    feat/text-range-word-navigation
+    feat/version-suffix-and-update-error-clarity
+    feature/stage-1-conpty-hello-world
+    feature/stage-2-vt-parser
+    feature/stage-3a-screen-model
+    feature/stage-3b-wpf-rendering
+    fix/main-window-focuses-terminal-view
+    fix/parser-param-push-and-delta-nupkg
+    fix/release-fetch-prior-walks-back-burned-tags
+    fix/stage-4-text-pattern-navigation
+    fix/test-script-already-running-mode
+    fix/wpf-subsystem-no-console
+    sec/sr1-parser-hardening
+    sec/sr2-accessibility-hardening
+    sec/sr3-security-md-audit-response
+    spike/flaui-integration-test
+    spike/fsharp-rawelementprovider-compile
+    spike/getpatterncore-reflection-probe
+    spike/stage-4-fsharp-uia-interop
+    spike/textblock-peer-visibility
+    spike/wm-getobject-window-subclass
+    test/burn-down-deferred-tests
+)
+
+deleted_count=0
+skipped_count=0
+failed_count=0
+
+for branch in "${BRANCHES[@]}"; do
+    if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+        if git push origin --delete "$branch"; then
+            echo "deleted: $branch"
+            deleted_count=$((deleted_count + 1))
+        else
+            echo "FAILED: $branch"
+            failed_count=$((failed_count + 1))
+        fi
+    else
+        echo "skipped (already gone): $branch"
+        skipped_count=$((skipped_count + 1))
+    fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Deleted:  $deleted_count"
+echo "Skipped:  $skipped_count"
+echo "Failed:   $failed_count"
+echo ""
+echo "Run 'git fetch --prune origin' afterwards to refresh local"
+echo "remote-tracking branches."


### PR DESCRIPTION
## Summary

Post-Stage-4.5 hygiene sweep: two small documentation fixes, a future-proofing convention added to `CONTRIBUTING.md`, and a one-time bulk-delete script for the 77 accumulated stale post-merge branches the audit identified.

## Changes

- **`docs/USER-SETTINGS.md`** Keybindings section said "Four app-level keybindings shipped today" but the bullet list correctly enumerates **three shipped** (`Ctrl+Shift+U/D/R`) plus **two reserved** (`Ctrl+Shift+M`, `Alt+Shift+R`). Off-by-one prose bug; change "Four" to "Three".

- **`CONTRIBUTING.md`** Branching and pull requests: new bullet under "Squash-merge by default" documenting the post-merge convention to delete the source branch (both remote and local). Prevents future accumulation; previously not codified, which is how 75+ stale branches accumulated.

- **`scripts/cleanup-stale-branches.sh`** (new) — bundled maintainer-side script that deletes the 77 accumulated stale branches in one go. The agent sandbox cannot delete remote refs (proxy returns HTTP 403 on `git push --delete`), so this is a one-time maintainer action runnable from any workstation with normal git push permissions. Idempotent (`git ls-remote --exit-code` check skips branches that have already been deleted). The script can be deleted from the repo after the one-time cleanup finishes; future hygiene is covered by the per-PR convention in CONTRIBUTING.md.

- **`docs/SESSION-HANDOFF.md`** "Pending action items" item 7 tracks the cleanup-script run as a maintainer-side action.

- **`CHANGELOG.md`** `[Unreleased]` → Changed entry covers all four bullets above.

No code paths touched.

## Run instructions for the cleanup script

After this PR merges, on your dev workstation:

```bash
bash scripts/cleanup-stale-branches.sh
```

~30 sec. Reports `deleted: <branch>` / `skipped (already gone): <branch>` / `FAILED: <branch>` per branch + a summary count.

## Why now

Maintainer flagged a hygiene concern after the long Stage 4.5 + audit-cycle session. An audit confirmed `origin/main` is in genuinely good shape (CHANGELOG / SECURITY.md / SESSION-HANDOFF / README.md all current with shipped code). The only real drift was the USER-SETTINGS off-by-one. The CONTRIBUTING addition closes the loop on why 75+ stale branches accumulated; the script handles the one-time cleanup the sandbox can't do.

## Test plan

- [ ] CI green on actionlint
- [ ] CI green on Markdown link check (no broken cross-references)
- [ ] CI green on Build and test (no F# touched)
- [ ] After merge: maintainer runs `bash scripts/cleanup-stale-branches.sh` from their workstation; remote branch count drops to ~3 (`main`, this PR's branch if not yet auto-deleted, plus any in-flight new work).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh