### PR TITLE
fix(hotkeys): Ctrl+Alt+L direct dispatch + SystemKey-aware filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Fixed
 
+- **`Ctrl+Alt+L` clipboard-copy hotkey didn't fire.** Maintainer
+  reported pressing the gesture on a current-main build and not
+  hearing the "Log copied to clipboard. N bytes" announcement;
+  the session log confirmed the handler never ran (no
+  `Ctrl+Alt+L pressed — copying active log to clipboard` entry).
+
+  Root cause: WPF's input pipeline reports `Alt`-modified key
+  events with `e.Key == Key.System` and the actual key in
+  `e.SystemKey`. The Window-level `KeyBinding` on
+  `Ctrl+Alt+L` *should* match via `KeyGesture.MatchesImpl`
+  (which honours `SystemKey`), but in practice the
+  `CommandManager` class-handler routing for that gesture
+  doesn't reliably fire `runCopyLatestLog` on a custom
+  `FrameworkElement` like `TerminalView`. Same family of
+  routing-flakiness we hit on Ctrl+V earlier in Stage 6.
+
+  Fix: handle Ctrl+Alt+L directly in
+  `TerminalView.HandleAppLevelShortcut`, the same path that
+  handles Ctrl+V and Ctrl+L. New `SetCopyLogToClipboardHandler`
+  callback wired by `Program.fs compose ()` invokes the
+  existing `runCopyLatestLog` handler. Both the direct path
+  AND the Window-level `KeyBinding` are wired now; whichever
+  fires first wins. Direct path is reliable; Window-level is
+  defence in depth.
+
+  Also fixed a related issue while in the area: the
+  `OnPreviewKeyDown` filter (AppReservedHotkeys check + NVDA-
+  modifier filter + HandleAppLevelShortcut) was reading
+  `e.Key` rather than the actual key, meaning `Alt`-modified
+  gestures (like the future Stage 10 `Alt+Shift+R` review-
+  mode toggle) would have failed similarly. Now reads
+  `(e.Key == Key.System) ? e.SystemKey : e.Key` everywhere
+  in the filter chain.
+
 - **Streaming-silence root cause: `PeriodicTimer` reuse bug in
   `Coalescer.runLoop`.** Diagnosed via the maintainer's manual
   NVDA verification on the post-Stage-6 preview, where typing

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -550,6 +550,19 @@ module Program =
         // to a maintainer without navigating Explorer.
         setupCopyLatestLogKeybinding window
 
+        // Post-PR-#106 fix — also wire Ctrl+Alt+L through the
+        // TerminalView's OnPreviewKeyDown direct-handling path.
+        // The Window-level KeyBinding above (setupCopyLatestLogKeybinding)
+        // SHOULD be sufficient on paper — KeyGesture.MatchesImpl
+        // honours WPF's e.SystemKey for Alt-modified gestures —
+        // but in practice the maintainer reported the gesture
+        // never reaches `runCopyLatestLog` on a current-main
+        // build. The direct path bypasses the unreliable
+        // CommandManager class-handler routing entirely.
+        // Both paths are wired; whichever fires first wins.
+        window.TerminalSurface.SetCopyLogToClipboardHandler(
+            Action(fun () -> runCopyLatestLog window))
+
         // Stage 5 — two-channel pipeline:
         //
         //   parser thread → notificationChannel (256, DropOldest)

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -62,6 +62,25 @@ public class TerminalView : FrameworkElement
     private Action<int, int>? _resize;
 
     /// <summary>
+    /// Post-PR-#106 fix — direct callback for the
+    /// `Ctrl+Alt+L` "copy active log to clipboard" hotkey.
+    /// Wired by <see cref="SetCopyLogToClipboardHandler"/> from
+    /// <c>Program.fs compose ()</c>. Bypasses the Window-level
+    /// `KeyBinding` route because that route doesn't reliably
+    /// fire for `Alt`-modified gestures on a custom
+    /// <see cref="FrameworkElement"/>: WPF reports
+    /// <c>e.Key == Key.System</c> + <c>e.SystemKey == Key.L</c>
+    /// for these events, and the `CommandManager`'s class
+    /// handler routing through Window-level `InputBindings`
+    /// has been observed to NOT fire `runCopyLatestLog` even
+    /// though `KeyGesture.MatchesImpl` should handle SystemKey.
+    /// Direct handling at the top of <see cref="OnPreviewKeyDown"/>
+    /// guarantees the gesture is processed regardless of the
+    /// vagaries of the WPF input pipeline.
+    /// </summary>
+    private Action? _copyActiveLogToClipboard;
+
+    /// <summary>
     /// Stage 6 PR-B — 200ms trailing-edge debounce for
     /// SizeChanged → ResizePseudoConsole. WPF SizeChanged fires
     /// per pixel during a window drag (60Hz); resizing the PTY
@@ -167,6 +186,19 @@ public class TerminalView : FrameworkElement
     {
         _writeBytes = writeBytes ?? throw new ArgumentNullException(nameof(writeBytes));
         _resize = resize ?? throw new ArgumentNullException(nameof(resize));
+    }
+
+    /// <summary>
+    /// Post-PR-#106 fix — wire the Ctrl+Alt+L handler. Called
+    /// from <c>Program.fs compose ()</c> with a closure that
+    /// invokes <c>runCopyLatestLog</c>. The handler must run on
+    /// the WPF dispatcher thread (it touches the clipboard);
+    /// our caller in OnPreviewKeyDown already runs on the
+    /// dispatcher so no marshalling needed.
+    /// </summary>
+    public void SetCopyLogToClipboardHandler(Action handler)
+    {
+        _copyActiveLogToClipboard = handler ?? throw new ArgumentNullException(nameof(handler));
     }
 
     /// <summary>
@@ -376,17 +408,24 @@ public class TerminalView : FrameworkElement
 
         var pressedModifiers = Keyboard.Modifiers;
 
+        // For Alt-modified gestures, WPF reports e.Key = Key.System
+        // and the actual key in e.SystemKey. Reading the "actual"
+        // key here makes downstream filters and HandleAppLevelShortcut
+        // work for Ctrl+Alt+L (and any future Alt-modified gesture
+        // like Stage 10's reserved Alt+Shift+R).
+        var actualKey = (e.Key == Key.System) ? e.SystemKey : e.Key;
+
         // 1. App-reserved hotkey check.
         foreach (var (key, modifiers, _) in AppReservedHotkeys)
         {
-            if (e.Key == key && pressedModifiers == modifiers)
+            if (actualKey == key && pressedModifiers == modifiers)
             {
                 return;
             }
         }
 
         // 2. NVDA / screen-reader modifier filter.
-        if (IsScreenReaderCandidate(e.Key))
+        if (IsScreenReaderCandidate(actualKey))
         {
             return;
         }
@@ -404,7 +443,7 @@ public class TerminalView : FrameworkElement
         // CommandManager / InputBinding routing — that route doesn't
         // fire reliably for a custom FrameworkElement, and any
         // CanExecute=false branch falls through to the encoder.
-        if (HandleAppLevelShortcut(e.Key, pressedModifiers))
+        if (HandleAppLevelShortcut(actualKey, pressedModifiers))
         {
             e.Handled = true;
             return;
@@ -412,7 +451,7 @@ public class TerminalView : FrameworkElement
 
         // 3. Translate.
         var keyMods = TranslateModifiers(pressedModifiers);
-        var keyCode = TranslateKey(e.Key);
+        var keyCode = TranslateKey(actualKey);
 
         // 4. Defer plain typing to OnPreviewTextInput.
         var ctrlOrAltHeld =
@@ -555,6 +594,20 @@ public class TerminalView : FrameworkElement
     /// </summary>
     private bool HandleAppLevelShortcut(Key key, ModifierKeys modifiers)
     {
+        // Ctrl+Alt+L → copy active log to clipboard.
+        // Handled FIRST and independent of _writeBytes because this
+        // gesture is meaningful even when no PTY host is attached
+        // (e.g. early in app lifecycle if compose() hasn't finished
+        // wiring SetPtyHost). Window-level KeyBinding routing for
+        // Alt-modified gestures has been observed not to fire on
+        // a custom FrameworkElement; direct handling here is the
+        // reliable path.
+        if (key == Key.L && modifiers == (ModifierKeys.Control | ModifierKeys.Alt))
+        {
+            _copyActiveLogToClipboard?.Invoke();
+            return true;
+        }
+
         if (_writeBytes is null) return false;
 
         // Ctrl+V / Shift+Insert → paste.


### PR DESCRIPTION
## Summary

Maintainer reported on a current-main build that **pressing `Ctrl+Alt+L` doesn't copy the active log to clipboard** — no "Log copied to clipboard" announcement, and the session log confirmed `runCopyLatestLog` never ran (no `[INF] [Terminal.App.Program.runCopyLatestLog] Ctrl+Alt+L pressed` entry).

## Root cause

WPF's input pipeline reports **Alt-modified key events with `e.Key == Key.System` and the actual key in `e.SystemKey`**. The Window-level `KeyBinding` on `Ctrl+Alt+L` *should* match via `KeyGesture.MatchesImpl` (which honours SystemKey), but in practice the `CommandManager` class-handler routing doesn't reliably fire `runCopyLatestLog` on a custom `FrameworkElement` like `TerminalView`.

Same family of routing flakiness Stage 6 hit on `Ctrl+V` — which we worked around by handling it directly in `HandleAppLevelShortcut`. Applying the same pattern here.

## Fix

Three changes:

1. **New `Action _copyActiveLogToClipboard` field on `TerminalView`** + `SetCopyLogToClipboardHandler` setter, wired from `Program.fs compose ()` to invoke the existing `runCopyLatestLog`.

2. **`HandleAppLevelShortcut` gains a `Ctrl+Alt+L` case.** Direct dispatch — the gesture is processed at the top of `OnPreviewKeyDown` and never depends on the Window-level routing that's been observed unreliable.

3. **SystemKey-aware filter throughout `OnPreviewKeyDown`.** AppReservedHotkeys check, `IsScreenReaderCandidate`, `HandleAppLevelShortcut`, and `TranslateKey` now read:
   ```csharp
   var actualKey = (e.Key == Key.System) ? e.SystemKey : e.Key;
   ```
   This future-proofs the reserved `Alt+Shift+R` gesture (Stage 10 review-mode toggle) — without this fix, that gesture would silently fail the same way `Ctrl+Alt+L` did.

The Window-level `KeyBinding` (existing `setupCopyLatestLogKeybinding`) stays wired as defence-in-depth. Both paths attempt to fire; whichever wins, wins. The direct path is now the reliable route.

## Test plan

- [ ] CI green
- [ ] All existing tests still pass (encoder + screen tests; no test-shape changes)
- [ ] **Manual NVDA verification on next preview:**
  - [ ] Launch pty-speak. Press `Ctrl+Alt+L`. NVDA should announce "Log copied to clipboard. N bytes; ready to paste."
  - [ ] Switch to a text editor or chat; paste — pty-speak's session log appears.
  - [ ] No regression in `Ctrl+V` paste, `Ctrl+L` clear-screen, `Ctrl+Shift+L` open-folder, `Ctrl+Shift+U` update, `Ctrl+Shift+D` diagnostic, `Ctrl+Shift+R` releases-form.
  - [ ] No regression in NVDA review-cursor (filter now uses `actualKey`; still filters Insert / CapsLock as expected).

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_