### PR TITLE
feat(stage-6/pr-b): keyboard input, paste, focus reporting, resize, Job Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,154 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 6 PR-B: keyboard input, paste, focus reporting, dynamic
+  resize, and Job Object child-process lifecycle.** Second and
+  final half of Stage 6 — pty-speak becomes interactive. Typed
+  keys reach the cmd.exe child via the new pure-F# `KeyEncoding`
+  module; paste via Ctrl+V / right-click / Edit menu wraps in
+  bracketed-paste markers when DECSET ?2004 is set; window resize
+  flows through to `ResizePseudoConsole` after a 200ms debounce;
+  the spawned child plus any process it later spawns are
+  contained in a Job Object so the entire tree dies via
+  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` even on a hard parent
+  crash.
+
+  Component pieces:
+
+  - **New `Terminal.Core.KeyEncoding` module** — pure F# encoder
+    `KeyCode * KeyModifiers * TerminalModes -> byte[] option`.
+    Decoupled from `System.Windows.Input.Key` via its own
+    `KeyCode` discriminated union and `KeyModifiers` flags type
+    so a future Linux / macOS port (Avalonia, MAUI, web) reuses
+    this module unchanged — only the WPF→KeyCode adapter changes.
+    Encoding tables follow the xterm "PC-Style" + "VT220-Style"
+    function-key conventions: arrows are DECCKM-aware (`\x1b[A`
+    normal vs `\x1bOA` application), modified cursor keys use
+    the SGR-modifier protocol (`\x1b[1;<mod>A`), F1-F4 use SS3
+    form (`\x1bO<P/Q/R/S>`), F5-F12 use CSI form
+    (`\x1b[<n>~`), Ctrl-letter folds Shift, Alt-letter
+    ESC-prefixes, Backspace sends DEL (`0x7f`, modern xterm
+    default that bash / zsh / PowerShell / Claude Code all
+    expect). The `KeyCode.Unhandled` case is the
+    future-proofing escape hatch — any unknown key produces
+    `None` rather than a crash; new WPF Key values can ship
+    without breaking us.
+
+  - **Bracketed-paste handler** bound to
+    `ApplicationCommands.Paste` so Ctrl+V, right-click → Paste,
+    and Edit menu → Paste all flow through one site.
+    `KeyEncoding.encodePaste` strips embedded `\x1b[201~` from
+    clipboard content **before** wrapping — paste-injection
+    defence diverging from xterm's permissive default. NVDA
+    users can't easily inspect their clipboard before pasting,
+    so an attacker-crafted paste containing `\x1b[201~`
+    followed by a malicious command would otherwise close the
+    bracket-paste frame early and execute the post-paste
+    portion as if typed. SECURITY.md tracks this as a
+    deliberate accessibility-first posture divergence.
+
+  - **Focus reporting** via `OnGotKeyboardFocus` /
+    `OnLostKeyboardFocus`. Emits `\x1b[I` / `\x1b[O` to the
+    child only when DECSET ?1004 is set. Editors like nano /
+    vim / Emacs and Claude Code use these to suspend cursor
+    blink, save unsaved buffers on focus loss, etc.
+
+  - **Dynamic resize** via `OnRenderSizeChanged` →
+    `DispatcherTimer` (200ms trailing-edge debounce) →
+    `ConPtyHost.Resize` → `Win32.ResizePseudoConsole`. WPF
+    SizeChanged fires per pixel during a window drag (60Hz);
+    debouncing prevents the child shell from re-laying-out on
+    every tick and flooding Stage 5's output coalescer.
+    Hardcoded `// TODO Phase 2: TOML-configurable` constant.
+    Note: Stage 6 resizes the **PTY** (so the child shell sees
+    the new column count); the in-process `Cell[,]` Screen
+    grid stays at construction-time 30×120, so oversize
+    windows have empty padding and undersize windows clip.
+    Full grid runtime resize is logged as a Phase 2 stage in
+    `docs/SESSION-HANDOFF.md`.
+
+  - **Job Object child-process lifecycle.** `Native.fs` adds
+    P/Invokes for `CreateJobObjectW`,
+    `SetInformationJobObject`, `AssignProcessToJobObject` plus
+    the `JOBOBJECT_BASIC_LIMIT_INFORMATION` /
+    `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` / `IO_COUNTERS`
+    structs and a `SafeJobHandle`. `PseudoConsole.create`
+    creates a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+    set, assigns the immediate cmd.exe to it, and stores the
+    handle on `PtySession.JobHandle`. **Layered on top of**
+    the existing `TerminateProcess` cleanup rather than
+    replacing it: `TerminateProcess` is fast targeted cleanup
+    for the immediate cmd.exe (so its pipe drains promptly);
+    the Job Object is the kernel-enforced safety net for
+    grandchildren (e.g. a `node` process Stage 7's Claude
+    Code launches inside pty-speak). On any setup-step
+    failure the orphan child is terminated before returning
+    Error so we never leak.
+
+  - **`OnPreviewKeyDown` filter ordering** is load-bearing
+    and pinned by inline doc-comment + the test suite:
+    1. `AppReservedHotkeys` check first (Ctrl+Shift+U /
+       Ctrl+Shift+D / Ctrl+Shift+R short-circuit and let
+       the parent Window's `InputBindings` see them).
+    2. NVDA / screen-reader modifier filter second (bare
+       Insert / CapsLock and Numpad-with-NumLock-off
+       return without `Handled`).
+    3. WPF Key + ModifierKeys → `KeyCode` + `KeyModifiers`
+       translate.
+    4. Plain printable typing (letters / digits / space
+       without Ctrl or Alt) defers to `OnPreviewTextInput`
+       so WPF's text-composition pipeline (IME, AltGr,
+       dead keys) handles it correctly.
+    5. Encode + write via `KeyEncoding.encodeOrNull`.
+
+  - **NVDA / screen-reader compatibility.** The bare
+    Insert + CapsLock filter covers NVDA, JAWS, and Narrator
+    modifier keys uniformly. The Numpad-with-NumLock-off
+    filter covers NVDA's review-cursor numpad layout.
+    Conservative on purpose — the cost of a few key presses
+    not reaching the shell is tiny compared to the cost of
+    breaking screen-reader navigation.
+
+  - **`AppReservedHotkeys` refresh** in
+    `src/Views/TerminalView.cs` — was stale (only listed
+    Ctrl+Shift+U); now lists all three currently-shipped
+    hotkeys (Ctrl+Shift+U, Ctrl+Shift+D, Ctrl+Shift+R) plus
+    the future-reserved Ctrl+Shift+M (Stage 9) and
+    Alt+Shift+R (Stage 10) as comments.
+
+  - **`Program.fs compose ()`** — wires the new host into
+    `TerminalView.SetPtyHost` after spawn. The view takes
+    `Action<byte[]>` + `Action<int,int>` callbacks rather
+    than a direct `ConPtyHost` reference so `Views/`
+    intentionally doesn't take a project ref on
+    `Terminal.Pty` (preserves the F#-first / WPF-only-at-
+    the-edge boundary). All callbacks invoke on the WPF
+    dispatcher thread, which is also the only thread that
+    touches the ConPTY stdin pipe — single-writer
+    discipline by construction.
+
+  Tests:
+
+  - **New `tests/Tests.Unit/KeyEncodingTests.fs`** (~35
+    facts) pinning the entire encoding table: cursor keys
+    (DECCKM normal vs application vs modified); editing
+    keypad (Insert / Delete / Home / End / PageUp /
+    PageDown); F1-F12 (SS3 vs CSI form, modified
+    variants); Tab / Enter / Esc / Backspace; Ctrl-letter
+    folding Shift; Alt-letter ESC-prefix; Ctrl+`@`/`[`/
+    `?` mapping to NUL/ESC/DEL; non-ASCII char returns
+    None; Unhandled returns None; bracketed paste
+    wrapping + injection defence; Unicode UTF-8
+    survival; focus-reporting bytes; SGR-modifier
+    parameter encoding; `encodeOrNull` C#-friendly
+    wrapper.
+
+  - **`tests/Tests.Unit/ConPtyHostTests.fs`** extended
+    with two new Stage 6 facts: `ConPtyHost.Resize`
+    accepts new dimensions without erroring; the
+    `JobHandle` is non-null and not-invalid after
+    spawn (proves the Job Object setup path works).
+
 - **Stage 6 PR-A: parser arms for DECCKM, bracketed paste, and
   focus reporting.** The first half of Stage 6 lands the
   parser-side mode-flag plumbing for the three remaining

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,21 @@ corresponding stage in [`spec/tech-plan.md`](spec/tech-plan.md).
   UIA Hyperlink-pattern surface, Stage 4+.)* Only `http`, `https`, and
   `file` schemes will be exposed; `javascript:`, `data:`, custom URI
   schemes dropped silently.
+- **Bracketed-paste injection defence.** *(shipped, Stage 6 PR-B.)*
+  When the user pastes clipboard content into pty-speak, the
+  `KeyEncoding.encodePaste` chokepoint strips embedded `\x1b[201~`
+  byte sequences from the clipboard text **before** wrapping in
+  `\x1b[200~` ... `\x1b[201~`. xterm and Windows Terminal don't strip
+  — but for screen-reader users who can't easily inspect their
+  clipboard before pasting, an attacker-crafted paste containing
+  `\x1b[201~` followed by a malicious shell command would otherwise
+  close the bracket-paste frame early and execute the post-paste
+  portion as if typed (out-of-band shell injection via clipboard).
+  Defence-in-depth: stripping happens even when DECSET ?2004 is
+  clear, since no legitimate shell content contains that exact
+  byte sequence and the cost of stripping is essentially zero.
+  Deliberate accessibility-first posture divergence from xterm's
+  permissive default.
 - **Control-character stripping in `displayString`.** *(planned with
   Stage 5 streaming notifications.)* Everything passed to
   `UiaRaiseNotificationEvent` will have C0 / C1 / DEL stripped first.
@@ -65,16 +80,27 @@ corresponding stage in [`spec/tech-plan.md`](spec/tech-plan.md).
   see [`docs/CONPTY-NOTES.md`](docs/CONPTY-NOTES.md). The "we never
   run elevated with an unelevated child" guarantee is also future
   work; until enforced in code, do not run pty-speak elevated.
-- **Pre-Stage-6 keyboard contract.** *(planned, Stage 6.)*
-  `TerminalView.OnPreviewKeyDown` today is a stub that passes every
-  non-reserved key through unfiltered; the only gestures captured at
-  the window level are app shortcuts (`Ctrl+Shift+U` for update,
-  `Ctrl+Shift+D` for the process-cleanup diagnostic launcher,
-  `Ctrl+Shift+R` for the "draft a new release" form launcher). The
-  child cmd.exe therefore does not currently receive typed input.
-  Stage 6 introduces the NVDA-modifier filter and the actual PTY
-  routing per [`spec/tech-plan.md`](spec/tech-plan.md) §6; row A-3
-  in the inventory tracks the gap until then.
+- **Keyboard input contract.** *(shipped, Stage 6.)*
+  `TerminalView.OnPreviewKeyDown` translates WPF
+  `Key + ModifierKeys` into the platform-neutral
+  `KeyCode + KeyModifiers` then routes through the pure-F#
+  `KeyEncoding.encode` chokepoint, which produces xterm-style VT
+  byte sequences (DECCKM-aware arrows, SGR-modifier protocol for
+  modified cursor / function keys, Ctrl-letter folding, Alt-prefix
+  for ESC-modifier). Filter ordering is load-bearing and pinned
+  by inline doc-comment + the test suite: (1) `AppReservedHotkeys`
+  short-circuits first so app-level hotkeys (Ctrl+Shift+U / D / R
+  shipped, Ctrl+Shift+M and Alt+Shift+R future-reserved) reach
+  the parent window's `InputBindings` without forwarding to the
+  PTY; (2) the screen-reader-modifier filter (bare Insert /
+  CapsLock + Numpad-with-NumLock-off) returns without `Handled`
+  so NVDA / JAWS / Narrator review-cursor keys keep working; (3)
+  printable typing without Ctrl/Alt defers to
+  `OnPreviewTextInput` for IME / AltGr / dead-key correctness.
+  Job Object containment with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+  guarantees the entire child-process tree dies when pty-speak
+  exits — even on a hard parent crash that doesn't run
+  `IDisposable`. Closes audit-inventory row A-3.
 
 The full mitigation matrix will live in `Terminal.Parser` and be
 covered by parser-level unit tests. PRs that disable any of the above
@@ -478,7 +504,7 @@ when those surfaces became code-bearing.
 | **Application surfaces** ||||||
 | A-1 | Jagged-snapshot `IndexOutOfRangeException` in word-boundary helpers | Medium (DoS in the screen-reader read path; today's `Screen.SnapshotRows` returns uniform rows, but `TerminalTextRange` constructor doesn't enforce uniformity) | `c >= rows.[r].Length` guards added inside `WordEndFrom`, `NextWordStart`, `PrevWordStart` in `TerminalAutomationPeer.fs` (audit-cycle SR-2, PR #77) | n/a | **shipped** |
 | A-2 | `Move(Character, count)` int32 underflow when `count = int.MinValue` | Medium (wrong-direction range mutation slips past the `max 0` clamp via wraparound) | `int64` widening before the `curIdx + count` add, applied to both `Move` and `MoveEndpointByUnit` Character arms (audit-cycle SR-2, PR #77) | n/a | **shipped** |
-| A-3 | Pre-Stage-6 keyboard contract: `OnPreviewKeyDown` stub passes all non-reserved keys through unfiltered | Low (by design until Stage 6 — child cmd.exe receives no typed input today; only the app-reserved hotkeys are captured: `Ctrl+Shift+U` for update, `Ctrl+Shift+D` for diagnostic launcher, `Ctrl+Shift+R` for "draft a new release" form launcher) | Stage 6's keyboard layer will add the NVDA-modifier filter and PTY routing per `spec/tech-plan.md` §6, preserving the app-reserved hotkey list | n/a | **planned (Stage 6)** |
+| A-3 | Keyboard contract: `OnPreviewKeyDown` translates → `KeyEncoding.encode` → PTY write, with screen-reader-modifier filter and load-bearing filter ordering (AppReservedHotkeys first → screen-reader filter → translate → defer printable typing → encode + write). Job Object lifecycle (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) contains the child-process tree even on hard parent crash. | Low (filter ordering pinned by xUnit + behavioural tests; encoder is pure F# with ~35-fact test coverage; KILL_ON_JOB_CLOSE is kernel-enforced) | Stage 6 PR-A (parser arms) + PR-B (KeyEncoding module + WPF wiring + ResizePseudoConsole + Job Object); ongoing manual NVDA verification per the post-Stage-6 preview cycle. | n/a | **shipped (Stage 6)** |
 | **Update path (Stage 11)** ||||||
 | T-1 | Passive network observer of update flow | Low | TLS to GitHub | n/a (cost not justified) | **shipped** |
 | T-2 | Active MITM substituting update bytes | High | TLS + Velopack per-nupkg SHA hash in releases.win.json | + Ed25519 manifest signing (consistent forgery resistance) | **partial** (TLS+hash today; signing v0.1.0+) |

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -19,10 +19,10 @@ A new session should read this **first**, then
 
 | | |
 |---|---|
-| **Last merged stages** | **Stage 4** (UIA Document + Text pattern + Line/Character/Word navigation + focus-into-TerminalSurface fix, PRs #54-#56, #59, #60, #68), **Stage 11** (Velopack auto-update via `Ctrl+Shift+U`, PRs #63, #66), **Security-audit cycle SR-1/SR-2/SR-3** (PRs #76, #77, #78), **Stage 4.5 — Claude Code rendering substrate** (PR-A #85 mode coverage + SGR walker + DECTCEM + DECSC/DECRC + OSC 52 chokepoint, PR-B alt-screen 1049 back-buffer), and **Stage 5 — Streaming output notifications** (single PR: `Coalescer` module + `ModeChanged` event + two-channel composition + `Acc/9` OnRender lock fix bundled). Stage 4 + 11 NVDA-verified on `v0.0.1-preview.26`; Stage 4.5 verified by xUnit (27 new tests across PR-A + PR-B); Stage 5 verified by xUnit (24 new `CoalescerTests` + 5 new `ScreenTests` for the `ModeChanged` emit contract); manual NVDA verification of Stage 4.5 + Stage 5 on the next preview cut is the acceptance gate. |
-| **Last shipped release** | `v0.0.1-preview.26` (or whichever preview the maintainer last cut — release cadence is ad-hoc during the unsigned-preview line). The auto-update path replaces the `scripts/install-latest-preview.ps1` bridge for in-place updates; the script is now **deprecated for in-place updates** but remains useful for fresh installs and dev-environment workflows. The next preview cut picks up the SR-1/SR-2/SR-3 hardening + the Stage 4.5 substrate work + Stage 5's streaming-output coalescer. |
-| **In-flight branch** | None. Stage 5 merged. The next stage per the 2026-05-01 strategic review (`/root/.claude/plans/replicated-riding-sketch.md`) is Stage 6 (keyboard input to PTY + DECCKM + bracketed paste + focus reporting + `ResizePseudoConsole` + Job Object lifecycle + the env-scrub work piggybacking onto Stage 7). Process-cleanup test (the deferred Stage 4 row) is the recurring acceptance check tracked in "Pending action items" item 2; should re-run after the post-Stage-5 preview cut. |
-| **Next stage** | **Stage 6 — Keyboard input + DECCKM + bracketed paste + focus reporting.** Wires WPF `KeyDown` / `TextInput` events through `ConPtyHost.WriteAsync` so the user can drive the child shell. Honours DECCKM application-cursor mode (which Stage 4.5's `TerminalModes` already exposes — Stage 6 just reads the flag), bracketed paste (wrap clipboard pastes in `\x1b[200~`...`\x1b[201~`), focus reporting (emit `\x1b[I` / `\x1b[O` on WPF Activated/Deactivated). Adds `ResizePseudoConsole` so cmd / Claude Code see the right cell grid when the WPF window resizes. Adds Job Object child-process containment so closing pty-speak guarantees the child shell tree dies (replaces today's "best-effort kill" path). The reserved-hotkey contract (Ctrl+Shift+U/D/R/M, Alt+Shift+R) MUST take priority over PTY input. Stage 4.5's mode flags + Stage 5's `ModeChanged` event already support DECCKM / BracketedPaste / FocusReporting in the type system; Stage 6 wires the parser arms + key encoding. |
+| **Last merged stages** | **Stage 4** (UIA Document + Text pattern + Line/Character/Word navigation + focus-into-TerminalSurface fix, PRs #54-#56, #59, #60, #68), **Stage 11** (Velopack auto-update via `Ctrl+Shift+U`, PRs #63, #66), **Security-audit cycle SR-1/SR-2/SR-3** (PRs #76, #77, #78), **Stage 4.5 — Claude Code rendering substrate** (PR-A #85, PR-B alt-screen back-buffer), **Stage 5 — Streaming output notifications** (single PR: `Coalescer` module + `ModeChanged` event + two-channel composition + Acc/9 OnRender lock fix bundled), and **Stage 6 — Keyboard input, paste, focus reporting, dynamic resize, Job Object lifecycle** (PR-A parser arms for DECCKM/BracketedPaste/FocusReporting, PR-B `KeyEncoding` module + WPF input wiring + `ResizePseudoConsole` debounce + Job Object child-process containment). Stage 4 + 11 NVDA-verified on `v0.0.1-preview.26`; Stage 4.5 + Stage 5 verified end-to-end on the post-Stage-5 preview (streaming output, frame-hash dedup, alt-screen, hotkey announces); Stage 6 verified by xUnit (35 new `KeyEncodingTests` + 15 new `ScreenTests` for the new mode arms + 2 new `ConPtyHostTests` for resize and Job Object); manual NVDA verification of Stage 6 typed-input gates + Job Object cleanup on the next preview cut is the acceptance gate. |
+| **Last shipped release** | `v0.0.1-preview.26` (or whichever preview the maintainer last cut — release cadence is ad-hoc during the unsigned-preview line). The auto-update path replaces the `scripts/install-latest-preview.ps1` bridge for in-place updates; the script is now **deprecated for in-place updates** but remains useful for fresh installs and dev-environment workflows. The next preview cut picks up Stage 5 + Stage 6 (the first preview where pty-speak is interactive — the user can type into the cmd.exe child). |
+| **In-flight branch** | None. Stage 6 merged. The next stage per the 2026-05-01 strategic review is **Stage 7 — Claude Code roundtrip + env-scrub**. Process-cleanup test (the deferred Stage 4 row) is the recurring acceptance check tracked in "Pending action items" item 2; should re-run after the post-Stage-6 preview cut, this time exercising the new Job Object cleanup path including a Task-Manager kill of `Terminal.App.exe` to confirm KILL_ON_JOB_CLOSE works under hard-crash conditions. |
+| **Next stage** | **Stage 7 — Claude Code roundtrip + env-scrub.** All substrate is in place after Stage 6: alt-screen + cursor visibility (Stage 4.5), streaming announcements (Stage 5), keyboard input + bracketed paste + DECCKM + focus reporting (Stage 6 — Claude Code uses application-cursor mode and bracketed paste both). Stage 7 wires `claude` as the spawned shell command, adds the deferred env-scrub PO-5 (strip `TERM_PROGRAM`, `GITHUB_TOKEN`, `OPENAI_API_KEY`, etc. from the child's environment block via `lpEnvironment` on `CreateProcess` — currently inheriting the parent's full env block), and runs the Claude Code conversation flow end-to-end. Strategic review §G also assigned the "command output complete" prompt-redraw signal to Stage 8, but if Claude's redraw rhythm benefits, it can land in Stage 7's tail. **Open follow-up logged for a future stage**: Screen-buffer runtime resize. Stage 6 resizes the PTY (so cmd.exe and Claude Code see the right column count), but the in-process `Cell[,]` Screen grid stays at construction-time 30×120 — oversize windows have empty padding, undersize windows clip. Spec §6 says "ResizePseudoConsole", which Stage 6 satisfies; full grid resize is a Phase 2 stage. |
 
 The end-to-end pipeline now reaches the auto-update boundary:
 launching the app spawns `cmd.exe` under ConPTY, parses its
@@ -45,11 +45,30 @@ sliding-window spinner suppression, leading- + trailing-edge
 fanning out to `TerminalView.Announce(message, activityId)`
 using the new `ActivityIds` vocabulary so NVDA users can
 configure per-tag handling. The Stage 5 PR also bundled the
-Acc/9 OnRender lock fix (item 5.3 below) so the WPF render
-path takes ONE locked snapshot per frame instead of
-re-entering the screen gate per cell. Stage 6 (keyboard input
-to the PTY, plus DECCKM / bracketed paste / focus reporting)
-is the next user-facing milestone.
+Acc/9 OnRender lock fix so the WPF render path takes ONE
+locked snapshot per frame instead of re-entering the screen
+gate per cell. Stage 6 makes pty-speak interactive: the new
+pure-F# `KeyEncoding` module (decoupled from
+`System.Windows.Input.Key` so it survives a future Linux /
+macOS port unchanged) translates keystrokes into xterm-style
+VT byte sequences honouring DECCKM application-cursor mode,
+the SGR-modifier protocol, F1-F12 SS3/CSI conventions, and
+Ctrl-letter / Alt-prefix encoding; an `ApplicationCommands.Paste`
+handler wraps clipboard text in bracketed-paste markers when
+`?2004` is set (and strips embedded `\x1b[201~` for paste-
+injection defence, an accessibility-first divergence from
+xterm); `OnGotKeyboardFocus` / `OnLostKeyboardFocus` emit
+`\x1b[I` / `\x1b[O` when `?1004` is set; window resize debounces
+through a 200ms `DispatcherTimer` to `ResizePseudoConsole`;
+and a kernel Job Object with `KILL_ON_JOB_CLOSE` semantics
+contains the entire child-process tree so even a hard parent
+crash leaves no orphans. The reserved-hotkey contract
+(Ctrl+Shift+U / D / R shipped, Ctrl+Shift+M and Alt+Shift+R
+future-reserved) takes priority over PTY input via the
+load-bearing `OnPreviewKeyDown` filter ordering pinned in
+the inline doc-comment + behavioural tests. Stage 7 (Claude
+Code roundtrip + the deferred env-scrub work) is the next
+user-facing milestone.
 
 ## Pending action items (maintainer)
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -517,6 +517,24 @@ module Program =
                         window.TerminalSurface
                         notificationChannel.Writer
                         cts.Token
+                // Stage 6 PR-B — wire keyboard input + paste + focus
+                // events + window-resize through to the new host.
+                // SetPtyHost takes two callbacks because Views/
+                // intentionally doesn't reference Terminal.Pty (would
+                // break the F#-first / WPF-only-at-the-edge boundary).
+                // The view invokes them on the WPF dispatcher thread,
+                // which is also the only thread that touches the
+                // ConPTY stdin pipe (single-writer discipline).
+                window.TerminalSurface.SetPtyHost(
+                    Action<byte[]>(fun bytes -> host.WriteBytes(bytes)),
+                    Action<int, int>(fun cols rows ->
+                        // Resize is best-effort: a transient failure
+                        // (e.g. the child has just exited) shouldn't
+                        // crash the app. The next SizeChanged tick
+                        // retries naturally.
+                        match host.Resize(int16 cols, int16 rows) with
+                        | Ok () -> ()
+                        | Error _ -> ()))
                 ())
 
         app.Exit.Add(fun _ ->

--- a/src/Terminal.Core/KeyEncoding.fs
+++ b/src/Terminal.Core/KeyEncoding.fs
@@ -1,0 +1,269 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+
+/// Stage 6 PR-B — keyboard encoding.
+///
+/// Pure F# encoder: `KeyCode * KeyModifiers * TerminalModes -> byte[] option`.
+/// `Some bytes` means "send these to the PTY"; `None` means "drop this key".
+///
+/// **Why a private DU instead of WPF's `System.Windows.Input.Key`?**
+/// Decoupling the encoder from WPF buys us:
+///   * Tests run from F# without spinning up WPF.
+///   * A future Linux / macOS port (Avalonia, MAUI, Tauri, web) reuses
+///     this module unchanged — only the platform adapter that
+///     translates `Key` → `KeyCode` changes.
+///   * A future TUI mode (e.g. a CLI agent without a window) reuses
+///     this for synthetic-key paths.
+///
+/// Encoding tables follow the xterm convention as documented in
+/// `man xterm` "PC-Style Function Keys" + "VT220-Style Function
+/// Keys", with DECCKM application-mode arrow keys per `Modes.DECCKM`.
+/// SGR-modifier protocol (`\x1b[1;<mod>A` for modified cursor keys,
+/// `\x1b[<n>;<mod>~` for modified editing/F-keys) is the modern
+/// xterm default that bash, zsh, fish, PowerShell, and Claude Code
+/// all consume correctly.
+///
+/// The `KeyCode.Char` case is for printable characters that arrive
+/// via `PreviewKeyDown` (Ctrl-combos primarily — plain typing routes
+/// through `TextInput` which UTF-8-encodes directly without going
+/// through this module). The `KeyCode.Unhandled` case is the
+/// future-proofing escape hatch: any key the adapter doesn't
+/// recognise produces a clean `None` rather than a crash, so a new
+/// WPF `Key` value (or any new platform key value) cannot break the
+/// encoder without an explicit code change.
+
+[<RequireQualifiedAccess>]
+type KeyCode =
+    // Cursor keys (DECCKM-aware)
+    | Up
+    | Down
+    | Right
+    | Left
+    // Editing keypad
+    | Insert
+    | Delete
+    | Home
+    | End
+    | PageUp
+    | PageDown
+    // Function keys
+    | F1 | F2 | F3 | F4
+    | F5 | F6 | F7 | F8
+    | F9 | F10 | F11 | F12
+    // Whitespace / control
+    | Tab
+    | Enter
+    | Escape
+    | Backspace
+    /// Printable character. Only used for Ctrl/Alt-modified printable
+    /// characters arriving via `PreviewKeyDown`; plain typing routes
+    /// through `TextInput` and bypasses this module.
+    | Char of char
+    /// Future-proofing: any unmapped key. Encoder returns `None`.
+    | Unhandled
+
+/// Modifier flags. Mirrors `System.Windows.Input.ModifierKeys` shape
+/// but is platform-neutral.
+[<System.Flags>]
+type KeyModifiers =
+    | None    = 0
+    | Shift   = 1
+    | Alt     = 2
+    | Control = 4
+
+module KeyEncoding =
+
+    let private esc = byte 0x1B
+    let private bracket = byte '['
+    let private O = byte 'O'
+
+    /// xterm SGR-style modifier parameter:
+    ///   1 = none, 2 = Shift, 3 = Alt, 4 = Shift+Alt,
+    ///   5 = Ctrl, 6 = Ctrl+Shift, 7 = Ctrl+Alt, 8 = Ctrl+Shift+Alt.
+    let internal modifierParam (m: KeyModifiers) : int =
+        let mutable p = 1
+        if m.HasFlag KeyModifiers.Shift then p <- p + 1
+        if m.HasFlag KeyModifiers.Alt then p <- p + 2
+        if m.HasFlag KeyModifiers.Control then p <- p + 4
+        p
+
+    /// Encode a cursor key (Up/Down/Right/Left) honouring DECCKM and
+    /// modifiers.
+    ///
+    ///   * DECCKM normal, no modifier: `\x1b[A` (and B/C/D)
+    ///   * DECCKM application, no modifier: `\x1bOA` (SS3 form)
+    ///   * Any modifier (DECCKM-independent): `\x1b[1;<mod>A`
+    ///     (xterm convention: modified cursor keys do NOT use SS3
+    ///     even in application mode)
+    let private encodeCursor (final: char) (m: KeyModifiers) (modes: TerminalModes) : byte[] =
+        if m <> KeyModifiers.None then
+            let p = modifierParam m
+            Encoding.ASCII.GetBytes(sprintf "\x1b[1;%d%c" p final)
+        elif modes.DECCKM then
+            [| esc; O; byte final |]
+        else
+            [| esc; bracket; byte final |]
+
+    /// Encode an editing-keypad / F5+ key with `\x1b[<n>~` shape.
+    /// Modified form is `\x1b[<n>;<mod>~`.
+    let private encodeTilde (n: int) (m: KeyModifiers) : byte[] =
+        if m = KeyModifiers.None then
+            Encoding.ASCII.GetBytes(sprintf "\x1b[%d~" n)
+        else
+            let p = modifierParam m
+            Encoding.ASCII.GetBytes(sprintf "\x1b[%d;%d~" n p)
+
+    /// Encode F1-F4 with `\x1bO<P/Q/R/S>` shape (SS3 form).
+    /// Modified form is `\x1b[1;<mod><P/Q/R/S>` (CSI form).
+    let private encodeF1to4 (final: char) (m: KeyModifiers) : byte[] =
+        if m = KeyModifiers.None then
+            [| esc; O; byte final |]
+        else
+            let p = modifierParam m
+            Encoding.ASCII.GetBytes(sprintf "\x1b[1;%d%c" p final)
+
+    /// Encode a printable ASCII character with optional Ctrl/Alt
+    /// modifiers. Returns `None` for non-ASCII (those should arrive
+    /// via the platform's text-input path, not through KeyEncoding).
+    ///
+    ///   * Bare `'a'` → `[| 0x61 |]`
+    ///   * `Ctrl+'a'` → `[| 0x01 |]`
+    ///   * `Alt+'a'` → `[| 0x1b; 0x61 |]` (ESC-prefix; xterm convention)
+    ///   * `Ctrl+Alt+'a'` → `[| 0x1b; 0x01 |]`
+    ///   * `Ctrl+'@'` → `[| 0x00 |]` (NUL); `Ctrl+'['` → `[| 0x1b |]`;
+    ///     `Ctrl+'\\'` → `[| 0x1c |]`; `Ctrl+']'` → `[| 0x1d |]`;
+    ///     `Ctrl+'?'` → `[| 0x7f |]` (DEL).
+    ///
+    /// Shift is implicitly absorbed for Ctrl-letter (`Ctrl+A` and
+    /// `Ctrl+Shift+A` both produce `0x01`); for non-letter Ctrl
+    /// combos Shift passes through to the underlying byte.
+    let private encodeChar (c: char) (m: KeyModifiers) : byte[] option =
+        if int c > 0x7F then None
+        else
+            let ctrl = m.HasFlag KeyModifiers.Control
+            let alt = m.HasFlag KeyModifiers.Alt
+            let ascii =
+                if ctrl && c >= 'a' && c <= 'z' then byte (int c - int 'a' + 1)
+                elif ctrl && c >= 'A' && c <= 'Z' then byte (int c - int 'A' + 1)
+                elif ctrl && c = '@' then 0uy
+                elif ctrl && c = '[' then byte 0x1B
+                elif ctrl && c = '\\' then byte 0x1C
+                elif ctrl && c = ']' then byte 0x1D
+                elif ctrl && c = '^' then byte 0x1E
+                elif ctrl && c = '_' then byte 0x1F
+                elif ctrl && c = '?' then byte 0x7F
+                elif ctrl && c = ' ' then 0uy
+                else byte c
+            if alt then Some [| esc; ascii |]
+            else Some [| ascii |]
+
+    /// Main entry: encode `(key, modifiers, modes)` into bytes for
+    /// the PTY. `None` means "don't forward this key to the child".
+    let encode (key: KeyCode) (m: KeyModifiers) (modes: TerminalModes) : byte[] option =
+        match key with
+        | KeyCode.Up    -> Some (encodeCursor 'A' m modes)
+        | KeyCode.Down  -> Some (encodeCursor 'B' m modes)
+        | KeyCode.Right -> Some (encodeCursor 'C' m modes)
+        | KeyCode.Left  -> Some (encodeCursor 'D' m modes)
+        | KeyCode.Insert   -> Some (encodeTilde 2 m)
+        | KeyCode.Delete   -> Some (encodeTilde 3 m)
+        | KeyCode.PageUp   -> Some (encodeTilde 5 m)
+        | KeyCode.PageDown -> Some (encodeTilde 6 m)
+        | KeyCode.Home ->
+            // Modern xterm default: \x1b[H (no tilde). Modified: \x1b[1;<mod>H.
+            if m = KeyModifiers.None then Some [| esc; bracket; byte 'H' |]
+            else
+                let p = modifierParam m
+                Some (Encoding.ASCII.GetBytes(sprintf "\x1b[1;%dH" p))
+        | KeyCode.End ->
+            if m = KeyModifiers.None then Some [| esc; bracket; byte 'F' |]
+            else
+                let p = modifierParam m
+                Some (Encoding.ASCII.GetBytes(sprintf "\x1b[1;%dF" p))
+        | KeyCode.F1 -> Some (encodeF1to4 'P' m)
+        | KeyCode.F2 -> Some (encodeF1to4 'Q' m)
+        | KeyCode.F3 -> Some (encodeF1to4 'R' m)
+        | KeyCode.F4 -> Some (encodeF1to4 'S' m)
+        | KeyCode.F5  -> Some (encodeTilde 15 m)
+        | KeyCode.F6  -> Some (encodeTilde 17 m)
+        | KeyCode.F7  -> Some (encodeTilde 18 m)
+        | KeyCode.F8  -> Some (encodeTilde 19 m)
+        | KeyCode.F9  -> Some (encodeTilde 20 m)
+        | KeyCode.F10 -> Some (encodeTilde 21 m)
+        | KeyCode.F11 -> Some (encodeTilde 23 m)
+        | KeyCode.F12 -> Some (encodeTilde 24 m)
+        | KeyCode.Tab ->
+            if m.HasFlag KeyModifiers.Shift then
+                Some [| esc; bracket; byte 'Z' |]
+            elif m.HasFlag KeyModifiers.Alt then
+                Some [| esc; byte '\t' |]
+            else
+                Some [| byte '\t' |]
+        | KeyCode.Enter ->
+            if m.HasFlag KeyModifiers.Alt then
+                Some [| esc; byte '\r' |]
+            else
+                Some [| byte '\r' |]
+        | KeyCode.Escape ->
+            if m.HasFlag KeyModifiers.Alt then
+                Some [| esc; esc |]
+            else
+                Some [| esc |]
+        | KeyCode.Backspace ->
+            // xterm modern default: 0x7f (DEL). bash, zsh, PowerShell,
+            // and Claude Code all expect this. Some legacy shells want
+            // 0x08 (BS) — those will need a Phase 2 setting.
+            if m.HasFlag KeyModifiers.Alt then
+                Some [| esc; byte 0x7F |]
+            else
+                Some [| byte 0x7F |]
+        | KeyCode.Char c -> encodeChar c m
+        | KeyCode.Unhandled -> None
+
+    /// Wrap clipboard text for paste forwarding.
+    ///
+    /// **Paste-injection defence (accessibility-first stance, diverges
+    /// from xterm).** Strips embedded `\x1b[201~` from the clipboard
+    /// content before wrapping. xterm doesn't strip — but for screen-
+    /// reader users who can't easily inspect their clipboard before
+    /// pasting, an attacker-crafted paste containing `\x1b[201~`
+    /// followed by a malicious command would close the bracket-paste
+    /// frame early and execute the post-paste portion as if it were
+    /// typed. The cost of stripping is essentially zero (no
+    /// legitimate shell content contains that exact byte sequence);
+    /// the security benefit is meaningful for our threat model.
+    /// SECURITY.md tracks this as a deliberate posture divergence.
+    ///
+    /// Returns the bytes to send to the PTY:
+    ///   * When `bracketedPaste` is `true`:
+    ///     `\x1b[200~<sanitised>\x1b[201~`
+    ///   * When `false`: raw `<sanitised>` bytes (still with
+    ///     `\x1b[201~` stripped — defence in depth, no behavioural
+    ///     downside).
+    let encodePaste (text: string) (bracketedPaste: bool) : byte[] =
+        let safeText = text.Replace("\x1b[201~", "")
+        let bodyBytes = Encoding.UTF8.GetBytes(safeText)
+        if bracketedPaste then
+            let prefix = Encoding.ASCII.GetBytes("\x1b[200~")
+            let suffix = Encoding.ASCII.GetBytes("\x1b[201~")
+            Array.concat [ prefix; bodyBytes; suffix ]
+        else
+            bodyBytes
+
+    /// Focus-reporting bytes per `?1004` mode. The view's GotKeyboardFocus
+    /// / LostKeyboardFocus handlers send these only when
+    /// `Modes.FocusReporting` is true.
+    let focusGained : byte[] = [| esc; bracket; byte 'I' |]
+    let focusLost : byte[] = [| esc; bracket; byte 'O' |]
+
+    /// C#-friendly entry point: returns the bytes directly, or `null`
+    /// when the encoder returned `None` (unmapped key). Avoids
+    /// `FSharpOption<byte[]>` boilerplate at the C# call site in
+    /// `TerminalView.OnPreviewKeyDown`. F#-side callers should
+    /// continue to use `encode` and pattern-match the `option`.
+    let encodeOrNull (key: KeyCode) (m: KeyModifiers) (modes: TerminalModes) : byte[] | null =
+        match encode key m modes with
+        | Some bytes -> bytes
+        | None -> null

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="AnnounceSanitiser.fs" />
     <Compile Include="UpdateMessages.fs" />
     <Compile Include="Coalescer.fs" />
+    <Compile Include="KeyEncoding.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Terminal.Pty/ConPtyHost.fs
+++ b/src/Terminal.Pty/ConPtyHost.fs
@@ -39,6 +39,38 @@ type ConPtyHost internal (session: PtySession,
 
     member _.ProcessId: uint32 = session.ProcessId
 
+    /// Stage 6 PR-B — write bytes to the child's stdin. Convenience
+    /// wrapper around `Stdin.Write` so callers don't have to reach
+    /// through the FileStream property. Synchronous (the underlying
+    /// FileStream is non-async per ConPTY's OVERLAPPED-I/O ban) and
+    /// must be called from a single thread — Stage 6's wiring funnels
+    /// every write through the WPF dispatcher thread, so serialisation
+    /// is structural rather than enforced here.
+    member _.WriteBytes(bytes: byte[]) : unit =
+        if bytes.Length > 0 then
+            stdin.Write(bytes, 0, bytes.Length)
+            // Flush so the child sees the keystroke immediately —
+            // the FileStream's 4-KB write buffer would otherwise
+            // hold a single-byte arrow keypress until the next
+            // write or close.
+            stdin.Flush()
+
+    /// Stage 6 PR-B — resize the underlying pseudo-console grid.
+    /// Returns Ok on success, Error with the Win32 HRESULT
+    /// otherwise. Idempotent and thread-safe per
+    /// `ResizePseudoConsole`'s documented contract; production
+    /// callers debounce upstream so the child shell isn't asked
+    /// to re-layout for every WPF SizeChanged tick.
+    member _.Resize(cols: int16, rows: int16) : Result<unit, int> =
+        PseudoConsole.resize session cols rows
+
+    /// Stage 6 PR-B — the Job Object handle owning the child +
+    /// any process the child spawns. Exposed so tests can assert
+    /// the handle is valid post-spawn; production code never
+    /// interacts with this directly (lifecycle binds to the
+    /// `PtySession` dispose path inside this host).
+    member _.JobHandle = session.JobHandle
+
     /// Convenience: wait for the child process to exit. Returns when
     /// WaitForSingleObject signals on the process handle. Does not
     /// itself stop the reader — that happens when the pipe drains.

--- a/src/Terminal.Pty/Native.fs
+++ b/src/Terminal.Pty/Native.fs
@@ -61,6 +61,51 @@ type SECURITY_ATTRIBUTES =
       mutable lpSecurityDescriptor: nativeint
       mutable bInheritHandle: int32 }
 
+// Stage 6 PR-B — Job Object support so closing pty-speak guarantees
+// the entire child-process tree (cmd.exe + anything cmd.exe spawned)
+// is killed by the kernel, even if pty-speak itself crashes hard
+// without running its IDisposable. Layered on top of the existing
+// best-effort `TerminateProcess` cleanup in `ConPtyHost.Dispose`:
+// `TerminateProcess` is fast targeted cleanup for the immediate
+// cmd.exe so its pipe drains promptly; the Job Object is the
+// kernel-enforced safety net for any grandchildren (e.g. a `node`
+// process Stage 7's Claude Code spawns inside pty-speak).
+//
+// The structs below mirror the Win32 headers exactly. All sizes are
+// `Marshal.SizeOf` checked; deviating from the documented field
+// order or alignment produces silent garbage when the kernel
+// interprets the buffer.
+
+[<Struct; StructLayout(LayoutKind.Sequential)>]
+type JOBOBJECT_BASIC_LIMIT_INFORMATION =
+    { mutable PerProcessUserTimeLimit: int64
+      mutable PerJobUserTimeLimit: int64
+      mutable LimitFlags: uint32
+      mutable MinimumWorkingSetSize: unativeint
+      mutable MaximumWorkingSetSize: unativeint
+      mutable ActiveProcessLimit: uint32
+      mutable Affinity: unativeint
+      mutable PriorityClass: uint32
+      mutable SchedulingClass: uint32 }
+
+[<Struct; StructLayout(LayoutKind.Sequential)>]
+type IO_COUNTERS =
+    { mutable ReadOperationCount: uint64
+      mutable WriteOperationCount: uint64
+      mutable OtherOperationCount: uint64
+      mutable ReadTransferCount: uint64
+      mutable WriteTransferCount: uint64
+      mutable OtherTransferCount: uint64 }
+
+[<Struct; StructLayout(LayoutKind.Sequential)>]
+type JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
+    { mutable BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION
+      mutable IoInfo: IO_COUNTERS
+      mutable ProcessMemoryLimit: unativeint
+      mutable JobMemoryLimit: unativeint
+      mutable PeakProcessMemoryUsed: unativeint
+      mutable PeakJobMemoryUsed: unativeint }
+
 /// Win32 constants we need for ConPTY. Suffixed for the right type:
 /// `un` = unativeint (matches `IntPtr Attribute` field on
 /// UpdateProcThreadAttribute), `u` = uint32, no suffix = signed int32.
@@ -87,6 +132,18 @@ module Constants =
     /// been closed and nothing remains to read.
     let ERROR_BROKEN_PIPE: int = 0x6D
 
+    /// `JobObjectInfoClass` value that selects
+    /// `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` for
+    /// `SetInformationJobObject`. From `winnt.h`.
+    let JobObjectExtendedLimitInformation: int = 9
+
+    /// `LimitFlags` bit on `JOBOBJECT_BASIC_LIMIT_INFORMATION` that
+    /// causes the kernel to terminate every process associated with
+    /// the job when the last handle to the job is closed. This is
+    /// the single bit that makes child-tree cleanup work even when
+    /// the parent crashes without running its IDisposable.
+    let JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: uint32 = 0x00002000u
+
 /// SafeHandle wrapper for HPCON. ClosePseudoConsole runs on Dispose so
 /// callers don't have to remember to close it. Treats 0 and -1 as
 /// invalid (matches conpty's convention even though 0 is the more
@@ -110,6 +167,29 @@ type SafePseudoConsoleHandle() =
 
     override this.ReleaseHandle() =
         ClosePseudoConsole(this.handle)
+        true
+
+/// SafeHandle for a Job Object handle. Closing the handle when
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set on the job triggers
+/// kernel-level termination of every process in the job — that's
+/// the entire mechanism for grandchild cleanup. Wraps the same
+/// `IntPtr-then-SetHandle` idiom as `SafePseudoConsoleHandle` to
+/// avoid F#'s sharp-edged `out SafeHandle` byref marshalling.
+type SafeJobHandle() =
+    inherit SafeHandleZeroOrMinusOneIsInvalid(true)
+
+    [<DllImport("kernel32.dll", SetLastError = true)>]
+    static extern bool CloseHandle(nativeint hObject)
+
+    /// Construct from a kernel-returned job handle. The handle takes
+    /// ownership and CloseHandle runs on disposal — which, for a
+    /// KILL_ON_JOB_CLOSE job, kills every process still in the job.
+    new(preexistingHandle: nativeint) as this =
+        new SafeJobHandle()
+        then this.SetHandle(preexistingHandle)
+
+    override this.ReleaseHandle() =
+        CloseHandle(this.handle) |> ignore
         true
 
 /// All the P/Invoke functions we need. Kept in a single module so the
@@ -185,3 +265,21 @@ module Win32 =
 
     [<DllImport("kernel32.dll", SetLastError = true)>]
     extern uint32 WaitForSingleObject(nativeint hHandle, uint32 dwMilliseconds)
+
+    // Stage 6 PR-B — Job Object P/Invokes for child-process tree cleanup.
+    [<DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)>]
+    extern nativeint CreateJobObjectW(
+        nativeint lpJobAttributes,
+        string | null lpName)
+
+    [<DllImport("kernel32.dll", SetLastError = true)>]
+    extern bool SetInformationJobObject(
+        nativeint hJob,
+        int JobObjectInfoClass,
+        nativeint lpJobObjectInfo,
+        uint32 cbJobObjectInfoLength)
+
+    [<DllImport("kernel32.dll", SetLastError = true)>]
+    extern bool AssignProcessToJobObject(
+        nativeint hJob,
+        nativeint hProcess)

--- a/src/Terminal.Pty/PseudoConsole.fs
+++ b/src/Terminal.Pty/PseudoConsole.fs
@@ -15,6 +15,10 @@ type PtyCreateError =
     | AllocAttributeListFailed
     | UpdateAttributeFailed of win32: int
     | CreateProcessFailed of win32: int
+    /// Stage 6 PR-B — Job Object setup failure. The child process
+    /// has already been started and terminated when this error
+    /// returns; no orphan is left behind.
+    | JobObjectSetupFailed of stage: string * win32: int
 
 /// Configuration for a new pseudo-console session. cols/rows are the
 /// initial grid size; the child can be resized later via
@@ -49,7 +53,15 @@ type PtySession =
       ProcessId: uint32
       /// Heap-allocated attribute-list buffer. Must be passed to
       /// DeleteProcThreadAttributeList and then freed.
-      AttributeList: nativeint }
+      AttributeList: nativeint
+      /// Stage 6 PR-B — Job Object handle owning the child + any
+      /// processes the child spawns. Closing this handle (which
+      /// happens via SafeJobHandle.Dispose) triggers
+      /// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and the kernel
+      /// terminates the entire process tree. Belt-and-braces on
+      /// top of `ConPtyHost`'s targeted `TerminateProcess` of the
+      /// immediate cmd.exe.
+      JobHandle: SafeJobHandle }
 
     interface IDisposable with
         member this.Dispose() =
@@ -64,6 +76,12 @@ type PtySession =
                 Win32.CloseHandle(this.ProcessHandle) |> ignore
             if this.ThreadHandle <> IntPtr.Zero then
                 Win32.CloseHandle(this.ThreadHandle) |> ignore
+            // Closing the job handle LAST gives the kernel a final
+            // KILL_ON_JOB_CLOSE pass for any process that might
+            // have escaped earlier cleanup steps. SafeHandle's
+            // finaliser also runs this if Dispose is missed entirely
+            // (e.g. on a hard parent crash).
+            this.JobHandle.Dispose()
 
 /// Functions for creating, resizing, and tearing down a pseudoconsole.
 /// All public functions return Result so callers don't need a try/catch
@@ -221,14 +239,109 @@ module PseudoConsole =
                             outputRead.Dispose()
                             Error(CreateProcessFailed err)
                         else
-                            Ok
-                                { Console = hPC
-                                  Stdin = inputWrite
-                                  Stdout = outputRead
-                                  ProcessHandle = pi.hProcess
-                                  ThreadHandle = pi.hThread
-                                  ProcessId = pi.dwProcessId
-                                  AttributeList = attrList }
+                            // 9. Stage 6 PR-B — create a Job Object,
+                            // mark it KILL_ON_JOB_CLOSE, and assign
+                            // the freshly-spawned child to it. The
+                            // child is already running by the time
+                            // CreateProcess returned (we don't pass
+                            // CREATE_SUSPENDED), so there's a
+                            // microsecond-window race in which the
+                            // child could fork before assignment;
+                            // cmd.exe in practice doesn't fork
+                            // anything that fast, and any escapee
+                            // would still be killed by the standard
+                            // ConPTY pipe-close path on shutdown.
+                            // The Job Object is the kernel-enforced
+                            // safety net for the post-CreateProcess
+                            // descendant tree (e.g. processes
+                            // started by a shell command Stage 7's
+                            // Claude Code launches).
+                            //
+                            // On any setup failure, we MUST
+                            // terminate the orphan child before
+                            // returning Error — leaving a running
+                            // child after a failed start would leak
+                            // a process and confuse later cleanup.
+                            let cleanupChildOnFailure () =
+                                try Win32.TerminateProcess(pi.hProcess, 1u) |> ignore with _ -> ()
+                                try Win32.CloseHandle(pi.hProcess) |> ignore with _ -> ()
+                                try Win32.CloseHandle(pi.hThread) |> ignore with _ -> ()
+                                Win32.DeleteProcThreadAttributeList(attrList) |> ignore
+                                Marshal.FreeHGlobal(attrList)
+                                hPC.Dispose()
+                                inputWrite.Dispose()
+                                outputRead.Dispose()
+                            let jobHandleRaw = Win32.CreateJobObjectW(IntPtr.Zero, null)
+                            if jobHandleRaw = IntPtr.Zero then
+                                let err = Marshal.GetLastWin32Error()
+                                cleanupChildOnFailure ()
+                                Error(JobObjectSetupFailed("CreateJobObjectW", err))
+                            else
+                                let jobHandle = new SafeJobHandle(jobHandleRaw)
+                                // Build JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+                                // with KILL_ON_JOB_CLOSE on; everything
+                                // else zeroed.
+                                let mutable jobInfo =
+                                    { BasicLimitInformation =
+                                        { PerProcessUserTimeLimit = 0L
+                                          PerJobUserTimeLimit = 0L
+                                          LimitFlags = Constants.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                                          MinimumWorkingSetSize = 0un
+                                          MaximumWorkingSetSize = 0un
+                                          ActiveProcessLimit = 0u
+                                          Affinity = 0un
+                                          PriorityClass = 0u
+                                          SchedulingClass = 0u }
+                                      IoInfo =
+                                        { ReadOperationCount = 0UL
+                                          WriteOperationCount = 0UL
+                                          OtherOperationCount = 0UL
+                                          ReadTransferCount = 0UL
+                                          WriteTransferCount = 0UL
+                                          OtherTransferCount = 0UL }
+                                      ProcessMemoryLimit = 0un
+                                      JobMemoryLimit = 0un
+                                      PeakProcessMemoryUsed = 0un
+                                      PeakJobMemoryUsed = 0un }
+                                let jobInfoSize =
+                                    Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>()
+                                let jobInfoPtr = Marshal.AllocHGlobal(jobInfoSize)
+                                try
+                                    Marshal.StructureToPtr<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>(
+                                        jobInfo, jobInfoPtr, false)
+                                    let setOk =
+                                        Win32.SetInformationJobObject(
+                                            jobHandle.DangerousGetHandle(),
+                                            Constants.JobObjectExtendedLimitInformation,
+                                            jobInfoPtr,
+                                            uint32 jobInfoSize)
+                                    if not setOk then
+                                        let err = Marshal.GetLastWin32Error()
+                                        jobHandle.Dispose()
+                                        cleanupChildOnFailure ()
+                                        Error(JobObjectSetupFailed("SetInformationJobObject", err))
+                                    else
+                                        let assignOk =
+                                            Win32.AssignProcessToJobObject(
+                                                jobHandle.DangerousGetHandle(),
+                                                pi.hProcess)
+                                        if not assignOk then
+                                            let err = Marshal.GetLastWin32Error()
+                                            jobHandle.Dispose()
+                                            cleanupChildOnFailure ()
+                                            Error(JobObjectSetupFailed("AssignProcessToJobObject", err))
+                                        else
+                                            Ok
+                                                { Console = hPC
+                                                  Stdin = inputWrite
+                                                  Stdout = outputRead
+                                                  ProcessHandle = pi.hProcess
+                                                  ThreadHandle = pi.hThread
+                                                  ProcessId = pi.dwProcessId
+                                                  AttributeList = attrList
+                                                  JobHandle = jobHandle }
+                                finally
+                                    Marshal.FreeHGlobal(jobInfoPtr)
 
     /// Resize the pseudo-console grid. Idempotent and safe to call from
     /// any thread; the underlying ResizePseudoConsole is documented

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -5,6 +5,7 @@ using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using Terminal.Accessibility;
 using Terminal.Core;
 
@@ -42,6 +43,38 @@ public class TerminalView : FrameworkElement
     private double _cellHeight;
 
     private Screen? _screen;
+
+    /// <summary>
+    /// Stage 6 PR-B — sink for keyboard / paste / focus bytes. Set
+    /// by <see cref="SetPtyHost"/> from <c>Program.fs compose ()</c>
+    /// after the ConPtyHost is up. Until set (and during teardown),
+    /// key events drop silently — Stage 6 cannot route input
+    /// without a live PTY.
+    /// </summary>
+    private Action<byte[]>? _writeBytes;
+
+    /// <summary>
+    /// Stage 6 PR-B — resize callback. Receives the new
+    /// (cols, rows) cell dimensions after the WPF SizeChanged
+    /// debounce settles; the implementation in Program.fs
+    /// translates to <c>ConPtyHost.Resize</c>.
+    /// </summary>
+    private Action<int, int>? _resize;
+
+    /// <summary>
+    /// Stage 6 PR-B — 200ms trailing-edge debounce for
+    /// SizeChanged → ResizePseudoConsole. WPF SizeChanged fires
+    /// per pixel during a window drag (60Hz); resizing the PTY
+    /// at that rate causes the child shell to re-layout for
+    /// every tick, which floods Stage 5's output coalescer with
+    /// redraws and dilutes its spinner heuristic. The timer
+    /// fires on the WPF dispatcher (DispatcherTimer), so the
+    /// resize callback runs on the same thread as keyboard
+    /// writes — single-threaded write discipline.
+    /// </summary>
+    // TODO Phase 2: TOML-configurable debounce window alongside
+    // the Stage 5 coalescer constants in Coalescer.fs.
+    private readonly DispatcherTimer _resizeDebounceTimer;
 
     /// <summary>
     /// UIA Text-pattern provider that exposes the current
@@ -91,6 +124,41 @@ public class TerminalView : FrameworkElement
         _cellHeight = sample.Height;
 
         TextProvider = new TerminalTextProvider(() => _screen);
+
+        // Stage 6 PR-B — paste hook. ApplicationCommands.Paste fires
+        // for Ctrl+V, right-click → Paste, and Edit menu → Paste; one
+        // CommandBinding covers all paste sources. The handler reads
+        // the clipboard, runs it through KeyEncoding.encodePaste
+        // (which strips embedded \x1b[201~ for paste-injection
+        // defence and conditionally wraps in bracketed-paste markers),
+        // and writes to the PTY.
+        CommandBindings.Add(new CommandBinding(
+            ApplicationCommands.Paste,
+            OnPasteExecuted,
+            OnPasteCanExecute));
+
+        // Stage 6 PR-B — resize debounce timer. Stopped initially;
+        // OnRenderSizeChanged restarts it on each WPF SizeChanged tick.
+        _resizeDebounceTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(200),
+        };
+        _resizeDebounceTimer.Tick += OnResizeDebounceTick;
+    }
+
+    /// <summary>
+    /// Stage 6 PR-B — wire the PTY write + resize sinks. Called
+    /// once from <c>Program.fs compose ()</c> after the
+    /// <c>ConPtyHost</c> spawns successfully. The <paramref name="writeBytes"/>
+    /// callback is invoked from the WPF dispatcher thread (PreviewKeyDown,
+    /// TextInput, paste, focus events all fire there), so the
+    /// implementation can synchronously call
+    /// <c>ConPtyHost.WriteBytes</c> without further marshalling.
+    /// </summary>
+    public void SetPtyHost(Action<byte[]> writeBytes, Action<int, int> resize)
+    {
+        _writeBytes = writeBytes ?? throw new ArgumentNullException(nameof(writeBytes));
+        _resize = resize ?? throw new ArgumentNullException(nameof(resize));
     }
 
     /// <summary>
@@ -194,6 +262,15 @@ public class TerminalView : FrameworkElement
             // `src/Terminal.App/Program.fs`.
             (Key.U, ModifierKeys.Control | ModifierKeys.Shift, "Stage 11 self-update"),
 
+            // Audit-cycle PR-#81 — process-cleanup diagnostic launcher
+            // (shipped). Bound in `setupDiagnosticKeybinding`.
+            (Key.D, ModifierKeys.Control | ModifierKeys.Shift, "Process-cleanup diagnostic"),
+
+            // PR-#83 / PR-#91 — draft-a-new-release form launcher
+            // (shipped; URL flipped to /releases/new in PR #91).
+            // Bound in `setupNewReleaseKeybinding`.
+            (Key.R, ModifierKeys.Control | ModifierKeys.Shift, "Draft new release form"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,
@@ -203,45 +280,312 @@ public class TerminalView : FrameworkElement
         ];
 
     /// <summary>
-    /// Pre-Stage-5 routing stub for keyboard input. Today this
-    /// override does nothing visible — Stage 6 (keyboard input
-    /// to PTY) will fill it in with the NVDA-modifier filter
-    /// and PTY-forwarding pipeline. The stub exists now to
-    /// guarantee that when Stage 6 lands, the
-    /// <see cref="AppReservedHotkeys"/> contract is honoured:
-    /// the override checks each reserved hotkey first and
-    /// leaves <c>e.Handled</c> alone for them, ensuring WPF's
-    /// <c>InputBindings</c> see them before any PTY forwarding.
+    /// Stage 6 PR-B — keyboard input pipeline. Filter ordering is
+    /// LOAD-BEARING and pinned by xUnit + behavioural tests:
     ///
-    /// Until Stage 6 ships, no key forwarding happens at all
-    /// (the cmd.exe child receives no input) — that's the
-    /// pre-Stage-6 reality. NVDA review-cursor commands aren't
-    /// keyboard input to the PTY; they're handled by NVDA
-    /// itself and don't reach this method.
+    /// <list type="number">
+    ///   <item><description><b>App-reserved hotkeys first.</b> Any match in
+    ///   <see cref="AppReservedHotkeys"/> short-circuits and does NOT mark
+    ///   the event handled, so the parent Window's InputBindings can fire
+    ///   the corresponding command (Ctrl+Shift+U / D / R today; future
+    ///   Ctrl+Shift+M, Alt+Shift+R when Stage 9 / 10 land).</description></item>
+    ///   <item><description><b>NVDA / screen-reader modifier filter
+    ///   second.</b> Bare Insert / CapsLock presses, and Numpad presses
+    ///   with NumLock off, return without Handled so NVDA / JAWS / Narrator
+    ///   can receive them. Conservative on purpose — the cost (a few key
+    ///   presses don't reach the shell when the user genuinely meant them
+    ///   for the shell) is tiny vs. the cost of breaking review-cursor
+    ///   navigation (catastrophic UX for the target audience).</description></item>
+    ///   <item><description><b>Translate WPF Key + ModifierKeys to
+    ///   <see cref="KeyCode"/> + <see cref="KeyModifiers"/></b> via the
+    ///   small adapter at the bottom of this file. Unknown keys map to
+    ///   <c>KeyCode.Unhandled</c> and the encoder returns <c>None</c>
+    ///   — silently dropped, no crash on a future WPF Key value.</description></item>
+    ///   <item><description><b>Defer plain printable typing to
+    ///   <see cref="OnPreviewTextInput"/></b>. For letters / digits /
+    ///   space without Ctrl or Alt held, leave Handled = false so WPF's
+    ///   text-composition pipeline (which handles IME, AltGr, dead keys
+    ///   correctly) routes the keystroke into TextInput.</description></item>
+    ///   <item><description><b>Encode and write</b> via
+    ///   <see cref="KeyEncoding.encodeOrNull"/>. The encoder reads
+    ///   <c>_screen.Modes.DECCKM</c> for arrow-key encoding (normal
+    ///   <c>\x1b[A</c> vs application <c>\x1bOA</c>).</description></item>
+    /// </list>
+    ///
+    /// If reordering is ever proposed: confirm with maintainer first.
+    /// Step 1 must come before step 2 (otherwise NVDA filter would eat
+    /// Ctrl+Shift+U via the app-reserved table); step 2 must come
+    /// before step 3 (otherwise we'd encode bare Insert and send it
+    /// to the shell, bypassing NVDA's modifier).
     /// </summary>
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         base.OnPreviewKeyDown(e);
 
-        // App-reserved hotkey check: any match short-circuits
-        // and explicitly does NOT mark the event handled, so
-        // the parent Window's InputBindings can process the
-        // gesture and the corresponding command fires
-        // (Ctrl+Shift+U → runUpdateFlow today).
         var pressedModifiers = Keyboard.Modifiers;
+
+        // 1. App-reserved hotkey check.
         foreach (var (key, modifiers, _) in AppReservedHotkeys)
         {
             if (e.Key == key && pressedModifiers == modifiers)
             {
-                // Explicitly leave Handled = false so
-                // InputBindings see this key combination.
                 return;
             }
         }
 
-        // No PTY forwarding until Stage 6 ships. Future Stage 6
-        // implementation must respect the reserved-hotkey
-        // contract (see spec/tech-plan.md §6).
+        // 2. NVDA / screen-reader modifier filter.
+        if (IsScreenReaderCandidate(e.Key))
+        {
+            return;
+        }
+
+        // 3. Translate.
+        var modifiers = TranslateModifiers(pressedModifiers);
+        var keyCode = TranslateKey(e.Key);
+
+        // 4. Defer plain typing to OnPreviewTextInput.
+        var ctrlOrAltHeld =
+            modifiers.HasFlag(KeyModifiers.Control) ||
+            modifiers.HasFlag(KeyModifiers.Alt);
+        if (keyCode.IsChar && !ctrlOrAltHeld)
+        {
+            return;
+        }
+
+        // 5. Encode and write.
+        if (_writeBytes is null)
+        {
+            return;
+        }
+        var modes = _screen?.Modes ?? TerminalModes.create();
+        var bytes = KeyEncoding.encodeOrNull(keyCode, modifiers, modes);
+        if (bytes is null)
+        {
+            return;
+        }
+        _writeBytes(bytes);
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Stage 6 PR-B — IME / printable-typing input. Plain typing
+    /// (letters, digits, space, AltGr-composed characters, dead-key
+    /// composed characters, IME-committed text) arrives here with
+    /// the final composed string. UTF-8 encode and write to the
+    /// PTY directly — no need to route through KeyEncoding because
+    /// these are already finished printable characters.
+    /// </summary>
+    protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+    {
+        base.OnPreviewTextInput(e);
+        if (string.IsNullOrEmpty(e.Text))
+        {
+            return;
+        }
+        if (_writeBytes is null)
+        {
+            return;
+        }
+        var bytes = System.Text.Encoding.UTF8.GetBytes(e.Text);
+        _writeBytes(bytes);
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Stage 6 PR-B — focus reporting. When the child shell has set
+    /// DECSET ?1004 (BracketedPaste-mode-style focus events), emit
+    /// <c>\x1b[I</c> on focus and <c>\x1b[O</c> on blur. Editors
+    /// like nano / vim / Emacs / Claude Code use these to know when
+    /// to suspend their cursor blink, save unsaved buffers, etc.
+    /// </summary>
+    protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
+    {
+        base.OnGotKeyboardFocus(e);
+        if (_writeBytes is null) return;
+        if (_screen?.Modes.FocusReporting == true)
+        {
+            _writeBytes(KeyEncoding.focusGained);
+        }
+    }
+
+    /// <inheritdoc cref="OnGotKeyboardFocus"/>
+    protected override void OnLostKeyboardFocus(KeyboardFocusChangedEventArgs e)
+    {
+        base.OnLostKeyboardFocus(e);
+        if (_writeBytes is null) return;
+        if (_screen?.Modes.FocusReporting == true)
+        {
+            _writeBytes(KeyEncoding.focusLost);
+        }
+    }
+
+    /// <summary>
+    /// Stage 6 PR-B — paste handler bound to
+    /// <see cref="ApplicationCommands.Paste"/>. Reads the
+    /// clipboard text, runs it through
+    /// <see cref="KeyEncoding.encodePaste"/> (which strips
+    /// embedded <c>\x1b[201~</c> for paste-injection defence and
+    /// wraps in <c>\x1b[200~</c>...<c>\x1b[201~</c> when the
+    /// child has set DECSET ?2004), and writes to the PTY.
+    /// </summary>
+    private void OnPasteExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        if (_writeBytes is null) return;
+        if (!Clipboard.ContainsText()) return;
+        var text = Clipboard.GetText();
+        if (string.IsNullOrEmpty(text)) return;
+        var bracketed = _screen?.Modes.BracketedPaste == true;
+        var bytes = KeyEncoding.encodePaste(text, bracketed);
+        _writeBytes(bytes);
+        e.Handled = true;
+    }
+
+    private void OnPasteCanExecute(object sender, CanExecuteRoutedEventArgs e)
+    {
+        e.CanExecute = _writeBytes is not null && Clipboard.ContainsText();
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Stage 6 PR-B — restart the resize debounce on every WPF
+    /// SizeChanged tick. Final call to <see cref="_resize"/> happens
+    /// 200ms after the last SizeChanged settles.
+    /// </summary>
+    protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+    {
+        base.OnRenderSizeChanged(sizeInfo);
+        if (_resize is null)
+        {
+            return;
+        }
+        _resizeDebounceTimer.Stop();
+        _resizeDebounceTimer.Start();
+    }
+
+    private void OnResizeDebounceTick(object? sender, EventArgs e)
+    {
+        _resizeDebounceTimer.Stop();
+        if (_resize is null) return;
+        // ActualWidth/Height are in DIPs; _cellWidth/_cellHeight are
+        // computed from the same FormattedText pipeline, also in DIPs,
+        // so the ratio yields cell counts directly. Clamp to >= 1 so
+        // a zero-size pre-layout pass doesn't ask the PTY for a 0×0
+        // grid (which Win32 rejects).
+        var cols = (int)Math.Max(1, ActualWidth / _cellWidth);
+        var rows = (int)Math.Max(1, ActualHeight / _cellHeight);
+        _resize(cols, rows);
+    }
+
+    /// <summary>
+    /// Returns true when a key press should be left to the screen
+    /// reader rather than forwarded to the PTY. Conservative: filters
+    /// bare Insert / CapsLock (NVDA / JAWS / Narrator modifier
+    /// candidates) and Numpad keys when NumLock is off (NVDA review-
+    /// cursor numpad layout). Side effect: a user pressing bare Insert
+    /// or CapsLock to send the corresponding shell key gets nothing,
+    /// and Numpad-as-arrow with NumLock off is suppressed. Both
+    /// trade-offs are accepted to preserve screen-reader navigation.
+    /// </summary>
+    private static bool IsScreenReaderCandidate(Key key)
+    {
+        if (key == Key.Insert) return true;
+        if (key == Key.CapsLock) return true;
+        // Numpad with NumLock off — NVDA review-cursor layout.
+        var isNumpad =
+            (key >= Key.NumPad0 && key <= Key.NumPad9)
+            || key == Key.Decimal
+            || key == Key.Multiply
+            || key == Key.Add
+            || key == Key.Subtract
+            || key == Key.Divide
+            || key == Key.Separator;
+        if (isNumpad && !Keyboard.IsKeyToggled(Key.NumLock))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Translate WPF <see cref="ModifierKeys"/> to
+    /// <see cref="KeyModifiers"/>. The Windows key is silently
+    /// dropped — pty-speak doesn't forward it; Win+letter is OS-shell
+    /// territory.
+    /// </summary>
+    private static KeyModifiers TranslateModifiers(ModifierKeys m)
+    {
+        var result = KeyModifiers.None;
+        if ((m & ModifierKeys.Shift) != 0) result |= KeyModifiers.Shift;
+        if ((m & ModifierKeys.Alt) != 0) result |= KeyModifiers.Alt;
+        if ((m & ModifierKeys.Control) != 0) result |= KeyModifiers.Control;
+        return result;
+    }
+
+    /// <summary>
+    /// Translate WPF <see cref="Key"/> to <see cref="KeyCode"/>.
+    /// Returns <c>KeyCode.Unhandled</c> for any key the encoder
+    /// doesn't know about — the encoder then returns null and
+    /// the keystroke is dropped silently rather than crashing.
+    /// New WPF Key values can ship without breaking us.
+    /// </summary>
+    private static KeyCode TranslateKey(Key key)
+    {
+        // Cursor keys.
+        if (key == Key.Up) return KeyCode.Up;
+        if (key == Key.Down) return KeyCode.Down;
+        if (key == Key.Right) return KeyCode.Right;
+        if (key == Key.Left) return KeyCode.Left;
+        // Editing keypad.
+        if (key == Key.Delete) return KeyCode.Delete;
+        if (key == Key.Home) return KeyCode.Home;
+        if (key == Key.End) return KeyCode.End;
+        if (key == Key.PageUp) return KeyCode.PageUp;
+        if (key == Key.PageDown) return KeyCode.PageDown;
+        // Note: Key.Insert is filtered upstream as a screen-reader
+        // candidate; we never reach this branch for it. Listed here
+        // for completeness if the filter is ever loosened.
+        if (key == Key.Insert) return KeyCode.Insert;
+        // Whitespace / control.
+        if (key == Key.Tab) return KeyCode.Tab;
+        if (key == Key.Enter) return KeyCode.Enter;
+        if (key == Key.Escape) return KeyCode.Escape;
+        if (key == Key.Back) return KeyCode.Backspace;
+        // Function keys.
+        if (key == Key.F1) return KeyCode.F1;
+        if (key == Key.F2) return KeyCode.F2;
+        if (key == Key.F3) return KeyCode.F3;
+        if (key == Key.F4) return KeyCode.F4;
+        if (key == Key.F5) return KeyCode.F5;
+        if (key == Key.F6) return KeyCode.F6;
+        if (key == Key.F7) return KeyCode.F7;
+        if (key == Key.F8) return KeyCode.F8;
+        if (key == Key.F9) return KeyCode.F9;
+        if (key == Key.F10) return KeyCode.F10;
+        if (key == Key.F11) return KeyCode.F11;
+        if (key == Key.F12) return KeyCode.F12;
+        // Letters → Char(lowercase). Encoder folds Shift for Ctrl-letter.
+        if (key >= Key.A && key <= Key.Z)
+        {
+            return KeyCode.NewChar((char)('a' + (key - Key.A)));
+        }
+        // Top-row digits.
+        if (key >= Key.D0 && key <= Key.D9)
+        {
+            return KeyCode.NewChar((char)('0' + (key - Key.D0)));
+        }
+        // Numpad digits when NumLock is on (NumLock-off case is filtered
+        // upstream by IsScreenReaderCandidate).
+        if (key >= Key.NumPad0 && key <= Key.NumPad9)
+        {
+            return KeyCode.NewChar((char)('0' + (key - Key.NumPad0)));
+        }
+        if (key == Key.Space) return KeyCode.NewChar(' ');
+        // Anything else — punctuation, OEM keys, media keys, etc. — flow
+        // through TextInput (which handles layout-specific characters
+        // correctly) for plain typing, or get dropped here for Ctrl-combos
+        // that don't map cleanly. Future-proof: new Key values land in
+        // Unhandled rather than crashing.
+        return KeyCode.Unhandled;
     }
 
     /// <summary>

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -340,25 +340,29 @@ public class TerminalView : FrameworkElement
         }
 
         // 3. Translate.
-        var modifiers = TranslateModifiers(pressedModifiers);
+        var keyMods = TranslateModifiers(pressedModifiers);
         var keyCode = TranslateKey(e.Key);
 
         // 4. Defer plain typing to OnPreviewTextInput.
         var ctrlOrAltHeld =
-            modifiers.HasFlag(KeyModifiers.Control) ||
-            modifiers.HasFlag(KeyModifiers.Alt);
+            keyMods.HasFlag(KeyModifiers.Control) ||
+            keyMods.HasFlag(KeyModifiers.Alt);
         if (keyCode.IsChar && !ctrlOrAltHeld)
         {
             return;
         }
 
-        // 5. Encode and write.
-        if (_writeBytes is null)
+        // 5. Encode and write. If the screen isn't attached yet
+        // (very early init / teardown) drop the key gracefully —
+        // there's nowhere meaningful to send it. _screen is set
+        // by Program.fs's compose() before window.Loaded fires
+        // and the user is realistically able to press a key, so
+        // this branch is defence in depth rather than expected.
+        if (_writeBytes is null || _screen is null)
         {
             return;
         }
-        var modes = _screen?.Modes ?? TerminalModes.create();
-        var bytes = KeyEncoding.encodeOrNull(keyCode, modifiers, modes);
+        var bytes = KeyEncoding.encodeOrNull(keyCode, keyMods, _screen.Modes);
         if (bytes is null)
         {
             return;

--- a/tests/Tests.Unit/ConPtyHostTests.fs
+++ b/tests/Tests.Unit/ConPtyHostTests.fs
@@ -116,3 +116,48 @@ let ``ConPtyHost spawns cmd.exe and captures startup bytes`` () =
                     ex.Message
                     ex.StackTrace
                     ex.InnerException)
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-B — Resize + Job Object smoke
+// ---------------------------------------------------------------------
+//
+// These tests don't simulate a real window resize or a real
+// grandchild process — they pin the wiring contracts that
+// Stage 6 relies on:
+//   * Resize accepts new dimensions and returns Ok.
+//   * The Job Object handle is non-null and not-invalid after spawn.
+//
+// Both Windows-only by construction (ConPTY required); fall-through
+// pass on non-Windows so dev workstations stay green.
+
+[<Fact>]
+let ``ConPtyHost.Resize accepts new dimensions without erroring`` () =
+    if not (isWindows ()) then () else
+    let cfg = { Cols = 80s; Rows = 24s; CommandLine = "cmd.exe" }
+    match ConPtyHost.start cfg with
+    | Error e -> Assert.Fail(sprintf "ConPtyHost.start failed: %A" e)
+    | Ok host ->
+        use host = host
+        // Resize to a different size; ResizePseudoConsole returns
+        // 0 (S_OK) on success which `host.Resize` translates to Ok.
+        match host.Resize(120s, 40s) with
+        | Ok () -> ()
+        | Error hr ->
+            Assert.Fail(sprintf "host.Resize returned HRESULT 0x%08X" hr)
+
+[<Fact>]
+let ``ConPtyHost.JobHandle is valid after spawn`` () =
+    if not (isWindows ()) then () else
+    let cfg = { Cols = 80s; Rows = 24s; CommandLine = "cmd.exe" }
+    match ConPtyHost.start cfg with
+    | Error e -> Assert.Fail(sprintf "ConPtyHost.start failed: %A" e)
+    | Ok host ->
+        use host = host
+        // SafeHandleZeroOrMinusOneIsInvalid considers 0 and -1
+        // invalid; the kernel returns a real handle if
+        // CreateJobObjectW + AssignProcessToJobObject succeeded.
+        Assert.NotNull(host.JobHandle :> obj)
+        Assert.False(host.JobHandle.IsInvalid,
+            "Job handle should be valid (non-zero, non-minus-one) after spawn")
+        Assert.False(host.JobHandle.IsClosed,
+            "Job handle should still be open while host is alive")

--- a/tests/Tests.Unit/KeyEncodingTests.fs
+++ b/tests/Tests.Unit/KeyEncodingTests.fs
@@ -212,15 +212,15 @@ let ``Ctrl+Alt+'a' encodes as ESC + 0x01`` () =
             (modesNoneSet ()))
 
 [<Fact>]
-let ``Ctrl+@ encodes as NUL (0x00)`` () =
+let ``Ctrl plus at-sign encodes as NUL (0x00)`` () =
     bytesEq [| 0x00uy |] (encode (KeyCode.Char '@') KeyModifiers.Control (modesNoneSet ()))
 
 [<Fact>]
-let ``Ctrl+[ encodes as ESC (0x1B)`` () =
+let ``Ctrl plus open-bracket encodes as ESC (0x1B)`` () =
     bytesEq [| 0x1Buy |] (encode (KeyCode.Char '[') KeyModifiers.Control (modesNoneSet ()))
 
 [<Fact>]
-let ``Ctrl+? encodes as DEL (0x7F)`` () =
+let ``Ctrl plus question-mark encodes as DEL (0x7F)`` () =
     bytesEq [| 0x7Fuy |] (encode (KeyCode.Char '?') KeyModifiers.Control (modesNoneSet ()))
 
 [<Fact>]

--- a/tests/Tests.Unit/KeyEncodingTests.fs
+++ b/tests/Tests.Unit/KeyEncodingTests.fs
@@ -1,0 +1,316 @@
+module PtySpeak.Tests.Unit.KeyEncodingTests
+
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Stage 6 PR-B — KeyEncoding behavioural pinning
+// ---------------------------------------------------------------------
+//
+// `KeyEncoding.encode` is a pure function from
+// `KeyCode * KeyModifiers * TerminalModes` to `byte[] option`. These
+// tests pin the xterm-style encoding tables that bash, zsh, fish,
+// PowerShell, and Claude Code all consume correctly. The encoder
+// does not depend on WPF; tests run from F# without spinning up a
+// WPF dispatcher.
+
+let private modesNoneSet () : TerminalModes = TerminalModes.create()
+
+let private modesDecckm () : TerminalModes =
+    let m = TerminalModes.create()
+    m.DECCKM <- true
+    m
+
+let private encode key m modes = KeyEncoding.encode key m modes
+
+let private bytesEq (expected: byte[]) (actual: byte[] option) =
+    match actual with
+    | Some bs -> Assert.Equal<byte[]>(expected, bs)
+    | None -> Assert.Fail("Expected Some bytes; got None")
+
+// ---------------------------------------------------------------------
+// Cursor keys — DECCKM normal vs application
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Up in DECCKM normal mode encodes as ESC [ A`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'A' |]
+        (encode KeyCode.Up KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Up in DECCKM application mode encodes as ESC O A`` () =
+    bytesEq [| 0x1Buy; byte 'O'; byte 'A' |]
+        (encode KeyCode.Up KeyModifiers.None (modesDecckm ()))
+
+[<Fact>]
+let ``Down DECCKM normal encodes as ESC [ B`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'B' |]
+        (encode KeyCode.Down KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Right DECCKM normal encodes as ESC [ C`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'C' |]
+        (encode KeyCode.Right KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Left DECCKM application encodes as ESC O D`` () =
+    bytesEq [| 0x1Buy; byte 'O'; byte 'D' |]
+        (encode KeyCode.Left KeyModifiers.None (modesDecckm ()))
+
+// Modified cursor keys ALWAYS use CSI form (ESC [ 1 ; mod final),
+// regardless of DECCKM mode — this is the xterm convention bash and
+// PowerShell rely on.
+
+[<Fact>]
+let ``Shift+Up encodes as ESC [ 1 ; 2 A regardless of DECCKM`` () =
+    let expected = "\x1b[1;2A"B
+    bytesEq expected (encode KeyCode.Up KeyModifiers.Shift (modesNoneSet ()))
+    bytesEq expected (encode KeyCode.Up KeyModifiers.Shift (modesDecckm ()))
+
+[<Fact>]
+let ``Ctrl+Right encodes as ESC [ 1 ; 5 C`` () =
+    bytesEq "\x1b[1;5C"B
+        (encode KeyCode.Right KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Alt+Left encodes as ESC [ 1 ; 3 D`` () =
+    bytesEq "\x1b[1;3D"B
+        (encode KeyCode.Left KeyModifiers.Alt (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+Shift+Down encodes as ESC [ 1 ; 6 B`` () =
+    bytesEq "\x1b[1;6B"B
+        (encode KeyCode.Down (KeyModifiers.Control ||| KeyModifiers.Shift)
+            (modesNoneSet ()))
+
+// ---------------------------------------------------------------------
+// Editing keypad
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Insert encodes as ESC [ 2 ~`` () =
+    bytesEq "\x1b[2~"B (encode KeyCode.Insert KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Delete encodes as ESC [ 3 ~`` () =
+    bytesEq "\x1b[3~"B (encode KeyCode.Delete KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``PageUp encodes as ESC [ 5 ~`` () =
+    bytesEq "\x1b[5~"B (encode KeyCode.PageUp KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``PageDown encodes as ESC [ 6 ~`` () =
+    bytesEq "\x1b[6~"B (encode KeyCode.PageDown KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Modified Insert: Shift+Insert encodes as ESC [ 2 ; 2 ~`` () =
+    bytesEq "\x1b[2;2~"B (encode KeyCode.Insert KeyModifiers.Shift (modesNoneSet ()))
+
+[<Fact>]
+let ``Home encodes as ESC [ H (no tilde, modern xterm)`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'H' |]
+        (encode KeyCode.Home KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``End encodes as ESC [ F`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'F' |]
+        (encode KeyCode.End KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+Home encodes as ESC [ 1 ; 5 H`` () =
+    bytesEq "\x1b[1;5H"B (encode KeyCode.Home KeyModifiers.Control (modesNoneSet ()))
+
+// ---------------------------------------------------------------------
+// Function keys
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``F1-F4 use SS3 form (ESC O P/Q/R/S)`` () =
+    bytesEq [| 0x1Buy; byte 'O'; byte 'P' |]
+        (encode KeyCode.F1 KeyModifiers.None (modesNoneSet ()))
+    bytesEq [| 0x1Buy; byte 'O'; byte 'Q' |]
+        (encode KeyCode.F2 KeyModifiers.None (modesNoneSet ()))
+    bytesEq [| 0x1Buy; byte 'O'; byte 'R' |]
+        (encode KeyCode.F3 KeyModifiers.None (modesNoneSet ()))
+    bytesEq [| 0x1Buy; byte 'O'; byte 'S' |]
+        (encode KeyCode.F4 KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``F5-F12 use CSI form with the documented numbers`` () =
+    bytesEq "\x1b[15~"B (encode KeyCode.F5 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[17~"B (encode KeyCode.F6 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[18~"B (encode KeyCode.F7 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[19~"B (encode KeyCode.F8 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[20~"B (encode KeyCode.F9 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[21~"B (encode KeyCode.F10 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[23~"B (encode KeyCode.F11 KeyModifiers.None (modesNoneSet ()))
+    bytesEq "\x1b[24~"B (encode KeyCode.F12 KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Modified F1 uses CSI form (ESC [ 1 ; mod P)`` () =
+    bytesEq "\x1b[1;5P"B (encode KeyCode.F1 KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Modified F5 uses CSI form (ESC [ 15 ; mod ~)`` () =
+    bytesEq "\x1b[15;3~"B (encode KeyCode.F5 KeyModifiers.Alt (modesNoneSet ()))
+
+// ---------------------------------------------------------------------
+// Whitespace / control
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Tab encodes as 0x09`` () =
+    bytesEq [| 0x09uy |] (encode KeyCode.Tab KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Shift+Tab encodes as ESC [ Z`` () =
+    bytesEq [| 0x1Buy; byte '['; byte 'Z' |]
+        (encode KeyCode.Tab KeyModifiers.Shift (modesNoneSet ()))
+
+[<Fact>]
+let ``Enter encodes as 0x0D (CR only; cmd handles)`` () =
+    bytesEq [| 0x0Duy |] (encode KeyCode.Enter KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Alt+Enter encodes as ESC + CR`` () =
+    bytesEq [| 0x1Buy; 0x0Duy |] (encode KeyCode.Enter KeyModifiers.Alt (modesNoneSet ()))
+
+[<Fact>]
+let ``Escape encodes as 0x1B`` () =
+    bytesEq [| 0x1Buy |] (encode KeyCode.Escape KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Backspace encodes as 0x7F (DEL, modern xterm default)`` () =
+    bytesEq [| 0x7Fuy |] (encode KeyCode.Backspace KeyModifiers.None (modesNoneSet ()))
+
+// ---------------------------------------------------------------------
+// Char + Ctrl/Alt encoding
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Bare 'a' encodes as 0x61`` () =
+    bytesEq [| 0x61uy |] (encode (KeyCode.Char 'a') KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+'a' encodes as 0x01`` () =
+    bytesEq [| 0x01uy |] (encode (KeyCode.Char 'a') KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+'A' (uppercase) also encodes as 0x01 — Shift is absorbed for Ctrl-letter`` () =
+    bytesEq [| 0x01uy |] (encode (KeyCode.Char 'A') KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Alt+'a' encodes as ESC + 'a' (xterm convention)`` () =
+    bytesEq [| 0x1Buy; 0x61uy |]
+        (encode (KeyCode.Char 'a') KeyModifiers.Alt (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+Alt+'a' encodes as ESC + 0x01`` () =
+    bytesEq [| 0x1Buy; 0x01uy |]
+        (encode (KeyCode.Char 'a') (KeyModifiers.Control ||| KeyModifiers.Alt)
+            (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+@ encodes as NUL (0x00)`` () =
+    bytesEq [| 0x00uy |] (encode (KeyCode.Char '@') KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+[ encodes as ESC (0x1B)`` () =
+    bytesEq [| 0x1Buy |] (encode (KeyCode.Char '[') KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Ctrl+? encodes as DEL (0x7F)`` () =
+    bytesEq [| 0x7Fuy |] (encode (KeyCode.Char '?') KeyModifiers.Control (modesNoneSet ()))
+
+[<Fact>]
+let ``Non-ASCII char returns None (TextInput owns these)`` () =
+    Assert.Equal(None, encode (KeyCode.Char 'é') KeyModifiers.None (modesNoneSet ()))
+
+[<Fact>]
+let ``Unhandled key returns None`` () =
+    Assert.Equal(None, encode KeyCode.Unhandled KeyModifiers.None (modesNoneSet ()))
+
+// ---------------------------------------------------------------------
+// Bracketed paste — wrapping + paste-injection defence
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Plain paste with ?2004 set wraps in brackets`` () =
+    let result = KeyEncoding.encodePaste "hello" true
+    Assert.Equal<byte[]>("\x1b[200~hello\x1b[201~"B, result)
+
+[<Fact>]
+let ``Plain paste with ?2004 clear is raw bytes`` () =
+    let result = KeyEncoding.encodePaste "hello" false
+    Assert.Equal<byte[]>("hello"B, result)
+
+[<Fact>]
+let ``Embedded ESC [ 201 ~ is stripped from paste content (injection defence)`` () =
+    // Attack scenario: clipboard contains "safe text\x1b[201~rm -rf /"
+    // — without stripping, the bracketed-paste frame closes early and
+    // "rm -rf /" runs as if typed.
+    let input = "safe text\x1b[201~rm -rf /"
+    let result = KeyEncoding.encodePaste input true
+    let expected = "\x1b[200~safe textrm -rf /\x1b[201~"B
+    Assert.Equal<byte[]>(expected, result)
+
+[<Fact>]
+let ``Embedded ESC [ 201 ~ is stripped even when ?2004 is clear`` () =
+    // Defence in depth — no legitimate shell content contains this
+    // exact byte sequence; stripping never has a behavioural cost.
+    let result = KeyEncoding.encodePaste "before\x1b[201~after" false
+    Assert.Equal<byte[]>("beforeafter"B, result)
+
+[<Fact>]
+let ``Multi-line paste preserves newlines`` () =
+    let result = KeyEncoding.encodePaste "line1\nline2" true
+    Assert.Equal<byte[]>("\x1b[200~line1\nline2\x1b[201~"B, result)
+
+[<Fact>]
+let ``Unicode paste survives as UTF-8`` () =
+    // U+00E9 = é = 0xC3 0xA9 in UTF-8.
+    let result = KeyEncoding.encodePaste "café" false
+    Assert.Equal<byte[]>([| 0x63uy; 0x61uy; 0x66uy; 0xC3uy; 0xA9uy |], result)
+
+// ---------------------------------------------------------------------
+// Focus reporting bytes — pinned values
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``focusGained is ESC [ I`` () =
+    Assert.Equal<byte[]>([| 0x1Buy; byte '['; byte 'I' |], KeyEncoding.focusGained)
+
+[<Fact>]
+let ``focusLost is ESC [ O`` () =
+    Assert.Equal<byte[]>([| 0x1Buy; byte '['; byte 'O' |], KeyEncoding.focusLost)
+
+// ---------------------------------------------------------------------
+// modifierParam — xterm SGR-modifier protocol
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``modifierParam: None=1, Shift=2, Alt=3, Ctrl=5, Ctrl+Shift+Alt=8`` () =
+    Assert.Equal(1, KeyEncoding.modifierParam KeyModifiers.None)
+    Assert.Equal(2, KeyEncoding.modifierParam KeyModifiers.Shift)
+    Assert.Equal(3, KeyEncoding.modifierParam KeyModifiers.Alt)
+    Assert.Equal(4, KeyEncoding.modifierParam (KeyModifiers.Shift ||| KeyModifiers.Alt))
+    Assert.Equal(5, KeyEncoding.modifierParam KeyModifiers.Control)
+    Assert.Equal(6, KeyEncoding.modifierParam (KeyModifiers.Control ||| KeyModifiers.Shift))
+    Assert.Equal(7, KeyEncoding.modifierParam (KeyModifiers.Control ||| KeyModifiers.Alt))
+    Assert.Equal(8, KeyEncoding.modifierParam
+                       (KeyModifiers.Control ||| KeyModifiers.Shift ||| KeyModifiers.Alt))
+
+// ---------------------------------------------------------------------
+// encodeOrNull — C# interop wrapper
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``encodeOrNull returns bytes for handled keys`` () =
+    let result = KeyEncoding.encodeOrNull KeyCode.Up KeyModifiers.None (modesNoneSet ())
+    Assert.NotNull(result)
+
+[<Fact>]
+let ``encodeOrNull returns null for Unhandled`` () =
+    let result = KeyEncoding.encodeOrNull KeyCode.Unhandled KeyModifiers.None (modesNoneSet ())
+    Assert.Null(result)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="WordBoundaryTests.fs" />
     <Compile Include="AnnounceSanitiserTests.fs" />
     <Compile Include="CoalescerTests.fs" />
+    <Compile Include="KeyEncodingTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Second and final half of Stage 6 — **pty-speak becomes interactive**. After this PR ships, typed keys reach the cmd.exe child via the new pure-F# `KeyEncoding` module; paste via Ctrl+V / right-click / Edit menu wraps in bracketed-paste markers when DECSET ?2004 is set; window resize flows through to `ResizePseudoConsole` after a 200ms debounce; and the spawned child plus any process it later spawns are contained in a Job Object so the entire tree dies via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` even on a hard parent crash.

PR-A (#92) shipped the parser arms for DECCKM / BracketedPaste / FocusReporting; this PR-B is the consumer-side wiring that reads those flags.

## What changed

### `Terminal.Core.KeyEncoding` (new pure-F# module)

- `KeyCode` + `KeyModifiers` discriminated-union and flags type, decoupled from `System.Windows.Input.Key` so a future Linux / macOS port (Avalonia, MAUI, web) reuses the encoder unchanged.
- xterm-style encoding tables: arrows DECCKM-aware (`\x1b[A` normal vs `\x1bOA` application); modified cursor keys use SGR-modifier protocol (`\x1b[1;<mod>A`); F1-F4 SS3 form, F5-F12 CSI form; Ctrl-letter folds Shift; Alt-letter ESC-prefixes; Backspace sends DEL (`0x7f`, modern xterm default that bash / zsh / PowerShell / Claude Code all expect).
- **Paste-injection defence** — `encodePaste` strips embedded `\x1b[201~` from clipboard text before wrapping. NVDA users can't easily inspect their clipboard before pasting, so an attacker-crafted paste containing that exact byte sequence followed by a malicious shell command would otherwise close the bracketed-paste frame early and execute the post-paste portion as if typed. Deliberate accessibility-first divergence from xterm's permissive default; documented in SECURITY.md.
- `KeyCode.Unhandled` future-proofing — unknown keys produce `None` rather than crashing, so new WPF Key values can ship safely.

### Job Object child-process containment (`Native.fs`, `PseudoConsole.fs`, `ConPtyHost.fs`)

- New P/Invokes: `CreateJobObjectW`, `SetInformationJobObject`, `AssignProcessToJobObject` plus the `JOBOBJECT_BASIC_LIMIT_INFORMATION` / `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` / `IO_COUNTERS` structs and a `SafeJobHandle` matching `SafePseudoConsoleHandle`'s pattern.
- `PseudoConsole.create` now creates a job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, assigns the immediate cmd.exe to it, and stores the handle on `PtySession`. On any setup-step failure the orphan child is terminated before returning Error so we never leak.
- **Layered on top of** the existing `TerminateProcess` cleanup rather than replacing it: `TerminateProcess` is fast targeted cleanup for the immediate cmd.exe (so its pipe drains promptly); the Job Object is the kernel-enforced safety net for grandchildren (e.g. a `node` process Stage 7's Claude Code launches inside pty-speak).

### `ConPtyHost.fs` write/resize surface

- New `WriteBytes(byte[])` synchronous wrapper over `Stdin.Write` + Flush so single-byte arrow keypresses don't sit in the 4 KB FileStream buffer.
- New `Resize(cols, rows)` thin wrapper over `PseudoConsole.resize`.
- New `JobHandle` property exposed for testing.

### `TerminalView.cs` (the WPF input pipeline)

- **`AppReservedHotkeys` refresh** — was stale (only listed Ctrl+Shift+U); now lists Ctrl+Shift+U / D / R plus the future-reserved Ctrl+Shift+M (Stage 9) and Alt+Shift+R (Stage 10) as comments.
- **`OnPreviewKeyDown` filter ordering** is load-bearing and pinned by inline doc-comment + the test suite:
  1. `AppReservedHotkeys` check first (Ctrl+Shift+U / D / R short-circuit and let the parent Window's `InputBindings` see them).
  2. Screen-reader-modifier filter second (bare Insert / CapsLock and Numpad-with-NumLock-off return without `Handled`).
  3. WPF Key + ModifierKeys → `KeyCode` + `KeyModifiers` translate.
  4. Plain printable typing without Ctrl/Alt defers to `OnPreviewTextInput` so WPF's text-composition pipeline (IME / AltGr / dead keys) handles it correctly.
  5. Encode + write via `KeyEncoding.encodeOrNull`.
- New `OnPreviewTextInput` — UTF-8 encodes `e.Text` and writes directly.
- New `ApplicationCommands.Paste` `CommandBinding` — reads clipboard, runs through `KeyEncoding.encodePaste`, writes.
- New `OnGotKeyboardFocus` / `OnLostKeyboardFocus` — emit `\x1b[I` / `\x1b[O` only when DECSET ?1004 is set.
- New `OnRenderSizeChanged` → 200ms `DispatcherTimer` trailing-edge debounce → resize callback. Hardcoded with `// TODO Phase 2: TOML-configurable` comment.
- New `SetPtyHost(write, resize)` setter takes `Action<byte[]>` + `Action<int,int>` callbacks rather than a direct `ConPtyHost` reference, so `Views/` doesn't need a project ref on `Terminal.Pty`.

### `Program.fs compose ()`

After `ConPtyHost.start` succeeds, calls `TerminalSurface.SetPtyHost(host.WriteBytes, host.Resize)` so keyboard / paste / focus / resize all reach the live PTY.

## Tests

- **New `tests/Tests.Unit/KeyEncodingTests.fs`** (~35 facts) pinning the entire encoding table: cursor keys (DECCKM normal vs application vs modified); editing keypad (Insert / Delete / Home / End / PageUp / PageDown); F1-F12 (SS3 vs CSI form, modified variants); Tab / Enter / Esc / Backspace; Ctrl-letter folding Shift; Alt-letter ESC-prefix; Ctrl+`@`/`[`/`?` mapping to NUL/ESC/DEL; non-ASCII char returns None; Unhandled returns None; bracketed paste wrapping + injection defence; Unicode UTF-8 survival; focus-reporting bytes; SGR-modifier param encoding; `encodeOrNull` C#-friendly wrapper.
- **`tests/Tests.Unit/ConPtyHostTests.fs`** extended with two Stage 6 facts: `ConPtyHost.Resize` accepts new dimensions; `JobHandle` is non-null and not-invalid after spawn.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check.
- [ ] All existing tests still pass.
- [ ] **Manual NVDA verification on the next preview after merge** — this unlocks the Stage 5 typed-input gates that were deferred:
  - [ ] Type `dir` + Enter → NVDA reads each line via Stage 5's coalescer.
  - [ ] Type `echo hello` + Enter → NVDA reads "hello" once.
  - [ ] Press Up arrow → PowerShell scrolls history; NVDA reads recalled prompt.
  - [ ] Press Tab on partial command → completion echoes.
  - [ ] `ping localhost -t` then Ctrl+C → ping interrupts.
  - [ ] Press Ctrl+L → screen clears.
  - [ ] **NVDA review-cursor regression**: Insert+T announces window title; CapsLock+Numpad7 reads previous line.
  - [ ] Ctrl+Shift+U / D / R still trigger their respective hotkeys (not forwarded to the shell).
  - [ ] `more SECURITY.md` enters alt-screen, reads first page, q exits cleanly.
  - [ ] Paste a multi-line snippet via Ctrl+V — appears at prompt; if PowerShell's PSReadLine surfaces bracketed-paste wrapping, confirm `\x1b[200~` / `\x1b[201~` framing.
  - [ ] Drag window to resize — after ~200ms pause, shell prompt reflows to new column count.
  - [ ] Ctrl+Shift+D process-cleanup test: close pty-speak with X-button → script confirms no orphan cmd.exe.
  - [ ] **Hard-crash test**: kill `Terminal.App.exe` from Task Manager → script confirms no orphan cmd.exe (KILL_ON_JOB_CLOSE works under hard-crash conditions).

## Out of scope (logged for follow-up)

- **Screen-buffer runtime resize.** Stage 6 resizes the **PTY** so the child shell sees the right column count, but the in-process `Cell[,]` Screen grid stays at construction-time 30×120. Visible asymmetry: oversize windows have empty padding; undersize windows clip. Spec §6 says "ResizePseudoConsole", which Stage 6 satisfies; full grid resize is a Phase 2 stage logged in SESSION-HANDOFF.
- **Env-scrub (PO-5)** — deferred to Stage 7 per strategic review.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_