### PR TITLE
feat(logging): refine session filename to yyyy-MM-dd-HH-mm-ss-fff (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1251,6 +1251,54 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Changed
 
+- **Per-session log filenames now use full date+time + millisecond
+  tie-breaker** ([#107](https://github.com/KyleKeane/pty-speak/issues/107),
+  Option A). Filename scheme moves from
+  `pty-speak-HH-mm-ss.log` to
+  `pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log`; day folders stay
+  `yyyy-MM-dd`. Two motivating concerns:
+
+  1. **Self-describing when extracted.** The old filename
+     dropped the date because the day-folder carried it; the
+     moment a user copied a single log out of its folder
+     (email attachment, paste into a bug report, drag into a
+     chat) it lost its date context and became hard to
+     correlate with the session it described. Embedding the
+     full date in the filename keeps it self-describing
+     anywhere it lands.
+
+  2. **Uniqueness when the second tier collides.** Two
+     launches in the same UTC second produced identical
+     filenames under the old scheme; Issue #107's three
+     candidate tie-breakers (millisecond suffix, short UUID,
+     incremental counter) settled on milliseconds via Option
+     A — alphabetical sort still equals chronological sort,
+     no UUID-readability cost, no concurrent-counter retry
+     code path. Two launches inside the same millisecond
+     remain a theoretical collision but are vanishingly
+     unlikely for human-launched terminal sessions.
+
+  Affected code: `src/Terminal.Core/FileLogger.fs`'s
+  `pathsForLaunch ()` (one-line format-string change) plus
+  the doc-comment file-layout example. Tests:
+  `tests/Tests.Unit/FileLoggerTests.fs` gains a
+  `assertSessionFilenameFormat` helper that parses the
+  filename through `DateTime.TryParseExact` against the new
+  format string; the two existing tests
+  (`active log lives inside a day-folder named yyyy-MM-dd`
+  and `ActiveLogPath member exposes the per-session file
+  inside today's day-folder`) tighten via the helper, plus
+  a new test
+  (`session filename uses yyyy-MM-dd-HH-mm-ss-fff format per
+  Issue #107`) pins the parsed timestamp within 5 seconds of
+  `DateTime.UtcNow` so the format reflects the launch
+  instant rather than random digits. `docs/LOGGING.md`
+  example tree updated. `tests/Tests.Unit/FileLoggerTests.fs`
+  retention-sweep test fixtures use derived filenames
+  (`pty-speak-{stale-or-fresh-yyyy-MM-dd}-12-00-00-000.log`)
+  so the placeholder filenames match their day-folder for
+  readability.
+
 - **Restored two strategic INFO log entries that PR #111
   over-demoted.** Coalescer "Emit OutputBatch (leading-edge
   | trailing-edge)" and `TerminalView.Announce`
@@ -1333,27 +1381,28 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
   folders.** The previous layout kept one daily-rolled file
   per UTC day; long-running development days produced massive
   aggregated files that were painful to navigate when grabbing
-  a slice for a bug report. New layout:
+  a slice for a bug report. New layout (filename refined per
+  Issue #107 — see the matching Changed entry):
 
   ```
   %LOCALAPPDATA%\PtySpeak\logs\
   ├── 2026-05-02\
-  │   ├── pty-speak-13-45-23.log    ← session that launched at 13:45:23
-  │   ├── pty-speak-15-12-08.log
-  │   └── pty-speak-16-30-44.log
+  │   ├── pty-speak-2026-05-02-13-45-23-189.log    ← session that launched at 13:45:23.189 UTC
+  │   ├── pty-speak-2026-05-02-15-12-08-401.log
+  │   └── pty-speak-2026-05-02-16-30-44-027.log
   ├── 2026-05-01\
-  │   └── pty-speak-09-15-22.log
+  │   └── pty-speak-2026-05-01-09-15-22-318.log
   └── ... (up to 7 days)
   ```
 
   Each launch creates a fresh session file named with its
-  launch timestamp inside today's day-folder. Sessions don't
-  split across midnight (a long-running session stays in its
-  launch-day folder). Retention deletes whole day-folders
-  older than 7 days; folders with non-date names are ignored
-  defensively. New `FileLoggerSink.ActiveLogPath` member
-  exposes this session's file path for tools that want to
-  grab the active session directly.
+  full launch timestamp inside today's day-folder. Sessions
+  don't split across midnight (a long-running session stays
+  in its launch-day folder). Retention deletes whole
+  day-folders older than 7 days; folders with non-date names
+  are ignored defensively. New `FileLoggerSink.ActiveLogPath`
+  member exposes this session's file path for tools that
+  want to grab the active session directly.
 
   `Ctrl+Shift+L` still opens the logs root; the user
   navigates one click into today's day-folder and picks the

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -19,20 +19,26 @@ session:
 
 ```
 %LOCALAPPDATA%\PtySpeak\logs\
-├── 2026-05-02\                                ← today's day-folder
-│   ├── pty-speak-13-45-23.log                 ← session that launched at 13:45:23 UTC
-│   ├── pty-speak-15-12-08.log                 ← session that launched at 15:12:08 UTC
-│   └── pty-speak-16-30-44.log                 ← active session (still being written)
-├── 2026-05-01\                                ← yesterday's day-folder
-│   ├── pty-speak-09-15-22.log
-│   └── pty-speak-22-04-11.log
+├── 2026-05-02\                                            ← today's day-folder
+│   ├── pty-speak-2026-05-02-13-45-23-189.log              ← session that launched at 13:45:23.189 UTC
+│   ├── pty-speak-2026-05-02-15-12-08-401.log              ← session that launched at 15:12:08.401 UTC
+│   └── pty-speak-2026-05-02-16-30-44-027.log              ← active session (still being written)
+├── 2026-05-01\                                            ← yesterday's day-folder
+│   ├── pty-speak-2026-05-01-09-15-22-318.log
+│   └── pty-speak-2026-05-01-22-04-11-902.log
 └── ... (up to 7 days of day-folders)
 ```
 
 - **One file per launch / session** inside a per-day folder
-  named `yyyy-MM-dd` (UTC). Each session gets its own file
-  named with its launch timestamp (`pty-speak-HH-mm-ss.log`,
-  no colons because Windows file paths reject them).
+  named `yyyy-MM-dd` (UTC). Each session file is named with
+  its full launch timestamp (`pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log`,
+  no colons because Windows file paths reject them). The full
+  date+time in the filename keeps the file self-describing
+  when extracted from its day-folder context (e.g. attached
+  to a bug report) and means alphabetical sort equals
+  chronological sort. The trailing `fff` is the millisecond
+  tie-breaker — two launches in the same UTC second produce
+  different filenames per [Issue #107](https://github.com/KyleKeane/pty-speak/issues/107).
 - **7-day retention** — entire day-folders older than 7 days
   are deleted on every fresh launch. Folders with names that
   don't parse as `yyyy-MM-dd` (manual subfolders, etc.) are

--- a/src/Terminal.Core/FileLogger.fs
+++ b/src/Terminal.Core/FileLogger.fs
@@ -101,15 +101,15 @@ type internal LogEntry =
 /// process. Owns the background drain task + the active file
 /// stream.
 ///
-/// File layout (post-restructure):
+/// File layout (per-session files in per-day folders):
 ///
 /// ```text
 /// %LOCALAPPDATA%\PtySpeak\logs\
 /// ├── 2026-05-02\
-/// │   ├── pty-speak-13-45-23.log    ← session that launched at 13:45:23 UTC
-/// │   └── pty-speak-15-30-44.log
+/// │   ├── pty-speak-2026-05-02-13-45-23-189.log    ← session that launched at 13:45:23.189 UTC
+/// │   └── pty-speak-2026-05-02-15-30-44-027.log
 /// └── 2026-05-01\
-///     └── pty-speak-09-15-22.log
+///     └── pty-speak-2026-05-01-09-15-22-318.log
 /// ```
 ///
 /// One file per launch (per-session) inside a day-folder.
@@ -167,8 +167,17 @@ type FileLoggerSink (options: FileLoggerOptions) =
 
     /// Compute the day-folder path + session-file path for the
     /// launch instant. Day folder named `yyyy-MM-dd`; file
-    /// named `pty-speak-HH-mm-ss.log` (no colons; Windows file
-    /// paths reject `:`).
+    /// named `pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log` (no colons;
+    /// Windows file paths reject `:`). The full date+time in the
+    /// filename keeps the file self-describing when extracted
+    /// from its day-folder context (e.g. when emailed as a bug
+    /// report attachment) and means alphabetical sort equals
+    /// chronological sort. The `fff` (millisecond) suffix is the
+    /// uniqueness tie-breaker per Issue #107: two launches in
+    /// the same UTC second collide on the seconds field but
+    /// differ on milliseconds, so `FileMode.CreateNew`-style
+    /// retry isn't required. Time fields are UTC for
+    /// timezone-independent sorting.
     let pathsForLaunch () : string * string =
         let dayFolder =
             Path.Combine(
@@ -176,7 +185,7 @@ type FileLoggerSink (options: FileLoggerOptions) =
                 launchUtc.UtcDateTime.ToString("yyyy-MM-dd"))
         let fileName =
             sprintf "pty-speak-%s.log"
-                (launchUtc.UtcDateTime.ToString("HH-mm-ss"))
+                (launchUtc.UtcDateTime.ToString("yyyy-MM-dd-HH-mm-ss-fff"))
         let filePath = Path.Combine(dayFolder, fileName)
         dayFolder, filePath
 

--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -30,6 +30,32 @@ let private optionsAt (dir: string) (minLevel: LogLevel) : FileLoggerOptions =
       MinLevel = minLevel
       ChannelCapacity = 256 }
 
+/// Asserts that `fileName` matches the per-Issue-#107 session
+/// filename scheme `pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log` and
+/// returns the parsed launch `DateTime` (UTC). Used by the
+/// filename-shape tests + the Issue-#107 acceptance test.
+let private assertSessionFilenameFormat (fileName: string) : DateTime =
+    Assert.StartsWith("pty-speak-", fileName)
+    Assert.EndsWith(".log", fileName)
+    let prefixLen = "pty-speak-".Length
+    let suffixLen = ".log".Length
+    let timestampPart =
+        fileName.Substring(prefixLen, fileName.Length - prefixLen - suffixLen)
+    let mutable parsed = DateTime.MinValue
+    let parsedOk =
+        DateTime.TryParseExact(
+            timestampPart,
+            "yyyy-MM-dd-HH-mm-ss-fff",
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            &parsed)
+    Assert.True(
+        parsedOk,
+        sprintf
+            "Expected filename timestamp matching yyyy-MM-dd-HH-mm-ss-fff per Issue #107; got '%s'"
+            timestampPart)
+    parsed
+
 /// Read the active session's log file via the sink's
 /// `ActiveLogPath` accessor. Tests in this file capture the
 /// sink before disposal (or use the sink directly) so they
@@ -78,7 +104,8 @@ let ``active log lives inside a day-folder named yyyy-MM-dd`` () =
     let logger = provider.CreateLogger("Test")
     logger.LogInformation("create the file")
     (provider :> IDisposable).Dispose()
-    // ActiveLogPath should be: {dir}\{yyyy-MM-dd}\pty-speak-{HH-mm-ss}.log
+    // ActiveLogPath should be:
+    //   {dir}\{yyyy-MM-dd}\pty-speak-{yyyy-MM-dd-HH-mm-ss-fff}.log
     let parentFolder = Path.GetDirectoryName(sink.ActiveLogPath)
     let parentName = Path.GetFileName(parentFolder)
     let mutable parsed = DateTime.MinValue
@@ -92,8 +119,8 @@ let ``active log lives inside a day-folder named yyyy-MM-dd`` () =
     Assert.True(parsedOk,
         sprintf "Expected day-folder named yyyy-MM-dd; got '%s'" parentName)
     let fileName = Path.GetFileName(sink.ActiveLogPath)
-    Assert.StartsWith("pty-speak-", fileName)
-    Assert.EndsWith(".log", fileName)
+    let _ = assertSessionFilenameFormat fileName
+    ()
 
 [<Fact>]
 let ``logger respects minimum level filtering`` () =
@@ -135,7 +162,9 @@ let ``retention sweep deletes day-folders older than RetentionDays`` () =
     let staleDir = Path.Combine(dir, staleDirName)
     Directory.CreateDirectory(staleDir) |> ignore
     File.WriteAllText(
-        Path.Combine(staleDir, "pty-speak-12-00-00.log"),
+        Path.Combine(
+            staleDir,
+            sprintf "pty-speak-%s-12-00-00-000.log" staleDirName),
         "old content\n")
     Assert.True(Directory.Exists(staleDir))
     // Plant a fresh day-folder (yesterday) — should survive.
@@ -144,7 +173,9 @@ let ``retention sweep deletes day-folders older than RetentionDays`` () =
     let freshDir = Path.Combine(dir, freshDirName)
     Directory.CreateDirectory(freshDir) |> ignore
     File.WriteAllText(
-        Path.Combine(freshDir, "pty-speak-12-00-00.log"),
+        Path.Combine(
+            freshDir,
+            sprintf "pty-speak-%s-12-00-00-000.log" freshDirName),
         "fresh content\n")
     // Plant a folder with a non-date name — should be ignored
     // entirely (defensive: stray folders shouldn't crash).
@@ -191,11 +222,33 @@ let ``ActiveLogPath member exposes the per-session file inside today's day-folde
     let dir = freshTempDir ()
     use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
     // The path should start with `{dir}\{yyyy-MM-dd}\` and end
-    // with `pty-speak-{HH-mm-ss}.log`.
+    // with `pty-speak-{yyyy-MM-dd-HH-mm-ss-fff}.log`.
     Assert.StartsWith(dir, sink.ActiveLogPath)
     let fileName = Path.GetFileName(sink.ActiveLogPath)
-    Assert.StartsWith("pty-speak-", fileName)
-    Assert.EndsWith(".log", fileName)
+    let _ = assertSessionFilenameFormat fileName
+    ()
+
+[<Fact>]
+let ``session filename uses yyyy-MM-dd-HH-mm-ss-fff format per Issue #107`` () =
+    // Issue #107 (Option A): the filename must be self-describing
+    // when extracted from the day-folder context AND must include a
+    // millisecond tie-breaker so two launches in the same UTC second
+    // produce different filenames. Asserts the parse-back chain end
+    // to end + sanity-checks the parsed timestamp is within a few
+    // seconds of `DateTime.UtcNow` (proves the timestamp reflects
+    // launch time, not random digits).
+    let dir = freshTempDir ()
+    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let fileName = Path.GetFileName(sink.ActiveLogPath)
+    let parsed = assertSessionFilenameFormat fileName
+    let now = DateTime.UtcNow
+    let delta = (now - parsed).Duration()
+    Assert.True(
+        delta.TotalSeconds < 5.0,
+        sprintf
+            "Expected timestamp ~UtcNow; got %s (delta %s)"
+            (parsed.ToString("o"))
+            (delta.ToString()))
 
 // Note: a "Logger module returns NullLogger before configure"
 // test was tried and removed. The Logger module's `factory`

--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -34,7 +34,16 @@ let private optionsAt (dir: string) (minLevel: LogLevel) : FileLoggerOptions =
 /// filename scheme `pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log` and
 /// returns the parsed launch `DateTime` (UTC). Used by the
 /// filename-shape tests + the Issue-#107 acceptance test.
-let private assertSessionFilenameFormat (fileName: string) : DateTime =
+///
+/// Accepts `string | null` because `Path.GetFileName` (the typical
+/// caller) is annotated `string?` in .NET 9; the helper handles
+/// the null case with an explicit failure rather than forcing
+/// every call site to coerce.
+let private assertSessionFilenameFormat (fileName: string | null) : DateTime =
+    let fileName =
+        match fileName with
+        | null -> failwith "session log filename was null (Path.GetFileName returned null)"
+        | name -> name
     Assert.StartsWith("pty-speak-", fileName)
     Assert.EndsWith(".log", fileName)
     let prefixLen = "pty-speak-".Length


### PR DESCRIPTION
Filename moves from pty-speak-HH-mm-ss.log to
pty-speak-yyyy-MM-dd-HH-mm-ss-fff.log per Issue #107's Option A recommendation:

  Before: 2026-05-02/pty-speak-13-45-23.log
  After:  2026-05-02/pty-speak-2026-05-02-13-45-23-189.log

Day folders stay yyyy-MM-dd. Two motivating concerns from the issue brief:

1. Self-describing when extracted. Embedding full date+time in the filename keeps the file self-describing anywhere it lands (email attachment, bug-report paste, etc.).
2. Uniqueness in the same UTC second. The fff (millisecond) suffix is the tie-breaker — alphabetical sort still equals chronological sort with no UUID-readability cost and no concurrent-counter retry code path.

Implementation:

- src/Terminal.Core/FileLogger.fs: one-line format-string change in pathsForLaunch (); doc-comment + file-layout example updated.
- tests/Tests.Unit/FileLoggerTests.fs: new helper `assertSessionFilenameFormat` parses filenames through DateTime.TryParseExact against the new format; two existing tests tighten via the helper; new test pins the format end to end and sanity-checks the parsed timestamp is within 5 seconds of UtcNow.
- docs/LOGGING.md: example tree + filename-format prose updated.
- CHANGELOG.md: new Changed entry; PR #103 historical entry's example tree updated so [Unreleased] release notes don't show contradictory examples.

Closes #107.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
