### PR TITLE
docs(contributing): add F# 9 nullness gotcha + fixup-commit rhythm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,39 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **`CONTRIBUTING.md` gains two session-tested practice notes** —
+  one F# gotcha and one PR-workflow convention captured during the
+  May-2026 cleanup cycle so future contributors don't re-learn them:
+
+  - **F# 9 nullness annotations bite at .NET-API boundaries**
+    (under "F# gotchas learned in practice"). Many .NET-API
+    methods are typed `string?` under `<Nullable>enable</Nullable>`
+    — `Path.GetFileName`, `Path.GetDirectoryName`,
+    `Environment.GetEnvironmentVariable`, `StreamReader.ReadLine`,
+    etc. Passing the result to a non-null `string` parameter
+    compiles to an `FS3261` warning that becomes a build error
+    under `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.
+    Two acceptable patterns documented: helper signature accepts
+    `string | null` and pattern-matches the null case (matches
+    the `AnnounceSanitiser.sanitise` / `KeyEncoding.encodeOrNull`
+    convention), or coerce at the call site via `nonNull` /
+    inline `match`. PR #121 (Issue #107 filename refinement) hit
+    this and is the worked example.
+
+  - **CI failure on an open PR → push a fixup commit to the same
+    branch** (under "Branching and pull requests"). GitHub PRs
+    track the branch HEAD, not a snapshot at PR-creation time;
+    pushing additional commits auto-extends the PR and re-runs
+    CI without disturbing the PR number, title, body, or
+    `Closes #N` references. **Don't open a new PR for a fixup**
+    — the squash-merge convention combines original + fixup
+    into a single canonical commit on `main`. PR #121 (same
+    Issue #107 work) used this rhythm and is the worked
+    example.
+
+  Both bullets cross-reference each other so a reader landing on
+  either entry finds the other.
+
 - **`docs/CHECKPOINTS.md` checkpoint rows for shipped post-Stage-3b
   stages.** The 2026-05-03 audit (in
   [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,24 @@ See [`docs/BUILD.md`](docs/BUILD.md) for build instructions.
   split them. Past frustrations on this repo trace back to oversized
   PRs with multiple moving parts; small focused PRs review faster and
   bisect cleaner.
+- **CI failure on an open PR → push a fixup commit to the same
+  branch.** GitHub PRs track the branch HEAD, not a snapshot at
+  PR-creation time. A `git push` to the open PR's branch
+  auto-extends the PR with the new commit and re-runs CI against
+  the new HEAD; the PR number, title, body, `Closes #N`
+  references, and any auto-merge configuration are preserved.
+  **Don't open a new PR for a fixup** — that creates a stack the
+  maintainer has to merge in order. The standing rule is
+  **one PR per concern, multiple commits on the branch as needed**;
+  the squash-merge convention combines the original + fixup into
+  a single canonical commit on `main`. PR #121 (Issue #107
+  filename refinement) used this rhythm: initial commit hit a
+  F# 9 nullness `FS3261` error in CI, a single fixup commit on
+  the same branch updated the helper signature, CI re-ran green,
+  the PR auto-extended, and the maintainer merged the
+  two-commit branch as one squashed commit. See "F# gotchas
+  learned in practice" — F# 9 nullness for the underlying
+  technical issue.
 - **PR body**: brief Summary + What changed + Test plan checklist.
   Stage-implementation PRs also include a "What this PR deliberately
   omits" section pointing at the stage(s) that own the deferred items,
@@ -224,6 +242,44 @@ new code.
   `Views/TerminalView.cs` reads `Cell.Attrs.Fg.IsDefaultFg` and
   `Cell.Attrs.Fg.Item` (the `int` payload of the `Indexed` case).
   Worth knowing before the Stage-4 UIA peer crosses the boundary.
+- **F# 9 nullness annotations bite at .NET-API boundaries.** Many
+  .NET-API methods are typed `string?` (nullable string) under
+  `<Nullable>enable</Nullable>` — `Path.GetFileName`,
+  `Path.GetDirectoryName`, `Environment.GetEnvironmentVariable`,
+  `StreamReader.ReadLine`, etc. Passing the result to a non-null
+  `string` parameter compiles to an `FS3261` warning that becomes
+  a build error under
+  `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` (CI fails
+  on Windows-latest with the actual error text reading
+  "Nullness warning: A non-nullable 'string' was expected but
+  this expression is nullable"). Two acceptable patterns:
+
+    - **Helper / function signature accepts `string | null`** and
+      pattern-matches the null case at the boundary. Matches the
+      convention established by `Terminal.Core.AnnounceSanitiser.sanitise`
+      and `Terminal.Core.KeyEncoding.encodeOrNull`. Useful when
+      many call sites would otherwise duplicate null-coercion.
+      Inside the function:
+
+      ```fsharp
+      let foo (x: string | null) : 'T =
+          let x =
+              match x with
+              | null -> failwith "x was null"
+              | s -> s
+          // ... use non-null x ...
+      ```
+    - **Coerce at the call site** with `nonNull` (from `FSharp.Core`)
+      or an inline `match ... with | null -> ... | s -> s`. Useful
+      for one-off boundary crossings without changing helper
+      signatures.
+
+    Issue #107's filename-format helper hit this when test code
+    passed `Path.GetFileName(...)` to a non-null parameter; PR #121
+    moved the helper signature to `string | null` and added the
+    pattern-match. The fix landed as a fixup commit on the same
+    branch (see "Branching and pull requests" — fixup-commit
+    rhythm) so the PR auto-extended without scope churn.
 
 ### WPF gotchas learned in practice
 


### PR DESCRIPTION
Two session-tested practice notes captured during the May-2026 cleanup cycle so future contributors don't re-learn them:

1. F# gotchas learned in practice — F# 9 nullness annotations bite at .NET-API boundaries. Many .NET-API methods are typed `string?` under <Nullable>enable</Nullable>; passing to a non-null `string` parameter triggers FS3261 (build error under <TreatWarningsAsErrors>true</TreatWarningsAsErrors>). Two acceptable patterns documented: helper accepts `string | null` and pattern-matches the null case (`AnnounceSanitiser.sanitise` / `KeyEncoding.encodeOrNull` convention), or coerce at call site via `nonNull` / inline match. Worked example: PR #121 (Issue #107).

2. Branching and pull requests — CI failure on an open PR -> push a fixup commit to the same branch. GitHub PRs track branch HEAD; pushing additional commits auto-extends the PR and re-runs CI without disturbing the PR number, title, body, or Closes #N references. Don't open a new PR for a fixup — the squash-merge convention combines original + fixup into a single canonical commit on main. Worked example: PR #121 (same Issue #107 work).

Both bullets cross-reference each other. CHANGELOG entry under [Unreleased] Added.

Closes the final context-dump candidate from the May-2026 cleanup cycle's handoff queue.

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
