### PR TITLE
fix(coalescer): remove broken any-hash spinner gate (root cause of streaming silence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Fixed
 
+- **Streaming output was permanently silent.** Root cause:
+  the coalescer's "any-hash-anywhere" spinner gate was
+  fundamentally broken. It triggered when
+  `AllHashHistory.Count >= 20`, but every call to
+  `processRowsChanged` iterates all 30 screen rows and
+  appends to that same history — so a single user event
+  added 30 entries, instantly exceeding the 20-entry
+  threshold. Once tripped, every subsequent event added
+  another 30 entries faster than the 1-second sliding
+  window could drain them, so the gate stayed permanently
+  triggered for the entire session. Net effect: the
+  cmd.exe banner, every typed character, and every command
+  output were all silently suppressed at the coalescer
+  before the dispatcher / NVDA path ever saw them.
+
+  Diagnosed from a `PTYSPEAK_LOG_LEVEL=Debug` capture on
+  the post-#114 preview where every `Reader published
+  RowsChanged` entry was followed by `Suppressed (spinner)`
+  — including the very first 16-byte cmd.exe banner chunk.
+  No real spinner was running; the heuristic was firing on
+  legitimate output.
+
+  Fix: remove the broken any-hash-anywhere gate entirely.
+  The per-`(rowIdx, hash)` gate (the OTHER spinner check,
+  which fires when the same row state recurs ≥5 times in
+  1s) handles the common spinner case (`|/-\` cycling on
+  one cell) correctly and stays in place. Cross-row
+  spinner detection — the original motivation for the
+  any-hash gate — is filed as a follow-up issue with a
+  proper redesign brief: count unique-hash recurrences,
+  not total entries.
+
+  Tests unchanged: existing `CoalescerTests.fs` covers
+  the per-key gate; nothing covered the broken any-hash
+  gate, so removing it doesn't regress any tested
+  behaviour.
+
 - **`Ctrl+Shift+;` log-copy failed with "file is in use by
   another process".** Maintainer-reported on the post-#111
   preview. The clipboard handler used `File.ReadAllText(path)`

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -39,10 +39,18 @@ open Microsoft.Extensions.Logging
 ///     layer, every row hash changes per redraw and
 ///     per-row dedup never fires).
 ///   * **Spinner heuristic.** Sliding window keyed by
-///     `(rowIdx, hash)` AND a generic
-///     "any-hash-anywhere ≥5 in last 1s" gate. Suppresses
-///     repeated frames at high rate (e.g. spinners that
-///     wrap row indices).
+///     `(rowIdx, hash)`. Suppresses repeated frames at high
+///     rate (e.g. spinners that overwrite the same row's
+///     content with cycling characters — `|/-\` etc.). The
+///     original Stage 5 design also included a generic
+///     "any-hash-anywhere" gate intended to catch cross-row
+///     spinners, but its count-of-total-entries threshold
+///     was fundamentally incompatible with the per-row scan
+///     (every event added one entry per row of the screen,
+///     and 30 rows instantly exceeded the 20-entry threshold,
+///     producing permanent silence). Removed in the post-#114
+///     fix; cross-row spinner detection is a future
+///     improvement tracked separately.
 ///   * **Debounce.** Leading-edge + trailing-edge: first
 ///     event in an idle period (no flush in last 200ms)
 ///     emits immediately for fast single-event UX
@@ -182,9 +190,11 @@ module Coalescer =
         | ModeBarrier of flag: TerminalModeFlag * value: bool
 
     /// Spinner-suppression key: the per-row hash plus the row
-    /// index it came from. The "any-hash-anywhere" generic
-    /// gate uses just the hash (key-by-uint64-hash without
-    /// the index).
+    /// index it came from. A spinner that overwrites the same
+    /// cell with cycling characters (`|/-\` etc.) generates
+    /// the same `(rowIdx, hash)` tuple repeatedly across each
+    /// cycle, which the per-key history catches once the
+    /// recurrence count crosses the threshold.
     type private SpinnerKey = int * uint64
 
     /// Coalescer's mutable state. Owned by the single reader
@@ -196,16 +206,14 @@ module Coalescer =
           mutable LastFlushAt: DateTimeOffset voption
           mutable PendingFrame: Cell[][] voption
           mutable PendingHash: uint64 voption
-          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
-          AllHashHistory: ResizeArray<DateTimeOffset> }
+          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>> }
 
     let internal createState () : State =
         { LastFrameHash = ValueNone
           LastFlushAt = ValueNone
           PendingFrame = ValueNone
           PendingHash = ValueNone
-          PerRowHistory = Dictionary()
-          AllHashHistory = ResizeArray() }
+          PerRowHistory = Dictionary() }
 
     /// Trim history older than `spinnerWindow`. Mutates in
     /// place. Called on every event arrival to keep histories
@@ -218,7 +226,6 @@ module Coalescer =
             if kvp.Value.Count = 0 then staleKeys.Add(kvp.Key)
         for k in staleKeys do
             state.PerRowHistory.Remove(k) |> ignore
-        state.AllHashHistory.RemoveAll(fun ts -> ts < cutoff) |> ignore
 
     /// Test whether this frame should be suppressed by the
     /// spinner heuristic. Records the timestamps even on
@@ -237,9 +244,7 @@ module Coalescer =
                 state.PerRowHistory.[key] <- h
                 h
         history.Add(now)
-        state.AllHashHistory.Add(now)
         history.Count >= spinnerThreshold
-        || state.AllHashHistory.Count >= spinnerThreshold * 4
 
     /// Decide what (if anything) to emit for an incoming
     /// `RowsChanged []` notification. Reads the current
@@ -371,7 +376,6 @@ module Coalescer =
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueSome now
         state.PerRowHistory.Clear()
-        state.AllHashHistory.Clear()
         flushed @ [ ModeBarrier (flag, value) ]
 
     /// Pass-through for parser errors. No coalescing — errors


### PR DESCRIPTION
## Summary

**Root cause of the streaming-silence symptom** the maintainer reported on the post-#114 preview. `PTYSPEAK_LOG_LEVEL=Debug` capture proved it: every `Reader published RowsChanged` entry was followed by `Suppressed (spinner)` — including the very first 16-byte cmd.exe banner chunk, when no real spinner was running.

## The bug

`Coalescer.isSpinnerSuppressed` had two gates:

1. **Per-`(rowIdx, hash)` recurrence** — counts how many times the same row state has been seen at the same row index within 1s. Fires correctly for `|/-\` style spinners that overwrite the same cell with cycling characters.
2. **Any-hash-anywhere total-count gate** — counts ALL hash entries observed in `AllHashHistory`, threshold = `spinnerThreshold * 4` = 20.

The any-hash gate was fundamentally broken. Every `processRowsChanged` call iterates the 30-row screen and calls `isSpinnerSuppressed` for each row, which appends to `AllHashHistory`. **A single user event added 30 entries**, instantly exceeding the 20-entry threshold. Each subsequent event added another 30 entries faster than the 1-second sliding window could drain them. Once tripped, the gate stayed permanently triggered for the rest of the session.

Net effect: the cmd.exe banner, every typed character, and every command output were all silently suppressed at the coalescer before the dispatcher / NVDA path ever saw them.

## Diagnosis trail

The maintainer pasted a Debug-level log captured via `PTYSPEAK_LOG_LEVEL=Debug` after the post-#114 preview cycle:

```
21:42:40.387 [DBG] Reader published RowsChanged. ChunkBytes=16 Events=2 ChannelAccepted=True
21:42:40.395 [DBG] Suppressed (spinner). FrameHash=0x9C42FA1563500E3D
21:42:40.397 [DBG] Reader published RowsChanged. ChunkBytes=97 Events=49 ChannelAccepted=True
21:42:40.399 [DBG] Suppressed (spinner). FrameHash=0x900E32746BD264FB
21:42:40.405 [DBG] Reader published RowsChanged. ChunkBytes=113 Events=98 ChannelAccepted=True
21:42:40.405 [DBG] Suppressed (spinner). FrameHash=0x01532228A03A88B2
... [pattern continues for the entire session]
```

Every event suppressed. Even the 16-byte first chunk of the cmd.exe banner — when there is no possible 1-second history of recurrences yet.

## Fix

Remove the any-hash-anywhere gate entirely along with its backing field (`State.AllHashHistory`), the corresponding entry in `gcHistory`, and the `Clear()` call in the mode-change barrier. The per-`(rowIdx, hash)` gate handles the common single-cell spinner case correctly and stays in place.

## Files

- `src/Terminal.Core/Coalescer.fs` — drop `AllHashHistory` field, `Add`, `RemoveAll`, `Clear`, threshold check; update module-level docstring + `SpinnerKey` docstring to reflect the simplified design.
- `CHANGELOG.md` — `[Unreleased]` Fixed entry with the full diagnosis trail.

## Out of scope (filed separately)

Cross-row spinner detection — the original motivation for the any-hash gate — needs a proper redesign that counts **unique-hash recurrences**, not total entries. Tracked as a follow-up issue. Stage-5-era code for the broken gate did the wrong thing; cleanly removing it now leaves room for the right design later.

## Test plan

- [ ] CI green on Build & test (windows-latest), actionlint, Markdown link check.
- [ ] All existing `CoalescerTests` still pass — they cover the per-key gate only; nothing tested the broken any-hash gate.
- [ ] **Manual NVDA verification on next preview:**
  - [ ] cmd.exe banner reads on launch.
  - [ ] `echo hello` produces NVDA speech.
  - [ ] `dir` produces NVDA speech (multi-line output).
  - [ ] Default-log-level (`Information`) trace shows `Emit OutputBatch` entries (was: zero entries; should now be one per coalesced batch).

## Related

- #114 — fixed the file-lock blocker so the maintainer could capture the Debug log that diagnosed THIS bug.
- #115 — coalescer suffix-diff emission (separate UX issue: even with this fix, NVDA reads the whole frame on every emit, so typing produces verbose readback).
- Stage 5 plan in `docs/SESSION-HANDOFF.md` (historical) — described the any-hash gate as catching cross-row spinners; the design intent was correct but the implementation was incompatible with the per-row scan.

https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZEWHADXq7SrsxS44wSNh)_