### PR TITLE
fix(hotkeys): announce before spawning window so NVDA isn't cut off by focus-grab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Ctrl+Shift+D` and `Ctrl+Shift+R` announcements no longer get
+  cut off by the spawned window's focus-grab.** Discovered during
+  Stage 5 manual NVDA verification: pressing `Ctrl+Shift+D` started
+  the diagnostic announcement but NVDA was interrupted as soon as
+  the new PowerShell window activated and stole focus (NVDA's
+  default interrupt-on-focus-change). Same shape for
+  `Ctrl+Shift+R` once the browser activated. Pre-existing since
+  the diagnostic hotkey shipped in PR #81 and the releases hotkey
+  shipped in PR #84; latent because no NVDA verification cycle
+  before today exercised the announce path end-to-end.
+
+  Fix in `src/Terminal.App/Program.fs runDiagnostic` and
+  `runOpenReleases`: announce a SHORT cue ("Launching
+  diagnostic.", "Opening release notes.") FIRST, then schedule
+  the actual `Process.Start` on a ~700ms `Task.Delay` so NVDA's
+  speech queue has time to play the cue before the new window's
+  title takes over. The longer guidance ("Switch to that window
+  to follow the test.") is dropped from the cue — once the
+  user hears the spawned window's title, they have all the
+  context the long version provided. Both announces are also
+  re-tagged with the proper `ActivityIds.diagnostic` /
+  `ActivityIds.releases` per-class tags introduced in Stage 5
+  (replacing the back-compat default `pty-speak.update`).
+
+  No new hotkey contract; same `Ctrl+Shift+D/R` behaviour from
+  the user's side, just audible. Phase 2 TOML config will make
+  the 700ms delay configurable alongside the Stage 5 coalescer
+  constants.
+
 ### Added
 
 - **Stage 5: streaming-output coalescer.** First stage where

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -229,21 +229,49 @@ module Program =
                     "Diagnostic script not found at %s. Re-install pty-speak or report this as a packaging regression."
                     scriptPath)
         else
-            try
-                let psi = System.Diagnostics.ProcessStartInfo()
-                psi.FileName <- "powershell.exe"
-                psi.Arguments <-
-                    sprintf
-                        "-ExecutionPolicy Bypass -NoExit -File \"%s\""
-                        scriptPath
-                psi.UseShellExecute <- true
-                System.Diagnostics.Process.Start(psi) |> ignore
-                window.TerminalSurface.Announce(
-                    "Diagnostic launched in a separate PowerShell window. Switch to that window to follow the test.")
-            with ex ->
-                let safe = AnnounceSanitiser.sanitise ex.Message
-                window.TerminalSurface.Announce(
-                    sprintf "Could not launch diagnostic: %s" safe)
+            // Announce FIRST so NVDA's speech queue holds the message
+            // before focus shifts. The new PowerShell window's
+            // activation triggers NVDA's interrupt-on-focus-change,
+            // which truncates whatever is currently being spoken — so
+            // the previous "Process.Start then Announce" order made the
+            // announce effectively silent (the queued speech was
+            // immediately overwritten by NVDA reading the new PowerShell
+            // window's title). Pre-Stage-5 NVDA verification on
+            // `v0.0.1-preview.NN` confirmed the regression.
+            //
+            // Fix: announce a SHORT cue ("Launching diagnostic.") that
+            // NVDA can fully read in well under the focus-grab latency,
+            // wait ~700ms, then start the process. The PowerShell
+            // window's title takes over from there — which is the
+            // natural way for screen-reader users to confirm the new
+            // window arrived.
+            // TODO Phase 2: the 700ms delay should come from a TOML
+            // setting alongside the Stage 5 coalescer constants.
+            window.TerminalSurface.Announce(
+                "Launching diagnostic.",
+                ActivityIds.diagnostic)
+            let _ =
+                task {
+                    do! Task.Delay(700)
+                    let action () =
+                        try
+                            let psi = System.Diagnostics.ProcessStartInfo()
+                            psi.FileName <- "powershell.exe"
+                            psi.Arguments <-
+                                sprintf
+                                    "-ExecutionPolicy Bypass -NoExit -File \"%s\""
+                                    scriptPath
+                            psi.UseShellExecute <- true
+                            System.Diagnostics.Process.Start(psi) |> ignore
+                        with ex ->
+                            let safe = AnnounceSanitiser.sanitise ex.Message
+                            window.TerminalSurface.Announce(
+                                sprintf "Could not launch diagnostic: %s" safe,
+                                ActivityIds.error)
+                    do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                    ()
+                }
+            ()
 
     /// Wire `Ctrl+Shift+D` to trigger `runDiagnostic`. Same
     /// pattern as `setupAutoUpdateKeybinding` above. Per the
@@ -286,17 +314,32 @@ module Program =
     /// inherits whatever the user configures.
     let private runOpenReleases (window: MainWindow) : unit =
         let url = UpdateRepoUrl + "/releases"
-        try
-            let psi = System.Diagnostics.ProcessStartInfo()
-            psi.FileName <- url
-            psi.UseShellExecute <- true
-            System.Diagnostics.Process.Start(psi) |> ignore
-            window.TerminalSurface.Announce(
-                sprintf "Opened release notes in default browser: %s" url)
-        with ex ->
-            let safe = AnnounceSanitiser.sanitise ex.Message
-            window.TerminalSurface.Announce(
-                sprintf "Could not open release notes: %s" safe)
+        // Same announce-before-focus-grab pattern as `runDiagnostic`
+        // above (the launched browser will steal focus and NVDA's
+        // interrupt-on-focus-change will truncate the queued speech
+        // unless we give it ~700ms head start).
+        // TODO Phase 2: TOML-configurable delay.
+        window.TerminalSurface.Announce(
+            "Opening release notes.",
+            ActivityIds.releases)
+        let _ =
+            task {
+                do! Task.Delay(700)
+                let action () =
+                    try
+                        let psi = System.Diagnostics.ProcessStartInfo()
+                        psi.FileName <- url
+                        psi.UseShellExecute <- true
+                        System.Diagnostics.Process.Start(psi) |> ignore
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        window.TerminalSurface.Announce(
+                            sprintf "Could not open release notes: %s" safe,
+                            ActivityIds.error)
+                do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                ()
+            }
+        ()
 
     /// Wire `Ctrl+Shift+R` to trigger `runOpenReleases`. Same
     /// pattern as the other reserved hotkeys above.


### PR DESCRIPTION
## Summary

Pre-existing latent bug discovered during Stage 5 manual NVDA verification on the post-Stage-5 preview: pressing `Ctrl+Shift+D` (diagnostic) started the announcement but NVDA was interrupted as soon as the new PowerShell window activated and stole focus. Same shape for `Ctrl+Shift+R` (releases) once the browser activated. NVDA's default interrupt-on-focus-change behaviour means any queued speech is truncated when focus shifts.

The previous `Process.Start` → `Announce` order made the announce effectively silent — the queued UIA Notification was overwritten by NVDA reading the new window's title before it ever played.

Pre-existing since `Ctrl+Shift+D` shipped in PR #81 and `Ctrl+Shift+R` shipped in PR #84; latent because no NVDA verification cycle before today exercised the announce path end-to-end.

## What changed

`src/Terminal.App/Program.fs` `runDiagnostic` and `runOpenReleases`:

- **Announce a SHORT cue first** — "Launching diagnostic." / "Opening release notes." — so NVDA can fully read it inside the ~700-1000ms window before focus shifts.
- **Schedule `Process.Start` on a `Task.Delay(700)`** marshalled back to the WPF Dispatcher so the announce gets head start, the process launches, and the new window's title takes over the speech.
- **Drop the longer guidance** ("Switch to that window to follow the test.", "Opened release notes in default browser: URL") from the cue — once the user hears the spawned window's title via NVDA, they have all the context the long version provided.
- **Re-tag** with the proper `ActivityIds.diagnostic` / `ActivityIds.releases` per-class tags introduced in Stage 5 (replacing the back-compat default `pty-speak.update`).

The 700ms delay is hardcoded with a `// TODO Phase 2` comment for TOML-configurable user setting alongside the Stage 5 coalescer constants.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check
- [ ] All existing tests still pass (no test changes; this is a small dispatcher-pattern refactor of two hotkey handlers)
- [ ] **Manual NVDA verification on the next preview after merge:**
  - [ ] Press `Ctrl+Shift+D`. NVDA reads "Launching diagnostic." cleanly to completion. PowerShell window appears ~700ms later; NVDA reads the PowerShell window's title.
  - [ ] Press `Ctrl+Shift+R`. NVDA reads "Opening release notes." cleanly to completion. Browser opens ~700ms later; NVDA reads the browser's tab title.
- [ ] Once the cleaner announce flow is verified, return to the deferred SESSION-HANDOFF item 2 step 3: read the diagnostic script's PASS/FAIL verdict in the spawned PowerShell window to formally close the post-Stage-5 process-cleanup gate.

No hotkey contract change; same `Ctrl+Shift+D/R` behaviour from the user's side, just audible.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_