### PR TITLE
docs: final-handoff audit closing the May-2026 cleanup cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,60 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Final-handoff audit closing the May-2026 cleanup cycle.** Sweeps
+  the last staleness in the entry-point docs so the next session
+  picks up cleanly:
+
+  - **`docs/SESSION-HANDOFF.md` "Where we left off" cell rewritten**
+    to reflect post-cleanup-cycle state. "In-flight branch" flips
+    from the long-merged `claude/audit-repo-handoff-FCsnT` to
+    explicit "_None._ The May-2026 cleanup cycle is complete; next
+    session starts from Part 2." "Last merged stages" gains the
+    spec-formalized Stages 4a / 4b / 5a + the full PR #118 → #128
+    cleanup-cycle narrative. "Next stage" rewritten to point at
+    Stage 7 with explicit reference to the Stage 7 implementation
+    sketch in this same file. "Last shipped release" caveat clarified
+    (preview.43 is the latest code-bearing preview; subsequent PRs
+    are docs-only).
+  - **`docs/SESSION-HANDOFF.md` "Pending action items" #1
+    expanded** from "five pending baseline tags" (Stages 0-3b) to
+    twelve (5 original + 7 added per PR #127 for Stages 4 / 4a /
+    4b / 5 / 5a / 6 / 11). Maintainer-side action: push the tags
+    from a workstation, then delete each row from the
+    `docs/CHECKPOINTS.md` "Pending checkpoint tags" table per the
+    existing convention.
+  - **`docs/SESSION-HANDOFF.md` closing notes** gain a paragraph
+    documenting the May-2026 cleanup-cycle context (PRs #118 →
+    #128 closed Part 1 + the bonus context-dump work; the
+    fixup-commit rhythm was exercised on PR #121; small-focused-PR
+    cadence works smoothly with squash-merge).
+  - **`README.md` status block** realigned: "Stage 4.5" updates to
+    "Stage 4a" (matches the spec-formalization in `spec/tech-plan.md`
+    §4a); explicit mentions of newly-formalized Stages 4b and 5a
+    added; cleanup is marked shipped; Stage 7 explicitly called out
+    as next.
+  - **`docs/PROJECT-PLAN-2026-05.md`** gains a "Status as of
+    2026-05-03 cleanup cycle close" note at the top so a reader
+    doesn't mistake Part 1's sub-items for live to-dos. The plan
+    body below the note is preserved verbatim for decision-history
+    continuity per the doc's own "Future revisions should land as
+    new dated plans" rule.
+  - **New `docs/STAGE-7-ISSUES.md` stub.** Pre-creates the file the
+    Stage 7 implementation sketch references (per
+    `docs/SESSION-HANDOFF.md` §5 of the sketch). Contains the
+    framework-taxonomy category tags (`[output-stream]`,
+    `[output-form]`, `[output-selection]`, `[output-earcon]`,
+    `[output-tui]`, `[output-repl]`, `[input-suggest]`,
+    `[input-buffer]`, `[input-form]`, `[input-nl]`,
+    `[review-mode]`, `[other]`), an entry template, instructions
+    for use, and explicit cross-references to the spec / plan /
+    sketch. Empty entries section so the next session writes into
+    a structured place without making meta-decisions.
+
+  Closes the final context-dump candidate from the May-2026
+  cleanup-cycle handoff queue. **Next session starts at Part 2 —
+  Stage 7. Read `docs/SESSION-HANDOFF.md` first.**
+
 - **`CONTRIBUTING.md` gains two session-tested practice notes** —
   one F# gotcha and one PR-workflow convention captured during the
   May-2026 cleanup cycle so future contributors don't re-learn them:

--- a/README.md
+++ b/README.md
@@ -5,27 +5,34 @@ from the ground up for blind developers using NVDA, JAWS, or Narrator —
 with Anthropic's Claude Code (and other Ink/React TUIs) as the primary
 target workload.
 
-> Status: **pre-alpha.** Latest preview is
-> [`v0.0.1-preview.43`](../../releases) (preview cadence has
-> continued through the post-Stage-6 streaming-fix cycle).
-> Shipped on `main` and NVDA-verified on Windows 11:
+> Status: **pre-alpha.** Latest code-bearing preview is
+> [`v0.0.1-preview.43`](../../releases). Shipped on `main`
+> and NVDA-verified on Windows 11:
 > Stages 0-4 (skeleton + CI, ConPTY host, Williams VT500
 > parser, screen model + WPF rendering, UIA Document role
-> + Text pattern + Line/Word/Character navigation), Stage
-> 4.5 (Claude Code rendering substrate: alt-screen + DECTCEM
-> + 256/truecolor SGR), Stage 5 (streaming output via
+> + Text pattern + Line/Word/Character navigation),
+> **Stage 4a** (Claude Code rendering substrate: alt-screen
+> + DECTCEM + 256/truecolor SGR + DECSC/DECRC + OSC 52 silent
+> drop), **Stage 4b** (process-cleanup diagnostic via
+> `Ctrl+Shift+D`), **Stage 5** (streaming output via
 > `Coalescer`; functional end-to-end as of PR #116 — pipeline
 > reaches NVDA, though the verbose-readback issue is the
 > first foundational architecture decision the May-2026 plan
-> addresses), Stage 6 (keyboard input to PTY + paste +
-> focus reporting + dynamic resize + Job Object lifecycle),
-> and Stage 11 (Velopack auto-update via `Ctrl+Shift+U`).
-> Stages 7-10 are sequenced via
+> addresses), **Stage 5a** (diagnostic logging surface:
+> `FileLogger.fs` + `Ctrl+Shift+L` + `Ctrl+Shift+;` log-copy
+> with `FlushPending` barrier), **Stage 6** (keyboard input
+> to PTY + paste + focus reporting + dynamic resize + Job
+> Object lifecycle), and **Stage 11** (Velopack auto-update
+> via `Ctrl+Shift+U`). Stages 4a / 4b / 5a were formalized
+> in the spec per chat 2026-05-03 maintainer authorization;
+> see [`spec/tech-plan.md`](spec/tech-plan.md) §4a / §4b /
+> §5a. Stages 7-10 are sequenced via
 > [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md)
-> as cleanup → Stage 7 (validation gate) → Output framework
-> cycle (subsumes Stages 8 + 9) → Input framework cycle →
-> Stage 10. Follow [Releases](../../releases) for new
-> builds; once installed, `Ctrl+Shift+U` updates in place.
+> as cleanup (✓ shipped May 2026) → Stage 7 (validation
+> gate; **next**) → Output framework cycle (subsumes Stages
+> 8 + 9) → Input framework cycle → Stage 10. Follow
+> [Releases](../../releases) for new builds; once installed,
+> `Ctrl+Shift+U` updates in place.
 
 ## Why this exists
 

--- a/docs/PROJECT-PLAN-2026-05.md
+++ b/docs/PROJECT-PLAN-2026-05.md
@@ -17,6 +17,31 @@ should land as new dated plans (`PROJECT-PLAN-2026-MM.md`) rather than
 edits in place — the sequence shapes the architecture cycles below
 and rewriting it would lose decision history.
 
+> **Status as of 2026-05-03 cleanup cycle close (PR #128 merged).**
+> **Part 1 is shipped.** Every Part 1 sub-item below
+> (1.1 FluentAssertions removal, 1.2 CHANGELOG `[Unreleased]`
+> consolidation, 1.3 Issue #107 log-filename refinement, 1.4
+> `FlushPending` API, 1.5 docs freshness sweep, 1.6 plan committed
+> to repo) has merged to `main`. The spec stage-numbering hygiene
+> the plan flagged ("Stages 4a / 4b / 5a should be formal in the
+> spec") is also done — see `spec/tech-plan.md` §4a / §4b / §5a.
+> Part 1.7 (pre-architecture preview cut as a tagged save point)
+> remains a maintainer-side action.
+>
+> Bonus context-dump work shipped during the same cycle but not in
+> the original Part 1 scope: the **Stage 7 implementation sketch**
+> in `docs/SESSION-HANDOFF.md` (so the next session has a
+> pre-digested plan for Part 2), the **`baseline/stage-N`
+> rollback rows** for all shipped post-Stage-3b stages in
+> `docs/CHECKPOINTS.md`, and two new gotchas in `CONTRIBUTING.md`
+> (F# 9 `string | null` at .NET-API boundaries; fixup-commit
+> rhythm on open PRs that fail CI).
+>
+> **Next session starts at Part 2** (Stage 7). The plan body
+> below is preserved verbatim for decision-history continuity —
+> read it as the snapshot it was at authorship time, not as a
+> live to-do list.
+
 ## Context
 
 Streaming output reaches NVDA end-to-end as of PR #116 (the broken

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -28,10 +28,10 @@ canonical strategic plan for the next ~8-12 weeks of work),
 
 | | |
 |---|---|
-| **Last merged stages** | **Stages 0 → 6 + 11** all merged to `main`. Stage 5 (streaming output via `Coalescer`) and Stage 6 (keyboard input, paste, focus reporting, dynamic resize, Job Object lifecycle) shipped through PRs #100s; Stage 4 + Stage 11 NVDA-verified on `v0.0.1-preview.26`. The post-Stage-5/6 cycle then surfaced and fixed a series of streaming-pipeline bugs: PR #108 (`Ctrl+Alt+L` SystemKey-aware filter), PR #109 (streaming-path INFO instrumentation), PR #111 (`Ctrl+Shift+;` log-copy hotkey + Alt+F4 restoration + log-level demote), PR #114 (FileShare bug + restored two INFO entries), and **PR #116** (the cap-stone: removed the broken `AllHashHistory` spinner gate that was instantly silencing every event). As of PR #116 the streaming pipeline is provably alive end-to-end: cmd.exe banner reads on launch, typed characters trigger speech, command output triggers speech. |
-| **Last shipped release** | `v0.0.1-preview.43` (preview cadence has continued through the post-Stage-6 cycle of fixes). |
-| **In-flight branch** | `claude/audit-repo-handoff-FCsnT` — 2026-05-03 audit of the original `spec/tech-plan.md` Stages 7-10 against the post-#116 state, leading to the [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) sequencing. The branch lands the plan doc + the docs-freshness sweep (this file, ROADMAP.md, ACCESSIBILITY-INTERACTION-MODEL.md, README.md). Subsequent Part-1 cleanup PRs (FluentAssertions removal, CHANGELOG consolidation, Issue #107 log filename, FlushPending API) ship on separate `chore/`, `docs/`, and `feat/` branches per CONTRIBUTING.md's one-concern-per-PR rule. |
-| **Next stage** | Per [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md): **Part 1 cleanup** (this branch + its sibling PRs, ~1-2 days) → **Part 2: Stage 7 — Claude Code roundtrip + env-scrub PO-5** (~3-5 days, the validation gate before the framework cycles) → **Part 3: Output-handling framework cycle** (multi-week; subsumes original Stages 8 + 9 as Selection profile + earcons sink) → **Part 4: Input-interpretation framework cycle** (multi-week; partly overlaps Part 3) → **Part 5: Stage 10 — Review mode + quick-nav** (~1 week; first non-built-in consumer of the new semantic-event taxonomy). The original-plan Stages 7, 8, 9, 10 are all addressed: 7 is the validation gate, 8 + 9 fold into Part 3, 10 ships post-frameworks as their first consumer. **Open follow-up logged for a future stage**: Screen-buffer runtime resize. Stage 6 resizes the PTY (so cmd.exe and Claude Code see the right column count), but the in-process `Cell[,]` Screen grid stays at construction-time 30×120 — oversize windows have empty padding, undersize windows clip. Spec §6 says "ResizePseudoConsole", which Stage 6 satisfies; full grid resize is a Phase 2 stage. |
+| **Last merged stages** | **Stages 0 → 6 + 11** all merged to `main`, plus the retroactively-formalized **Stages 4a / 4b / 5a** (per chat 2026-05-03 maintainer authorization, now in `spec/tech-plan.md` §4a / §4b / §5a). Stage 4 + Stage 11 NVDA-verified on `v0.0.1-preview.26`. Stage 4a (Claude Code rendering substrate: alt-screen 1049 + DECTCEM + 256/truecolor SGR + DECSC/DECRC + OSC 52 silent drop) shipped via PR-A #85 + PR-B #86. Stage 4b (process-cleanup diagnostic + `Ctrl+Shift+D`) shipped via PR #81. Stage 5 (streaming output via `Coalescer`) shipped via PR #89; functional end-to-end as of PR #116 after the post-Stage-5 streaming-fix cycle (PRs #108 / #109 / #111 / #114 / #116). Stage 6 (keyboard input + paste + focus reporting + dynamic resize + Job Object lifecycle) shipped via PR-A #92 + PR-B #99 + fixup #100. Stage 5a (diagnostic logging surface: `FileLogger.fs` + `Ctrl+Shift+L` + `Ctrl+Shift+;` + Issue #107 filename refinement + `FlushPending` TCS-barrier) shipped via the multi-PR cycle through #102/#103/#109/#111/#114/#116/#121/#122. The May-2026 cleanup cycle (PRs #118 → #128) shipped Part 1 of [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) plus the spec stage-numbering hygiene (Stages 4a/4b/5a in spec) plus the Stage 7 implementation sketch in this file plus the `baseline/stage-N` rollback rows for all shipped post-Stage-3b stages plus the F# 9 nullness + fixup-commit-rhythm gotchas in `CONTRIBUTING.md`. |
+| **Last shipped release** | `v0.0.1-preview.43` (latest code-bearing preview as of plan authorship; preview cadence may have continued through subsequent docs-only PRs in the May-2026 cleanup cycle, but the last functional code change was Stage 5a's `FlushPending` API in PR #122). |
+| **In-flight branch** | _None._ The May-2026 cleanup cycle (Part 1 of the plan) is complete. Next session starts fresh from Part 2 — see "Next stage" + the **Stage 7 implementation sketch (next)** section below in this file. |
+| **Next stage** | **Stage 7 — Claude Code roundtrip + env-scrub PO-5** per [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) Part 2. The pre-digested execution plan is in this file's **"Stage 7 implementation sketch (next)"** section: `claude.exe` resolution via `where.exe`, `PTYSPEAK_SHELL` env-var override, `lpEnvironment`-based env-scrub with allow-list-with-deny-list-override scheme for PO-5, NVDA validation flow, `docs/STAGE-7-ISSUES.md` inventory format with framework-taxonomy category tags. Stage 7 is sequenced as the **validation gate** before the Output / Input framework cycles begin — the inventory it produces is the design input for Parts 3 + 4. After Stage 7 ships and NVDA-validates, the Output framework cycle (Part 3) starts with its research phase (`docs/research/OUTPUT-FRAMEWORK-PRIOR-ART.md`). **Open follow-ups logged for future stages**: (a) Screen-buffer runtime resize — Stage 6 resizes the PTY but the in-process `Cell[,]` Screen grid stays at construction-time 30×120 (Phase 2 stage). (b) The screen-reader-native diagnostic-launcher rework deferred per item 6 below — now actionable since Stage 6 keyboard input ships; user can type `pwsh ./scripts/test-process-cleanup.ps1` directly into pty-speak's child shell with output narrated via Stage 5's streaming announcements. |
 
 The end-to-end pipeline now reaches the auto-update boundary:
 launching the app spawns `cmd.exe` under ConPTY, parses its
@@ -120,11 +120,24 @@ GitHub-website access. They've accumulated because the development
 sandbox can't push tags and the GitHub MCP server occasionally
 disconnects mid-session.
 
-1. **Push the five pending baseline tags.** Exact commands are in
+1. **Push the twelve pending baseline tags.** Exact commands are in
    [`docs/CHECKPOINTS.md`](CHECKPOINTS.md#pending-checkpoint-tags):
-   `baseline/stage-{0-ci-release, 1-conpty-hello-world, 2-vt-parser,
-   3a-screen-model, 3b-wpf-rendering}`. Tags don't trigger any
-   workflow; they're rollback handles only.
+   - **Original five (Stages 0-3b):** `baseline/stage-{0-ci-release,
+     1-conpty-hello-world, 2-vt-parser, 3a-screen-model,
+     3b-wpf-rendering}`.
+   - **Seven added per PR #127 (post-Stage-3b shipped stages):**
+     `baseline/stage-{4-uia-document-text-pattern,
+     11-velopack-auto-update, 4b-process-cleanup-diagnostic,
+     4a-claude-code-substrate, 5-streaming-coalescer,
+     6-keyboard-input, 5a-diagnostic-logging}`.
+
+   Tags don't trigger any workflow; they're rollback handles only.
+   The dev sandbox can't push tags (proxy returns 403 on `refs/tags/`),
+   so this is a maintainer-side action from a workstation. After
+   pushing each tag, **delete the matching row from the "Pending
+   checkpoint tags" table** in `docs/CHECKPOINTS.md` per the
+   existing convention (avoids orphan rows in the table claiming
+   tags exist that don't).
 
 2. **Stage 4 + Stage 11 NVDA verification — complete except
    for one process-cleanup row.** The maintainer ran the
@@ -1197,7 +1210,21 @@ prefer asking for whole-log paste over "search for X then paste a
 snippet". Small focused PRs with detailed test plans are
 appreciated; sprawling PRs with multiple moving parts are not.
 
+The May-2026 cleanup cycle (PRs #118 → #128, all merged) closed
+out Part 1 of [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md)
+and produced the handoff infrastructure that makes this file
+useful as a starting point: the canonical plan doc itself, the
+Stage 7 implementation sketch, the spec stage-numbering hygiene
+(Stages 4a/4b/5a in spec), the rollback-tag rows for all shipped
+post-Stage-3b stages, and the F# 9 nullness + fixup-commit-rhythm
+gotchas in `CONTRIBUTING.md`. The cycle also exercised the
+fixup-commit-on-open-PR rhythm (PR #121 hit FS3261 in CI; fixup
+commit on the same branch closed it) and confirmed that the
+small-focused-PR cadence the maintainer prefers works smoothly
+when paired with the squash-merge convention. The next session
+starts at Part 2 — Stage 7.
+
 Thanks for picking it up. The accessibility differentiation
 (`UIA_ForegroundColorAttributeId`, semantic prompts, listbox
 exposure) is what actually makes this project worth shipping —
-Stages 4–10 are where that work happens.
+Stages 4–10 are where that work happens; Stage 7 is next.

--- a/docs/STAGE-7-ISSUES.md
+++ b/docs/STAGE-7-ISSUES.md
@@ -1,0 +1,127 @@
+# Stage 7 issues inventory
+
+This file is the **explicit design input for Parts 3 + 4 of**
+[`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) — the
+Output-handling and Input-interpretation framework cycles. Stage 7's
+job (per
+[`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) "Stage 7
+implementation sketch (next)") is to ship a Claude Code roundtrip
+end-to-end and **surface every gap that NVDA validation reveals** —
+not solve them. Each gap below becomes a framework requirement that
+the corresponding cycle's RFC must address.
+
+> **Status:** stub created in PR #129 (final-handoff audit). **No
+> entries yet** — Stage 7 implementation hasn't started. The next
+> session that picks up Part 2 / Stage 7 fills this file as it
+> validates Claude Code under NVDA. Don't try to fix anything from
+> the inventory in Stage 7; that's framework-cycle work.
+
+## How to use this file
+
+1. **Run the Stage 7 NVDA validation flow** per
+   `docs/SESSION-HANDOFF.md` "Stage 7 implementation sketch (next)"
+   §4 (launch pty-speak with Claude Code as the spawned shell, type
+   prompts, navigate responses, accept tool-use prompts, read
+   results).
+2. **For every gap surfaced** — every "broken" / "awkward" /
+   "verbose" / "silent" / "this should be a list but reads as text"
+   moment — add an entry to the appropriate section below with:
+   - **One-line summary** in the section heading.
+   - **What broke** — the literal user-observable behaviour
+     (concrete enough that a reader can reproduce it).
+   - **Why it matters** — what the user couldn't do, or what the
+     speech queue did that was wrong.
+   - **Reproduction steps** — exact prompt, exact key sequence,
+     exact NVDA configuration if relevant.
+   - **Hypothesised root cause** if known. Don't speculate
+     architecturally yet; just describe what part of the pipeline
+     looks suspect (parser? coalescer? UIA peer? input encoder?).
+3. **Don't fix anything inline.** Each entry is a framework
+   requirement; the framework cycles produce the fix.
+4. **Update the framework cycle reading their input.** Once the
+   inventory has enough entries to inform the Output framework
+   cycle's research phase, link from there back to specific entries
+   here so the design rationale traces back to the validation
+   evidence.
+
+## Category tags
+
+Each entry is tagged with the framework taxonomy from the May-2026
+plan so the relevant cycle can filter cleanly:
+
+- `[output-stream]` — Stream profile concerns (echo dedup, suffix-diff,
+  OSC 133 prompt awareness).
+- `[output-form]` — Form profile concerns (Claude Code Ink fields,
+  field detection, focus model).
+- `[output-selection]` — Selection profile concerns (list detection,
+  arrow-key navigation, item enumeration; subsumes original Stage 8).
+- `[output-earcon]` — Earcon presentation-sink concerns (colour-to-earcon
+  mapping; subsumes original Stage 9).
+- `[output-tui]` — TUI profile concerns (alt-screen apps that aren't
+  forms or selections — `less`, `vim`, `htop`).
+- `[output-repl]` — REPL profile concerns (Python, Node, sqlite3 —
+  prompt-aware; current line is input).
+- `[input-suggest]` — Input-interpretation concerns (suggestion engine,
+  command grammar lookup, fuzzy typo correction).
+- `[input-buffer]` — Rolling-buffer concerns (echo correlation,
+  on-demand surfacing via `Ctrl+Space` / `Tab` / `Ctrl+H`).
+- `[input-form]` — Form-input concerns (field-aware input for
+  Ink-rendered prompts).
+- `[input-nl]` — Natural-language interpreter concerns (opt-in LLM
+  backend for "list all hidden files" → command suggestion).
+- `[review-mode]` — Stage 10 / Part 5 concerns (quick-nav letters,
+  semantic-event taxonomy).
+- `[other]` — Doesn't fit cleanly into the framework taxonomy; flag
+  for triage.
+
+A single entry can carry multiple tags if it crosses framework
+boundaries (e.g. typed-input echo dedup is both `[output-stream]`
+and `[input-buffer]` because the bridge is the echo-correlation
+API).
+
+## Entries
+
+_(empty — Stage 7 NVDA validation hasn't started yet. First entry
+arrives when the next session ships Stage 7 and runs the
+`docs/ACCESSIBILITY-TESTING.md` Stage 7 manual matrix row.)_
+
+### Template (delete when first real entry lands)
+
+```markdown
+### [tag-1] [tag-2] One-line summary of the gap
+
+**What broke.** Literal user-observable behaviour. Concrete enough
+to reproduce.
+
+**Why it matters.** What the user couldn't do; what the speech
+queue did wrong; what the screen reader silenced or repeated
+inappropriately.
+
+**Reproduction.** Exact prompt to type into Claude Code; exact key
+sequence; NVDA configuration if relevant (speak-typed-characters
+on/off, review cursor mode, etc.).
+
+**Hypothesised root cause.** Which part of the pipeline looks
+suspect — parser? coalescer? UIA peer? input encoder? activity-ID
+processing? Don't speculate architecturally; just point at the
+component.
+
+**Inventory date.** YYYY-MM-DD; pty-speak version
+(`v0.0.1-preview.N`); Claude Code version (`claude --version`);
+NVDA version.
+```
+
+## Cross-references
+
+- [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) "Stage 7
+  implementation sketch (next)" §5 — the "Capture a Stage 7 issues
+  inventory" step that produces entries here.
+- [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) Part 2
+  (Stage 7 validation gate) and Parts 3 + 4 (Output / Input
+  framework cycles) that consume this inventory as design input.
+- [`spec/tech-plan.md`](../spec/tech-plan.md) §7 — the canonical
+  Stage 7 specification; this file documents the gaps the
+  spec-conformant implementation surfaces.
+- [`docs/ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md) — the
+  manual NVDA matrix Stage 7 ships a row in; the matrix is the
+  procedure that produces the inventory entries.


### PR DESCRIPTION
Sweeps the last staleness in the entry-point docs so the next session picks up cleanly. Final PR (PR #129) of the May-2026 cleanup-cycle handoff queue.

SESSION-HANDOFF.md "Where we left off":
- Last merged stages: gains spec-formalized Stages 4a/4b/5a + full PR #118 → #128 cleanup-cycle narrative.
- Last shipped release: caveats clarified (preview.43 is the latest code-bearing preview; subsequent docs-only PRs may have bumped the preview number).
- In-flight branch: "_None._" with explicit handoff to Part 2.
- Next stage: Stage 7 with explicit cross-reference to the Stage 7 implementation sketch in this same file. Lists open follow-ups (screen-buffer runtime resize, screen-reader-native diagnostic-launcher rework now actionable since Stage 6).

SESSION-HANDOFF.md pending action items #1: expanded from "five pending baseline tags" (Stages 0-3b) to twelve (5 original + 7 added per PR #127). Maintainer-side action: push tags from a workstation, then delete each row from the CHECKPOINTS.md "Pending checkpoint tags" table per existing convention.

SESSION-HANDOFF.md closing notes: added a paragraph documenting the May-2026 cleanup-cycle context (PRs #118 → #128 closed Part 1 + bonus context-dump work; fixup-commit rhythm exercised on PR #121; small-focused-PR cadence works smoothly with squash- merge).

README.md status block: "Stage 4.5" -> "Stage 4a" (matches spec §4a formalization); explicit Stage 4b + Stage 5a mentions; cleanup marked shipped; Stage 7 explicitly called out as next.

PROJECT-PLAN-2026-05.md: added "Status as of 2026-05-03 cleanup cycle close" note at the top so a reader doesn't mistake Part 1's sub-items for live to-dos. The plan body below the note is preserved verbatim for decision-history continuity per the doc's own "Future revisions should land as new dated plans" rule.

NEW: docs/STAGE-7-ISSUES.md stub. Pre-creates the file the Stage 7 implementation sketch references. Contains the framework-taxonomy category tags (output-stream / output-form / output-selection / output-earcon / output-tui / output-repl / input-suggest / input-buffer / input-form / input-nl / review-mode / other), an entry template, instructions for use, and explicit cross-references to the spec / plan / sketch. Empty entries section so the next session writes into a structured place without making meta-decisions.

Closes the final context-dump candidate from the May-2026 cleanup-cycle handoff queue. **Next session starts at Part 2 — Stage 7. Read docs/SESSION-HANDOFF.md first.**

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
