### PR TITLE
fix: rebind log-copy to Ctrl+Shift+; restore Alt+F4 demote streaming logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,89 +15,109 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- **Streaming-path instrumentation.** Diagnostic log entries at
-  the five stages the streaming-output pipeline can silently
-  fail at. Each stage now leaves a metadata-only trace at INFO
-  level so a future bug-report log captures the exact stage
-  where the chain broke down rather than a black-box silence.
-  Stages instrumented:
+- **Log-copy hotkey rebound from `Ctrl+Alt+L` to
+  `Ctrl+Shift+;`** (the semicolon / colon key, immediately
+  to the right of `L` on a US-layout keyboard).
+  Maintainer-reported regressions on the post-#109 preview
+  drove the move:
 
-  1. **Reader publish** (`Terminal.App.startReaderLoop`) —
-     `Reader published RowsChanged. ChunkBytes={N} Events={M} ChannelAccepted={true|false}`
-  2. **Coalescer suppress / emit** (`Terminal.Core.Coalescer.processRowsChanged`,
-     `onTimerTick`) — distinguishes frame-dedup, spinner-
-     suppress, accumulate-into-debounce, leading-edge emit,
-     and trailing-edge emit. Each branch logs the frame hash
-     and (when emitting) the rendered text length.
-  3. **Drain dispatch** (`Terminal.App.Program.drain`) —
-     `Drain → Announce. ActivityId={tag} MsgLen={N}` for
-     non-empty messages; explicit `Drain skipped empty msg`
-     for ModeBarrier passes.
-  4. **Peer raise** (`PtySpeak.Views.TerminalView.Announce`) —
-     `RaiseNotificationEvent firing. ActivityId={tag}
-     MsgLen={N} Processing={MostRecent|ImportantAll|...}`
-     when peer is non-null; **`Announce skipped: peer was
-     null`** at WARN level when peer hasn't been created yet
-     (this would mean NVDA / a UIA client hasn't connected
-     and notifications are silently dropped — a critical
-     diagnostic signal).
+  1. `Ctrl+Alt+L` collides with the **Windows Magnifier**
+     zoom-in shortcut on some default Magnifier configs;
+     the OS swallowed the gesture before pty-speak saw it.
+  2. The original fix for `Ctrl+Alt+L` not firing (PR #108)
+     introduced a `SystemKey`-aware filter at the top of
+     `OnPreviewKeyDown` so that `Alt`-modified gestures (which
+     WPF reports as `e.Key == Key.System` + `e.SystemKey ==
+     Key.L`) were unwrapped to the underlying key. Side
+     effect: `Alt+F4` was unwrapped to `Key.F4 + Alt`, the
+     encoder produced bytes, `e.Handled` became `true`, and
+     the OS window-close gesture stopped working.
 
-  All log entries are metadata-only (counts, hashes,
-  activity-IDs, levels). The streamed text content itself
-  is never logged, per the `docs/LOGGING.md` "What pty-speak
-  NEVER logs" policy and the `SECURITY.md` "Logging
-  chokepoint" entry.
+  `Ctrl+Shift+;` is a clean Ctrl+Shift gesture: no Alt path,
+  no Magnifier collision, no SystemKey unwrap needed in the
+  filter chain. Removing the SystemKey unwrap restored
+  `Alt+F4` because `Key.System` falls through to
+  `KeyCode.Unhandled`, the encoder returns null, `e.Handled`
+  stays false, and WPF's default close handler fires.
 
-  Volume: at typing speed (~5 coalesced batches per second)
-  this adds ~25 log entries/second across all stages — a few
-  thousand lines for a 30-second `dir`-and-friends test
-  session. Acceptable for a diagnostic period; can be
-  lowered to Debug after the streaming bug is verified
-  fixed.
+  Mnemonic: physical proximity. The semicolon / colon key
+  sits right next to `L`, so `Ctrl+Shift+L` (open the logs
+  folder) and `Ctrl+Shift+;` (copy the active session log)
+  live under one hand position. `Ctrl+Shift+C` was
+  considered as the natural "copy" mnemonic but reserved
+  for a future copy-latest-command-output feature (the
+  cross-terminal convention for that gesture). `Ctrl+Shift+M`
+  was considered but stays reserved for the Stage 9 earcon
+  mute toggle. Layout caveat: on non-US keyboards the
+  `OemSemicolon` virtual-key sits in a different physical
+  position; remap support is on the Phase 2 user-settings
+  roadmap.
 
-  Together with PR #106's `PeriodicTimer` reuse fix and the
-  drain-task error-surfacing from earlier work, the
-  streaming-output pipeline is now fully observable: any
-  silence has a definite cause that the next captured log
-  will pinpoint.
+  Updated everywhere it was documented: README,
+  `docs/LOGGING.md`, `docs/USER-SETTINGS.md`,
+  `docs/ACCESSIBILITY-INTERACTION-MODEL.md`, the
+  `AppReservedHotkeys` table in `TerminalView.cs`, the
+  `setupCopyLatestLogKeybinding` wiring in `Program.fs`, and
+  the `HandleAppLevelShortcut` direct-dispatch path. The
+  `Ctrl+Shift+L` open-folder primary is unchanged.
+
+- **Streaming-path instrumentation demoted from `Information`
+  to `Debug`** so the production default sees no per-frame
+  log I/O. The PR #109 instrumentation at typing speed
+  produced ~25 entries/second across all stages, which
+  manifested as visible WPF dispatcher lag during streaming
+  output. Demoting the per-event entries (reader publish,
+  coalescer suppress / accumulate / emit, drain dispatch,
+  peer-present raise) leaves the trail intact for diagnosis
+  — set `PTYSPEAK_LOG_LEVEL=Debug` before launch to capture
+  the full chain — but keeps the steady-state log silent.
+  The peer-NULL `WARN` stays at `WARN` (rare, and the
+  smoking-gun signal that a UIA client never connected and
+  notifications are silently dropping). One-time entries
+  (runLoop start, cancellation, hotkey invocations) stay at
+  `Information`.
 
 ### Fixed
 
-- **`Ctrl+Alt+L` clipboard-copy hotkey didn't fire.** Maintainer
-  reported pressing the gesture on a current-main build and not
-  hearing the "Log copied to clipboard. N bytes" announcement;
-  the session log confirmed the handler never ran (no
-  `Ctrl+Alt+L pressed — copying active log to clipboard` entry).
+- **Log-copy hotkey didn't fire on the post-#103 preview.**
+  Maintainer reported pressing the gesture and not hearing the
+  "Log copied to clipboard. N bytes" announcement; the session
+  log confirmed the handler never ran. The Window-level
+  `KeyBinding` for the gesture was registered, but WPF's
+  `CommandManager` class-handler routing on a custom
+  `FrameworkElement` (`TerminalView`) didn't reliably fire
+  `runCopyLatestLog` — same family of routing flakiness that
+  bit `Ctrl+V` earlier in Stage 6.
 
-  Root cause: WPF's input pipeline reports `Alt`-modified key
-  events with `e.Key == Key.System` and the actual key in
-  `e.SystemKey`. The Window-level `KeyBinding` on
-  `Ctrl+Alt+L` *should* match via `KeyGesture.MatchesImpl`
-  (which honours `SystemKey`), but in practice the
-  `CommandManager` class-handler routing for that gesture
-  doesn't reliably fire `runCopyLatestLog` on a custom
-  `FrameworkElement` like `TerminalView`. Same family of
-  routing-flakiness we hit on Ctrl+V earlier in Stage 6.
-
-  Fix: handle Ctrl+Alt+L directly in
+  Fix: handle the gesture directly in
   `TerminalView.HandleAppLevelShortcut`, the same path that
-  handles Ctrl+V and Ctrl+L. New `SetCopyLogToClipboardHandler`
-  callback wired by `Program.fs compose ()` invokes the
-  existing `runCopyLatestLog` handler. Both the direct path
-  AND the Window-level `KeyBinding` are wired now; whichever
-  fires first wins. Direct path is reliable; Window-level is
-  defence in depth.
+  handles `Ctrl+V` and `Ctrl+L`. New
+  `SetCopyLogToClipboardHandler` callback wired by
+  `Program.fs compose ()` invokes the existing
+  `runCopyLatestLog` handler. Both the direct path AND the
+  Window-level `KeyBinding` are wired; whichever fires first
+  wins. Direct path is reliable; Window-level is defence in
+  depth.
 
-  Also fixed a related issue while in the area: the
-  `OnPreviewKeyDown` filter (AppReservedHotkeys check + NVDA-
-  modifier filter + HandleAppLevelShortcut) was reading
-  `e.Key` rather than the actual key, meaning `Alt`-modified
-  gestures (like the future Stage 10 `Alt+Shift+R` review-
-  mode toggle) would have failed similarly. Now reads
-  `(e.Key == Key.System) ? e.SystemKey : e.Key` everywhere
-  in the filter chain.
+- **`Alt+F4` window-close gesture stopped working** under the
+  PR #108 SystemKey-aware filter. WPF reports Alt-modified
+  gestures with `e.Key == Key.System` + the actual key in
+  `e.SystemKey`. The PR #108 filter unwrapped that to make
+  the original `Ctrl+Alt+L` reach the handler — but the same
+  unwrap converted `Alt+F4` into `Key.F4 + Alt`, the encoder
+  produced bytes, `e.Handled` became `true`, and the OS
+  window-close gesture died.
+
+  Fix: drop the SystemKey unwrap and rebind the log-copy
+  hotkey to `Ctrl+Shift+;` (a clean Ctrl+Shift gesture that
+  doesn't need the unwrap). `Key.System` now falls through
+  to `KeyCode.Unhandled`, the encoder returns null, `e.Handled`
+  stays false, and the OS default `Alt+F4` close handler
+  fires. If a future Alt-modified reserved hotkey (Stage 10's
+  `Alt+Shift+R`) is added, the unwrap can come back with an
+  explicit `Alt+F4` fall-through.
 
 - **Streaming-silence root cause: `PeriodicTimer` reuse bug in
   `Coalescer.runLoop`.** Diagnosed via the maintainer's manual
@@ -140,26 +160,33 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
-- **`Ctrl+Alt+L` copies the active session's log file content to
-  the clipboard.** Bundled with the logging-restructure work.
-  Pressing the hotkey reads the active log file (the one
+- **`Ctrl+Shift+;` copies the active session's log file content
+  to the clipboard.** Bundled with the logging-restructure
+  work. Pressing the hotkey reads the active log file (the one
   `FileLoggerSink.ActiveLogPath` points to), sets the OS
   clipboard, and announces the byte count via NVDA ("Log
   copied to clipboard. N bytes; ready to paste."). Fastest
   path to send a session log to a maintainer for bug-report
-  diagnosis — no File Explorer navigation required. Mnemonic:
-  alt-action paired with the existing `Ctrl+Shift+L` open-folder
-  primary.
+  diagnosis — no File Explorer navigation required.
 
-  Hotkey choice rationale: NOT `Ctrl+Shift+C`. The latter looks
-  intuitive (`C` = copy) but Ctrl-letter encoding folds Shift
-  in the keyboard pipeline, meaning `Ctrl+Shift+C` currently
-  sends `0x03` to the shell — that's the standard SIGINT /
-  Ctrl-Break gesture for interrupting a running command (e.g.
-  `ping localhost -t`). Claiming `Ctrl+Shift+C` for log-copy
-  would break shell-interrupt UX. `Ctrl+Alt+L` doesn't collide
-  with any shell encoding and isn't a printable on US
-  keyboards.
+  Hotkey-choice rationale. The semicolon / colon key sits
+  immediately to the right of `L` on a US-layout keyboard,
+  so it pairs by physical proximity with `Ctrl+Shift+L`
+  (open logs folder) — same hand position, two adjacent keys.
+  Other candidates considered and declined: `Ctrl+Alt+L` (the
+  original; collides with the Windows Magnifier zoom-in
+  shortcut, AND the `Alt`-modifier path through WPF's input
+  pipeline required a SystemKey-aware filter that broke
+  `Alt+F4`); `Ctrl+Shift+C` (the cross-terminal "copy"
+  convention but reserved here for a future
+  copy-latest-command-output feature, plus today it folds to
+  `0x03` / SIGINT in the keyboard encoder — claiming it
+  would lose the `Ctrl+Shift+C`-as-interrupt habit some
+  users have); `Ctrl+Shift+M` (stays reserved for the Stage 9
+  earcon mute toggle). Layout caveat: on non-US keyboards
+  the `OemSemicolon` virtual-key sits in a different
+  physical position; remap support is on the Phase 2
+  user-settings roadmap.
 
   Added to `AppReservedHotkeys`; wired in
   `setupCopyLatestLogKeybinding` in `Program.fs`. The handler
@@ -171,7 +198,7 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
   Documentation: README, USER-SETTINGS.md, and LOGGING.md
   updated with the new hotkey, the rationale, and a refreshed
   "Sharing logs with a maintainer" section that promotes
-  Ctrl+Alt+L as the fastest path.
+  `Ctrl+Shift+;` as the fastest path.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -154,15 +154,17 @@ preserve this list per the app-reserved-hotkey contract in
 - **`Ctrl+Shift+L`** — open the logs folder
   (`%LOCALAPPDATA%\PtySpeak\logs\`) in File Explorer. Useful for
   grabbing a previous session's log when reporting a bug.
-- **`Ctrl+Alt+L`** — copy the active session's log file content
-  to the clipboard. NVDA announces the byte count; switch to
-  the chat / email / issue and paste. The fastest way to send
-  a session log to a maintainer. See
-  [`docs/LOGGING.md`](docs/LOGGING.md) for what is and isn't
-  logged.
+- **`Ctrl+Shift+;`** — copy the active session's log file content
+  to the clipboard. The semicolon / colon key sits right next
+  to `L` on a US-layout keyboard, so it pairs by physical
+  proximity with the `Ctrl+Shift+L` open-folder primary. NVDA
+  announces the byte count; switch to the chat / email / issue
+  and paste. The fastest way to send a session log to a
+  maintainer. See [`docs/LOGGING.md`](docs/LOGGING.md) for what
+  is and isn't logged.
 
-Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute toggle),
-`Alt+Shift+R` (Stage 10 review-mode toggle).
+Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute
+toggle), `Alt+Shift+R` (Stage 10 review-mode toggle).
 
 The historical Stage 0 preview installer opens an empty window. Once
 the next preview is cut from the current `main`, the installer launches

--- a/docs/ACCESSIBILITY-INTERACTION-MODEL.md
+++ b/docs/ACCESSIBILITY-INTERACTION-MODEL.md
@@ -477,9 +477,12 @@ config substrate (catalogued in
 and send to a maintainer / contributor.
 
 **Current state:** Logging shipped (PR #102; logs at
-`%LOCALAPPDATA%\PtySpeak\logs\`). PR #103 in flight to
-add per-session files + `Ctrl+Alt+L` clipboard copy for
-one-keypress sharing.
+`%LOCALAPPDATA%\PtySpeak\logs\`). PR #103 added per-session
+files + `Ctrl+Shift+;` clipboard copy (semicolon key, next
+to `L` for proximity-pairing with `Ctrl+Shift+L` open-folder)
+for one-keypress sharing. The original `Ctrl+Alt+L` binding
+was moved because of a Windows Magnifier collision and a
+SystemKey-filter side effect on `Alt+F4`.
 
 ### W14 — Interrupt a stuck process
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -6,11 +6,14 @@ the logs easy to grab when reporting a bug or reviewing a
 session:
 
 - **`Ctrl+Shift+L`** — open the logs folder in File Explorer.
-- **`Ctrl+Alt+L`** — copy the active session's log file content
-  to the clipboard as a single string. NVDA announces the byte
-  count on success ("Log copied to clipboard. N bytes; ready to
-  paste."). Most efficient way to send a log to a maintainer:
-  press the hotkey, switch to the chat / email / issue, paste.
+- **`Ctrl+Shift+;`** — copy the active session's log file content
+  to the clipboard as a single string. The semicolon / colon
+  key is physically adjacent to `L` on a US-layout keyboard,
+  so the open-folder + copy-active-file pair lives under one
+  hand position. NVDA announces the byte count on success
+  ("Log copied to clipboard. N bytes; ready to paste."). Most
+  efficient way to send a log to a maintainer: press the hotkey,
+  switch to the chat / email / issue, paste.
 
 ## Where the logs live
 
@@ -142,14 +145,27 @@ any log site that risks leaking these categories.
 
 ## Sharing logs with a maintainer
 
-**Fastest path** — `Ctrl+Alt+L`:
+**Fastest path** — `Ctrl+Shift+;`:
 
 1. Reproduce the issue (or wait for it to happen — for the
    intermittent ones).
-2. **Press `Ctrl+Alt+L`.** NVDA announces "Log copied to
-   clipboard. N bytes; ready to paste." The active session's
-   entire log file is now on the clipboard.
+2. **Press `Ctrl+Shift+;`** (the semicolon / colon key, right
+   next to `L`). NVDA announces "Log copied to clipboard. N
+   bytes; ready to paste." The active session's entire log
+   file is now on the clipboard.
 3. Switch to the chat / email / issue and paste.
+
+> **Note:** the previous binding was `Ctrl+Alt+L`. It was moved
+> because (a) it collides with the Windows Magnifier zoom-in
+> shortcut on some Magnifier configs and (b) the Alt-modifier
+> path required a SystemKey-aware filter that interfered with
+> the OS `Alt+F4` window-close gesture. `Ctrl+Shift+C` was
+> considered as the natural "copy" mnemonic but reserved for
+> a future copy-latest-command-output feature; `Ctrl+Shift+;`
+> wins on physical proximity to `Ctrl+Shift+L` instead.
+> Layout caveat: on non-US keyboards the `OemSemicolon`
+> virtual-key sits in a different physical position; remap
+> support is on the Phase 2 user-settings roadmap.
 
 **Manual path** — `Ctrl+Shift+L`:
 

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -301,15 +301,20 @@ for future stages — listed inline below):
   (typed input, paste content, full screen contents,
   environment variables — never). Wired in
   `setupOpenLogsKeybinding`.
-- **`Ctrl+Alt+L`** — copy the active session's log file content
-  to the clipboard as a single string (Logging-restructure PR).
-  NVDA announces the byte count on success ("Log copied to
-  clipboard. N bytes; ready to paste."). Fastest path to send
-  a session log to a maintainer. NOT `Ctrl+Shift+C` —
-  Ctrl+Shift+C currently sends `0x03` (SIGINT) to the shell
-  via the Ctrl-letter encoding, and overriding that would
-  break the standard "press Ctrl+C to interrupt a running
-  command" gesture. Wired in `setupCopyLatestLogKeybinding`.
+- **`Ctrl+Shift+;`** — copy the active session's log file content
+  to the clipboard as a single string. The semicolon / colon
+  key is physically next to `L` on a US-layout keyboard, so it
+  pairs with the `Ctrl+Shift+L` open-folder primary by
+  proximity. NVDA announces the byte count on success ("Log
+  copied to clipboard. N bytes; ready to paste."). Fastest
+  path to send a session log to a maintainer. Hotkey-choice
+  history: the original binding was `Ctrl+Alt+L` (Magnifier
+  collision + the SystemKey filter for the Alt path broke
+  `Alt+F4`); `Ctrl+Shift+C` was considered but reserved for a
+  future copy-latest-command-output feature. Layout caveat:
+  on non-US keyboards the `OemSemicolon` virtual-key sits in
+  a different physical position. Wired in
+  `setupCopyLatestLogKeybinding`.
 - (planned) **`Ctrl+Shift+M`** — earcon mute toggle (Stage 9).
 - (planned) **`Alt+Shift+R`** — review-mode toggle (Stage 10).
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -83,14 +83,16 @@ module Program =
                                 // compute the row-set from screen
                                 // sequence number deltas.
                                 let written = notifications.TryWrite(RowsChanged [])
-                                // Streaming-path instrumentation:
-                                // log every reader-side publish so
-                                // we can verify the parser → channel
-                                // seam is alive when diagnosing
-                                // streaming-silence bugs. Metadata
-                                // only — chunk byte count and event
-                                // count — never the bytes themselves.
-                                logger.LogInformation(
+                                // Streaming-path instrumentation at
+                                // Debug — production default
+                                // (Information) is silent; flip the
+                                // min-level via env override to
+                                // capture the parser → channel seam
+                                // when diagnosing streaming-silence
+                                // bugs. Metadata only (chunk byte
+                                // count + event count); never the
+                                // bytes themselves.
+                                logger.LogDebug(
                                     "Reader published RowsChanged. ChunkBytes={ChunkBytes} Events={Events} ChannelAccepted={ChannelAccepted}",
                                     chunk.Length, events.Length, written)
                                 ()
@@ -426,25 +428,38 @@ module Program =
     /// Copy the active session's log file content to the
     /// system clipboard so the maintainer can paste it into a
     /// bug report without navigating File Explorer. Triggered
-    /// by `Ctrl+Alt+L` (mnemonic: alt-action paired with
-    /// `Ctrl+Shift+L` open-folder primary). Reads the file
-    /// pointed to by `FileLoggerSink.ActiveLogPath`, copies
-    /// the entire content as a single string, and announces
-    /// the byte count via NVDA on success.
+    /// by `Ctrl+Shift+;` (the semicolon / colon key, immediately
+    /// to the right of `L` on a US-layout keyboard). Pairs by
+    /// physical proximity with the `Ctrl+Shift+L` open-folder
+    /// primary: same hand position, two adjacent keys, "open
+    /// the folder | copy the active file". Reads the file
+    /// pointed to by `FileLoggerSink.ActiveLogPath`, copies the
+    /// entire content as a single string, and announces the
+    /// byte count via NVDA on success.
     ///
-    /// Hotkey choice: `Ctrl+Alt+L`, not `Ctrl+Shift+C`. The
-    /// latter looks intuitive (`C` = copy) but Ctrl-letter
-    /// encoding folds Shift in the keyboard encoder, meaning
-    /// `Ctrl+Shift+C` currently sends `0x03` to the shell
-    /// (the SIGINT / Ctrl-Break gesture) — claiming it for
-    /// log-copy would break shell-interrupt for commands like
-    /// `ping localhost -t`. `Ctrl+Alt+L` doesn't collide with
-    /// any shell encoding, doesn't produce a printable on US
-    /// keyboards, and pairs naturally with the existing
-    /// `Ctrl+Shift+L`.
+    /// Hotkey-choice history. The original binding was
+    /// `Ctrl+Alt+L` (paired with `Ctrl+Shift+L` open-folder).
+    /// Two production issues forced the move:
+    ///
+    /// 1. `Ctrl+Alt+L` is the Windows Magnifier "zoom-in"
+    ///    shortcut on some default Magnifier configurations,
+    ///    so the OS swallowed the gesture before it reached
+    ///    pty-speak.
+    /// 2. The `Alt`-modifier path through WPF's input pipeline
+    ///    delivers `e.Key = Key.System` + `e.SystemKey = Key.L`,
+    ///    which required a SystemKey-aware filter throughout
+    ///    `OnPreviewKeyDown` — and that filter then intercepted
+    ///    `Alt+F4`, breaking the OS window-close gesture.
+    ///
+    /// `Ctrl+Shift+C` was considered but reserved for a future
+    /// copy-latest-command-output feature (the cross-terminal
+    /// convention for that gesture). Layout caveat: on non-US
+    /// keyboards the `OemSemicolon` virtual-key sits in a
+    /// different physical position; remap when configurable
+    /// keybindings ship in Phase 2.
     let private runCopyLatestLog (window: MainWindow) : unit =
         let log = Logger.get "Terminal.App.Program.runCopyLatestLog"
-        log.LogInformation("Ctrl+Alt+L pressed — copying active log to clipboard.")
+        log.LogInformation("Ctrl+Shift+; pressed — copying active log to clipboard.")
         match loggerSink with
         | None ->
             window.TerminalSurface.Announce(
@@ -485,10 +500,10 @@ module Program =
                     sprintf "Could not copy log: %s" safe,
                     ActivityIds.error)
 
-    /// Wire `Ctrl+Alt+L` to trigger `runCopyLatestLog`.
+    /// Wire `Ctrl+Shift+;` to trigger `runCopyLatestLog`.
     let private setupCopyLatestLogKeybinding (window: MainWindow) : unit =
         let cmd = RoutedCommand("CopyLatestLog", typeof<MainWindow>)
-        let gesture = KeyGesture(Key.L, ModifierKeys.Control ||| ModifierKeys.Alt)
+        let gesture = KeyGesture(Key.OemSemicolon, ModifierKeys.Control ||| ModifierKeys.Shift)
         window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
         window.CommandBindings.Add(
             CommandBinding(
@@ -556,21 +571,20 @@ module Program =
         // Wire Ctrl+Shift+L to open the logs folder in File Explorer.
         setupOpenLogsKeybinding window
 
-        // Wire Ctrl+Alt+L to copy the active session's log file
+        // Wire Ctrl+Shift+; to copy the active session's log file
         // contents to the clipboard. Useful for sending the log
         // to a maintainer without navigating Explorer.
         setupCopyLatestLogKeybinding window
 
-        // Post-PR-#106 fix — also wire Ctrl+Alt+L through the
-        // TerminalView's OnPreviewKeyDown direct-handling path.
-        // The Window-level KeyBinding above (setupCopyLatestLogKeybinding)
-        // SHOULD be sufficient on paper — KeyGesture.MatchesImpl
-        // honours WPF's e.SystemKey for Alt-modified gestures —
-        // but in practice the maintainer reported the gesture
-        // never reaches `runCopyLatestLog` on a current-main
-        // build. The direct path bypasses the unreliable
-        // CommandManager class-handler routing entirely.
+        // Direct dispatch via TerminalView.OnPreviewKeyDown is
+        // kept as a defence-in-depth path because Window-level
+        // KeyBinding routing for custom FrameworkElements has
+        // been observed to flake (the Ctrl+V family of bugs).
         // Both paths are wired; whichever fires first wins.
+        // Ctrl+Shift+; is a plain Ctrl+Shift gesture so no
+        // SystemKey unwrap is needed in the filter chain — the
+        // PR #108 SystemKey filter was removed in this PR
+        // because it intercepted Alt+F4.
         window.TerminalSurface.SetCopyLogToClipboardHandler(
             Action(fun () -> runCopyLatestLog window))
 
@@ -667,13 +681,15 @@ module Program =
                                             // "DECCKM application mode", etc.).
                                             "", ActivityIds.mode
                                     if msg <> "" then
-                                        // Streaming-path instrumentation:
-                                        // log every dispatch to Announce.
-                                        // Metadata only (activityId +
-                                        // length); never the message
-                                        // text itself, per security
-                                        // chokepoint policy.
-                                        drainLog.LogInformation(
+                                        // Streaming-path instrumentation
+                                        // at Debug — same rationale as
+                                        // the reader and coalescer
+                                        // entries: production stays
+                                        // silent, env override flips on
+                                        // for diagnosis. Metadata only
+                                        // (activityId + length); never
+                                        // the message text.
+                                        drainLog.LogDebug(
                                             "Drain → Announce. ActivityId={ActivityId} MsgLen={MsgLen}",
                                             activityId, msg.Length)
                                         let action () =
@@ -684,7 +700,7 @@ module Program =
                                                 .Task
                                         ()
                                     else
-                                        drainLog.LogInformation(
+                                        drainLog.LogDebug(
                                             "Drain skipped empty msg. ActivityId={ActivityId}",
                                             activityId)
                     with

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -254,14 +254,16 @@ module Coalescer =
             (state: State)
             (now: DateTimeOffset)
             (snapshot: Cell[][]) : CoalescedNotification list =
-        // Streaming-path instrumentation. Defaults to NullLogger
-        // before Logger.configure runs (production sets this in
-        // Program.fs compose(); tests that don't configure get
-        // NullLogger and pay no cost). Each branch below logs the
-        // suppression reason or the emit so the diagnosis trail
-        // distinguishes "Coalescer dropped the event by design"
-        // from "Coalescer didn't see the event" from "Coalescer
-        // emitted but Drain didn't pick up".
+        // Streaming-path instrumentation. Per-event entries are
+        // emitted at Debug so the production default (Information)
+        // sees no per-frame I/O. Set the min-level to Debug via
+        // env-var override when reproducing a streaming-silence
+        // bug; the trail then distinguishes "Coalescer dropped
+        // the event by design" from "Coalescer didn't see the
+        // event" from "Coalescer emitted but Drain didn't pick
+        // up". Information-level was tried in PR #109 but
+        // produced enough log I/O at typing speed to lag the WPF
+        // dispatcher visibly; demoted to Debug here.
         let logger = Logger.get "Terminal.Core.Coalescer.processRowsChanged"
         let frameHash = hashFrame snapshot
         // Frame-level dedup: identical content → suppress
@@ -269,7 +271,7 @@ module Coalescer =
         // Ink's full-frame redraws.
         match state.LastFrameHash with
         | ValueSome prev when prev = frameHash ->
-            logger.LogInformation(
+            logger.LogDebug(
                 "Suppressed (frame-dedup). FrameHash=0x{Hash:X16}", frameHash)
             []
         | _ ->
@@ -286,7 +288,7 @@ module Coalescer =
                 // Update LastFrameHash so we don't re-suppress
                 // when content actually changes again.
                 state.LastFrameHash <- ValueSome frameHash
-                logger.LogInformation(
+                logger.LogDebug(
                     "Suppressed (spinner). FrameHash=0x{Hash:X16}", frameHash)
                 []
             else
@@ -302,7 +304,7 @@ module Coalescer =
                     state.PendingFrame <- ValueNone
                     state.PendingHash <- ValueNone
                     let rendered = renderRows snapshot
-                    logger.LogInformation(
+                    logger.LogDebug(
                         "Emit OutputBatch (leading-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
                         frameHash, rendered.Length)
                     [ OutputBatch rendered ]
@@ -311,7 +313,7 @@ module Coalescer =
                     // edge will flush.
                     state.PendingFrame <- ValueSome snapshot
                     state.PendingHash <- ValueSome frameHash
-                    logger.LogInformation(
+                    logger.LogDebug(
                         "Accumulated (within debounce window). FrameHash=0x{Hash:X16}",
                         frameHash)
                     []
@@ -334,7 +336,7 @@ module Coalescer =
                 state.PendingFrame <- ValueNone
                 state.PendingHash <- ValueNone
                 let rendered = renderRows snapshot
-                logger.LogInformation(
+                logger.LogDebug(
                     "Emit OutputBatch (trailing-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
                     hash, rendered.Length)
                 [ OutputBatch rendered ]

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -62,21 +62,31 @@ public class TerminalView : FrameworkElement
     private Action<int, int>? _resize;
 
     /// <summary>
-    /// Post-PR-#106 fix — direct callback for the
-    /// `Ctrl+Alt+L` "copy active log to clipboard" hotkey.
-    /// Wired by <see cref="SetCopyLogToClipboardHandler"/> from
-    /// <c>Program.fs compose ()</c>. Bypasses the Window-level
-    /// `KeyBinding` route because that route doesn't reliably
-    /// fire for `Alt`-modified gestures on a custom
-    /// <see cref="FrameworkElement"/>: WPF reports
-    /// <c>e.Key == Key.System</c> + <c>e.SystemKey == Key.L</c>
-    /// for these events, and the `CommandManager`'s class
-    /// handler routing through Window-level `InputBindings`
-    /// has been observed to NOT fire `runCopyLatestLog` even
-    /// though `KeyGesture.MatchesImpl` should handle SystemKey.
-    /// Direct handling at the top of <see cref="OnPreviewKeyDown"/>
-    /// guarantees the gesture is processed regardless of the
-    /// vagaries of the WPF input pipeline.
+    /// Direct callback for the `Ctrl+Shift+;` "copy active log
+    /// to clipboard" hotkey. Wired by
+    /// <see cref="SetCopyLogToClipboardHandler"/> from
+    /// <c>Program.fs compose ()</c>. Defence-in-depth path
+    /// alongside the Window-level `KeyBinding`, which has been
+    /// observed to flake for custom <see cref="FrameworkElement"/>s
+    /// (see the Ctrl+V family of bugs). Direct handling at the
+    /// top of <see cref="OnPreviewKeyDown"/> guarantees the
+    /// gesture reaches <c>runCopyLatestLog</c> regardless of
+    /// any quirks in WPF's CommandManager class routing.
+    ///
+    /// Hotkey-choice history: `Ctrl+Alt+L` was the original
+    /// binding but collided with the Windows Magnifier zoom-in
+    /// shortcut on some default Magnifier configs, AND required
+    /// a SystemKey-aware filter in this method that in turn
+    /// intercepted `Alt+F4`. `Ctrl+Shift+;` (the semicolon /
+    /// colon key, <see cref="Key.OemSemicolon"/>) was chosen for
+    /// proximity recall — physically adjacent to `L` (the
+    /// `Ctrl+Shift+L` open-folder primary) on a US-layout
+    /// keyboard. Reserves `Ctrl+Shift+C` for a future
+    /// copy-latest-command-output feature, which is the cross-
+    /// terminal convention for that gesture. Layout caveat: on
+    /// non-US layouts the `OemSemicolon` virtual-key may sit in
+    /// a different physical position; remap when configurable
+    /// keybindings ship in Phase 2.
     /// </summary>
     private Action? _copyActiveLogToClipboard;
 
@@ -189,12 +199,12 @@ public class TerminalView : FrameworkElement
     }
 
     /// <summary>
-    /// Post-PR-#106 fix — wire the Ctrl+Alt+L handler. Called
-    /// from <c>Program.fs compose ()</c> with a closure that
-    /// invokes <c>runCopyLatestLog</c>. The handler must run on
-    /// the WPF dispatcher thread (it touches the clipboard);
-    /// our caller in OnPreviewKeyDown already runs on the
-    /// dispatcher so no marshalling needed.
+    /// Wire the Ctrl+Shift+; handler. Called from
+    /// <c>Program.fs compose ()</c> with a closure that invokes
+    /// <c>runCopyLatestLog</c>. The handler must run on the WPF
+    /// dispatcher thread (it touches the clipboard); our caller
+    /// in OnPreviewKeyDown already runs on the dispatcher so no
+    /// marshalling needed.
     /// </summary>
     public void SetCopyLogToClipboardHandler(Action handler)
     {
@@ -299,17 +309,20 @@ public class TerminalView : FrameworkElement
         string activityId,
         AutomationNotificationProcessing processing)
     {
-        // Streaming-path instrumentation: log whether the UIA peer
-        // is actually present (peer creation is lazy — UIA clients
-        // like NVDA trigger it on first query) and whether the
-        // RaiseNotificationEvent call fired. Metadata only:
+        // Streaming-path instrumentation. The peer-present path
+        // logs at Debug (off by default; flip min-level via env
+        // override for diagnosis) so streaming output doesn't
+        // generate per-batch I/O on the dispatcher thread. The
+        // peer-NULL path stays at WARN — that's the diagnostic
+        // smoking gun (UIA client never connected; notifications
+        // silently dropping) and it's rare. Metadata only:
         // activityId + length; never the message text itself, per
         // SECURITY.md "Logging chokepoint" policy.
         var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.Announce");
         var peer = UIElementAutomationPeer.FromElement(this);
         if (peer is not null)
         {
-            Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(
+            Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(
                 log,
                 "RaiseNotificationEvent firing. ActivityId={ActivityId} MsgLen={MsgLen} Processing={Processing}",
                 activityId, message.Length, processing);
@@ -372,12 +385,19 @@ public class TerminalView : FrameworkElement
 
             // Logging-restructure PR — copy active session log to
             // clipboard. Bound in `setupCopyLatestLogKeybinding`.
-            // Mnemonic: alt-action paired with Ctrl+Shift+L
-            // open-folder primary. NOT Ctrl+Shift+C (that would
-            // collide with the Ctrl-letter shell-interrupt
-            // encoding, where Ctrl+Shift+C currently sends
-            // 0x03 / SIGINT to the running command).
-            (Key.L, ModifierKeys.Control | ModifierKeys.Alt, "Copy active log to clipboard"),
+            // Mnemonic: physical proximity — the semicolon /
+            // colon key sits right next to `L`, the
+            // `Ctrl+Shift+L` open-folder primary, on a US-layout
+            // keyboard. The pair "open the folder | copy the
+            // active file" lives under one hand position.
+            // Originally bound to Ctrl+Alt+L but moved because
+            // that gesture collides with the Windows Magnifier
+            // zoom-in shortcut AND required a SystemKey-aware
+            // filter that broke Alt+F4. Ctrl+Shift+C is left
+            // unclaimed for a future copy-latest-command-output
+            // feature (the cross-terminal convention for that
+            // gesture).
+            (Key.OemSemicolon, ModifierKeys.Control | ModifierKeys.Shift, "Copy active log to clipboard"),
 
             // Future entries (NOT yet bound; commented for
             // forward-planning):
@@ -395,8 +415,8 @@ public class TerminalView : FrameworkElement
     ///   <item><description><b>App-reserved hotkeys first.</b> Any match in
     ///   <see cref="AppReservedHotkeys"/> short-circuits and does NOT mark
     ///   the event handled, so the parent Window's InputBindings can fire
-    ///   the corresponding command (Ctrl+Shift+U / D / R today; future
-    ///   Ctrl+Shift+M, Alt+Shift+R when Stage 9 / 10 land).</description></item>
+    ///   the corresponding command (Ctrl+Shift+U / D / R / L / ; today;
+    ///   future Ctrl+Shift+M, Alt+Shift+R when Stage 9 / 10 land).</description></item>
     ///   <item><description><b>NVDA / screen-reader modifier filter
     ///   second.</b> Bare Insert / CapsLock presses, and Numpad presses
     ///   with NumLock off, return without Handled so NVDA / JAWS / Narrator
@@ -432,24 +452,31 @@ public class TerminalView : FrameworkElement
 
         var pressedModifiers = Keyboard.Modifiers;
 
-        // For Alt-modified gestures, WPF reports e.Key = Key.System
-        // and the actual key in e.SystemKey. Reading the "actual"
-        // key here makes downstream filters and HandleAppLevelShortcut
-        // work for Ctrl+Alt+L (and any future Alt-modified gesture
-        // like Stage 10's reserved Alt+Shift+R).
-        var actualKey = (e.Key == Key.System) ? e.SystemKey : e.Key;
+        // For Alt-modified gestures WPF reports e.Key == Key.System
+        // and the actual key in e.SystemKey. We deliberately do NOT
+        // unwrap that here: every reserved hotkey today is a clean
+        // Ctrl+Shift gesture (no Alt path), and unwrapping was found
+        // to intercept Alt+F4 — F4 reaches the encoder, gets bytes
+        // produced, e.Handled becomes true, and the OS window-close
+        // gesture dies. Letting Key.System fall through to
+        // TranslateKey returns KeyCode.Unhandled, the encoder
+        // returns null, e.Handled stays false, and WPF's default
+        // Alt+F4 close handler fires. If a future Alt-modified
+        // reserved hotkey (Stage 10's Alt+Shift+R review-mode
+        // toggle) lands, reintroduce the unwrap with an explicit
+        // Alt+F4 fall-through.
 
         // 1. App-reserved hotkey check.
         foreach (var (key, modifiers, _) in AppReservedHotkeys)
         {
-            if (actualKey == key && pressedModifiers == modifiers)
+            if (e.Key == key && pressedModifiers == modifiers)
             {
                 return;
             }
         }
 
         // 2. NVDA / screen-reader modifier filter.
-        if (IsScreenReaderCandidate(actualKey))
+        if (IsScreenReaderCandidate(e.Key))
         {
             return;
         }
@@ -467,7 +494,7 @@ public class TerminalView : FrameworkElement
         // CommandManager / InputBinding routing — that route doesn't
         // fire reliably for a custom FrameworkElement, and any
         // CanExecute=false branch falls through to the encoder.
-        if (HandleAppLevelShortcut(actualKey, pressedModifiers))
+        if (HandleAppLevelShortcut(e.Key, pressedModifiers))
         {
             e.Handled = true;
             return;
@@ -475,7 +502,7 @@ public class TerminalView : FrameworkElement
 
         // 3. Translate.
         var keyMods = TranslateModifiers(pressedModifiers);
-        var keyCode = TranslateKey(actualKey);
+        var keyCode = TranslateKey(e.Key);
 
         // 4. Defer plain typing to OnPreviewTextInput.
         var ctrlOrAltHeld =
@@ -618,15 +645,15 @@ public class TerminalView : FrameworkElement
     /// </summary>
     private bool HandleAppLevelShortcut(Key key, ModifierKeys modifiers)
     {
-        // Ctrl+Alt+L → copy active log to clipboard.
-        // Handled FIRST and independent of _writeBytes because this
+        // Ctrl+Shift+; → copy active log to clipboard. Handled
+        // FIRST and independent of _writeBytes because this
         // gesture is meaningful even when no PTY host is attached
-        // (e.g. early in app lifecycle if compose() hasn't finished
-        // wiring SetPtyHost). Window-level KeyBinding routing for
-        // Alt-modified gestures has been observed not to fire on
-        // a custom FrameworkElement; direct handling here is the
-        // reliable path.
-        if (key == Key.L && modifiers == (ModifierKeys.Control | ModifierKeys.Alt))
+        // (e.g. early in app lifecycle if compose() hasn't
+        // finished wiring SetPtyHost). Window-level KeyBinding
+        // routing has been observed to flake on custom
+        // FrameworkElements; direct handling here is the reliable
+        // path.
+        if (key == Key.OemSemicolon && modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
         {
             _copyActiveLogToClipboard?.Invoke();
             return true;


### PR DESCRIPTION
## Summary

Three regressions surfaced on the post-#109 preview, fixed together because they share an `OnPreviewKeyDown` / log-volume root area.

### 1. `Ctrl+Alt+L` log-copy hotkey didn't work + `Alt+F4` broken

- **`Ctrl+Alt+L` collides with the Windows Magnifier zoom-in shortcut** on some default Magnifier configs; the OS swallowed the gesture before pty-speak saw it.
- The PR #108 `SystemKey`-aware filter that fixed the original "Ctrl+Alt+L doesn't fire" bug **intercepted `Alt+F4`** as a side effect: the filter unwrapped `Key.System` + `SystemKey=F4` to `Key.F4` with Alt held, the encoder produced bytes, `e.Handled` became `true`, and the OS window-close gesture stopped working.

**Fix**: rebind log-copy to **`Ctrl+Shift+;`** (the semicolon / colon key, `OemSemicolon`), which is physically next to `L` on a US-layout keyboard, and **drop the SystemKey unwrap entirely**. `Key.System` now falls through `TranslateKey` to `KeyCode.Unhandled`, the encoder returns null, `e.Handled` stays false, and WPF's default `Alt+F4` close handler fires again.

Mnemonic: physical proximity — `Ctrl+Shift+L` (open logs folder) and `Ctrl+Shift+;` (copy active session log) live under one hand position. Other candidates considered:
- `Ctrl+Shift+C` — reserved for a future copy-latest-command-output feature (cross-terminal convention for that gesture).
- `Ctrl+Shift+M` — stays reserved for the Stage 9 earcon mute toggle.

Layout caveat: on non-US keyboards the `OemSemicolon` virtual-key sits in a different physical position; remap support is on the Phase 2 user-settings roadmap.

### 2. UI lag during streaming output

PR #109 instrumented the streaming-output path at `Information` level. At typing speed (~5 coalesced batches/sec) that produced ~25 log entries/sec across all stages, which manifested as visible WPF dispatcher lag.

**Fix**: demote per-event entries from `Information` to `Debug` — reader publish, coalescer suppress / accumulate / emit, drain dispatch, peer-present raise. Production default is silent; set `PTYSPEAK_LOG_LEVEL=Debug` before launch to capture the full chain when reproducing a streaming-silence bug.

Kept at `Information`/higher:
- `runLoop` start + clean cancellation (one-time)
- Hotkey-invocation entries (one per press)
- `Logger.LogWarning("Announce skipped: peer was null")` — the rare smoking-gun signal that a UIA client never connected and notifications are silently dropping.

### 3. Streaming silence (still open)

`echo hello` continues to read silent on the post-#109 preview. The instrumentation in this branch (now at `Debug`) will pinpoint the failure stage when the maintainer captures a log under `PTYSPEAK_LOG_LEVEL=Debug`. Diagnosis continues in a follow-up PR.

## Files

- `src/Views/TerminalView.cs` — drop SystemKey unwrap; `AppReservedHotkeys` entry → `(Key.OemSemicolon, Ctrl|Shift)`; `HandleAppLevelShortcut` → `Key.OemSemicolon`; demote per-Announce peer-present log to `Debug`.
- `src/Terminal.App/Program.fs` — `setupCopyLatestLogKeybinding` → `KeyGesture(Key.OemSemicolon, Ctrl|Shift)`; demote reader-publish + drain-dispatch logs to `Debug`; doc-comment rewrite for `runCopyLatestLog`.
- `src/Terminal.Core/Coalescer.fs` — demote five per-event entries (frame-dedup suppress, spinner suppress, leading-edge emit, accumulate, trailing-edge emit) to `Debug`.
- `README.md`, `docs/LOGGING.md`, `docs/USER-SETTINGS.md`, `docs/ACCESSIBILITY-INTERACTION-MODEL.md` — updated to `Ctrl+Shift+;` with proximity rationale + layout caveat.
- `CHANGELOG.md` — `[Unreleased]` updated: new "rebound log-copy + restored Alt+F4 + demoted streaming logs" entries; existing entries describing the binding flipped from `Ctrl+Alt+L` to `Ctrl+Shift+;`.
- `spec/tech-plan.md` — unchanged (Stage 9 `Ctrl+Shift+M` mute reservation intact).

## Test plan

- [ ] CI green on Build & test (windows-latest), actionlint, Markdown link check.
- [ ] All existing tests still pass (no test asserts on log levels for the demoted streaming-path entries).
- [ ] **Manual NVDA verification on next preview:**
  - [ ] `Alt+F4` closes the window (regression check on the SystemKey-unwrap removal).
  - [ ] `Ctrl+Shift+;` triggers "Log copied to clipboard. N bytes; ready to paste." NVDA announcement.
  - [ ] Streaming output (e.g. `echo hello`) — confirm whether UI lag is gone (instrumentation demotion).
  - [ ] If streaming still silent: relaunch with `PTYSPEAK_LOG_LEVEL=Debug`, repro, press `Ctrl+Shift+;` to copy log, paste.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_