### PR TITLE
chore: drop unused FluentAssertions package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2409,6 +2409,16 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
   The file's other smoke ("Terminal.Core assembly loads") is
   preserved as a project-reference / type-loading sanity check.
 
+- **Unused `FluentAssertions` package dependency.** The package was
+  pinned in `Directory.Packages.props` and referenced in
+  `tests/Tests.Unit/Tests.Unit.fsproj` but no test file used it
+  (no `open FluentAssertions` / `using FluentAssertions` anywhere
+  in the codebase). The project's testing convention is xUnit +
+  FsCheck.Xunit (per `CONTRIBUTING.md` § Tests); FluentAssertions
+  was never adopted. Removing the dead reference shrinks the
+  restore graph and removes a meaningless dependency-update
+  surface for Dependabot.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FlaUI.Core" Version="5.0.0" />
     <PackageVersion Include="FlaUI.UIA3" Version="5.0.0" />
     <!--

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -41,7 +41,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FsCheck.Xunit" />
-    <PackageReference Include="FluentAssertions" />
     <!--
       Stage 5 — FakeTimeProvider so CoalescerTests can pin
       debounce + spinner-window assertions deterministically


### PR DESCRIPTION
The FluentAssertions NuGet package was pinned in
Directory.Packages.props and referenced from
tests/Tests.Unit/Tests.Unit.fsproj, but no test file actually uses it. The project's testing convention is xUnit + FsCheck.Xunit (per CONTRIBUTING.md), and FluentAssertions was never adopted.

Removes the package version + project reference, plus a CHANGELOG [Unreleased] Removed entry. Shrinks the restore graph and removes a meaningless dependency-update surface for Dependabot.

No code changes; no test changes.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
