### PR TITLE
feat(logging): instrument the streaming-output path for diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added
+
+- **Streaming-path instrumentation.** Diagnostic log entries at
+  the five stages the streaming-output pipeline can silently
+  fail at. Each stage now leaves a metadata-only trace at INFO
+  level so a future bug-report log captures the exact stage
+  where the chain broke down rather than a black-box silence.
+  Stages instrumented:
+
+  1. **Reader publish** (`Terminal.App.startReaderLoop`) —
+     `Reader published RowsChanged. ChunkBytes={N} Events={M} ChannelAccepted={true|false}`
+  2. **Coalescer suppress / emit** (`Terminal.Core.Coalescer.processRowsChanged`,
+     `onTimerTick`) — distinguishes frame-dedup, spinner-
+     suppress, accumulate-into-debounce, leading-edge emit,
+     and trailing-edge emit. Each branch logs the frame hash
+     and (when emitting) the rendered text length.
+  3. **Drain dispatch** (`Terminal.App.Program.drain`) —
+     `Drain → Announce. ActivityId={tag} MsgLen={N}` for
+     non-empty messages; explicit `Drain skipped empty msg`
+     for ModeBarrier passes.
+  4. **Peer raise** (`PtySpeak.Views.TerminalView.Announce`) —
+     `RaiseNotificationEvent firing. ActivityId={tag}
+     MsgLen={N} Processing={MostRecent|ImportantAll|...}`
+     when peer is non-null; **`Announce skipped: peer was
+     null`** at WARN level when peer hasn't been created yet
+     (this would mean NVDA / a UIA client hasn't connected
+     and notifications are silently dropped — a critical
+     diagnostic signal).
+
+  All log entries are metadata-only (counts, hashes,
+  activity-IDs, levels). The streamed text content itself
+  is never logged, per the `docs/LOGGING.md` "What pty-speak
+  NEVER logs" policy and the `SECURITY.md` "Logging
+  chokepoint" entry.
+
+  Volume: at typing speed (~5 coalesced batches per second)
+  this adds ~25 log entries/second across all stages — a few
+  thousand lines for a 30-second `dir`-and-friends test
+  session. Acceptable for a diagnostic period; can be
+  lowered to Debug after the streaming bug is verified
+  fixed.
+
+  Together with PR #106's `PeriodicTimer` reuse fix and the
+  drain-task error-surfacing from earlier work, the
+  streaming-output pipeline is now fully observable: any
+  silence has a definite cause that the next captured log
+  will pinpoint.
+
 ### Fixed
 
 - **`Ctrl+Alt+L` clipboard-copy hotkey didn't fire.** Maintainer

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -60,6 +60,7 @@ module Program =
             (ct: CancellationToken) : Task =
         Task.Run(fun () ->
             task {
+                let logger = Logger.get "Terminal.App.startReaderLoop"
                 try
                     while not ct.IsCancellationRequested do
                         let! chunk = host.Stdout.ReadAsync(ct).AsTask()
@@ -81,7 +82,17 @@ module Program =
                                 // to read"). A future revision can
                                 // compute the row-set from screen
                                 // sequence number deltas.
-                                let _ = notifications.TryWrite(RowsChanged [])
+                                let written = notifications.TryWrite(RowsChanged [])
+                                // Streaming-path instrumentation:
+                                // log every reader-side publish so
+                                // we can verify the parser → channel
+                                // seam is alive when diagnosing
+                                // streaming-silence bugs. Metadata
+                                // only — chunk byte count and event
+                                // count — never the bytes themselves.
+                                logger.LogInformation(
+                                    "Reader published RowsChanged. ChunkBytes={ChunkBytes} Events={Events} ChannelAccepted={ChannelAccepted}",
+                                    chunk.Length, events.Length, written)
                                 ()
                 with
                 | :? OperationCanceledException -> ()
@@ -629,6 +640,7 @@ module Program =
         let _ =
             Task.Run(fun () ->
                 task {
+                    let drainLog = Logger.get "Terminal.App.Program.drain"
                     try
                         let reader = coalescedChannel.Reader
                         let mutable keepGoing = true
@@ -655,6 +667,15 @@ module Program =
                                             // "DECCKM application mode", etc.).
                                             "", ActivityIds.mode
                                     if msg <> "" then
+                                        // Streaming-path instrumentation:
+                                        // log every dispatch to Announce.
+                                        // Metadata only (activityId +
+                                        // length); never the message
+                                        // text itself, per security
+                                        // chokepoint policy.
+                                        drainLog.LogInformation(
+                                            "Drain → Announce. ActivityId={ActivityId} MsgLen={MsgLen}",
+                                            activityId, msg.Length)
                                         let action () =
                                             window.TerminalSurface.Announce(msg, activityId)
                                         let! _ =
@@ -662,6 +683,10 @@ module Program =
                                                 .InvokeAsync(Action(action))
                                                 .Task
                                         ()
+                                    else
+                                        drainLog.LogInformation(
+                                            "Drain skipped empty msg. ActivityId={ActivityId}",
+                                            activityId)
                     with
                     | :? OperationCanceledException -> ()
                     | ex ->

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -254,12 +254,24 @@ module Coalescer =
             (state: State)
             (now: DateTimeOffset)
             (snapshot: Cell[][]) : CoalescedNotification list =
+        // Streaming-path instrumentation. Defaults to NullLogger
+        // before Logger.configure runs (production sets this in
+        // Program.fs compose(); tests that don't configure get
+        // NullLogger and pay no cost). Each branch below logs the
+        // suppression reason or the emit so the diagnosis trail
+        // distinguishes "Coalescer dropped the event by design"
+        // from "Coalescer didn't see the event" from "Coalescer
+        // emitted but Drain didn't pick up".
+        let logger = Logger.get "Terminal.Core.Coalescer.processRowsChanged"
         let frameHash = hashFrame snapshot
         // Frame-level dedup: identical content → suppress
         // entirely. This is the layer that composes with
         // Ink's full-frame redraws.
         match state.LastFrameHash with
-        | ValueSome prev when prev = frameHash -> []
+        | ValueSome prev when prev = frameHash ->
+            logger.LogInformation(
+                "Suppressed (frame-dedup). FrameHash=0x{Hash:X16}", frameHash)
+            []
         | _ ->
             gcHistory state now
             // Spinner check: walk per-row hashes; if ANY row
@@ -274,6 +286,8 @@ module Coalescer =
                 // Update LastFrameHash so we don't re-suppress
                 // when content actually changes again.
                 state.LastFrameHash <- ValueSome frameHash
+                logger.LogInformation(
+                    "Suppressed (spinner). FrameHash=0x{Hash:X16}", frameHash)
                 []
             else
                 // Debounce decision: leading-edge or queue?
@@ -287,12 +301,19 @@ module Coalescer =
                     state.LastFlushAt <- ValueSome now
                     state.PendingFrame <- ValueNone
                     state.PendingHash <- ValueNone
-                    [ OutputBatch (renderRows snapshot) ]
+                    let rendered = renderRows snapshot
+                    logger.LogInformation(
+                        "Emit OutputBatch (leading-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
+                        frameHash, rendered.Length)
+                    [ OutputBatch rendered ]
                 else
                     // Within debounce: accumulate; trailing
                     // edge will flush.
                     state.PendingFrame <- ValueSome snapshot
                     state.PendingHash <- ValueSome frameHash
+                    logger.LogInformation(
+                        "Accumulated (within debounce window). FrameHash=0x{Hash:X16}",
+                        frameHash)
                     []
 
     /// Trailing-edge timer tick. If anything is pending and
@@ -300,6 +321,7 @@ module Coalescer =
     let onTimerTick
             (state: State)
             (now: DateTimeOffset) : CoalescedNotification list =
+        let logger = Logger.get "Terminal.Core.Coalescer.onTimerTick"
         match state.PendingFrame, state.PendingHash with
         | ValueSome snapshot, ValueSome hash ->
             let elapsed =
@@ -311,7 +333,11 @@ module Coalescer =
                 state.LastFlushAt <- ValueSome now
                 state.PendingFrame <- ValueNone
                 state.PendingHash <- ValueNone
-                [ OutputBatch (renderRows snapshot) ]
+                let rendered = renderRows snapshot
+                logger.LogInformation(
+                    "Emit OutputBatch (trailing-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
+                    hash, rendered.Length)
+                [ OutputBatch rendered ]
             else
                 []
         | _ -> []

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -299,14 +299,38 @@ public class TerminalView : FrameworkElement
         string activityId,
         AutomationNotificationProcessing processing)
     {
+        // Streaming-path instrumentation: log whether the UIA peer
+        // is actually present (peer creation is lazy — UIA clients
+        // like NVDA trigger it on first query) and whether the
+        // RaiseNotificationEvent call fired. Metadata only:
+        // activityId + length; never the message text itself, per
+        // SECURITY.md "Logging chokepoint" policy.
+        var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.Announce");
         var peer = UIElementAutomationPeer.FromElement(this);
         if (peer is not null)
         {
+            Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(
+                log,
+                "RaiseNotificationEvent firing. ActivityId={ActivityId} MsgLen={MsgLen} Processing={Processing}",
+                activityId, message.Length, processing);
             peer.RaiseNotificationEvent(
                 AutomationNotificationKind.Other,
                 processing,
                 message,
                 activityId);
+        }
+        else
+        {
+            // Peer is null when no UIA client (NVDA, Inspect.exe,
+            // etc.) has connected yet to trigger lazy peer creation.
+            // The Announce silently no-ops in this case; logging
+            // it tells us *that* it happened so a streaming-silence
+            // diagnosis doesn't need to guess whether the peer
+            // existed.
+            Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(
+                log,
+                "Announce skipped: peer was null. ActivityId={ActivityId} MsgLen={MsgLen}",
+                activityId, message.Length);
         }
     }
 


### PR DESCRIPTION
## Summary

Per maintainer's request: instrument the **streaming-output path** for diagnosis. Adds INFO-level log entries at the 5 stages the pipeline can silently fail at, so a future bug-report log captures the exact stage where the chain broke down rather than a black-box silence.

This is a follow-up safety-net to PR #106 (PeriodicTimer reuse fix). If the next preview test still has silent streaming despite #106, this log trail tells us exactly which stage failed:

| Stage | Log entry | Failure mode it catches |
|---|---|---|
| 1. Reader publish | `Reader published RowsChanged. ChunkBytes={N} Events={M} ChannelAccepted={true\|false}` | parser/reader broken; channel back-pressured |
| 2. Coalescer suppress | `Suppressed (frame-dedup\|spinner)` | spurious dedup or spinner suppression of legitimate output |
| 2. Coalescer accumulate | `Accumulated (within debounce window)` | normal debounce — ensures we see the trail |
| 2. Coalescer emit | `Emit OutputBatch (leading-edge\|trailing-edge). FrameHash=... TextLen=...` | confirms coalescer produced output |
| 3. Drain dispatch | `Drain → Announce. ActivityId={tag} MsgLen={N}` | confirms the drain task picked up the emit |
| 4. Peer raise (success) | `RaiseNotificationEvent firing. ActivityId={tag} MsgLen={N} Processing={...}` | confirms UIA event fired |
| 4. Peer raise (failure) | **WARN**: `Announce skipped: peer was null` | critical diagnostic — UIA client hasn't connected; notifications silently drop |

## Security posture

All entries are **metadata-only** — counts, hashes, activity-IDs, processing modes. **The streamed text content itself is never logged**, per `docs/LOGGING.md` "What pty-speak NEVER logs" and the `SECURITY.md` "Logging chokepoint" entry.

The frame-hash logging is intentional: hashes are FNV-1a 64-bit fingerprints; useful for confirming "the same frame keeps arriving" without revealing the underlying text.

## Volume

At typing speed (~5 coalesced batches/sec) this adds ~25 log entries/sec across all stages — a few thousand lines for a 30-second `dir` test session. Acceptable for a diagnostic period.

After the streaming bug is verified fixed on the next preview, these can be lowered to Debug as a tidy-up. Or kept at INFO if useful for ongoing diagnostics.

## Test plan

- [ ] CI green
- [ ] All existing tests still pass (Logger.get returns NullLogger before configure(), so test-side logging is silent and free)
- [ ] **Manual NVDA verification on next preview:**
  - [ ] Launch pty-speak, confirm cmd.exe banner reads
  - [ ] Type `dir` + Enter; confirm streaming output reads
  - [ ] Press `Ctrl+Alt+L` to copy session log
  - [ ] Paste log; verify trail of "Reader published RowsChanged → ... → Drain → Announce → RaiseNotificationEvent firing" entries
  - [ ] If streaming silent: the same trail tells us which stage broke

## Combined effect (with #106 + #108)

The streaming-output pipeline is now **fully observable**. Any silence has a definite cause that the next captured log will pinpoint. The diagnostic-loop iteration cost drops from "speculate, build, ship, test, repeat" to "test, paste log, ship targeted fix".

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_