### PR TITLE
fix(stage-6): streaming announcements + paste InputBinding + window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,69 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three post-Stage-6 regressions surfaced during manual NVDA
+  verification on the post-Stage-6 preview**, all targeted in a
+  single follow-up PR:
+
+  - **Ctrl+V didn't paste; sent `^V` to the shell instead.**
+    `TerminalView`'s constructor added a `CommandBinding` for
+    `ApplicationCommands.Paste`, which tells WPF "if Paste is
+    invoked on me, here's the handler" — but did NOT add an
+    `InputBinding` mapping `Ctrl+V` (or `Shift+Insert`) to the
+    Paste command. Without the gesture-to-command map, Ctrl+V
+    flowed through `OnPreviewKeyDown` → encoder → `0x16` → and
+    cmd.exe echoed `^V` per its control-character display
+    convention. Adding the two `InputBinding`s
+    (`Ctrl+V` and `Shift+Insert`) wires the gestures to the
+    existing `OnPasteExecuted` handler so the paste-injection
+    chokepoint actually fires.
+
+  - **Window resize didn't reflow; text cut off the right
+    edge.** `TerminalView.MeasureOverride` returned the FIXED
+    preferred size (`Cols × Rows × cellSize`), so the view
+    never tracked window resize, so `OnRenderSizeChanged`
+    never fired, so the Stage 6 `SizeChanged` →
+    `DispatcherTimer` debounce → `ResizePseudoConsole` chain
+    was dead. Changed `MeasureOverride` to honour
+    `availableSize` (fall back to preferred size only when
+    availableSize is unbounded, e.g. inside a `ScrollViewer`).
+    The Screen buffer stays at construction-time 30×120 cells
+    internally — full grid runtime resize is a documented
+    Phase 2 stage — but cmd.exe now sees and adapts to the
+    window's actual dimensions via `ResizePseudoConsole`,
+    fixing the visible "text cuts off" symptom.
+
+  - **Stage 5 streaming output announcements were silent.**
+    `TerminalView.Announce` was hardcoded to use
+    `AutomationNotificationProcessing.MostRecent`. That's the
+    right choice for hotkey-style one-shot announcements
+    (Ctrl+Shift+U / D / R, Velopack progress) where each new
+    notification SHOULD supersede any in-flight one. But for
+    Stage 5's streaming-PTY-output path it was wrong: rapid
+    chunks arrive faster than NVDA can speak them, and under
+    `MostRecent` each new chunk discards the in-flight speech
+    of the previous one — typed-character echoes and command
+    output were silently superseded before NVDA could read
+    any of them. The two-arg `Announce(message, activityId)`
+    overload now selects processing per activityId:
+    `pty-speak.output` uses `ImportantAll` (queue all chunks);
+    everything else keeps `MostRecent`. A new three-arg
+    overload (`message, activityId, processing`) is exposed
+    for any future caller that needs to override.
+
+- **Diagnostic safety net for the coalescer drain task.**
+  Previously the `Program.fs compose ()` drain task swallowed
+  every unexpected exception silently with `| _ -> ()`. A
+  crashed drain looked identical to a working-but-silent one,
+  which made post-Stage-6 streaming-silence diagnosis hard
+  ("is the drain dying or is NVDA filtering?"). The catch-all
+  now sanitises the exception message through SR-2's
+  chokepoint and emits one final `Announce(..., pty-speak.error)`
+  before the task exits, so a future drain crash announces
+  itself rather than disappearing into the void.
+
 ### Added
 
 - **Stage 6 PR-B: keyboard input, paste, focus reporting, dynamic

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -483,7 +483,30 @@ module Program =
                                         ()
                     with
                     | :? OperationCanceledException -> ()
-                    | _ -> ()
+                    | ex ->
+                        // Post-Stage-6 diagnostic safety net.
+                        // Previously this was `| _ -> ()` — any
+                        // exception killed the drain task silently
+                        // and streaming announcements stopped
+                        // forever with no clue why. Surfacing the
+                        // exception via one final
+                        // `Announce(..., pty-speak.error)` lets a
+                        // user (or maintainer) hear that something
+                        // went wrong before the task exits.
+                        // Sanitise the message through SR-2's
+                        // chokepoint so PTY-originated control
+                        // bytes can't reach NVDA verbatim.
+                        try
+                            let safe =
+                                AnnounceSanitiser.sanitise ex.Message
+                            let action () =
+                                window.TerminalSurface.Announce(
+                                    sprintf
+                                        "Drain task exception: %s"
+                                        safe,
+                                    ActivityIds.error)
+                            window.Dispatcher.Invoke(Action(action))
+                        with _ -> ()
                 } :> Task)
 
         let cfg : PtyConfig =

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -132,10 +132,25 @@ public class TerminalView : FrameworkElement
         // (which strips embedded \x1b[201~ for paste-injection
         // defence and conditionally wraps in bracketed-paste markers),
         // and writes to the PTY.
+        //
+        // Post-Stage-6 fix: a CommandBinding alone tells WPF "if Paste
+        // is invoked on me, here's the handler" but does NOT wire any
+        // keyboard shortcut to invoke it. Without an InputBinding,
+        // Ctrl+V flows through OnPreviewKeyDown → encoder → 0x16 →
+        // cmd.exe echoes as `^V`. Adding the InputBindings below maps
+        // Ctrl+V and Shift+Insert (the two standard paste gestures) to
+        // the Paste command so they fire OnPasteExecuted instead of
+        // reaching the encoder.
         CommandBindings.Add(new CommandBinding(
             ApplicationCommands.Paste,
             OnPasteExecuted,
             OnPasteCanExecute));
+        InputBindings.Add(new KeyBinding(
+            ApplicationCommands.Paste,
+            new KeyGesture(Key.V, ModifierKeys.Control)));
+        InputBindings.Add(new KeyBinding(
+            ApplicationCommands.Paste,
+            new KeyGesture(Key.Insert, ModifierKeys.Shift)));
 
         // Stage 6 PR-B — resize debounce timer. Stopped initially;
         // OnRenderSizeChanged restarts it on each WPF SizeChanged tick.
@@ -225,15 +240,46 @@ public class TerminalView : FrameworkElement
     /// <c>"pty-speak.update"</c> via the back-compat overload
     /// above. The vocabulary is centralised in F# at
     /// <c>Terminal.Core.ActivityIds</c>.
+    ///
+    /// Post-Stage-6 fix: the underlying
+    /// <see cref="AutomationNotificationProcessing"/> defaults to
+    /// <see cref="AutomationNotificationProcessing.MostRecent"/>
+    /// for hotkey-style announcements (Ctrl+Shift+U / D / R, the
+    /// Velopack progress flow) where each new notification SHOULD
+    /// supersede any in-flight one. Streaming PTY output
+    /// (<c>"pty-speak.output"</c>) instead uses
+    /// <see cref="AutomationNotificationProcessing.ImportantAll"/>
+    /// so rapid chunks queue rather than discarding their
+    /// predecessors — without this, typed-character echoes and
+    /// command output were silently superseded before NVDA could
+    /// speak any of them.
     /// </remarks>
     public void Announce(string message, string activityId)
+    {
+        var processing = activityId == ActivityIds.output
+            ? AutomationNotificationProcessing.ImportantAll
+            : AutomationNotificationProcessing.MostRecent;
+        Announce(message, activityId, processing);
+    }
+
+    /// <summary>
+    /// Underlying overload that takes an explicit
+    /// <see cref="AutomationNotificationProcessing"/>. The
+    /// activity-id-aware overload above selects a default per
+    /// notification class; use this overload when a caller needs
+    /// to override the default (rare).
+    /// </summary>
+    public void Announce(
+        string message,
+        string activityId,
+        AutomationNotificationProcessing processing)
     {
         var peer = UIElementAutomationPeer.FromElement(this);
         if (peer is not null)
         {
             peer.RaiseNotificationEvent(
                 AutomationNotificationKind.Other,
-                AutomationNotificationProcessing.MostRecent,
+                processing,
                 message,
                 activityId);
         }
@@ -611,12 +657,34 @@ public class TerminalView : FrameworkElement
 
     protected override Size MeasureOverride(Size availableSize)
     {
+        // Post-Stage-6 fix: honour availableSize so the view tracks
+        // the parent window's size. Previously this returned the
+        // FIXED preferred size (Cols × Rows × cellSize) which meant
+        // the view never resized when the window did, OnRenderSizeChanged
+        // never fired, and the Stage 6 SizeChanged → ResizePseudoConsole
+        // chain was dead.
+        //
+        // The Screen buffer stays at construction-time 30×120 cells
+        // internally (full grid runtime resize is a documented Phase 2
+        // stage), but cmd.exe will see and adapt to the window's
+        // actual dimensions via ResizePseudoConsole, which fixes the
+        // visible "text cuts off the right edge" symptom.
+        //
+        // When availableSize is unbounded (e.g. inside a ScrollViewer
+        // or before a parent has been sized), fall back to the fixed
+        // preferred size so we still claim a sensible footprint.
         if (_screen is null)
         {
             return Size.Empty;
         }
-        var width = _cellWidth * _screen.Cols;
-        var height = _cellHeight * _screen.Rows;
+        var preferredWidth = _cellWidth * _screen.Cols;
+        var preferredHeight = _cellHeight * _screen.Rows;
+        var width = double.IsPositiveInfinity(availableSize.Width)
+            ? preferredWidth
+            : availableSize.Width;
+        var height = double.IsPositiveInfinity(availableSize.Height)
+            ? preferredHeight
+            : availableSize.Height;
         return new Size(width, height);
     }
 


### PR DESCRIPTION
## Summary

Three regressions surfaced during manual NVDA verification on the post-Stage-6 preview, fixed in a single PR. Plus a diagnostic safety net so the next test cycle gives us actionable info if any of these aren't the right diagnoses.

## What you reported

- ✅ Document focus, window title, Ctrl+Shift+U announces, typing reaches shell, review cursor reads output, Tab autocomplete works.
- ❌ **A** — `dir` / `echo` / streaming output never auto-spoken by NVDA.
- ❌ **B** — Ctrl+V sends `^V` to the shell instead of pasting.
- ❌ **C** — Window resize doesn't reflow; text cuts off the right edge.
- — Ctrl+L → `^L` is cmd.exe behaviour (encoder correctly sends 0x0C); not changing.

## Fixes

### 1. Ctrl+V paste (Issue B)

Adds `InputBinding`s for `Ctrl+V` and `Shift+Insert` mapped to `ApplicationCommands.Paste`. The `CommandBinding` shipped in Stage 6 PR-B told WPF *"here's the handler"* but never wired the gestures, so Ctrl+V flowed through the encoder → 0x16 → `^V`. Adding the InputBindings completes the chain so `OnPasteExecuted` fires (which already does the bracketed-paste wrapping + injection-defence stripping).

### 2. Window resize tracking (Issue C)

`TerminalView.MeasureOverride` now honours `availableSize` instead of returning the FIXED `Cols × Rows × cellSize`. Previously the view never resized when the window did, so `OnRenderSizeChanged` never fired, so the Stage 6 `SizeChanged → DispatcherTimer → ResizePseudoConsole` chain was dead.

Falls back to preferred size only when `availableSize` is unbounded (e.g. inside a `ScrollViewer`).

The Screen buffer stays 30×120 internally per the documented Phase 2 grid-resize deferral, but cmd.exe now sees and adapts to the window's actual dimensions via `ResizePseudoConsole`, fixing the visible "text cuts off" symptom.

### 3. Streaming announcements (Issue A — most likely root cause)

`TerminalView.Announce` was hardcoded to `AutomationNotificationProcessing.MostRecent`. That's right for hotkey-style one-shot announcements (Ctrl+Shift+U / D / R, Velopack progress) — each new notification SHOULD supersede any in-flight one. **Wrong for streaming PTY output**: rapid chunks arrive faster than NVDA can speak them, and under `MostRecent` each new chunk **discards the in-flight speech** of the previous one. Typed-character echoes and command output were silently superseded before NVDA could read any of them.

The `Announce(message, activityId)` overload now picks processing per activityId:
- `pty-speak.output` → `ImportantAll` (queue all chunks, speak in order)
- everything else → `MostRecent` (preserves hotkey behaviour)

A new three-arg overload (`message, activityId, processing`) is exposed for any future caller that needs to override.

### 4. Diagnostic safety net

Previously the `Program.fs compose ()` drain task swallowed every unexpected exception silently with `| _ -> ()`. A crashed drain looked identical to a working-but-silent one. The catch-all now sanitises the exception message and emits one final `Announce(..., pty-speak.error)` before the task exits.

## Decision tree for the next test cycle

| Observation after merge + new preview | Conclusion |
|---|---|
| Streaming + paste + resize all work | Stage 6 fully closed; Stage 7 next |
| Paste + resize work; streaming still silent + you hear "Drain task exception: ..." | The error text tells us the actual bug; targeted follow-up |
| Paste + resize work; streaming still silent + no error announcement | Drain isn't crashing; need NVDA Speech History snapshot to investigate further |

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check
- [ ] All existing tests still pass (no test changes; this is a small WPF + processing-flag refactor)
- [ ] Manual NVDA verification on the next preview cut after merge:
  - [ ] Type `dir` + Enter → NVDA speaks each output line
  - [ ] Type `echo HI` → NVDA speaks "HI"
  - [ ] Press Ctrl+V on a clipboard with text → text appears at the prompt (not `^V`)
  - [ ] Drag a window edge → after ~200ms, prompt reflows to the new column count

## Out of scope (logged for follow-up)

- **NVDA caret/insertion-point tracking via UIA Text pattern.** You hinted at this with "focus management". Right now we expose the screen as a static document; NVDA's review cursor walks it freely but there's no live caret NVDA can track to auto-announce content near the input cursor as it moves. Real Phase 2 feature, not a regression.
- **Screen-buffer runtime resize past 30×120.** Already logged in SESSION-HANDOFF as a Phase 2 stage.
- **Ctrl+L sending `^L`.** cmd.exe behaviour (encoder correctly sends 0x0C). PowerShell + PSReadLine clears on Ctrl+L. Leaving the encoder right for any future Unix-shell user.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_