### PR TITLE
fix(tests): bump UI test window-discovery timeout from 10s to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **UI test flakiness on the windows-2025 runner.** The
+  FlaUI-driven tests in `tests/Tests.Ui/` launch the actual
+  `Terminal.App.exe` and wait for the WPF main window to
+  appear. The previous 10-second timeout was tight; under
+  parallel xUnit-test load on a freshly-provisioned
+  Windows Server 2025 runner image, Velopack initialisation
+  + WPF subsystem startup + ConPTY spawn could exceed it.
+  Confirmed flake (not a code regression) by observing the
+  same failure mode on PR #104, a markdown-only PR with
+  zero code changes. Bumped to 30 seconds in three call
+  sites: `AutomationPeerTests.fs`, two locations in
+  `TextPatternTests.fs`. Same diagnostic messages preserved
+  with the new timeout value. No application code touched;
+  no behavioural change for users.
+
 ### Added
 
 - **File-based structured logging.** New

--- a/tests/Tests.Ui/AutomationPeerTests.fs
+++ b/tests/Tests.Ui/AutomationPeerTests.fs
@@ -60,9 +60,17 @@ let ``TerminalView is exposed as a UIA Document with the correct ClassName and N
         // null check. Pattern-match for null AND give a useful
         // failure message in one step — beats Assert.NotNull both
         // for nullability narrowing and for diagnostic value.
-        match app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0)) with
+        //
+        // Timeout bumped from 10s to 30s after observed flakiness on
+        // the windows-2025 runner image: under parallel xUnit-test
+        // load, Velopack initialisation + WPF subsystem startup +
+        // ConPTY spawn can exceed 10s on a freshly-provisioned VM.
+        // PRs that touched only docs (#104) hit this same timeout
+        // failure mode, ruling out code regressions; the fix is
+        // runner-tolerance, not changing application behaviour.
+        match app.GetMainWindow(automation, TimeSpan.FromSeconds(30.0)) with
         | null ->
-            failwith "Main window did not appear within 10 seconds. Possible causes: Velopack startup hang, WPF subsystem misconfiguration, or runner desktop session not available."
+            failwith "Main window did not appear within 30 seconds. Possible causes: Velopack startup hang, WPF subsystem misconfiguration, or runner desktop session not available."
         | mw -> mw
 
     let cf = automation.ConditionFactory

--- a/tests/Tests.Ui/TextPatternTests.fs
+++ b/tests/Tests.Ui/TextPatternTests.fs
@@ -86,9 +86,12 @@ let ``UIA Text pattern is reachable and DocumentRange.GetText reflects the scree
 
     use automation = new UIA3Automation()
     let mainWindow =
-        match app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0)) with
+        // Timeout bumped from 10s to 30s after observed flakiness
+        // on the windows-2025 runner image (see AutomationPeerTests
+        // for details).
+        match app.GetMainWindow(automation, TimeSpan.FromSeconds(30.0)) with
         | null ->
-            failwith "Main window did not appear within 10 seconds. The app may have crashed during MainWindow construction or the F# composition root (Program.compose). Check the SetScreen / channel-construction / focus-on-Loaded path."
+            failwith "Main window did not appear within 30 seconds. The app may have crashed during MainWindow construction or the F# composition root (Program.compose). Check the SetScreen / channel-construction / focus-on-Loaded path."
         | mw -> mw
 
     let textPattern =
@@ -202,8 +205,10 @@ let ``Text-pattern range navigation can pin to a single line and advance`` () =
     use app = Application.Launch(exePath)
     use automation = new UIA3Automation()
     let mainWindow =
-        match app.GetMainWindow(automation, TimeSpan.FromSeconds(10.0)) with
-        | null -> failwith "Main window did not appear within 10 seconds."
+        // Timeout bumped from 10s to 30s — see notes elsewhere in
+        // this file and in AutomationPeerTests.
+        match app.GetMainWindow(automation, TimeSpan.FromSeconds(30.0)) with
+        | null -> failwith "Main window did not appear within 30 seconds."
         | mw -> mw
 
     let textPattern =


### PR DESCRIPTION
## Summary

Three FlaUI-driven UI tests launch the actual `Terminal.App.exe` and wait up to 10 seconds for the WPF main window to appear. Under parallel xUnit-test load on the new `windows-2025` runner image, that timeout is tight; observed flakiness on multiple PRs **including PR #104, which is markdown-only (zero code changes)** — confirming this is a runner-side flake, not a regression.

Bump the threshold to 30 seconds in all three call sites:
- `tests/Tests.Ui/AutomationPeerTests.fs:63`
- `tests/Tests.Ui/TextPatternTests.fs:89`
- `tests/Tests.Ui/TextPatternTests.fs:208`

Same diagnostic messages, just with the new threshold value, so a future timeout failure still gives full diagnostic context. **No application code touched; no user-visible behavioural change.**

## Why now

Two PRs (#103 logging restructure + #104 design doc) are currently blocked by this flake. Once this fix-PR merges, those two need to rebase onto main and re-run CI; both should then go green.

Stage 7 work would have hit the same flake. Better to fix the root cause than retry CI repeatedly.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check
- [ ] All existing tests still pass with the new timeout
- The change is test-only; no manual NVDA verification needed

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_