### PR TITLE
fix: Ctrl+V paste re-fix + Ctrl+L cls override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,38 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Fixed
 
+- **Ctrl+V paste re-fix + Ctrl+L clear-screen.** The previous
+  attempt (in the post-Stage-6 fix-PR) added `KeyBinding`s mapping
+  Ctrl+V and Shift+Insert to `ApplicationCommands.Paste`, but
+  manual NVDA verification showed Ctrl+V still emitted `^V` to the
+  shell. Two compounding causes:
+  1. WPF's `CommandManager` class handler doesn't auto-process
+     `InputBindings` on a raw `FrameworkElement` the way it does
+     for built-in `Control`s, so the gesture wasn't reliably
+     reaching `OnPasteExecuted`.
+  2. Even when the routing did reach `OnPasteCanExecute`, an empty
+     clipboard returned `CanExecute = false`, the gesture fell
+     through unhandled to my `OnPreviewKeyDown` override, the
+     encoder produced `0x16`, and cmd.exe echoed `^V`.
+
+  Re-fix: handle Ctrl+V, Shift+Insert, and Ctrl+L explicitly at
+  the top of `OnPreviewKeyDown` (new `HandleAppLevelShortcut`
+  helper) before the encoder runs. Empty clipboard now becomes a
+  silent no-op instead of a `^V` emission. The
+  `ApplicationCommands.Paste` `CommandBinding` is kept for any
+  future right-click-menu / Edit-menu paste paths.
+
+  Ctrl+L is special-cased to send `cls\r` (the cmd.exe clear-
+  screen command) instead of `0x0C` (form feed). Strictly the
+  literally-correct terminal-emulator behaviour is to send `0x0C`
+  and let the shell decide — but cmd.exe ignores `0x0C` and
+  echoes `^L`, which is bad UX. Documented trade-off: when the
+  foreground process is something that DOES interpret `0x0C`
+  (Claude Code's Ink, `less`, `vim`), Ctrl+L will run `cls` as
+  if typed instead of triggering that program's redraw. Acceptable
+  for the current cmd.exe-only scope; revisit when Stage 7+ adds
+  shell flexibility.
+
 - **Three post-Stage-6 regressions surfaced during manual NVDA
   verification on the post-Stage-6 preview**, all targeted in a
   single follow-up PR:

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -126,31 +126,24 @@ public class TerminalView : FrameworkElement
         TextProvider = new TerminalTextProvider(() => _screen);
 
         // Stage 6 PR-B — paste hook. ApplicationCommands.Paste fires
-        // for Ctrl+V, right-click → Paste, and Edit menu → Paste; one
-        // CommandBinding covers all paste sources. The handler reads
-        // the clipboard, runs it through KeyEncoding.encodePaste
-        // (which strips embedded \x1b[201~ for paste-injection
-        // defence and conditionally wraps in bracketed-paste markers),
-        // and writes to the PTY.
-        //
-        // Post-Stage-6 fix: a CommandBinding alone tells WPF "if Paste
-        // is invoked on me, here's the handler" but does NOT wire any
-        // keyboard shortcut to invoke it. Without an InputBinding,
-        // Ctrl+V flows through OnPreviewKeyDown → encoder → 0x16 →
-        // cmd.exe echoes as `^V`. Adding the InputBindings below maps
-        // Ctrl+V and Shift+Insert (the two standard paste gestures) to
-        // the Paste command so they fire OnPasteExecuted instead of
-        // reaching the encoder.
+        // for right-click → Paste, Edit menu → Paste, and any future
+        // CommandBinding consumer; one CommandBinding covers all
+        // command-style paste sources. The keyboard gestures
+        // (Ctrl+V / Shift+Insert) are NOT wired through CommandManager
+        // any more — they're handled directly in OnPreviewKeyDown
+        // before the encoder runs (see post-Stage-6 fix-2 below).
+        // Reason: WPF's CommandManager class handler doesn't auto-
+        // process InputBindings on a raw FrameworkElement, AND when
+        // OnPasteCanExecute returns false (e.g. empty clipboard), the
+        // unhandled gesture falls through to the encoder and emits
+        // ^V to the shell — exactly what we wanted to avoid. Direct
+        // handling guarantees the encoder is bypassed regardless of
+        // clipboard state, with empty-clipboard becoming a silent
+        // no-op rather than a ^V emission.
         CommandBindings.Add(new CommandBinding(
             ApplicationCommands.Paste,
             OnPasteExecuted,
             OnPasteCanExecute));
-        InputBindings.Add(new KeyBinding(
-            ApplicationCommands.Paste,
-            new KeyGesture(Key.V, ModifierKeys.Control)));
-        InputBindings.Add(new KeyBinding(
-            ApplicationCommands.Paste,
-            new KeyGesture(Key.Insert, ModifierKeys.Shift)));
 
         // Stage 6 PR-B — resize debounce timer. Stopped initially;
         // OnRenderSizeChanged restarts it on each WPF SizeChanged tick.
@@ -385,6 +378,25 @@ public class TerminalView : FrameworkElement
             return;
         }
 
+        // 2.5. App-level keyboard shortcuts that bypass the encoder.
+        // Post-Stage-6 fix-2: these gestures look like Ctrl-letter
+        // combos to the encoder, but their user-facing meaning
+        // (paste, clear-screen) is fundamentally a UI concept that
+        // doesn't translate cleanly to a single PTY byte for cmd.exe.
+        // Sending the raw control byte (0x16, 0x0C) results in cmd.exe
+        // echoing them back as ^V / ^L caret-notation, which is the
+        // bug the maintainer hit during NVDA verification.
+        //
+        // Handle these explicitly here instead of relying on
+        // CommandManager / InputBinding routing — that route doesn't
+        // fire reliably for a custom FrameworkElement, and any
+        // CanExecute=false branch falls through to the encoder.
+        if (HandleAppLevelShortcut(e.Key, pressedModifiers))
+        {
+            e.Handled = true;
+            return;
+        }
+
         // 3. Translate.
         var keyMods = TranslateModifiers(pressedModifiers);
         var keyCode = TranslateKey(e.Key);
@@ -494,6 +506,73 @@ public class TerminalView : FrameworkElement
     {
         e.CanExecute = _writeBytes is not null && Clipboard.ContainsText();
         e.Handled = true;
+    }
+
+    /// <summary>
+    /// Post-Stage-6 fix — app-level keyboard shortcuts that bypass
+    /// the PTY encoder. These gestures look like Ctrl-letter combos
+    /// to the encoder, but their user-facing meaning (paste,
+    /// clear-screen) is a UI concept that doesn't translate cleanly
+    /// to a single PTY byte for cmd.exe. Returns true if the
+    /// gesture was handled (caller marks Handled and returns);
+    /// false if not (caller continues with encoder).
+    ///
+    /// Currently handles:
+    /// <list type="bullet">
+    ///   <item><description><b>Ctrl+V / Shift+Insert</b> — paste from
+    ///   clipboard via <see cref="KeyEncoding.encodePaste"/>. Empty
+    ///   clipboard becomes a silent no-op rather than a <c>^V</c>
+    ///   emission to the shell.</description></item>
+    ///   <item><description><b>Ctrl+L</b> — send <c>cls\r</c> to the
+    ///   shell. <b>Currently cmd.exe-specific.</b> The literally-correct
+    ///   thing to do is send <c>0x0C</c> (form feed) and let the
+    ///   shell decide; cmd.exe ignores it and echoes <c>^L</c>,
+    ///   which is bad UX. PowerShell + PSReadLine and Unix shells
+    ///   honour <c>0x0C</c> directly. A future stage with shell
+    ///   detection (or per-shell config) will pick the right
+    ///   behaviour automatically; for now we hardcode <c>cls\r</c>
+    ///   because the default shell is cmd.exe. Trade-off: when the
+    ///   foreground process is something that DOES interpret
+    ///   <c>0x0C</c> (Claude Code's Ink, <c>less</c>,
+    ///   <c>vim</c>, etc.), Ctrl+L will run <c>cls</c> as if typed
+    ///   instead of triggering that program's redraw. Acceptable
+    ///   compromise for the current cmd.exe-only scope; revisit
+    ///   when Stage 7+ adds shell flexibility.</description></item>
+    /// </list>
+    /// </summary>
+    private bool HandleAppLevelShortcut(Key key, ModifierKeys modifiers)
+    {
+        if (_writeBytes is null) return false;
+
+        // Ctrl+V / Shift+Insert → paste.
+        var isPaste =
+            (key == Key.V && modifiers == ModifierKeys.Control) ||
+            (key == Key.Insert && modifiers == ModifierKeys.Shift);
+        if (isPaste)
+        {
+            if (Clipboard.ContainsText())
+            {
+                var text = Clipboard.GetText();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    var bracketed = _screen?.Modes.BracketedPaste == true;
+                    var bytes = KeyEncoding.encodePaste(text, bracketed);
+                    _writeBytes(bytes);
+                }
+            }
+            // Silent no-op on empty clipboard — strictly better than
+            // the previous ^V emission to the shell.
+            return true;
+        }
+
+        // Ctrl+L → cls\r (cmd.exe-specific clear-screen).
+        if (key == Key.L && modifiers == ModifierKeys.Control)
+        {
+            _writeBytes(System.Text.Encoding.ASCII.GetBytes("cls\r"));
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Two keyboard-gesture fixes the previous post-Stage-6 fix-PR (#100) didn't correctly handle:

### Ctrl+V still emitted `^V`

PR #100 added `KeyBinding`s mapping Ctrl+V / Shift+Insert to `ApplicationCommands.Paste`, but two compounding issues:

1. WPF's `CommandManager` class handler doesn't auto-process `InputBindings` on a raw `FrameworkElement` (only on built-in `Control`s), so the gesture didn't reliably reach `OnPasteExecuted`.
2. Even when the routing did reach `OnPasteCanExecute`, an empty clipboard returned `CanExecute = false`, the gesture fell through unhandled to my `OnPreviewKeyDown` override, the encoder produced `0x16`, and cmd.exe echoed `^V`.

**Re-fix:** handle Ctrl+V and Shift+Insert explicitly at the top of `OnPreviewKeyDown` (new `HandleAppLevelShortcut` helper) **before** the encoder runs. Empty clipboard is now a silent no-op instead of a `^V` emission. The `CommandBinding` stays in place for any future right-click-menu / Edit-menu paste paths.

### Ctrl+L emitted `^L` (cmd.exe-specific UX)

The encoder correctly sends `0x0C` (form feed) which is what xterm-style terminals emit for Ctrl+L. The literally-correct thing is to let the shell decide. But cmd.exe ignores `0x0C` and echoes `^L` caret-notation, which is bad UX for the user's day-to-day. PowerShell + PSReadLine and Unix shells handle `0x0C` natively.

**Pragmatic fix:** special-case Ctrl+L in `HandleAppLevelShortcut` to send `cls\r` (cmd.exe clear-screen command) instead of `0x0C`.

**Documented trade-off:** when the foreground process is something that DOES interpret `0x0C` (Claude Code's Ink, `less`, `vim`), Ctrl+L will run `cls` as if typed instead of triggering that program's redraw. Acceptable for the current cmd.exe-only scope; revisit when Stage 7+ adds shell flexibility.

## Why this approach

`HandleAppLevelShortcut` is the right home for any future "looks like a Ctrl-letter combo but means something to the UI" gestures (a future Ctrl+T tab, Ctrl+W window-close, etc.). It runs after the screen-reader-modifier filter and before the encoder, so it can short-circuit gestures the encoder shouldn't see.

## Test plan

- [ ] CI green
- [ ] All existing tests still pass (no test changes; pure WPF event-handler refactor)
- [ ] Manual NVDA verification on the next preview cut:
  - [ ] Copy something to clipboard, press Ctrl+V — pasted text appears at the prompt (not `^V`)
  - [ ] Empty clipboard, press Ctrl+V — silent no-op (no `^V` either)
  - [ ] Press Shift+Insert with text on clipboard — same paste behaviour
  - [ ] Type some commands, press Ctrl+L — screen clears (sends `cls\r`)

## Out of scope (logged)

- **Coalescer crash** — still need exception text from NVDA Speech Viewer.
- **Ctrl+L behaviour for non-cmd.exe shells** — Stage 7+ when shell becomes configurable.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_