### PR TITLE
feat(stage-6/pr-a): parser arms for DECCKM, bracketed paste, focus reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Stage 6 PR-A: parser arms for DECCKM, bracketed paste, and
+  focus reporting.** The first half of Stage 6 lands the
+  parser-side mode-flag plumbing for the three remaining
+  `TerminalModes` flags that were declared-but-inert in
+  Stage 4.5: `DECCKM` (`?1`, application vs normal cursor
+  mode), `BracketedPaste` (`?2004`), and `FocusReporting`
+  (`?1004`). Each new arm in
+  `src/Terminal.Core/Screen.fs csiPrivateDispatch` follows
+  the Stage 4.5 alt-screen template exactly: idempotence
+  guard (a no-op flip silently returns) + flag mutation +
+  `pendingModeChanges.Add` for the post-lock-release
+  `ModeChanged` event fire that Stage 5's coalescer
+  subscribes to. The flags are now toggleable from
+  child-shell escape sequences but the consumer-side
+  behaviour (key encoder reading `Modes.DECCKM`, paste
+  handler reading `Modes.BracketedPaste`, focus events
+  reading `Modes.FocusReporting`) lands in Stage 6 PR-B
+  alongside the WPF input wiring + `ResizePseudoConsole` +
+  Job Object lifecycle. PR-A is pure F#, no WPF, no Win32
+  — splitting the stage along that line lowers review cost
+  and keeps the bisect surface small if NVDA validation
+  catches something later.
+
+  Tests: 15 new `ScreenTests` (3 modes × 4 cases:
+  set-fires, reset-fires, idempotent-set-no-fire,
+  idempotent-reset-no-fire — plus 3 cross-flag
+  independence tests defending against future
+  shared-backing-field refactors). Templates from the
+  Stage 5 alt-screen `ModeChanged` test triplet.
+
 ### Changed
 
 - **`Ctrl+Shift+R` flipped from "open releases page" to "open

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -338,8 +338,12 @@ type Screen(rows: int, cols: int) =
     /// when the parser sees a `?` private byte (DECSET / DECRESET
     /// for terminal modes). Stage 4.5 PR-A wires DECTCEM (`?25h/l`,
     /// cursor visibility); PR-B wires alt-screen (`?1049h/l`).
-    /// Stage 6 will add DECCKM (`?1`), bracketed paste (`?2004`),
-    /// and focus reporting (`?1004`).
+    /// Stage 6 PR-A adds DECCKM (`?1`), bracketed paste (`?2004`),
+    /// and focus reporting (`?1004`) with the same idempotence-
+    /// guard + post-lock-release `ModeChanged` emit pattern that
+    /// `enterAltScreen` / `exitAltScreen` use, so Stage 5's
+    /// coalescer handles the new mode-change events without any
+    /// further wiring.
     ///
     /// Unknown private modes are silently dropped — they're
     /// non-malicious extensions whose UIA implications need a
@@ -352,8 +356,45 @@ type Screen(rows: int, cols: int) =
         | 'l', 25 -> modes.CursorVisible <- false
         | 'h', 1049 -> enterAltScreen ()
         | 'l', 1049 -> exitAltScreen ()
-        // Stage 6 will add: ?1 (DECCKM), ?2004 (bracketed paste),
-        //                   ?1004 (focus reporting)
+        // Stage 6 PR-A: DECCKM (?1) — application vs normal cursor mode.
+        // Stage 6 PR-B's KeyEncoding module reads `modes.DECCKM` to
+        // decide arrow-key encoding (`\x1b[A` normal vs `\x1bOA`
+        // application). Idempotence guard mirrors `enterAltScreen`'s
+        // — without it Stage 5's coalescer would see spurious
+        // ModeChanged events on no-op toggles.
+        | 'h', 1 ->
+            if not modes.DECCKM then
+                modes.DECCKM <- true
+                pendingModeChanges.Add((DECCKM, true))
+        | 'l', 1 ->
+            if modes.DECCKM then
+                modes.DECCKM <- false
+                pendingModeChanges.Add((DECCKM, false))
+        // Stage 6 PR-A: bracketed paste (?2004). When set,
+        // PR-B's paste handler wraps clipboard text in
+        // `\x1b[200~` ... `\x1b[201~`. PR-A just lets the parser
+        // flip the flag so xUnit can pin the toggle in
+        // isolation; PR-B reads the flag from the WPF paste
+        // CommandBinding.
+        | 'h', 2004 ->
+            if not modes.BracketedPaste then
+                modes.BracketedPaste <- true
+                pendingModeChanges.Add((BracketedPaste, true))
+        | 'l', 2004 ->
+            if modes.BracketedPaste then
+                modes.BracketedPaste <- false
+                pendingModeChanges.Add((BracketedPaste, false))
+        // Stage 6 PR-A: focus reporting (?1004). When set,
+        // PR-B's WPF GotKeyboardFocus / LostKeyboardFocus
+        // handlers emit `\x1b[I` / `\x1b[O` to the PTY.
+        | 'h', 1004 ->
+            if not modes.FocusReporting then
+                modes.FocusReporting <- true
+                pendingModeChanges.Add((FocusReporting, true))
+        | 'l', 1004 ->
+            if modes.FocusReporting then
+                modes.FocusReporting <- false
+                pendingModeChanges.Add((FocusReporting, false))
         | _ -> ()
 
     /// ESC dispatch (bare `ESC <intermediates> <final>`): handles

--- a/tests/Tests.Unit/ScreenTests.fs
+++ b/tests/Tests.Unit/ScreenTests.fs
@@ -687,3 +687,186 @@ let ``ModeChanged subscriber can call SnapshotRows without deadlock`` () =
         observedSeq <- seq)
     feed screen (ascii "\x1b[?1049h")
     Assert.True(observedSeq > 0L)
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-A — DECCKM (?1) application-cursor mode
+// ---------------------------------------------------------------------
+//
+// Stage 6 PR-B's KeyEncoding module reads `Modes.DECCKM` to decide
+// arrow-key encoding (`\x1b[A` normal vs `\x1bOA` application).
+// PR-A wires the parser side: the flag flips on `?1h/l`, with the
+// same idempotence + post-lock-release ModeChanged-emit contract
+// that Stage 4.5's alt-screen toggle pinned. These tests are the
+// xUnit gate; PR-B's manual NVDA tests will exercise the encoder
+// behaviour end-to-end.
+
+[<Fact>]
+let ``DECCKM ?1h sets Modes.DECCKM and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    Assert.False(screen.Modes.DECCKM)
+    feed screen (ascii "\x1b[?1h")
+    Assert.True(screen.Modes.DECCKM)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((DECCKM, true), received.[0])
+
+[<Fact>]
+let ``DECCKM ?1l clears Modes.DECCKM and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1h")  // prime; no subscriber yet
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1l")
+    Assert.False(screen.Modes.DECCKM)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((DECCKM, false), received.[0])
+
+[<Fact>]
+let ``DECCKM idempotent ?1h while already application-mode does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1h")
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1h")
+    Assert.True(screen.Modes.DECCKM)
+    Assert.Equal(0, received.Count)
+
+[<Fact>]
+let ``DECCKM idempotent ?1l while already normal-mode does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1l")
+    Assert.False(screen.Modes.DECCKM)
+    Assert.Equal(0, received.Count)
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-A — bracketed paste (?2004)
+// ---------------------------------------------------------------------
+//
+// Stage 6 PR-B's WPF paste handler wraps clipboard text in
+// `\x1b[200~` ... `\x1b[201~` when `Modes.BracketedPaste` is true.
+// PR-A pins the parser-side flag flip + ModeChanged emit.
+
+[<Fact>]
+let ``bracketed paste ?2004h sets Modes.BracketedPaste and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    Assert.False(screen.Modes.BracketedPaste)
+    feed screen (ascii "\x1b[?2004h")
+    Assert.True(screen.Modes.BracketedPaste)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((BracketedPaste, true), received.[0])
+
+[<Fact>]
+let ``bracketed paste ?2004l clears Modes.BracketedPaste and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?2004h")
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?2004l")
+    Assert.False(screen.Modes.BracketedPaste)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((BracketedPaste, false), received.[0])
+
+[<Fact>]
+let ``bracketed paste idempotent ?2004h while already on does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?2004h")
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?2004h")
+    Assert.True(screen.Modes.BracketedPaste)
+    Assert.Equal(0, received.Count)
+
+[<Fact>]
+let ``bracketed paste idempotent ?2004l while already off does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?2004l")
+    Assert.False(screen.Modes.BracketedPaste)
+    Assert.Equal(0, received.Count)
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-A — focus reporting (?1004)
+// ---------------------------------------------------------------------
+//
+// Stage 6 PR-B's WPF GotKeyboardFocus / LostKeyboardFocus handlers
+// emit `\x1b[I` / `\x1b[O` to the PTY when `Modes.FocusReporting`
+// is true. PR-A pins the parser-side flag flip + ModeChanged emit.
+
+[<Fact>]
+let ``focus reporting ?1004h sets Modes.FocusReporting and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    Assert.False(screen.Modes.FocusReporting)
+    feed screen (ascii "\x1b[?1004h")
+    Assert.True(screen.Modes.FocusReporting)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((FocusReporting, true), received.[0])
+
+[<Fact>]
+let ``focus reporting ?1004l clears Modes.FocusReporting and fires ModeChanged`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1004h")
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1004l")
+    Assert.False(screen.Modes.FocusReporting)
+    Assert.Equal(1, received.Count)
+    Assert.Equal((FocusReporting, false), received.[0])
+
+[<Fact>]
+let ``focus reporting idempotent ?1004h while already on does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1004h")
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1004h")
+    Assert.True(screen.Modes.FocusReporting)
+    Assert.Equal(0, received.Count)
+
+[<Fact>]
+let ``focus reporting idempotent ?1004l while already off does NOT fire`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    let received = ResizeArray<TerminalModeFlag * bool>()
+    screen.ModeChanged.Add(fun pair -> received.Add(pair))
+    feed screen (ascii "\x1b[?1004l")
+    Assert.False(screen.Modes.FocusReporting)
+    Assert.Equal(0, received.Count)
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-A — independence between new mode flags
+// ---------------------------------------------------------------------
+//
+// Pin that flipping one of the new modes does NOT accidentally
+// flip another (defence against a future refactor that might
+// share a backing field by mistake).
+
+[<Fact>]
+let ``DECCKM toggle does not affect BracketedPaste or FocusReporting`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1h")
+    Assert.True(screen.Modes.DECCKM)
+    Assert.False(screen.Modes.BracketedPaste)
+    Assert.False(screen.Modes.FocusReporting)
+
+[<Fact>]
+let ``BracketedPaste toggle does not affect DECCKM or FocusReporting`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?2004h")
+    Assert.False(screen.Modes.DECCKM)
+    Assert.True(screen.Modes.BracketedPaste)
+    Assert.False(screen.Modes.FocusReporting)
+
+[<Fact>]
+let ``FocusReporting toggle does not affect DECCKM or BracketedPaste`` () =
+    let screen = Screen(rows = 3, cols = 5)
+    feed screen (ascii "\x1b[?1004h")
+    Assert.False(screen.Modes.DECCKM)
+    Assert.False(screen.Modes.BracketedPaste)
+    Assert.True(screen.Modes.FocusReporting)


### PR DESCRIPTION
## Summary

First half of Stage 6 — the parser-side mode-flag plumbing for the three remaining `TerminalModes` flags that were declared-but-inert in Stage 4.5.

This is **PR-A of a 2-PR Stage 6 cycle**. PR-A is pure F# (no WPF, no Win32) and ships the parser arms + tests. PR-B will land the chunky pieces: pure-F# `KeyEncoding` module, WPF `OnPreviewKeyDown` / `OnPreviewTextInput` input wiring, bracketed-paste handler, focus-reporting hooks, `ResizePseudoConsole` debounce, and Job Object child-process lifecycle. The split lowers review cost and keeps the bisect surface small if NVDA validation catches something downstream.

## What changed

`src/Terminal.Core/Screen.fs csiPrivateDispatch` — three new mode arms:

- **DECCKM (`?1`)** — application vs normal cursor mode. Stage 6 PR-B's `KeyEncoding` will read `Modes.DECCKM` to choose `\x1b[A` (normal) vs `\x1bOA` (application) for arrow keys.
- **BracketedPaste (`?2004`)** — when set, PR-B's `ApplicationCommands.Paste` handler wraps clipboard text in `\x1b[200~` ... `\x1b[201~`.
- **FocusReporting (`?1004`)** — when set, PR-B's `GotKeyboardFocus` / `LostKeyboardFocus` handlers emit `\x1b[I` / `\x1b[O` to the PTY.

Each arm follows the Stage 4.5 alt-screen template exactly:
1. Idempotence guard (a no-op flip silently returns) — without this Stage 5's coalescer would see spurious `ModeChanged` events on no-op toggles.
2. Flag mutation under the gate lock.
3. `pendingModeChanges.Add` for the post-lock-release `ModeChanged` event fire that Stage 5's coalescer already subscribes to.

## Tests

15 new `ScreenTests` modeled on the Stage 5 alt-screen `ModeChanged` triplet at `tests/Tests.Unit/ScreenTests.fs:636-689`. Per-mode 4-test pattern (× 3 modes = 12) plus 3 cross-flag independence tests:

- **set-fires**: `?<n>h` with flag clear → flag flips, `ModeChanged` fires once with `(flag, true)`.
- **reset-fires**: `?<n>l` with flag set → flag flips, `ModeChanged` fires once with `(flag, false)`.
- **idempotent-set-no-fire**: `?<n>h` while already set → flag stays, no `ModeChanged`.
- **idempotent-reset-no-fire**: `?<n>l` while already clear → flag stays, no `ModeChanged`.
- **cross-flag independence** (× 3): toggling one of the new modes does NOT accidentally flip another. Defence against a future refactor that might share a backing field by mistake.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check.
- [ ] All existing tests still pass (no API changes; this is additive parser dispatch).
- [ ] **Manual NVDA verification** is deferred until PR-B lands the consumer-side wiring (key encoder, paste handler, focus reporter). The flag-flip-on-escape-sequence behaviour is xUnit-pinned by the new tests and doesn't have a user-visible surface yet.

## Out of scope (PR-B follow-up)

- Pure-F# `KeyEncoding.fs` module (`Terminal.Core/KeyEncoding.fs` with own `KeyCode` DU + `KeyModifiers` flags)
- WPF `OnPreviewKeyDown` PTY-forwarding fill-in with NVDA-modifier filter (filter all Insert + CapsLock bare presses for NVDA / JAWS / Narrator coverage)
- WPF `OnPreviewTextInput` for IME / AltGr / Unicode
- `ApplicationCommands.Paste` `CommandBinding` with bracketed-paste wrapping (will strip embedded `\x1b[201~` from clipboard content for paste-injection safety — accessibility-first posture diverging from xterm's permissive default)
- `GotKeyboardFocus` / `LostKeyboardFocus` for focus reporting
- `SizeChanged` → `ResizePseudoConsole` with 200ms `DispatcherTimer` trailing-edge debounce
- Job Object child-process lifecycle (`KILL_ON_JOB_CLOSE` layered on top of existing `TerminateProcess` for grandchild containment)
- `AppReservedHotkeys` refresh (the list at `TerminalView.cs:189-203` is stale — Ctrl+Shift+D and Ctrl+Shift+R aren't in it yet)
- SESSION-HANDOFF update marking Stage 6 shipped

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_