### PR TITLE
feat(logging): per-session files inside daily folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **`Ctrl+Alt+L` copies the active session's log file content to
+  the clipboard.** Bundled with the logging-restructure work.
+  Pressing the hotkey reads the active log file (the one
+  `FileLoggerSink.ActiveLogPath` points to), sets the OS
+  clipboard, and announces the byte count via NVDA ("Log
+  copied to clipboard. N bytes; ready to paste."). Fastest
+  path to send a session log to a maintainer for bug-report
+  diagnosis — no File Explorer navigation required. Mnemonic:
+  alt-action paired with the existing `Ctrl+Shift+L` open-folder
+  primary.
+
+  Hotkey choice rationale: NOT `Ctrl+Shift+C`. The latter looks
+  intuitive (`C` = copy) but Ctrl-letter encoding folds Shift
+  in the keyboard pipeline, meaning `Ctrl+Shift+C` currently
+  sends `0x03` to the shell — that's the standard SIGINT /
+  Ctrl-Break gesture for interrupting a running command (e.g.
+  `ping localhost -t`). Claiming `Ctrl+Shift+C` for log-copy
+  would break shell-interrupt UX. `Ctrl+Alt+L` doesn't collide
+  with any shell encoding and isn't a printable on US
+  keyboards.
+
+  Added to `AppReservedHotkeys`; wired in
+  `setupCopyLatestLogKeybinding` in `Program.fs`. The handler
+  catches and announces clipboard exceptions (the OS clipboard
+  can transiently throw COMException under contention; one
+  failed attempt becomes an audible error rather than a silent
+  no-op).
+
+  Documentation: README, USER-SETTINGS.md, and LOGGING.md
+  updated with the new hotkey, the rationale, and a refreshed
+  "Sharing logs with a maintainer" section that promotes
+  Ctrl+Alt+L as the fastest path.
+
 ### Changed
 
 - **Logging restructured to per-session files in per-day

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,46 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed
+
+- **Logging restructured to per-session files in per-day
+  folders.** The previous layout kept one daily-rolled file
+  per UTC day; long-running development days produced massive
+  aggregated files that were painful to navigate when grabbing
+  a slice for a bug report. New layout:
+
+  ```
+  %LOCALAPPDATA%\PtySpeak\logs\
+  ├── 2026-05-02\
+  │   ├── pty-speak-13-45-23.log    ← session that launched at 13:45:23
+  │   ├── pty-speak-15-12-08.log
+  │   └── pty-speak-16-30-44.log
+  ├── 2026-05-01\
+  │   └── pty-speak-09-15-22.log
+  └── ... (up to 7 days)
+  ```
+
+  Each launch creates a fresh session file named with its
+  launch timestamp inside today's day-folder. Sessions don't
+  split across midnight (a long-running session stays in its
+  launch-day folder). Retention deletes whole day-folders
+  older than 7 days; folders with non-date names are ignored
+  defensively. New `FileLoggerSink.ActiveLogPath` member
+  exposes this session's file path for tools that want to
+  grab the active session directly.
+
+  `Ctrl+Shift+L` still opens the logs root; the user
+  navigates one click into today's day-folder and picks the
+  most recent session by alphabetical sort. Bug reports are
+  now one-file pastes instead of "scroll a giant log to the
+  right time range".
+
+  `docs/LOGGING.md` updated with the new layout, retention
+  rules, and a one-line PowerShell snippet for grabbing the
+  latest session — useful for the future
+  Claude-Code-on-the-machine workflow where a script could
+  pull the most recent log without prompting the user.
+
 ### Fixed
 
 - **UI test flakiness on the windows-2025 runner.** The

--- a/README.md
+++ b/README.md
@@ -153,8 +153,13 @@ preserve this list per the app-reserved-hotkey contract in
   navigation step.
 - **`Ctrl+Shift+L`** — open the logs folder
   (`%LOCALAPPDATA%\PtySpeak\logs\`) in File Explorer. Useful for
-  grabbing the latest log when reporting a bug. See
-  [`docs/LOGGING.md`](docs/LOGGING.md) for what is and isn't logged.
+  grabbing a previous session's log when reporting a bug.
+- **`Ctrl+Alt+L`** — copy the active session's log file content
+  to the clipboard. NVDA announces the byte count; switch to
+  the chat / email / issue and paste. The fastest way to send
+  a session log to a maintainer. See
+  [`docs/LOGGING.md`](docs/LOGGING.md) for what is and isn't
+  logged.
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute toggle),
 `Alt+Shift+R` (Stage 10 review-mode toggle).

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,9 +1,16 @@
 # Logging
 
-pty-speak writes structured logs to a daily-rolling file under
-`%LOCALAPPDATA%\PtySpeak\logs\`. The `Ctrl+Shift+L` hotkey opens
-that folder in File Explorer so you can grab the latest log when
-reporting a bug or reviewing a session.
+pty-speak writes structured logs to per-session files under
+`%LOCALAPPDATA%\PtySpeak\logs\{yyyy-MM-dd}\`. Two hotkeys make
+the logs easy to grab when reporting a bug or reviewing a
+session:
+
+- **`Ctrl+Shift+L`** — open the logs folder in File Explorer.
+- **`Ctrl+Alt+L`** — copy the active session's log file content
+  to the clipboard as a single string. NVDA announces the byte
+  count on success ("Log copied to clipboard. N bytes; ready to
+  paste."). Most efficient way to send a log to a maintainer:
+  press the hotkey, switch to the chat / email / issue, paste.
 
 ## Where the logs live
 
@@ -135,18 +142,22 @@ any log site that risks leaking these categories.
 
 ## Sharing logs with a maintainer
 
-When reporting a bug:
+**Fastest path** — `Ctrl+Alt+L`:
 
 1. Reproduce the issue (or wait for it to happen — for the
    intermittent ones).
-2. Press `Ctrl+Shift+L` to open the logs folder.
-3. Open `pty-speak-{today}.log` in Notepad (or any reader).
-4. Either:
-   - Copy the relevant time-range of entries (Ctrl+A to grab
-     everything; or scroll to the relevant timestamp and
-     select from there), then paste in the bug report.
-   - OR attach the whole file (logs are small text — typically
-     a few KB to a few hundred KB per day).
+2. **Press `Ctrl+Alt+L`.** NVDA announces "Log copied to
+   clipboard. N bytes; ready to paste." The active session's
+   entire log file is now on the clipboard.
+3. Switch to the chat / email / issue and paste.
+
+**Manual path** — `Ctrl+Shift+L`:
+
+1. Press `Ctrl+Shift+L` to open the logs folder.
+2. Click into today's `yyyy-MM-dd` day-folder.
+3. The most recent session is alphabetically last (filenames
+   are launch timestamps).
+4. Open the file and copy whatever range you need.
 
 Logs do not contain personally-identifying information beyond
 your machine's username (which appears in path prefixes). If

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -9,18 +9,57 @@ reporting a bug or reviewing a session.
 
 ```
 %LOCALAPPDATA%\PtySpeak\logs\
-├── pty-speak-2026-05-02.log    ← today's log (active)
-├── pty-speak-2026-05-01.log    ← yesterday
-├── pty-speak-2026-04-30.log
-└── ... (up to 7 days)
+├── 2026-05-02\                                ← today's day-folder
+│   ├── pty-speak-13-45-23.log                 ← session that launched at 13:45:23 UTC
+│   ├── pty-speak-15-12-08.log                 ← session that launched at 15:12:08 UTC
+│   └── pty-speak-16-30-44.log                 ← active session (still being written)
+├── 2026-05-01\                                ← yesterday's day-folder
+│   ├── pty-speak-09-15-22.log
+│   └── pty-speak-22-04-11.log
+└── ... (up to 7 days of day-folders)
 ```
 
-- One file per UTC day. Daily rolling at midnight UTC.
-- 7-day retention. On startup, files older than 7 days are
-  deleted.
+- **One file per launch / session** inside a per-day folder
+  named `yyyy-MM-dd` (UTC). Each session gets its own file
+  named with its launch timestamp (`pty-speak-HH-mm-ss.log`,
+  no colons because Windows file paths reject them).
+- **7-day retention** — entire day-folders older than 7 days
+  are deleted on every fresh launch. Folders with names that
+  don't parse as `yyyy-MM-dd` (manual subfolders, etc.) are
+  ignored.
+- **Sessions don't split across midnight.** A long-running
+  session's file stays in its launch-day folder; no rolling
+  mid-session. The next launch creates a file in the new
+  day's folder.
 - The active file is opened with `FileShare.ReadWrite` so you
   can open it in Notepad, NVDA, or any other reader while
   pty-speak is still running.
+
+## Finding the right session for a bug report
+
+Sessions are named with their launch timestamp, so within a
+day-folder they sort alphabetically in chronological order.
+The latest is always alphabetically last. To grab the session
+where a bug just fired:
+
+1. Press `Ctrl+Shift+L` — File Explorer opens at
+   `%LOCALAPPDATA%\PtySpeak\logs\`.
+2. Open today's day-folder.
+3. Sort by Name (or Date Modified) — the most recent session
+   is at the bottom.
+4. Open that file. It contains ONLY this session's events,
+   typically a few hundred lines for a normal use; thousands
+   if the session was active for a long time.
+5. Copy the relevant slice (or the whole file — single-session
+   files are small) and paste it in a bug report.
+
+Future Claude-Code-on-the-machine integration can grab the
+latest log with one PowerShell line:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\PtySpeak\logs\$(Get-Date -Format yyyy-MM-dd)" |
+  Sort-Object Name -Descending | Select-Object -First 1
+```
 
 ## Format
 

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -294,12 +294,22 @@ for future stages — listed inline below):
   mnemonic similarity.
 - **`Ctrl+Shift+L`** — open the logs folder
   (`%LOCALAPPDATA%\PtySpeak\logs\`) in File Explorer (Logging-PR).
-  Useful for grabbing the latest log file when reporting a bug.
-  Logs are daily-rolled with 7-day retention. See
-  [`LOGGING.md`](LOGGING.md) for the full description of what's
-  logged and what isn't (typed input, paste content, full screen
-  contents, environment variables — never). Wired in
+  Useful for navigating into a previous session's log file when
+  reporting a bug. Logs are per-session files inside per-day
+  folders with 7-day retention. See [`LOGGING.md`](LOGGING.md)
+  for the full description of what's logged and what isn't
+  (typed input, paste content, full screen contents,
+  environment variables — never). Wired in
   `setupOpenLogsKeybinding`.
+- **`Ctrl+Alt+L`** — copy the active session's log file content
+  to the clipboard as a single string (Logging-restructure PR).
+  NVDA announces the byte count on success ("Log copied to
+  clipboard. N bytes; ready to paste."). Fastest path to send
+  a session log to a maintainer. NOT `Ctrl+Shift+C` —
+  Ctrl+Shift+C currently sends `0x03` (SIGINT) to the shell
+  via the Ctrl-letter encoding, and overriding that would
+  break the standard "press Ctrl+C to interrupt a running
+  command" gesture. Wired in `setupCopyLatestLogKeybinding`.
 - (planned) **`Ctrl+Shift+M`** — earcon mute toggle (Stage 9).
 - (planned) **`Alt+Shift+R`** — review-mode toggle (Stage 10).
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -412,6 +412,79 @@ module Program =
             }
         ()
 
+    /// Copy the active session's log file content to the
+    /// system clipboard so the maintainer can paste it into a
+    /// bug report without navigating File Explorer. Triggered
+    /// by `Ctrl+Alt+L` (mnemonic: alt-action paired with
+    /// `Ctrl+Shift+L` open-folder primary). Reads the file
+    /// pointed to by `FileLoggerSink.ActiveLogPath`, copies
+    /// the entire content as a single string, and announces
+    /// the byte count via NVDA on success.
+    ///
+    /// Hotkey choice: `Ctrl+Alt+L`, not `Ctrl+Shift+C`. The
+    /// latter looks intuitive (`C` = copy) but Ctrl-letter
+    /// encoding folds Shift in the keyboard encoder, meaning
+    /// `Ctrl+Shift+C` currently sends `0x03` to the shell
+    /// (the SIGINT / Ctrl-Break gesture) — claiming it for
+    /// log-copy would break shell-interrupt for commands like
+    /// `ping localhost -t`. `Ctrl+Alt+L` doesn't collide with
+    /// any shell encoding, doesn't produce a printable on US
+    /// keyboards, and pairs naturally with the existing
+    /// `Ctrl+Shift+L`.
+    let private runCopyLatestLog (window: MainWindow) : unit =
+        let log = Logger.get "Terminal.App.Program.runCopyLatestLog"
+        log.LogInformation("Ctrl+Alt+L pressed — copying active log to clipboard.")
+        match loggerSink with
+        | None ->
+            window.TerminalSurface.Announce(
+                "Logging is not initialised yet; nothing to copy.",
+                ActivityIds.error)
+        | Some sink ->
+            try
+                let path = sink.ActiveLogPath
+                if not (System.IO.File.Exists path) then
+                    window.TerminalSurface.Announce(
+                        "Active log file does not exist yet; press a key or wait for an event first.",
+                        ActivityIds.error)
+                else
+                    let content = System.IO.File.ReadAllText(path)
+                    // Clipboard.SetText must run on the WPF
+                    // dispatcher thread (STA). The hotkey
+                    // handler already runs there, so direct
+                    // call is safe. Wrap in try/catch because
+                    // Clipboard can transiently throw
+                    // COMException when the OS clipboard is
+                    // contended; one failed attempt is fine
+                    // — user retries.
+                    System.Windows.Clipboard.SetText(content)
+                    let bytes =
+                        System.Text.Encoding.UTF8.GetByteCount(content)
+                    log.LogInformation(
+                        "Copied active log to clipboard. Path={Path} Bytes={Bytes}",
+                        path, bytes)
+                    window.TerminalSurface.Announce(
+                        sprintf
+                            "Log copied to clipboard. %d bytes; ready to paste."
+                            bytes,
+                        ActivityIds.diagnostic)
+            with ex ->
+                let safe = AnnounceSanitiser.sanitise ex.Message
+                log.LogError(ex, "Failed to copy active log to clipboard.")
+                window.TerminalSurface.Announce(
+                    sprintf "Could not copy log: %s" safe,
+                    ActivityIds.error)
+
+    /// Wire `Ctrl+Alt+L` to trigger `runCopyLatestLog`.
+    let private setupCopyLatestLogKeybinding (window: MainWindow) : unit =
+        let cmd = RoutedCommand("CopyLatestLog", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.L, ModifierKeys.Control ||| ModifierKeys.Alt)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
+            CommandBinding(
+                cmd,
+                ExecutedRoutedEventHandler(fun _ _ -> runCopyLatestLog window)))
+        |> ignore
+
     /// Wire `Ctrl+Shift+L` to trigger `runOpenLogs`. Same
     /// pattern as the other reserved hotkeys above.
     let private setupOpenLogsKeybinding (window: MainWindow) : unit =
@@ -471,6 +544,11 @@ module Program =
 
         // Wire Ctrl+Shift+L to open the logs folder in File Explorer.
         setupOpenLogsKeybinding window
+
+        // Wire Ctrl+Alt+L to copy the active session's log file
+        // contents to the clipboard. Useful for sending the log
+        // to a maintainer without navigating Explorer.
+        setupCopyLatestLogKeybinding window
 
         // Stage 5 — two-channel pipeline:
         //

--- a/src/Terminal.Core/FileLogger.fs
+++ b/src/Terminal.Core/FileLogger.fs
@@ -100,7 +100,31 @@ type internal LogEntry =
 /// Shared sink behind every `FileLogger` instance. One per
 /// process. Owns the background drain task + the active file
 /// stream.
+///
+/// File layout (post-restructure):
+///
+/// ```text
+/// %LOCALAPPDATA%\PtySpeak\logs\
+/// ├── 2026-05-02\
+/// │   ├── pty-speak-13-45-23.log    ← session that launched at 13:45:23 UTC
+/// │   └── pty-speak-15-30-44.log
+/// └── 2026-05-01\
+///     └── pty-speak-09-15-22.log
+/// ```
+///
+/// One file per launch (per-session) inside a day-folder.
+/// Lets the maintainer / user navigate to a specific session
+/// when reporting a bug without scrolling a giant aggregated
+/// file. Retention deletes whole day-folders older than the
+/// configured window.
 type FileLoggerSink (options: FileLoggerOptions) =
+
+    /// Capture launch instant ONCE at construction. Each session
+    /// writes to a single file named after this timestamp; if
+    /// the session runs past midnight the file stays in its
+    /// launch-day folder rather than splitting across two
+    /// folders.
+    let launchUtc = DateTimeOffset.UtcNow
 
     let channel =
         let opts =
@@ -141,24 +165,45 @@ type FileLoggerSink (options: FileLoggerOptions) =
             sb.Append('\n').Append(ex.ToString()) |> ignore
         sb.ToString()
 
-    /// Compute the path for a given UTC date.
-    let pathForDate (utcDate: DateTime) : string =
-        Path.Combine(
-            options.LogDirectory,
-            sprintf "pty-speak-%s.log" (utcDate.ToString("yyyy-MM-dd")))
+    /// Compute the day-folder path + session-file path for the
+    /// launch instant. Day folder named `yyyy-MM-dd`; file
+    /// named `pty-speak-HH-mm-ss.log` (no colons; Windows file
+    /// paths reject `:`).
+    let pathsForLaunch () : string * string =
+        let dayFolder =
+            Path.Combine(
+                options.LogDirectory,
+                launchUtc.UtcDateTime.ToString("yyyy-MM-dd"))
+        let fileName =
+            sprintf "pty-speak-%s.log"
+                (launchUtc.UtcDateTime.ToString("HH-mm-ss"))
+        let filePath = Path.Combine(dayFolder, fileName)
+        dayFolder, filePath
 
-    /// Delete log files older than `RetentionDays` days. Best-
-    /// effort — exceptions are swallowed (a stray file in the
-    /// logs directory shouldn't crash the app).
+    /// Delete day-folders older than `RetentionDays`. Best-
+    /// effort — folder names that don't parse as `yyyy-MM-dd`
+    /// are ignored (someone's manually-created subfolder
+    /// shouldn't cause a crash). Exceptions on individual
+    /// folder deletes are swallowed (a stray file holding a
+    /// folder open shouldn't block startup).
     let runRetention () =
         try
             if Directory.Exists(options.LogDirectory) then
-                let cutoff = DateTime.UtcNow.AddDays(-(float options.RetentionDays))
-                for path in Directory.EnumerateFiles(options.LogDirectory, "pty-speak-*.log") do
+                let cutoff =
+                    DateTime.UtcNow.Date.AddDays(-(float options.RetentionDays))
+                for dirPath in Directory.EnumerateDirectories(options.LogDirectory) do
                     try
-                        let info = FileInfo(path)
-                        if info.LastWriteTimeUtc < cutoff then
-                            info.Delete()
+                        let dirName = Path.GetFileName(dirPath)
+                        let mutable parsed = DateTime.MinValue
+                        let ok =
+                            DateTime.TryParseExact(
+                                dirName,
+                                "yyyy-MM-dd",
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                System.Globalization.DateTimeStyles.None,
+                                &parsed)
+                        if ok && parsed.Date < cutoff then
+                            Directory.Delete(dirPath, true)
                     with _ -> ()
         with _ -> ()
 
@@ -167,42 +212,30 @@ type FileLoggerSink (options: FileLoggerOptions) =
     let drainTask =
         Task.Run(fun () ->
             task {
-                Directory.CreateDirectory(options.LogDirectory) |> ignore
+                let dayFolder, filePath = pathsForLaunch ()
+                Directory.CreateDirectory(dayFolder) |> ignore
                 runRetention ()
 
-                let mutable currentDate = DateTime.UtcNow.Date
+                // Per-session log: open ONCE at startup, write
+                // until the sink is disposed. No daily-roll
+                // logic — a session is one file by design. If a
+                // session runs past midnight it stays in its
+                // launch-day folder; the next launch creates a
+                // file in the new day's folder.
                 let mutable writer : StreamWriter | null = null
 
-                let openWriter (date: DateTime) =
+                let openWriter () =
                     let stream =
                         new FileStream(
-                            pathForDate date,
+                            filePath,
                             FileMode.Append,
                             FileAccess.Write,
                             FileShare.ReadWrite)
                     new StreamWriter(stream, Encoding.UTF8)
 
                 let ensureWriter () =
-                    let today = DateTime.UtcNow.Date
                     if writer = null then
-                        writer <- openWriter today
-                        currentDate <- today
-                    elif today <> currentDate then
-                        // Daily roll: close yesterday's writer,
-                        // open today's, run retention sweep again.
-                        // Pattern-match `writer` to satisfy F# 9
-                        // strict-null: even though we know writer
-                        // is non-null in this elif branch, the
-                        // compiler's flow analysis doesn't carry
-                        // that across the `today <> currentDate`
-                        // condition.
-                        (match writer with
-                         | null -> ()
-                         | w ->
-                             try (w :> IDisposable).Dispose() with _ -> ())
-                        writer <- openWriter today
-                        currentDate <- today
-                        runRetention ()
+                        writer <- openWriter ()
 
                 let writeOne (entry: LogEntry) =
                     try
@@ -273,9 +306,22 @@ type FileLoggerSink (options: FileLoggerOptions) =
                   Exception = ex }
             channel.Writer.TryWrite(entry) |> ignore
 
-    /// Path to the currently active log file. Useful for the
-    /// Ctrl+Shift+L "open logs folder" hotkey.
+    /// Path to the configured logs root directory (the parent
+    /// of the per-day folders). Used by the `Ctrl+Shift+L`
+    /// hotkey to open the root in File Explorer; the user
+    /// then navigates to today's day-folder and picks the
+    /// session of interest.
     member _.LogDirectory : string = options.LogDirectory
+
+    /// Path to THIS session's log file (inside today's day-
+    /// folder, named with the launch time). Useful for tools
+    /// that want to grab the active session's log directly,
+    /// e.g. a future "copy latest log to clipboard" hotkey or
+    /// a Claude-Code-on-the-machine integration that wants the
+    /// most recent log without scanning the directory.
+    member _.ActiveLogPath : string =
+        let _, filePath = pathsForLaunch ()
+        filePath
 
     interface IDisposable with
         member _.Dispose() =

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -314,6 +314,15 @@ public class TerminalView : FrameworkElement
             // Bound in `setupOpenLogsKeybinding`.
             (Key.L, ModifierKeys.Control | ModifierKeys.Shift, "Open logs folder"),
 
+            // Logging-restructure PR — copy active session log to
+            // clipboard. Bound in `setupCopyLatestLogKeybinding`.
+            // Mnemonic: alt-action paired with Ctrl+Shift+L
+            // open-folder primary. NOT Ctrl+Shift+C (that would
+            // collide with the Ctrl-letter shell-interrupt
+            // encoding, where Ctrl+Shift+C currently sends
+            // 0x03 / SIGINT to the running command).
+            (Key.L, ModifierKeys.Control | ModifierKeys.Alt, "Copy active log to clipboard"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,

--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -30,34 +30,75 @@ let private optionsAt (dir: string) (minLevel: LogLevel) : FileLoggerOptions =
       MinLevel = minLevel
       ChannelCapacity = 256 }
 
-/// Read the current day's log file as a single string.
-let private readTodayLog (dir: string) : string =
-    let path =
-        Path.Combine(
-            dir,
-            sprintf "pty-speak-%s.log"
-                (DateTime.UtcNow.Date.ToString("yyyy-MM-dd")))
-    if File.Exists(path) then File.ReadAllText(path) else ""
+/// Read the active session's log file via the sink's
+/// `ActiveLogPath` accessor. Tests in this file capture the
+/// sink before disposal (or use the sink directly) so they
+/// have a handle to the path.
+let private readActiveLog (sink: FileLoggerSink) : string =
+    if File.Exists(sink.ActiveLogPath) then
+        File.ReadAllText(sink.ActiveLogPath)
+    else
+        ""
+
+/// Read whatever log files exist in the logs root (across all
+/// day-folders) as a concatenated string. Useful when a test
+/// wants to verify content without holding the sink reference.
+let private readAllLogContent (dir: string) : string =
+    if not (Directory.Exists(dir)) then "" else
+    let allFiles =
+        Directory.EnumerateDirectories(dir)
+        |> Seq.collect (fun d ->
+            try Directory.EnumerateFiles(d, "pty-speak-*.log")
+            with _ -> Seq.empty)
+    let sb = System.Text.StringBuilder()
+    for f in allFiles do
+        try sb.Append(File.ReadAllText(f)) |> ignore with _ -> ()
+    sb.ToString()
 
 [<Fact>]
-let ``logger writes Information entries to today's log file`` () =
+let ``logger writes Information entries to the active session log file`` () =
     let dir = freshTempDir ()
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("Test.Category")
     logger.LogInformation("hello {Who}", "world")
-    // Disposing the sink awaits the background drain so the file
-    // is flushed deterministically before we read it.
+    // Disposing the provider awaits the background drain so the
+    // file is flushed deterministically before we read it.
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.Contains("[INF]", content)
     Assert.Contains("[Test.Category]", content)
     Assert.Contains("hello world", content)
 
 [<Fact>]
+let ``active log lives inside a day-folder named yyyy-MM-dd`` () =
+    let dir = freshTempDir ()
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let provider = new FileLoggerProvider(sink) :> ILoggerProvider
+    let logger = provider.CreateLogger("Test")
+    logger.LogInformation("create the file")
+    (provider :> IDisposable).Dispose()
+    // ActiveLogPath should be: {dir}\{yyyy-MM-dd}\pty-speak-{HH-mm-ss}.log
+    let parentFolder = Path.GetDirectoryName(sink.ActiveLogPath)
+    let parentName = Path.GetFileName(parentFolder)
+    let mutable parsed = DateTime.MinValue
+    let parsedOk =
+        DateTime.TryParseExact(
+            parentName,
+            "yyyy-MM-dd",
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            &parsed)
+    Assert.True(parsedOk,
+        sprintf "Expected day-folder named yyyy-MM-dd; got '%s'" parentName)
+    let fileName = Path.GetFileName(sink.ActiveLogPath)
+    Assert.StartsWith("pty-speak-", fileName)
+    Assert.EndsWith(".log", fileName)
+
+[<Fact>]
 let ``logger respects minimum level filtering`` () =
     let dir = freshTempDir ()
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Warning)
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Warning)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("Test")
     logger.LogDebug("debug-noise")
@@ -65,7 +106,7 @@ let ``logger respects minimum level filtering`` () =
     logger.LogWarning("warn-signal")
     logger.LogError("error-signal")
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.DoesNotContain("debug-noise", content)
     Assert.DoesNotContain("info-noise", content)
     Assert.Contains("warn-signal", content)
@@ -74,61 +115,87 @@ let ``logger respects minimum level filtering`` () =
 [<Fact>]
 let ``logger writes exception details when an exception is supplied`` () =
     let dir = freshTempDir ()
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("Test")
     let ex = InvalidOperationException("boom")
     logger.LogError(ex, "operation failed at step={Step}", 3)
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.Contains("operation failed at step=3", content)
     Assert.Contains("InvalidOperationException", content)
     Assert.Contains("boom", content)
 
 [<Fact>]
-let ``retention sweep deletes log files older than RetentionDays`` () =
+let ``retention sweep deletes day-folders older than RetentionDays`` () =
     let dir = freshTempDir ()
-    // Plant a stale log file: 30 days old.
-    let stalePath =
-        Path.Combine(dir, "pty-speak-2020-01-01.log")
-    File.WriteAllText(stalePath, "old content\n")
-    File.SetLastWriteTimeUtc(stalePath, DateTime.UtcNow.AddDays(-30.0))
-    Assert.True(File.Exists(stalePath))
-    // Plant a fresh log file: 1 day old. Should survive.
-    let freshPath =
-        Path.Combine(dir, "pty-speak-keep.log")
-    File.WriteAllText(freshPath, "fresh content\n")
-    File.SetLastWriteTimeUtc(freshPath, DateTime.UtcNow.AddDays(-1.0))
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    // Plant a stale day-folder named for a date >7 days ago.
+    let staleDate = DateTime.UtcNow.Date.AddDays(-30.0)
+    let staleDirName = staleDate.ToString("yyyy-MM-dd")
+    let staleDir = Path.Combine(dir, staleDirName)
+    Directory.CreateDirectory(staleDir) |> ignore
+    File.WriteAllText(
+        Path.Combine(staleDir, "pty-speak-12-00-00.log"),
+        "old content\n")
+    Assert.True(Directory.Exists(staleDir))
+    // Plant a fresh day-folder (yesterday) — should survive.
+    let freshDate = DateTime.UtcNow.Date.AddDays(-1.0)
+    let freshDirName = freshDate.ToString("yyyy-MM-dd")
+    let freshDir = Path.Combine(dir, freshDirName)
+    Directory.CreateDirectory(freshDir) |> ignore
+    File.WriteAllText(
+        Path.Combine(freshDir, "pty-speak-12-00-00.log"),
+        "fresh content\n")
+    // Plant a folder with a non-date name — should be ignored
+    // entirely (defensive: stray folders shouldn't crash).
+    let strayDir = Path.Combine(dir, "not-a-date")
+    Directory.CreateDirectory(strayDir) |> ignore
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     // Force the drain task to actually run by writing one entry.
     let logger = provider.CreateLogger("Test")
     logger.LogInformation("kick the writer")
     (provider :> IDisposable).Dispose()
-    Assert.False(File.Exists(stalePath),
-        "Expected the 30-day-old file to be deleted by retention sweep")
-    Assert.True(File.Exists(freshPath),
-        "Expected the 1-day-old file to survive retention sweep")
+    Assert.False(Directory.Exists(staleDir),
+        "Expected the 30-day-old day-folder to be deleted")
+    Assert.True(Directory.Exists(freshDir),
+        "Expected the 1-day-old day-folder to survive")
+    Assert.True(Directory.Exists(strayDir),
+        "Expected a folder with a non-date name to be ignored by retention")
 
 [<Fact>]
-let ``logger creates the log directory if it does not exist`` () =
+let ``logger creates the day-folder if it does not exist`` () =
     // Pick a path under a fresh temp dir but DON'T create it yet.
     let parent = freshTempDir ()
     let nestedDir = Path.Combine(parent, "nested", "logs")
     Assert.False(Directory.Exists(nestedDir))
-    use sink = new FileLoggerSink(optionsAt nestedDir LogLevel.Information)
+    let sink = new FileLoggerSink(optionsAt nestedDir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("Test")
-    logger.LogInformation("should create the parent dir")
+    logger.LogInformation("should create the parent dir + day folder")
     (provider :> IDisposable).Dispose()
     Assert.True(Directory.Exists(nestedDir),
-        "Expected sink to create the log directory tree on first write")
+        "Expected sink to create the log root")
+    let dayFolder = Path.GetDirectoryName(sink.ActiveLogPath)
+    Assert.True(Directory.Exists(dayFolder),
+        sprintf "Expected sink to create the day folder %s" dayFolder)
 
 [<Fact>]
-let ``LogDirectory member exposes the configured path`` () =
+let ``LogDirectory member exposes the configured root path`` () =
     let dir = freshTempDir ()
     use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     Assert.Equal(dir, sink.LogDirectory)
+
+[<Fact>]
+let ``ActiveLogPath member exposes the per-session file inside today's day-folder`` () =
+    let dir = freshTempDir ()
+    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    // The path should start with `{dir}\{yyyy-MM-dd}\` and end
+    // with `pty-speak-{HH-mm-ss}.log`.
+    Assert.StartsWith(dir, sink.ActiveLogPath)
+    let fileName = Path.GetFileName(sink.ActiveLogPath)
+    Assert.StartsWith("pty-speak-", fileName)
+    Assert.EndsWith(".log", fileName)
 
 // Note: a "Logger module returns NullLogger before configure"
 // test was tried and removed. The Logger module's `factory`
@@ -174,7 +241,7 @@ let ``concurrent writes from multiple threads all land in the file`` () =
     // criterion — sink survived.)
     logger.LogInformation("post-concurrent sentinel")
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.Contains("post-concurrent sentinel", content)
     // Verify SOMETHING from the concurrent burst made it too —
     // not every thread (the channel is bounded; if a future
@@ -192,7 +259,7 @@ let ``concurrent writes from multiple threads all land in the file`` () =
 [<Fact>]
 let ``formatter throwing does not crash the sink`` () =
     let dir = freshTempDir ()
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("FormatterCrash")
     // Issue a log call where the formatter throws.
@@ -207,7 +274,7 @@ let ``formatter throwing does not crash the sink`` () =
     // still land in the file.
     logger.LogInformation("post-crash entry survives")
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.Contains("post-crash entry survives", content)
     // The fallback message for the broken formatter should also
     // appear (so the diagnostic is captured rather than swallowed).
@@ -237,7 +304,7 @@ let ``PTYSPEAK_LOG_LEVEL with an invalid value falls back to Information`` () =
 [<Fact>]
 let ``Logger module returns the configured factory's logger after configure`` () =
     let dir = freshTempDir ()
-    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let factory = Logger.createFactory provider
     Logger.configure factory
@@ -245,6 +312,6 @@ let ``Logger module returns the configured factory's logger after configure`` ()
     Assert.True(logger.IsEnabled(LogLevel.Information))
     logger.LogInformation("via configured factory")
     (provider :> IDisposable).Dispose()
-    let content = readTodayLog dir
+    let content = readActiveLog sink
     Assert.Contains("[Configured.Category]", content)
     Assert.Contains("via configured factory", content)


### PR DESCRIPTION
## Summary

Restructures the log layout per the maintainer's request so each pty-speak launch produces a fresh, individually-named log file inside a per-day folder. Previous layout was one daily-rolled file per UTC day, which quickly grew unwieldy and made grabbing a relevant slice for a bug report tedious.

## New layout

```
%LOCALAPPDATA%\PtySpeak\logs\
├── 2026-05-02\
│   ├── pty-speak-13-45-23.log    ← session that launched at 13:45:23
│   ├── pty-speak-15-12-08.log
│   └── pty-speak-16-30-44.log    ← active session
├── 2026-05-01\
│   └── pty-speak-09-15-22.log
└── ... (up to 7 days)
```

## Mechanics

- **`FileLoggerSink` captures the launch instant once at construction** via `DateTimeOffset.UtcNow`. Every entry of this process goes to the single file `pty-speak-{HH-mm-ss}.log` inside the `{yyyy-MM-dd}` day-folder. No daily-roll branching at runtime.
- **Sessions don't split across midnight.** A session that runs from 23:55 to 00:30 stays in its launch-day folder. One session, one file.
- **Retention** deletes whole day-folders whose name parses as a date older than `RetentionDays`. Folders with non-date names (manually-created subfolders, etc.) are ignored defensively.
- **New `FileLoggerSink.ActiveLogPath` member** exposes this session's file path. Useful for a future "copy latest log to clipboard" hotkey or for Claude-Code-on-the-machine integration that wants the most recent session without scanning.

## Bug-reporting workflow (for the maintainer + future contributors)

1. Press `Ctrl+Shift+L` → File Explorer opens at the logs root.
2. Click into today's day-folder.
3. Sort by Name; latest session is alphabetically last.
4. Open that file — it's only THIS session's entries, typically a few hundred lines.
5. Copy the relevant slice (or the whole file — single-session files are small) and paste in the bug report.

## Tests

All 13 existing `FileLoggerTests` updated:
- New `readActiveLog` helper consults `sink.ActiveLogPath` instead of computing the daily-rolled path.
- Retention test now plants a stale day-folder with a >7-day-old name and verifies the whole folder is deleted; also plants a stray non-date-named folder and verifies it survives.
- "Creates the day-folder" replaces "creates the log dir" — verifies both the root AND the day-folder are created.

Two new tests added:
- `active log lives inside a day-folder named yyyy-MM-dd` — pins the path layout shape.
- `ActiveLogPath member exposes the per-session file inside today's day-folder` — pins the new accessor's contract.

## Test plan

- [ ] CI green
- [ ] All 14 `FileLoggerTests` pass (including 2 new)
- [ ] All other existing tests still pass
- [ ] Manual NVDA verification on next preview:
  - [ ] Launch pty-speak. Press `Ctrl+Shift+L`. File Explorer opens at the logs root.
  - [ ] Open today's `yyyy-MM-dd` folder; observe a single `pty-speak-{HH-mm-ss}.log` file with the launch time.
  - [ ] Open the file and verify entries for `pty-speak starting`, `Window loaded`, `ConPTY child spawned`, `runLoop starting`.
  - [ ] (When the streaming-silence bug fires) The whole session's events are in one tidy file — paste back to maintainer.

## Architectural addendum (not in this PR)

During testing the maintainer correctly identified a separate Phase 2 feature: **NVDA caret/selection sync**. Right now NVDA's "current line" command reads stale document content rather than the actual cursor line because we don't expose `ITextProvider.GetSelection()` returning a range at the cursor position. That's a real Phase 2 / future stage, separate from the streaming-silence bug. Logging it; not addressing in this PR.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_