### PR TITLE
fix(coalescer): reuse PeriodicTimer wait across loop iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming-silence root cause: `PeriodicTimer` reuse bug in
+  `Coalescer.runLoop`.** Diagnosed via the maintainer's manual
+  NVDA verification on the post-Stage-6 preview, where typing
+  `dir` produced no streaming announcement and the cmd.exe
+  banner sometimes worked while subsequent output went silent.
+  The audible signal was "Coalescer crashed: Operation is not
+  valid due to the state of the object" — the exact message
+  `PeriodicTimer.WaitForNextTickAsync` throws when called a
+  second time before the previous call completes.
+
+  Pre-fix, every iteration of the runLoop's main `while`
+  unconditionally called `timer.WaitForNextTickAsync(ct)` to
+  build a `Task.WhenAny` race against the input channel. When
+  the reader won the race, the previous tick wait was orphaned
+  but never cancelled; the next iteration called
+  `WaitForNextTickAsync` AGAIN while the previous was still
+  pending → `InvalidOperationException`. The catch handler
+  surfaced "Coalescer crashed" then exited the loop, stopping
+  all further streaming announcements for the rest of the
+  session.
+
+  Why intermittent: the bug requires the reader to win
+  `Task.WhenAny` at least once before any timer tick fires
+  (i.e. input arrives faster than the 200ms debounce). The
+  cmd.exe launch banner was a single big chunk that arrived
+  before any timer iteration cycled, so it announced
+  correctly. Subsequent typed-input echoes triggered multiple
+  fast iterations where the reader kept winning, and the
+  second iteration's `WaitForNextTickAsync` crashed.
+
+  Fix: track the pending timer task across loop iterations.
+  Reuse the same wait until it actually fires; only after a
+  timer tick wins does the next iteration start a fresh
+  `WaitForNextTickAsync`. New regression test
+  `runLoop survives multiple consecutive reader-wins without
+  crashing the PeriodicTimer` in `CoalescerTests.fs` pumps 20
+  fast events through the reader channel and asserts the
+  runLoop keeps delivering notifications without faulting.
+
 ### Added
 
 - **`Ctrl+Alt+L` copies the active session's log file content to

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -402,24 +402,50 @@ module Coalescer =
                 try
                     let! _ = input.WaitToReadAsync(ct).AsTask()
                     let mutable keepGoing = true
+                    // PeriodicTimer.WaitForNextTickAsync throws
+                    // InvalidOperationException ("Operation is not
+                    // valid due to the state of the object") if
+                    // called concurrently — a second call before the
+                    // previous returns. Each loop iteration's
+                    // Task.WhenAny wins on EITHER timer or reader; if
+                    // the reader wins, the timer's wait is still
+                    // pending. Without this state-tracking, the next
+                    // iteration would invoke WaitForNextTickAsync
+                    // again on a still-pending timer and crash.
+                    //
+                    // Fix: keep the pending timer task across
+                    // iterations. Only start a new
+                    // WaitForNextTickAsync after the previous one
+                    // has fired.
+                    let mutable pendingTimerWait : Task | null = null
                     while keepGoing && not ct.IsCancellationRequested do
                         // Drain everything currently available.
                         let mutable peek = Unchecked.defaultof<ScreenNotification>
                         while input.TryRead(&peek) do
                             do! processNotification peek
-                        // Wait for the next timer tick OR a new
-                        // notification (whichever comes first),
-                        // honouring cancellation.
-                        let timerWait = timer.WaitForNextTickAsync(ct).AsTask()
+                        // Reuse the still-pending timer task from a
+                        // previous reader-wins iteration; otherwise
+                        // start a fresh wait.
+                        let timerWait : Task =
+                            match pendingTimerWait with
+                            | null -> timer.WaitForNextTickAsync(ct).AsTask() :> Task
+                            | t -> t
+                        pendingTimerWait <- timerWait
                         let readWait = input.WaitToReadAsync(ct).AsTask()
-                        let! winner = Task.WhenAny(timerWait :> Task, readWait :> Task)
+                        let! winner = Task.WhenAny(timerWait, readWait :> Task)
                         if obj.ReferenceEquals(winner, timerWait) then
-                            // Timer tick: flush any pending.
+                            // Timer tick fired: clear the pending
+                            // slot so the next iteration starts a
+                            // fresh wait, and flush any pending
+                            // accumulator.
+                            pendingTimerWait <- null
                             let now = timeProvider.GetUtcNow()
                             let emits = onTimerTick state now
                             do! writeAll emits
                         else
-                            // Channel closed?
+                            // Reader won; timer wait stays in
+                            // pendingTimerWait for next iteration.
+                            // Did the channel close?
                             let! got = readWait
                             if not got then keepGoing <- false
                 with

--- a/tests/Tests.Unit/CoalescerTests.fs
+++ b/tests/Tests.Unit/CoalescerTests.fs
@@ -409,3 +409,68 @@ let ``runLoop emits OutputBatch end-to-end via real Screen + FakeTimeProvider`` 
     | other -> Assert.Fail(sprintf "Expected OutputBatch; got %A" other)
     cts.Cancel()
     task.Wait(TimeSpan.FromSeconds 2.0) |> ignore
+
+[<Fact>]
+let ``runLoop survives multiple consecutive reader-wins without crashing the PeriodicTimer`` () =
+    // Regression test for "Coalescer crashed: Operation is not
+    // valid due to the state of the object" surfaced during
+    // post-Stage-6 manual NVDA verification.
+    //
+    // Cause: PeriodicTimer.WaitForNextTickAsync throws
+    // InvalidOperationException ("Operation is not valid due to
+    // the state of the object") when called concurrently — i.e.
+    // a second call before the previous one has completed. The
+    // pre-fix runLoop called WaitForNextTickAsync at the top of
+    // every loop iteration; when the reader won Task.WhenAny,
+    // the timer's pending wait was abandoned but not cancelled,
+    // and the next iteration's WaitForNextTickAsync crashed.
+    //
+    // Repro: pump events through the reader channel faster than
+    // the 200ms timer would fire. Every iteration, the reader
+    // wins. The pre-fix code crashed on the second iteration.
+    let inCh, outCh = buildChannels ()
+    let screen = Screen(rows = 3, cols = 10)
+    // Apply enough content so each push produces a unique frame
+    // hash (avoiding the dedup short-circuit).
+    let parser = Terminal.Parser.Parser.create ()
+    let mutable applyCount = 0
+    let pushUniqueChunk () =
+        applyCount <- applyCount + 1
+        let chunk =
+            Encoding.ASCII.GetBytes(sprintf "x%d " applyCount)
+        let events = Terminal.Parser.Parser.feedArray parser chunk
+        for e in events do screen.Apply(e)
+    pushUniqueChunk ()
+    let cts = new CancellationTokenSource()
+    let timeProvider = FakeTimeProvider(epoch)
+    let task =
+        Coalescer.runLoop
+            inCh.Reader
+            outCh.Writer
+            screen
+            (timeProvider :> TimeProvider)
+            cts.Token
+    // Push 20 events as fast as we can; under the pre-fix code
+    // the loop crashes on iteration 2 with InvalidOperationException
+    // and the task transitions to Faulted.
+    for _ in 1 .. 20 do
+        pushUniqueChunk ()
+        Assert.True(inCh.Writer.TryWrite(RowsChanged []))
+    // Drain a few notifications to ensure the loop is making
+    // progress, NOT crashing.
+    let mutable got = 0
+    let drainCts = new CancellationTokenSource(TimeSpan.FromSeconds 3.0)
+    try
+        while got < 3 && not drainCts.IsCancellationRequested do
+            let readTask = outCh.Reader.ReadAsync(drainCts.Token).AsTask()
+            if readTask.Wait(500) then
+                got <- got + 1
+    with
+    | _ -> ()
+    Assert.True(
+        got >= 1,
+        sprintf "Expected runLoop to deliver at least one notification under reader-bursts; got %d. Task state: %A"
+            got task.Status)
+    Assert.NotEqual(TaskStatus.Faulted, task.Status)
+    cts.Cancel()
+    task.Wait(TimeSpan.FromSeconds 2.0) |> ignore


### PR DESCRIPTION
## Summary

Root cause of the **streaming-silence bug** surfaced during your post-Stage-6 manual NVDA verification. You reported "Coalescer crashed: Operation is not valid due to the state of the object" — that exact phrase is what `PeriodicTimer.WaitForNextTickAsync` throws when called concurrently. Logs would have caught this too once captured, but you nailed it from the audible message alone.

## The bug

In `Coalescer.runLoop`'s main `while`, every iteration unconditionally builds a new tick-wait:

```fsharp
let timerWait = timer.WaitForNextTickAsync(ct).AsTask()   // ← NEW each iteration
let readWait = input.WaitToReadAsync(ct).AsTask()
let! winner = Task.WhenAny(timerWait :> Task, readWait :> Task)
if reader-wins:
    // timerWait is orphaned but still pending
    next iteration:
        // CRASH: WaitForNextTickAsync called while previous still pending
```

Per .NET docs: *"InvalidOperationException is thrown when WaitForNextTickAsync is called more than once before completion of the previous call."*

## Why it presented the way it did

| Observation | Cause |
|---|---|
| Banner read on launch ✓ | Banner is one big chunk; arrives before any timer iteration cycles |
| `dir` output silent ✗ | Typed input → fast read events → reader wins iteration N, then iteration N+1's `WaitForNextTickAsync` crashes |
| Sometimes a different command worked | Depends on whether reader or timer happened to win the first race |
| "Coalescer crashed: ..." announce | The exception path I added in the logging PR fired correctly |
| All output silent after first crash | Crashed task exits; drain task completes; no more notifications ever |

## Fix

Track the pending timer task across loop iterations. Reuse the same wait until it actually fires; only after a timer tick wins does the next iteration start a fresh `WaitForNextTickAsync`.

```fsharp
let mutable pendingTimerWait : Task | null = null
while keepGoing && not ct.IsCancellationRequested do
    // ... drain reads ...
    let timerWait : Task =
        match pendingTimerWait with
        | null -> timer.WaitForNextTickAsync(ct).AsTask() :> Task
        | t -> t
    pendingTimerWait <- timerWait
    let readWait = input.WaitToReadAsync(ct).AsTask()
    let! winner = Task.WhenAny(timerWait, readWait :> Task)
    if obj.ReferenceEquals(winner, timerWait) then
        pendingTimerWait <- null   // consumed; fresh wait next iteration
        // ... process tick ...
    else
        // pendingTimerWait stays set for next iteration
        // ... drain reader ...
```

## Regression test

New test `runLoop survives multiple consecutive reader-wins without crashing the PeriodicTimer` in `CoalescerTests.fs`. Pumps 20 fast events through the reader channel and asserts:
1. The runLoop delivers at least one notification (proves it's alive).
2. The runLoop's task isn't `Faulted`.

Pre-fix, the test crashes on iteration 2 with `InvalidOperationException`. With the fix it completes all 20.

## Test plan

- [ ] CI green on Build and test (windows-latest), actionlint, Markdown link check.
- [ ] All existing tests still pass; new regression test passes.
- [ ] **Manual NVDA verification on the next preview after merge:**
  - [ ] Launch pty-speak. Type `dir` + Enter. NVDA reads each line of the directory listing in order via the streaming-output coalescer.
  - [ ] Type `echo HI`. NVDA reads "HI".
  - [ ] No "Coalescer crashed" announcement on any of these.

If anything still goes silent, the new logging will capture it and `Ctrl+Alt+L` ships the log to me in one keystroke.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_