### PR TITLE
feat(hotkeys): flip Ctrl+Shift+R to open the draft-a-new-release form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **`Ctrl+Shift+R` flipped from "open releases page" to "open
+  draft-a-new-release form".** The original PR #83 hotkey opened
+  `UpdateRepoUrl + "/releases"` (the listing). During post-Stage-5
+  manual NVDA verification on the just-cut preview, the maintainer
+  realised the daily-use path during the preview line is creating
+  a release (publishing in the GitHub Releases UI triggers the
+  Velopack build/upload workflow per `docs/RELEASE-PROCESS.md`),
+  not browsing existing releases. Flipping the URL to
+  `/releases/new` makes the hotkey a one-keypress shortcut to the
+  cadence step that matters every preview cut. Mnemonic stays "R
+  for **R**elease".
+
+  Renames that follow the behaviour change:
+
+  - `Program.fs runOpenReleases` → `runOpenNewRelease`
+  - `Program.fs setupReleasesKeybinding` → `setupNewReleaseKeybinding`
+  - `RoutedCommand("OpenReleases", ...)` → `"OpenNewRelease"`
+  - `Terminal.Core.ActivityIds.releases` (`"pty-speak.releases"`)
+    → `ActivityIds.newRelease` (`"pty-speak.new-release"`).
+    The activity-ID rename is a soft breaking change for any NVDA
+    user who already configured per-tag handling for the old
+    string, but Stage 5's tag vocabulary just shipped on the
+    preceding preview and is documented to accept renames until
+    v0.1.0+.
+  - Announce text: "Opened release notes in default browser:
+    {url}" → "Opening new release form."
+  - Doc updates: `README.md`, `SECURITY.md` (A-3 row + the
+    pre-Stage-6 keyboard contract paragraph), `docs/USER-SETTINGS.md`.
+
+  No hotkey contract change from the user's perspective; same
+  `Ctrl+Shift+R`, different (more useful) URL.
+
+- **SESSION-HANDOFF item 2 step 3 closed.** Post-Stage-5
+  process-cleanup re-run via `Ctrl+Shift+D` on the post-Stage-5
+  preview returned PASS for both close paths (Alt+F4 and
+  X-button) per the maintainer's manual NVDA verification.
+  Item 2 step 3 flips from "↻ pending" to "✓ PASS"; step 4
+  ("After Stage 6 ships") is now the next pending pass.
+
 ### Fixed
 
 - **`Ctrl+Shift+D` and `Ctrl+Shift+R` announcements no longer get
@@ -29,16 +70,16 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
   before today exercised the announce path end-to-end.
 
   Fix in `src/Terminal.App/Program.fs runDiagnostic` and
-  `runOpenReleases`: announce a SHORT cue ("Launching
-  diagnostic.", "Opening release notes.") FIRST, then schedule
-  the actual `Process.Start` on a ~700ms `Task.Delay` so NVDA's
-  speech queue has time to play the cue before the new window's
-  title takes over. The longer guidance ("Switch to that window
-  to follow the test.") is dropped from the cue — once the
-  user hears the spawned window's title, they have all the
-  context the long version provided. Both announces are also
-  re-tagged with the proper `ActivityIds.diagnostic` /
-  `ActivityIds.releases` per-class tags introduced in Stage 5
+  `runOpenNewRelease`: announce a SHORT cue ("Launching
+  diagnostic.", "Opening new release form.") FIRST, then
+  schedule the actual `Process.Start` on a ~700ms `Task.Delay`
+  so NVDA's speech queue has time to play the cue before the
+  new window's title takes over. The longer guidance ("Switch
+  to that window to follow the test.") is dropped from the cue
+  — once the user hears the spawned window's title, they have
+  all the context the long version provided. Both announces
+  are also re-tagged with the proper `ActivityIds.diagnostic` /
+  `ActivityIds.newRelease` per-class tags introduced in Stage 5
   (replacing the back-compat default `pty-speak.update`).
 
   No new hotkey contract; same `Ctrl+Shift+D/R` behaviour from

--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ preserve this list per the app-reserved-hotkey contract in
   via Alt+F4 or the X button leaves no orphan `Terminal.App.exe` /
   ConPTY child processes. Output is plain text NVDA reads aloud
   naturally.
-- **`Ctrl+Shift+R`** — open the GitHub Releases page in your default
-  browser. One-keypress answer to "what changed in this version?"
-  before deciding whether to update.
+- **`Ctrl+Shift+R`** — open the GitHub "draft a new release" form in
+  your default browser. Maintainer shortcut — the normal release flow
+  is to publish a release in the Releases UI (which creates the tag
+  and triggers the Velopack workflow), and this hotkey skips the
+  navigation step.
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute toggle),
 `Alt+Shift+R` (Stage 10 review-mode toggle).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ corresponding stage in [`spec/tech-plan.md`](spec/tech-plan.md).
   non-reserved key through unfiltered; the only gestures captured at
   the window level are app shortcuts (`Ctrl+Shift+U` for update,
   `Ctrl+Shift+D` for the process-cleanup diagnostic launcher,
-  `Ctrl+Shift+R` for the release-notes browser launcher). The
+  `Ctrl+Shift+R` for the "draft a new release" form launcher). The
   child cmd.exe therefore does not currently receive typed input.
   Stage 6 introduces the NVDA-modifier filter and the actual PTY
   routing per [`spec/tech-plan.md`](spec/tech-plan.md) §6; row A-3
@@ -478,7 +478,7 @@ when those surfaces became code-bearing.
 | **Application surfaces** ||||||
 | A-1 | Jagged-snapshot `IndexOutOfRangeException` in word-boundary helpers | Medium (DoS in the screen-reader read path; today's `Screen.SnapshotRows` returns uniform rows, but `TerminalTextRange` constructor doesn't enforce uniformity) | `c >= rows.[r].Length` guards added inside `WordEndFrom`, `NextWordStart`, `PrevWordStart` in `TerminalAutomationPeer.fs` (audit-cycle SR-2, PR #77) | n/a | **shipped** |
 | A-2 | `Move(Character, count)` int32 underflow when `count = int.MinValue` | Medium (wrong-direction range mutation slips past the `max 0` clamp via wraparound) | `int64` widening before the `curIdx + count` add, applied to both `Move` and `MoveEndpointByUnit` Character arms (audit-cycle SR-2, PR #77) | n/a | **shipped** |
-| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher, `Ctrl+Shift+R` for release-notes browser launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
+| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher, `Ctrl+Shift+R` for "draft a new release" form launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
 | **Update path (Stage 11)** ||||||
 | T-1 | Passive network observer of update flow | Low | TLS to GitHub | n/a (cost not justified) | **shipped** |
 | T-2 | Active MITM substituting update bytes | High | TLS + Velopack per-nupkg SHA hash in releases.win.json | + Ed25519 manifest signing (consistent forgery resistance) | **partial** (TLS+hash today; signing v0.1.0+) |

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -108,16 +108,16 @@ disconnects mid-session.
         Pending the next manual session on a preview that
         carries PR-B (already shipped to `main` via PR #86;
         cut whichever preview corresponds and run).
-     3. ↻ **After Stage 5 ships (post-Stage-5 preview)** —
-        re-run via `Ctrl+Shift+D` to confirm the new
-        coalescer task + Acc/9 OnRender refactor didn't
-        introduce a lifecycle regression. The coalescer is
-        a new background `Task.Run`; verify it cancels
-        cleanly on app exit (the `cts.Cancel()` +
-        `coalescedChannel.Writer.TryComplete()` ordering
-        in `Program.fs compose ()`'s `app.Exit.Add` is the
-        intended shutdown path). Pending the next manual
-        session on a preview that carries Stage 5.
+     3. ✓ **Post-Stage-5 preview — PASS** (2026-05-02, via
+        `Ctrl+Shift+D` diagnostic on the preview that carries
+        Stage 5 + the announce-before-launch fix). Both close
+        paths (Alt+F4 and X-button) returned no orphans.
+        Confirms the new coalescer task + Acc/9 OnRender
+        refactor introduced no process-lifecycle regression
+        (the coalescer's `cts.Cancel()` +
+        `coalescedChannel.Writer.TryComplete()` ordering in
+        `Program.fs compose ()`'s `app.Exit.Add` is the
+        intended shutdown path and works correctly).
      4. After Stage 6 ships (most important pass — Stage 6
         is where Job Object lifecycle lands per
         `spec/tech-plan.md` §160).

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -276,15 +276,22 @@ for future stages — listed inline below):
   cleanup on app close — added because Task Manager's
   Processes-tab chevron-expand affordance isn't NVDA-accessible.
   Wired in `setupDiagnosticKeybinding`.
-- **`Ctrl+Shift+R`** — release-notes browser launcher (PR #83).
-  Opens the GitHub Releases page (`UpdateRepoUrl` +
-  `/releases`) in the user's default web browser. Useful as
-  a one-keypress answer to "what changed in this version?"
-  before deciding whether to press `Ctrl+Shift+U`. Wired in
-  `setupReleasesKeybinding`. Note: `Ctrl+Shift+R` and
-  `Alt+Shift+R` (Stage 10 review-mode toggle, reserved) are
-  distinct WPF gestures — different modifier sets — so there
-  is no actual keypress conflict, only a mnemonic similarity.
+- **`Ctrl+Shift+R`** — "draft a new release" form launcher
+  (PR #83 originally shipped this as a release-notes browser;
+  flipped to the new-release form path during the post-Stage-5
+  manual NVDA verification cycle when the maintainer realised
+  the create-release flow is the actual daily-use path during
+  the preview line). Opens the GitHub draft-release form
+  (`UpdateRepoUrl` + `/releases/new`) in the user's default web
+  browser. The maintainer's release flow per
+  `docs/RELEASE-PROCESS.md` is to publish a release in the
+  Releases UI (which creates the tag and triggers the Velopack
+  build/upload workflow); this hotkey skips the navigation
+  step. Wired in `setupNewReleaseKeybinding`. Note:
+  `Ctrl+Shift+R` and `Alt+Shift+R` (Stage 10 review-mode toggle,
+  reserved) are distinct WPF gestures — different modifier
+  sets — so there is no actual keypress conflict, only a
+  mnemonic similarity.
 - (planned) **`Ctrl+Shift+M`** — earcon mute toggle (Stage 9).
 - (planned) **`Alt+Shift+R`** — review-mode toggle (Stage 10).
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -277,7 +277,7 @@ module Program =
     /// pattern as `setupAutoUpdateKeybinding` above. Per the
     /// app-reserved-hotkey contract, this gesture is in the
     /// reserved list (Ctrl+Shift+U for update, Ctrl+Shift+D
-    /// for diagnostic, Ctrl+Shift+R for release notes,
+    /// for diagnostic, Ctrl+Shift+R for new-release form,
     /// Ctrl+Shift+M for Stage 9 mute, Alt+Shift+R for Stage 10
     /// review mode) and Stage 6's keyboard layer must continue
     /// to honour the priority order.
@@ -291,20 +291,24 @@ module Program =
                 ExecutedRoutedEventHandler(fun _ _ -> runDiagnostic window)))
         |> ignore
 
-    /// Open the GitHub Releases page for this repository in the
-    /// user's default web browser. Triggered by `Ctrl+Shift+R`
-    /// (mnemonic: **R**eleases). Useful as a one-keypress answer
-    /// to "what changed in this version?" without leaving
-    /// pty-speak — the screen reader can navigate the rendered
-    /// release notes in the browser, which has its own
-    /// well-tested accessibility surface.
+    /// Open the GitHub "draft a new release" form for this
+    /// repository in the user's default web browser. Triggered
+    /// by `Ctrl+Shift+R` (mnemonic: **R**elease).
+    ///
+    /// The maintainer's normal release flow per
+    /// `docs/RELEASE-PROCESS.md` is to publish a release in the
+    /// GitHub Releases UI (which creates the tag), and the
+    /// `release: published` event then triggers the Velopack
+    /// build/upload workflow. This hotkey shortcuts directly to
+    /// that form so the release-cut step is one keypress
+    /// from inside pty-speak — saving a tab-and-click trip
+    /// every cadence.
     ///
     /// `Ctrl+Shift+R` and `Alt+Shift+R` (Stage 10 review-mode
     /// toggle, reserved) are different gestures — different
     /// modifier sets — so WPF treats them as distinct
     /// `KeyGesture`s. The mnemonic overlap (both R) is the only
-    /// cost; the maintainer chose Ctrl+Shift+R explicitly for
-    /// the "R for Releases" parallel.
+    /// cost.
     ///
     /// The URL is derived from `UpdateRepoUrl` (the same
     /// constant the Velopack auto-update flow uses) so a fork
@@ -312,16 +316,16 @@ module Program =
     /// constant. Phase 2's TOML config will make `UpdateRepoUrl`
     /// user-configurable per `SECURITY.md` row C-1; this hotkey
     /// inherits whatever the user configures.
-    let private runOpenReleases (window: MainWindow) : unit =
-        let url = UpdateRepoUrl + "/releases"
+    let private runOpenNewRelease (window: MainWindow) : unit =
+        let url = UpdateRepoUrl + "/releases/new"
         // Same announce-before-focus-grab pattern as `runDiagnostic`
         // above (the launched browser will steal focus and NVDA's
         // interrupt-on-focus-change will truncate the queued speech
         // unless we give it ~700ms head start).
         // TODO Phase 2: TOML-configurable delay.
         window.TerminalSurface.Announce(
-            "Opening release notes.",
-            ActivityIds.releases)
+            "Opening new release form.",
+            ActivityIds.newRelease)
         let _ =
             task {
                 do! Task.Delay(700)
@@ -334,23 +338,23 @@ module Program =
                     with ex ->
                         let safe = AnnounceSanitiser.sanitise ex.Message
                         window.TerminalSurface.Announce(
-                            sprintf "Could not open release notes: %s" safe,
+                            sprintf "Could not open new release form: %s" safe,
                             ActivityIds.error)
                 do! window.Dispatcher.InvokeAsync(Action(action)).Task
                 ()
             }
         ()
 
-    /// Wire `Ctrl+Shift+R` to trigger `runOpenReleases`. Same
+    /// Wire `Ctrl+Shift+R` to trigger `runOpenNewRelease`. Same
     /// pattern as the other reserved hotkeys above.
-    let private setupReleasesKeybinding (window: MainWindow) : unit =
-        let cmd = RoutedCommand("OpenReleases", typeof<MainWindow>)
+    let private setupNewReleaseKeybinding (window: MainWindow) : unit =
+        let cmd = RoutedCommand("OpenNewRelease", typeof<MainWindow>)
         let gesture = KeyGesture(Key.R, ModifierKeys.Control ||| ModifierKeys.Shift)
         window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
         window.CommandBindings.Add(
             CommandBinding(
                 cmd,
-                ExecutedRoutedEventHandler(fun _ _ -> runOpenReleases window)))
+                ExecutedRoutedEventHandler(fun _ _ -> runOpenNewRelease window)))
         |> ignore
 
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
@@ -374,9 +378,9 @@ module Program =
         // Same install-before-window-load reasoning as above.
         setupDiagnosticKeybinding window
 
-        // Wire Ctrl+Shift+R to open the GitHub Releases page in
-        // the user's default browser.
-        setupReleasesKeybinding window
+        // Wire Ctrl+Shift+R to open the GitHub "draft a new
+        // release" form in the user's default browser.
+        setupNewReleaseKeybinding window
 
         // Stage 5 — two-channel pipeline:
         //

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -264,8 +264,10 @@ module ActivityIds =
     /// Diagnostic launcher (`Ctrl+Shift+D` → process-cleanup
     /// PowerShell script).
     let diagnostic = "pty-speak.diagnostic"
-    /// Release-notes browser launcher (`Ctrl+Shift+R`).
-    let releases = "pty-speak.releases"
+    /// "Draft a new release" form launcher (`Ctrl+Shift+R`).
+    /// Opens the GitHub `/releases/new` page so the maintainer
+    /// can cut a preview without leaving pty-speak.
+    let newRelease = "pty-speak.new-release"
     /// Terminal-mode transition (alt-screen, etc.) — emitted
     /// when Stage 5's coalescer flushes around a `ModeChanged`
     /// event. Today the announcement is empty (silent flush


### PR DESCRIPTION
## Summary

Flip `Ctrl+Shift+R` from "browse the GitHub Releases listing" to "open the draft-a-new-release form" (`UpdateRepoUrl + "/releases/new"`).

## Why

PR #83 originally wired `Ctrl+Shift+R` as a release-notes browser — useful for end users asking "what changed in this version?" During post-Stage-5 manual NVDA verification on the just-cut preview, the maintainer realised the daily-use path during the preview line is **creating** a release, not browsing existing ones. Per `docs/RELEASE-PROCESS.md`, publishing a release in the GitHub Releases UI is what creates the tag and triggers the Velopack build/upload workflow. A hotkey that lands directly on the create-form is a real cadence-step shortcut every preview cut.

Mnemonic stays "R for **R**elease".

## What changed

### Code
- `Program.fs runOpenReleases` → `runOpenNewRelease`
- `Program.fs setupReleasesKeybinding` → `setupNewReleaseKeybinding`
- `RoutedCommand("OpenReleases", ...)` → `"OpenNewRelease"`
- `Terminal.Core.ActivityIds.releases` (`"pty-speak.releases"`) → `ActivityIds.newRelease` (`"pty-speak.new-release"`). Soft breaking change for NVDA users who configured per-tag handling on the old string, but Stage 5's tag vocabulary just shipped on the preceding preview and is documented to accept renames until v0.1.0+.
- Announce text: `"Opened release notes in default browser: {url}"` → `"Opening new release form."`

### Docs
- `README.md` — Ctrl+Shift+R bullet
- `SECURITY.md` — A-3 row + the pre-Stage-6 keyboard contract paragraph
- `docs/USER-SETTINGS.md` — Ctrl+Shift+R section
- `CHANGELOG.md` `[Unreleased]` `Changed` entry; existing `Fixed` entry's stale identifier names (`runOpenReleases`, `ActivityIds.releases`) updated inline to the new names so the entry is accurate at the time the next preview cuts.

### Bundled doc truth-up

- **`docs/SESSION-HANDOFF.md` item 2 step 3 closed.** Post-Stage-5 process-cleanup re-run via `Ctrl+Shift+D` on the post-Stage-5 preview returned PASS for both close paths (Alt+F4 and X-button) per the maintainer's manual verification just now. Item 2 step 3 flips from "↻ pending" to "✓ PASS"; step 4 ("After Stage 6 ships") is the next pending pass.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check
- [ ] All existing tests still pass (no test changes; pure rename + URL change + announce text)
- [ ] **Manual NVDA verification on the next preview after merge:**
  - [ ] Press `Ctrl+Shift+R`. NVDA reads "Opening new release form." cleanly. Browser opens to `https://github.com/KyleKeane/pty-speak/releases/new` (the draft-a-release form, not the listing).

No hotkey contract change from the user's perspective; same `Ctrl+Shift+R`, different (more useful) URL.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_