### PR TITLE
feat(logging): add FlushPending API; wire into Ctrl+Shift+; log-copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,52 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **`FileLoggerSink.FlushPending(timeoutMs)` API.** New public
+  member that returns a `Task<bool>` completing when the
+  background drain finishes its next per-batch flush, or after
+  the timeout — whichever comes first. `true` means a flush
+  completed within the window; `false` means the timeout fired
+  (channel was idle, or the host pegged for longer than the
+  budget).
+
+  Implementation: a TCS-barrier owned by the sink. The drain
+  loop atomically swaps the current `flushTcs` for a fresh one
+  after every successful `StreamWriter.Flush` and completes
+  the swapped one — so a caller that captures the current TCS
+  and awaits it gets signalled the next time the drain
+  completes a flush. Lock-protected swap; idempotent
+  `TrySetResult`; signalled once more after the dispose-time
+  final flush so callers awaiting at shutdown see completion
+  rather than timeout.
+
+  **Wired into `runCopyLatestLog` (`Ctrl+Shift+;`)** with a
+  500ms budget. Without this barrier, the bounded channel
+  could hold ~milliseconds of recent entries that hadn't been
+  written yet — the clipboard would capture a stale snapshot
+  of the file. The 500ms cap is the worst-case dispatcher
+  block under user-pressed-the-hotkey conditions; in practice
+  the drain finishes in low ms. On timeout, the handler logs
+  an `Information`-level note and proceeds with the
+  not-quite-current file content (better than no copy at all).
+
+  Caveat: if the channel is fully idle (no pending entries),
+  the drain loop is parked in `WaitToReadAsync` and won't fire
+  a flush until something arrives. `FlushPending` returns
+  `false` (timeout) in that case — but the file already
+  contains everything the writer has produced, so the
+  not-drained path is benign.
+
+  Test:
+  `tests/Tests.Unit/FileLoggerTests.fs` gains
+  `FlushPending makes recently-enqueued entries readable while
+  the writer is active` — enqueues 5 entries with a unique
+  marker, calls `FlushPending(2000)`, then reads the file
+  with `FileShare.ReadWrite` (matching `runCopyLatestLog`'s
+  production path) WITHOUT disposing the sink first, and
+  asserts every entry made it to disk. Failure here means
+  the drain's `signalFlushComplete` wiring or the TCS-swap
+  path regressed.
+
 - **Strategic plan committed to repo:
   [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md).**
   Captures the post-PR-#116 architecture review and sequences

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -13,7 +13,12 @@ session:
   hand position. NVDA announces the byte count on success
   ("Log copied to clipboard. N bytes; ready to paste."). Most
   efficient way to send a log to a maintainer: press the hotkey,
-  switch to the chat / email / issue, paste.
+  switch to the chat / email / issue, paste. Before reading,
+  the handler waits up to 500ms for any in-flight log entries
+  to reach disk via `FileLoggerSink.FlushPending` so the
+  clipboard captures up-to-the-moment state — without that
+  barrier the bounded channel could still hold ~milliseconds
+  of recent entries that hadn't been written yet.
 
 ## Where the logs live
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -467,6 +467,20 @@ module Program =
                 ActivityIds.error)
         | Some sink ->
             try
+                // Wait briefly for any in-flight log entries to reach
+                // disk before reading. Without this, the bounded
+                // channel can hold ~milliseconds of recent entries
+                // that haven't been written yet — the clipboard
+                // would then capture a stale snapshot of the file.
+                // Bounded by 500ms so the dispatcher can't freeze
+                // for longer than that worst-case; if no flush
+                // completes (channel idle, nothing to flush), the
+                // file already contains everything the writer has
+                // produced, so the false-return path is benign.
+                let drained = sink.FlushPending(500).Result
+                if not drained then
+                    log.LogInformation(
+                        "FlushPending timed out after 500ms; clipboard may be missing entries enqueued in the last few hundred ms.")
                 let path = sink.ActiveLogPath
                 if not (System.IO.File.Exists path) then
                     window.TerminalSurface.Announce(

--- a/src/Terminal.Core/FileLogger.fs
+++ b/src/Terminal.Core/FileLogger.fs
@@ -136,6 +136,29 @@ type FileLoggerSink (options: FileLoggerOptions) =
 
     let cts = new CancellationTokenSource()
 
+    // Flush-barrier TCS used by `FlushPending`. The drain loop
+    // atomically swaps in a fresh TCS after every successful
+    // `StreamWriter.Flush`, then completes the previous one — so a
+    // caller that captures the current TCS and awaits it gets
+    // signalled the next time the loop completes a flush. Used by
+    // `Ctrl+Shift+;` log-copy so the clipboard captures
+    // up-to-the-moment state instead of the file contents minus
+    // however many entries are still in flight in the channel.
+    let flushTcsLock = obj ()
+    let mutable flushTcs = TaskCompletionSource<unit>()
+
+    /// Atomically swap the current `flushTcs` for a fresh one and
+    /// complete the previous one. Called from the drain loop after
+    /// every successful flush. Idempotent — `TrySetResult` on an
+    /// already-completed TCS is a no-op.
+    let signalFlushComplete () =
+        let prev =
+            lock flushTcsLock (fun () ->
+                let p = flushTcs
+                flushTcs <- TaskCompletionSource<unit>()
+                p)
+        prev.TrySetResult(()) |> ignore
+
     /// Format one log entry as a single line. Multi-line text
     /// (exception stack traces) is preserved as-is so readers
     /// can navigate it; downstream tooling that expects
@@ -276,6 +299,11 @@ type FileLoggerSink (options: FileLoggerOptions) =
                                 | null -> ()
                                 | w -> w.Flush()
                             with _ -> ()
+                            // Signal any FlushPending callers that
+                            // a flush just completed; entries
+                            // enqueued before this iteration are
+                            // now on disk.
+                            signalFlushComplete ()
                 with
                 | :? OperationCanceledException -> ()
                 | _ -> ()
@@ -293,6 +321,11 @@ type FileLoggerSink (options: FileLoggerOptions) =
                         w.Flush()
                         (w :> IDisposable).Dispose()
                 with _ -> ()
+                // Final flush signal after cleanup. Unblocks any
+                // FlushPending caller still awaiting the TCS at
+                // dispose time so they hit completion rather than
+                // timeout.
+                signalFlushComplete ()
             } :> Task)
 
     member _.IsEnabled (level: LogLevel) : bool =
@@ -331,6 +364,46 @@ type FileLoggerSink (options: FileLoggerOptions) =
     member _.ActiveLogPath : string =
         let _, filePath = pathsForLaunch ()
         filePath
+
+    /// Wait for any in-flight log entries to reach disk, OR for
+    /// `timeoutMs` to elapse — whichever comes first. Returns
+    /// `true` if a flush completed within the window, `false` on
+    /// timeout. Pass `0` (or negative) to wait indefinitely.
+    ///
+    /// Use case: `Ctrl+Shift+;` log-copy needs the file to reflect
+    /// the most recent log entries before reading. Without this,
+    /// the bounded channel may still hold ~milliseconds of
+    /// entries that haven't been written yet, and the clipboard
+    /// captures a stale snapshot. Caller invokes this on the
+    /// dispatcher thread before reading the file; the brief block
+    /// is acceptable for an explicit-user-gesture hotkey but
+    /// unsuitable for hot paths (use `TryWrite` + best-effort
+    /// reads there).
+    ///
+    /// Caveat: if the channel is idle (no pending entries) the
+    /// drain loop is parked in `WaitToReadAsync` and won't fire
+    /// a flush until something arrives. In that case `FlushPending`
+    /// hits timeout and returns `false`. The caller's read still
+    /// produces correct output because there's nothing in the
+    /// pipeline to be missing — the timeout is benign in this
+    /// scenario.
+    member _.FlushPending (timeoutMs: int) : Task<bool> =
+        task {
+            // Capture the current TCS atomically. The drain loop
+            // will swap it for a fresh one after the next flush
+            // and complete the captured one — at which point our
+            // await returns.
+            let tcs =
+                lock flushTcsLock (fun () -> flushTcs)
+            // `Task.Delay(-1)` waits forever per Microsoft docs
+            // (Timeout.Infinite). Lets the same `WhenAny` line
+            // handle both bounded and unbounded waits without an
+            // extra `if`-branch.
+            let delayMs = if timeoutMs <= 0 then -1 else timeoutMs
+            let! winner =
+                Task.WhenAny(tcs.Task, Task.Delay(delayMs))
+            return winner = (tcs.Task :> Task)
+        }
 
     interface IDisposable with
         member _.Dispose() =

--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -270,6 +270,57 @@ let ``session filename uses yyyy-MM-dd-HH-mm-ss-fff format per Issue #107`` () =
 // `Logger.configure` running in `Program.fs compose ()`.
 
 [<Fact>]
+let ``FlushPending makes recently-enqueued entries readable while the writer is active`` () =
+    // FlushPending lets a caller (e.g. Ctrl+Shift+; log-copy)
+    // wait until the bounded-channel drain has written its
+    // queue to disk before reading the file. Without it, the
+    // reader could capture a stale snapshot with recent entries
+    // still in flight. Test enqueues a batch, calls FlushPending,
+    // then reads the file with FileShare.ReadWrite (matching
+    // runCopyLatestLog's production path) WITHOUT disposing
+    // the sink first, and asserts every entry made it to disk.
+    let dir = freshTempDir ()
+    use sink = new FileLoggerSink(optionsAt dir LogLevel.Information)
+    let provider = new FileLoggerProvider(sink) :> ILoggerProvider
+    let logger = provider.CreateLogger("Test")
+
+    // Unique-per-run marker so concurrent test runs don't
+    // collide via the shared file system tempdir parent.
+    let marker = Guid.NewGuid().ToString("N")
+    for i in 1..5 do
+        logger.LogInformation("flush-test-{Marker}-{Num}", marker, i)
+
+    // 2-second budget; on a healthy CI box this completes in
+    // low ms. Failure here means the drain loop didn't fire a
+    // flush within the window — likely a regression in
+    // signalFlushComplete wiring or the TCS-swap path.
+    let drained = sink.FlushPending(2000).Result
+    Assert.True(
+        drained,
+        "Expected FlushPending to signal completion within 2 seconds")
+
+    // Read while the writer is still active. File.ReadAllText
+    // would fail with the default FileShare.Read — the writer
+    // holds the file with FileAccess.Write, so the OS rejects
+    // the read open unless we opt into FileShare.ReadWrite
+    // (the same fix shipped via PR #114 for runCopyLatestLog).
+    let content =
+        use stream =
+            new FileStream(
+                sink.ActiveLogPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite)
+        use reader =
+            new StreamReader(stream, System.Text.Encoding.UTF8)
+        reader.ReadToEnd()
+
+    for i in 1..5 do
+        Assert.Contains(sprintf "flush-test-%s-%d" marker i, content)
+
+    (provider :> IDisposable).Dispose()
+
+[<Fact>]
 let ``concurrent writes from multiple threads all land in the file`` () =
     // Stress test: spawn N threads each writing M entries.
     // Channel + single-reader drain should serialise them


### PR DESCRIPTION
New `FileLoggerSink.FlushPending(timeoutMs) : Task<bool>` lets a caller wait until the bounded-channel drain has written its queue to disk before reading. Wired into `runCopyLatestLog` (`Ctrl+Shift+;`) with a 500ms budget so the clipboard captures up-to-the-moment state instead of a stale snapshot with recent entries still in flight.

Implementation: TCS-barrier owned by the sink. The drain loop atomically swaps `flushTcs` for a fresh one after every successful `StreamWriter.Flush` and completes the swapped one, so a caller that captures the current TCS and awaits it gets signalled the next time the drain completes a flush. Lock- protected swap; idempotent `TrySetResult`; signalled once more after the dispose-time final flush so callers awaiting at shutdown see completion rather than timeout.

Returns `Task<bool>`:
- `true`: a flush completed within the window
- `false`: timeout fired (channel idle, or host pegged for longer than the budget)

The timeout-and-proceed path is benign for the log-copy use case: if the channel was idle, the file already contains everything the writer has produced, so the not-drained read still produces correct output.

Test: `FlushPending makes recently-enqueued entries readable while the writer is active` enqueues 5 entries with a unique marker, calls `FlushPending(2000)`, then reads the file with `FileShare.ReadWrite` (matching `runCopyLatestLog`'s production path) WITHOUT disposing the sink first, and asserts every entry made it to disk. Failure here would mean either the drain's `signalFlushComplete` wiring or the TCS-swap path regressed.

Closes Part 1.4 of docs/PROJECT-PLAN-2026-05.md.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
