### PR TITLE
fix: log-copy file lock; restore two INFO entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,41 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Ctrl+Shift+;` log-copy failed with "file is in use by
+  another process".** Maintainer-reported on the post-#111
+  preview. The clipboard handler used `File.ReadAllText(path)`
+  which opens the file with `FileShare.Read` (the overload's
+  default) — meaning "I tolerate other readers but no
+  writers." Since the `FileLogger` writer holds the file
+  open with `FileAccess.Write`, the OS rejected the read
+  open because it couldn't honor the reader's "no writers"
+  requirement when the writer was already there.
+
+  Fix: open the file via an explicit `FileStream` with
+  `FileShare.ReadWrite`, matching the writer's policy. The
+  writer is happy to coexist with concurrent readers
+  (Notepad, NVDA, the Ctrl+Shift+; handler), so the OS
+  grants the handle.
+
 ### Changed
+
+- **Restored two strategic INFO log entries that PR #111
+  over-demoted.** Coalescer "Emit OutputBatch (leading-edge
+  | trailing-edge)" and `TerminalView.Announce`
+  "RaiseNotificationEvent firing" are back at `Information`.
+  These are bounded by the coalescer's 200ms debounce
+  (~5 events/sec at typing speed; far below any I/O lag
+  threshold) and constitute the primary "is the streaming
+  pipeline alive?" signal at default log level — without
+  them, default logs show nothing of the streaming path,
+  and a streaming-silence bug requires the user to launch
+  with `PTYSPEAK_LOG_LEVEL=Debug` to capture any trace at
+  all. The other PR #109 entries (reader publish, suppress,
+  accumulate, drain dispatch) stay at `Debug` to keep the
+  steady-state volume low; flip to Debug for full-chain
+  diagnosis when needed.
 
 - **Log-copy hotkey rebound from `Ctrl+Alt+L` to
   `Ctrl+Shift+;`** (the semicolon / colon key, immediately

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -473,7 +473,30 @@ module Program =
                         "Active log file does not exist yet; press a key or wait for an event first.",
                         ActivityIds.error)
                 else
-                    let content = System.IO.File.ReadAllText(path)
+                    // Read with FileShare.ReadWrite to match the
+                    // FileLogger writer's open mode. Using
+                    // File.ReadAllText here previously failed with
+                    // "The process cannot access the file because
+                    // it is being used by another process" — the
+                    // overload defaults to FileShare.Read, which
+                    // means "I tolerate other readers but no
+                    // writers." Since the writer IS holding the
+                    // file with write access, the OS rejected the
+                    // read open. FileShare.ReadWrite advertises
+                    // "I tolerate readers AND writers", which
+                    // matches the writer's policy and lets the
+                    // OS grant the handle.
+                    let content =
+                        use stream =
+                            new System.IO.FileStream(
+                                path,
+                                System.IO.FileMode.Open,
+                                System.IO.FileAccess.Read,
+                                System.IO.FileShare.ReadWrite)
+                        use reader =
+                            new System.IO.StreamReader(
+                                stream, System.Text.Encoding.UTF8)
+                        reader.ReadToEnd()
                     // Clipboard.SetText must run on the WPF
                     // dispatcher thread (STA). The hotkey
                     // handler already runs there, so direct

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -304,7 +304,12 @@ module Coalescer =
                     state.PendingFrame <- ValueNone
                     state.PendingHash <- ValueNone
                     let rendered = renderRows snapshot
-                    logger.LogDebug(
+                    // INFO — emit entries are bounded by the
+                    // 200ms debounce (~5/sec max) and are the
+                    // primary signal that the streaming pipeline
+                    // is alive. Suppress / accumulate entries
+                    // stay at Debug.
+                    logger.LogInformation(
                         "Emit OutputBatch (leading-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
                         frameHash, rendered.Length)
                     [ OutputBatch rendered ]
@@ -336,7 +341,7 @@ module Coalescer =
                 state.PendingFrame <- ValueNone
                 state.PendingHash <- ValueNone
                 let rendered = renderRows snapshot
-                logger.LogDebug(
+                logger.LogInformation(
                     "Emit OutputBatch (trailing-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
                     hash, rendered.Length)
                 [ OutputBatch rendered ]

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -310,19 +310,21 @@ public class TerminalView : FrameworkElement
         AutomationNotificationProcessing processing)
     {
         // Streaming-path instrumentation. The peer-present path
-        // logs at Debug (off by default; flip min-level via env
-        // override for diagnosis) so streaming output doesn't
-        // generate per-batch I/O on the dispatcher thread. The
-        // peer-NULL path stays at WARN — that's the diagnostic
-        // smoking gun (UIA client never connected; notifications
-        // silently dropping) and it's rare. Metadata only:
-        // activityId + length; never the message text itself, per
-        // SECURITY.md "Logging chokepoint" policy.
+        // logs at INFO — bounded by the coalescer's 200ms
+        // debounce (~5 emits/sec max), so the volume is well
+        // below any I/O lag threshold and the entry is the
+        // primary "did the announcement actually fire?" signal
+        // for streaming-silence diagnosis. The peer-NULL path
+        // stays at WARN: rare, and the smoking-gun signal that
+        // a UIA client never connected and notifications are
+        // silently dropping. Metadata only: activityId + length;
+        // never the message text itself, per SECURITY.md
+        // "Logging chokepoint" policy.
         var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.Announce");
         var peer = UIElementAutomationPeer.FromElement(this);
         if (peer is not null)
         {
-            Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(
+            Microsoft.Extensions.Logging.LoggerExtensions.LogInformation(
                 log,
                 "RaiseNotificationEvent firing. ActivityId={ActivityId} MsgLen={MsgLen} Processing={Processing}",
                 activityId, message.Length, processing);


### PR DESCRIPTION
## Summary

Two regressions surfaced on the post-#111 preview, fixed together because they share the streaming-output diagnosis workflow.

### 1. `Ctrl+Shift+;` failed with "file is in use by another process"

Maintainer-reported. The clipboard handler used `File.ReadAllText(path)`, which opens the file with `FileShare.Read` (the overload's default) — meaning "I tolerate other readers but no writers." Since the `FileLogger` writer holds the file open with `FileAccess.Write`, the OS rejected the read open because it couldn't honor the reader's "no writers" requirement when the writer was already there.

**Fix**: open the file via an explicit `FileStream` with `FileShare.ReadWrite`, matching the writer's policy. The writer is happy to coexist with concurrent readers (Notepad, NVDA, the Ctrl+Shift+; handler), so the OS grants the handle.

### 2. Default-log-level observability for the streaming pipeline was lost

PR #111 demoted the entire PR #109 instrumentation set to `Debug` to fix UI lag. That over-corrected: at the production default (`Information`) the maintainer's logs now contain zero trace of the streaming-output pipeline, which makes the still-open streaming-silence bug undiagnosable without setting `PTYSPEAK_LOG_LEVEL=Debug`.

**Fix**: restore two strategic entries to `Information`:
- Coalescer "Emit OutputBatch (leading-edge | trailing-edge)"
- `TerminalView.Announce` "RaiseNotificationEvent firing"

These are bounded by the coalescer's 200ms debounce (~5 events/sec at typing speed; well below any I/O lag threshold) and constitute the primary "is the streaming pipeline alive?" signal. They're the minimum needed to localize a streaming-silence bug to coalescer-emit / drain-dispatch / peer-raise from a default-level log.

Suppress / accumulate / reader-publish / drain-dispatch entries **stay at `Debug`** — flip `PTYSPEAK_LOG_LEVEL=Debug` for full-chain diagnosis when needed.

## Out of scope (filed separately)

The underlying **input-lag** the maintainer reported (typed-character speech taking ~1s instead of ~200ms) is rooted in the coalescer emitting the **entire screen** on every keystroke via `renderRows`, which causes NVDA to read the full `C:\path>` prompt + char each keystroke (with `MostRecent` notification preemption restarting the speech mid-sentence). Not a regression from #111 — a Stage 5 design issue that only became audible once PR #106 fixed the coalescer crash. The right fix is **suffix-diff emission**, but it has NVDA-verbosity trade-offs (typed-char-echo deduplication, paste handling) that need design discussion.

Tracked in a separate issue.

## Test plan

- [ ] CI green on Build & test (windows-latest), actionlint, Markdown link check.
- [ ] All existing tests still pass (no test asserts on the demoted/promoted entries; the promotions are at the `LogInformation` extension method level only).
- [ ] **Manual NVDA verification on next preview:**
  - [ ] `Ctrl+Shift+;` produces "Log copied to clipboard. N bytes; ready to paste." instead of the file-in-use error.
  - [ ] Default-log-level (`Information`) trace of `dir` shows entries from `Terminal.Core.Coalescer.processRowsChanged` ("Emit OutputBatch") AND `PtySpeak.Views.TerminalView.Announce` ("RaiseNotificationEvent firing"). Their absence pinpoints the failure stage.
  - [ ] Capture log via `Ctrl+Shift+;` after reproducing streaming silence; paste back for diagnosis.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_