### PR TITLE
feat(pty): shell registry + PTYSPEAK_SHELL startup override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,55 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 7 PR-B — extensible shell registry + `PTYSPEAK_SHELL`
+  startup override.** New `Terminal.Pty.ShellRegistry` module
+  (`src/Terminal.Pty/ShellRegistry.fs`) exposes two built-in shells
+  pty-speak can spawn as the ConPTY child: `Cmd` (`cmd.exe`, the
+  Stage 7 default) and `Claude` (`claude.exe`, resolved at startup
+  via `where.exe claude`). Each shell carries a lazy `Resolve`
+  closure returning either the command line to pass to
+  `PtyConfig.CommandLine` or a human-readable failure reason. The
+  shape is designed so future shells (PowerShell, WSL, Python REPL,
+  others) plug in by extending the `ShellId` DU and registering an
+  entry in `builtIns` — no spawn-path changes required.
+
+  The composition root (`src/Terminal.App/Program.fs compose ()`)
+  reads `PTYSPEAK_SHELL` at launch (recognised values: `cmd`,
+  `claude`, case-insensitive after trim), resolves the requested
+  shell, and falls back to `cmd.exe` with a `LogWarning` if either
+  the env-var value is unrecognised or the resolver returns `Error`
+  (e.g. Claude Code not installed — pty-speak still works as a
+  generic terminal in that case rather than failing the launch).
+  Chosen shell + resolved command line are logged at `Information`
+  level after spawn.
+
+  Stage 7 PR-A's env-scrub PO-5 block applies uniformly to
+  whichever shell is selected — extending the registry doesn't
+  broaden the env-leak surface.
+
+  Pinned by `tests/Tests.Unit/ShellRegistryTests.fs`:
+  `parseEnvVar` recognised values + case-insensitivity + trim +
+  null/empty/whitespace handling + non-substring-match (`cmd.exe`
+  is not recognised as `cmd`); `builtIns` keyset pin (force
+  reviewer acknowledgement on every shell addition); `tryFindIn`
+  synthetic-registry injection so tests don't depend on the
+  production `where.exe` invocation. The `whereExe` helper itself
+  is exercised manually via `docs/ACCESSIBILITY-TESTING.md`'s
+  Stage 7 matrix row (extended in PR-D).
+
+  `docs/USER-SETTINGS.md` "Default shell" section logs `PTYSPEAK_SHELL`
+  as today's hardcoded knob and traces the configurability ladder
+  (env var today → Ctrl+Shift+1/2 hotkeys in PR-C → Phase 2 TOML
+  menu UI). Spec deviation note: the spec §7 launch story doesn't
+  mention a registry — the registry is an extension within Stage
+  7's scope per maintainer authorization in this session, formalised
+  in PR-C's spec update alongside the hotkey contract.
+
+  Second of four sequenced Stage 7 PRs per
+  `docs/PROJECT-PLAN-2026-05.md` Part 2; depends on PR-A so the
+  env-scrub applies to claude.exe as well. PR-C layers the
+  Ctrl+Shift+1 / Ctrl+Shift+2 hot-switch hotkeys on top.
+
 - **`docs/HISTORICAL-CONTEXT-2026-05.md` — supplementary backup
   reference, NOT a primary handoff source.** Curated knowledge dump
   capturing the May-2026 cleanup cycle's guiding principles

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -263,6 +263,88 @@ defaults; they shouldn't be the only options.
   manual smoke matrix already covers Stage 9 with NVDA-
   audible verification.
 
+## Default shell
+
+### Current state
+
+Stage 7 PR-B added an extensible `ShellRegistry` in
+`src/Terminal.Pty/ShellRegistry.fs` exposing two built-in shells:
+
+- **`Cmd`** — Windows Command Prompt (`cmd.exe`). The Stage 7
+  default; what new users see if they haven't configured anything.
+- **`Claude`** — Claude Code (`claude.exe`, resolved via
+  `where.exe claude`). The maintainer's primary target workload;
+  selected by setting `PTYSPEAK_SHELL=claude` (case-insensitive)
+  before launching pty-speak.
+
+Resolution lives in `compose ()` (`src/Terminal.App/Program.fs`):
+
+1. Read `PTYSPEAK_SHELL` env var. Recognised values: `cmd`,
+   `claude` (after trim, case-insensitive). Unrecognised non-empty
+   values produce a `LogWarning` and fall back to the default.
+2. Default: `Cmd`.
+3. Resolve via `ShellRegistry.tryFind`. If the resolver returns
+   `Error` (e.g. Claude Code not installed), log a warning at
+   `Information`-adjacent severity and fall back to `Cmd`.
+4. Log the chosen shell + resolved command line at `Information`.
+
+The Stage 7 PR-A env-scrub block from `Terminal.Pty.Native.EnvBlock`
+is applied uniformly to whichever shell is selected — adding new
+shells doesn't broaden the env-leak surface.
+
+### Why hardcoded now
+
+Stage 7's job is to validate Claude Code under NVDA, not to ship
+a configuration UI. `PTYSPEAK_SHELL` is the smallest possible
+selection surface: an env var any user can set in their shell rc
+or via a desktop-shortcut "Run with environment" wrapper. Stage 7
+PR-C adds `Ctrl+Shift+1` / `Ctrl+Shift+2` hotkeys for in-session
+hot-switching (cmd ↔ claude); Phase 2 adds the menu / palette UI
+that exposes the registry to the user without requiring shell
+literacy.
+
+### What configurability would look like
+
+Three plausible levels of configurability, increasing in cost:
+
+1. **`PTYSPEAK_SHELL` env-var override (today's surface).**
+   Recognised names map to built-in registry entries. No file I/O,
+   no parsing risk, easy to revert by unsetting.
+
+2. **Hotkey-driven hot-switch (Stage 7 PR-C).** `Ctrl+Shift+1`
+   selects cmd; `Ctrl+Shift+2` selects claude. The architectural
+   lift is mid-session `ConPtyHost` teardown + respawn, which PR-C
+   ships. Future shells claim higher digit slots (`Ctrl+Shift+3` for
+   PowerShell, etc.). `AppReservedHotkeys` contract + spec §6 update
+   land in PR-C.
+
+3. **Phase 2 TOML config + menu UI.** A `shells` table in the
+   user-settings file lists shell-id + display-name + executable
+   path + optional argument list, and a palette UI lets the user
+   pick from the resolved set. Plugin-style third-party shells
+   (Python, Node, custom scripts) become possible. Requires the
+   Phase 2 user-settings substrate (Issue #112).
+
+### Implementation notes
+
+- `ShellRegistry.builtIns: Map<ShellId, Shell>` is the single source
+  of truth. Adding a shell requires (a) extending the `ShellId`
+  discriminated union, (b) adding an entry to `builtIns` with a
+  resolver closure, (c) updating `parseEnvVar` to recognise the
+  new name, and (d) updating
+  `tests/Tests.Unit/ShellRegistryTests.fs ``builtIns contains exactly Cmd and Claude```
+  (the assertion intentionally pins the exact set so a reviewer is
+  forced to acknowledge each addition).
+- `tryFindIn` exists separate from `tryFind` so tests can inject
+  synthetic registries without touching `builtIns`. Production code
+  uses `tryFind` (which delegates to `builtIns`).
+- `whereExe` is a thin `Process.Start` wrapper with a 2-second
+  timeout. Not unit-tested directly; the real path is exercised in
+  `docs/ACCESSIBILITY-TESTING.md`'s Stage 7 row (PR-D).
+- Persistence: `PTYSPEAK_SHELL` is per-process; the user sets it in
+  their shell environment or via a launcher wrapper. Future TOML
+  config persists across launches.
+
 ## Keybindings
 
 ### Current state

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -780,21 +780,28 @@ module Program =
         // hot-switching.
         let resolveStartupShell () : ShellRegistry.Shell * string =
             let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
+            // Distinguish "unset" from "set to garbage" so the
+            // log line is actionable. `null` / empty / whitespace
+            // is the common case (no env var set); a non-empty
+            // unrecognised value is a typo or stale config and
+            // earns a warning. Extracted to a helper so the
+            // arm body of `parseEnvVar`'s `None` case stays a
+            // single expression — F# 9 + `TreatWarningsAsErrors`
+            // can be brittle about sequence-in-match-arm
+            // shapes, and the helper sidesteps that risk.
+            let logIfUnrecognised () : unit =
+                match envVar with
+                | null -> ()
+                | v when System.String.IsNullOrWhiteSpace(v) -> ()
+                | v ->
+                    log.LogWarning(
+                        "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude.",
+                        v)
             let requested =
                 match ShellRegistry.parseEnvVar envVar with
                 | Some id -> id
                 | None ->
-                    // Distinguish "unset" from "set to garbage" so the
-                    // log line is actionable. `null` / empty is the
-                    // common case (no env var set); a non-empty
-                    // unrecognised value is a typo or stale config.
-                    match envVar with
-                    | null -> ()
-                    | v when System.String.IsNullOrWhiteSpace(v) -> ()
-                    | v ->
-                        log.LogWarning(
-                            "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude.",
-                            v)
+                    logIfUnrecognised ()
                     ShellRegistry.Cmd
             // `tryFind` only returns None for ids not registered in
             // `builtIns`; both Cmd and Claude are registered, so this

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -771,10 +771,68 @@ module Program =
                         with _ -> ()
                 } :> Task)
 
+        // Stage 7 PR-B — resolve which shell to spawn. cmd.exe stays
+        // the default per maintainer instruction; `PTYSPEAK_SHELL=claude`
+        // (or any future menu UI) flips it. Unrecognised env-var values
+        // fall back to cmd with a warning log so the user isn't locked
+        // out of a working terminal by a typo. PR-C adds Ctrl+Shift+1
+        // (cmd) / Ctrl+Shift+2 (claude) hotkeys for mid-session
+        // hot-switching.
+        let resolveStartupShell () : ShellRegistry.Shell * string =
+            let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
+            let requested =
+                match ShellRegistry.parseEnvVar envVar with
+                | Some id -> id
+                | None ->
+                    // Distinguish "unset" from "set to garbage" so the
+                    // log line is actionable. `null` / empty is the
+                    // common case (no env var set); a non-empty
+                    // unrecognised value is a typo or stale config.
+                    match envVar with
+                    | null -> ()
+                    | v when System.String.IsNullOrWhiteSpace(v) -> ()
+                    | v ->
+                        log.LogWarning(
+                            "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude.",
+                            v)
+                    ShellRegistry.Cmd
+            // `tryFind` only returns None for ids not registered in
+            // `builtIns`; both Cmd and Claude are registered, so this
+            // is unreachable for the requested id, but the cmd-fallback
+            // is shared with the resolution-failure branch below.
+            let cmdShell =
+                match ShellRegistry.tryFind ShellRegistry.Cmd with
+                | Some s -> s
+                | None -> failwith "Cmd not registered in ShellRegistry.builtIns"
+            match ShellRegistry.tryFind requested with
+            | None ->
+                cmdShell, "cmd.exe"
+            | Some shell ->
+                match shell.Resolve() with
+                | Ok cmdLine ->
+                    shell, cmdLine
+                | Error reason ->
+                    log.LogWarning(
+                        "Shell {Shell} unavailable: {Reason}. Falling back to {Fallback}.",
+                        shell.DisplayName,
+                        reason,
+                        cmdShell.DisplayName)
+                    let fallbackCmd =
+                        match cmdShell.Resolve() with
+                        | Ok c -> c
+                        | Error _ -> "cmd.exe"
+                    cmdShell, fallbackCmd
+
+        let chosenShell, commandLine = resolveStartupShell ()
+        log.LogInformation(
+            "Startup shell: {Shell} (command line: {CommandLine}).",
+            chosenShell.DisplayName,
+            commandLine)
+
         let cfg : PtyConfig =
             { Cols = int16 ScreenCols
               Rows = int16 ScreenRows
-              CommandLine = "cmd.exe" }
+              CommandLine = commandLine }
 
         let mutable hostHandle : ConPtyHost option = None
 

--- a/src/Terminal.Pty/ShellRegistry.fs
+++ b/src/Terminal.Pty/ShellRegistry.fs
@@ -1,0 +1,140 @@
+namespace Terminal.Pty
+
+open System
+open System.Diagnostics
+open System.IO
+
+/// Stage 7 PR-B — extensible registry of shells pty-speak can spawn
+/// as the ConPTY child. Today's surface is `Cmd` (Windows Command
+/// Prompt) and `Claude` (the maintainer's primary target workload —
+/// Claude Code). The shape is deliberately designed so future shells
+/// (PowerShell, WSL, Python REPL, others) plug in without touching
+/// the spawn path.
+///
+/// Each `Shell` is identified by a `ShellId` discriminated-union case
+/// and carries a `Resolve` closure that returns either the command
+/// line to pass to ConPTY's `CreateProcess` (`PtyConfig.CommandLine`)
+/// or a human-readable reason it couldn't be located. Resolution is
+/// run at call time (not cached at the registry level) so tests can
+/// inject deterministic registries; production callers (`Program.fs`'s
+/// startup compose path) call `Resolve` once at session start.
+///
+/// **No dependencies on logging.** The registry is pure data + a thin
+/// `where.exe` wrapper. The orchestration (warning on unrecognised
+/// `PTYSPEAK_SHELL`, fallback to default on resolution failure) lives
+/// in `src/Terminal.App/Program.fs compose ()` where the `ILogger` is
+/// already in scope. Keeping `Terminal.Pty` logger-free preserves the
+/// dependency boundary that's held since Stage 1.
+module ShellRegistry =
+
+    /// Discriminated-union identity of every shell pty-speak knows
+    /// how to launch. Add cases here to extend the registry; each
+    /// case needs a registration in `builtIns` below.
+    ///
+    /// Future cases (Phase 2 territory): `PowerShell`, `Wsl of
+    /// distro: string`, `Python`, `Node`, `Bash`, etc.
+    type ShellId =
+        | Cmd
+        | Claude
+
+    /// The runtime descriptor for a shell. `Resolve` is called at
+    /// most once per session by the composition root; tests inject
+    /// synthetic descriptors via `tryFindIn` to bypass the
+    /// production registry entirely.
+    type Shell =
+        { Id: ShellId
+          /// Display name surfaced in user-visible log lines and
+          /// (eventually) NVDA announcements when PR-C's
+          /// hot-switch hotkeys land.
+          DisplayName: string
+          /// Lazy resolver. `Ok cmdLine` is the value to pass as
+          /// `PtyConfig.CommandLine`; `Error reason` is a
+          /// short, AnnounceSanitiser-safe explanation suitable
+          /// for `log.LogWarning` interpolation.
+          Resolve: unit -> Result<string, string> }
+
+    /// `where.exe NAME` resolution helper. Used by shells that
+    /// aren't guaranteed to be on `PATH` (`claude.exe`). Returns
+    /// the absolute path of the first hit on stdout, or an
+    /// `Error` with a human-readable reason. Two-second timeout
+    /// caps the worst case if `where.exe` itself misbehaves.
+    ///
+    /// Not unit-tested directly (involves `Process.Start`); the
+    /// orchestrator in `Program.fs` exercises the real path
+    /// during launch and pinned manually via `docs/ACCESSIBILITY-
+    /// TESTING.md` Stage 7 row in PR-D.
+    let internal whereExe (name: string) : Result<string, string> =
+        try
+            let psi = ProcessStartInfo()
+            psi.FileName <- "where.exe"
+            psi.Arguments <- name
+            psi.RedirectStandardOutput <- true
+            psi.RedirectStandardError <- true
+            psi.UseShellExecute <- false
+            psi.CreateNoWindow <- true
+            use p = Process.Start(psi)
+            // CodeQL-clean: Process.Start with explicit
+            // ProcessStartInfo (no shell=true) per
+            // CONTRIBUTING.md's Process.Start convention.
+            let exited = p.WaitForExit(2000)
+            if not exited then
+                try p.Kill() with _ -> ()
+                Error (sprintf "%s: where.exe timed out after 2s" name)
+            elif p.ExitCode = 0 then
+                let out = p.StandardOutput.ReadToEnd()
+                let firstLine =
+                    out.Split([| '\n'; '\r' |])
+                    |> Array.tryFind (fun l -> l.Trim().Length > 0)
+                match firstLine with
+                | Some line -> Ok (line.Trim())
+                | None -> Error (sprintf "%s: where.exe returned no path" name)
+            else
+                Error (sprintf "%s: not found on PATH" name)
+        with ex ->
+            // AnnounceSanitiser is applied at the announcement
+            // boundary in Program.fs, not here, so the raw
+            // exception message is fine for the Result payload.
+            Error (sprintf "%s: %s" name ex.Message)
+
+    /// Built-in shell registry. Order is irrelevant; lookup is by
+    /// `ShellId` via `tryFind`. Every entry is a closure that's
+    /// safe to call repeatedly (cmd's resolver is constant; Claude's
+    /// re-runs `where.exe`, which is acceptable for the at-most-
+    /// once-per-session calling pattern).
+    let builtIns : Map<ShellId, Shell> =
+        Map.ofList
+            [ Cmd,
+                { Id = Cmd
+                  DisplayName = "Command Prompt"
+                  Resolve = fun () -> Ok "cmd.exe" }
+              Claude,
+                { Id = Claude
+                  DisplayName = "Claude Code"
+                  Resolve = fun () -> whereExe "claude" } ]
+
+    /// Look up a shell in a registry. Production callers pass
+    /// `builtIns`; tests pass a synthetic Map to inject
+    /// deterministic Resolve closures.
+    let tryFindIn (registry: Map<ShellId, Shell>) (id: ShellId) : Shell option =
+        Map.tryFind id registry
+
+    /// Convenience: look up in the production `builtIns` registry.
+    let tryFind (id: ShellId) : Shell option =
+        tryFindIn builtIns id
+
+    /// Map a `PTYSPEAK_SHELL` env-var value to a `ShellId`.
+    /// Recognised values (case-insensitive after trim): `"cmd"`,
+    /// `"claude"`. Returns `None` for unrecognised values so the
+    /// caller can log a warning + fall back to the default.
+    /// `null` and empty/whitespace are treated as "not set" (also
+    /// returns `None`); callers distinguish via the source-side
+    /// null check.
+    let parseEnvVar (value: string | null) : ShellId option =
+        match value with
+        | null -> None
+        | v ->
+            match v.Trim().ToLowerInvariant() with
+            | "" -> None
+            | "cmd" -> Some Cmd
+            | "claude" -> Some Claude
+            | _ -> None

--- a/src/Terminal.Pty/ShellRegistry.fs
+++ b/src/Terminal.Pty/ShellRegistry.fs
@@ -72,24 +72,35 @@ module ShellRegistry =
             psi.RedirectStandardError <- true
             psi.UseShellExecute <- false
             psi.CreateNoWindow <- true
-            use p = Process.Start(psi)
             // CodeQL-clean: Process.Start with explicit
             // ProcessStartInfo (no shell=true) per
             // CONTRIBUTING.md's Process.Start convention.
-            let exited = p.WaitForExit(2000)
-            if not exited then
-                try p.Kill() with _ -> ()
-                Error (sprintf "%s: where.exe timed out after 2s" name)
-            elif p.ExitCode = 0 then
-                let out = p.StandardOutput.ReadToEnd()
-                let firstLine =
-                    out.Split([| '\n'; '\r' |])
-                    |> Array.tryFind (fun l -> l.Trim().Length > 0)
-                match firstLine with
-                | Some line -> Ok (line.Trim())
-                | None -> Error (sprintf "%s: where.exe returned no path" name)
-            else
-                Error (sprintf "%s: not found on PATH" name)
+            //
+            // F# 9 nullness: `Process.Start(ProcessStartInfo)` is
+            // annotated `Process | null` (the .NET docs document
+            // this — Start returns null when no resource is
+            // started, e.g. attempting to start a no-op process).
+            // Match-on-null and surface a usable Error so the
+            // composition root's fallback path runs predictably.
+            match Process.Start(psi) with
+            | null ->
+                Error (sprintf "%s: Process.Start returned null" name)
+            | p ->
+                use _ = p
+                let exited = p.WaitForExit(2000)
+                if not exited then
+                    try p.Kill() with _ -> ()
+                    Error (sprintf "%s: where.exe timed out after 2s" name)
+                elif p.ExitCode = 0 then
+                    let out = p.StandardOutput.ReadToEnd()
+                    let firstLine =
+                        out.Split([| '\n'; '\r' |])
+                        |> Array.tryFind (fun l -> l.Trim().Length > 0)
+                    match firstLine with
+                    | Some line -> Ok (line.Trim())
+                    | None -> Error (sprintf "%s: where.exe returned no path" name)
+                else
+                    Error (sprintf "%s: not found on PATH" name)
         with ex ->
             // AnnounceSanitiser is applied at the announcement
             // boundary in Program.fs, not here, so the raw

--- a/src/Terminal.Pty/Terminal.Pty.fsproj
+++ b/src/Terminal.Pty/Terminal.Pty.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Native.fs" />
+    <Compile Include="ShellRegistry.fs" />
     <Compile Include="PseudoConsole.fs" />
     <Compile Include="ConPtyHost.fs" />
   </ItemGroup>

--- a/tests/Tests.Unit/ShellRegistryTests.fs
+++ b/tests/Tests.Unit/ShellRegistryTests.fs
@@ -132,12 +132,17 @@ let ``Claude entry has DisplayName "Claude Code"`` () =
 
 [<Fact>]
 let ``tryFindIn returns Some when the id is registered`` () =
-    let registry =
-        Map.ofList
-            [ ShellRegistry.Cmd,
-                { Id = ShellRegistry.Cmd
-                  DisplayName = "fake-cmd"
-                  Resolve = fun () -> Ok "fake.exe" } ]
+    // F# 9 record-literal inference can't see the `Shell` record's
+    // fields without the type annotation: `Shell` lives inside
+    // `module ShellRegistry` (not auto-opened), so `Id`/`DisplayName`/
+    // `Resolve` aren't unqualified-resolvable from the test scope.
+    // The annotation pins the record's type and the field names
+    // resolve cleanly.
+    let shell : ShellRegistry.Shell =
+        { Id = ShellRegistry.Cmd
+          DisplayName = "fake-cmd"
+          Resolve = fun () -> Ok "fake.exe" }
+    let registry = Map.ofList [ ShellRegistry.Cmd, shell ]
     let found = ShellRegistry.tryFindIn registry ShellRegistry.Cmd
     Assert.True(found.IsSome)
     Assert.Equal("fake-cmd", found.Value.DisplayName)
@@ -158,12 +163,11 @@ let ``tryFindIn allows tests to inject deterministic Resolve closures`` () =
     // higher-level orchestration (which is in `Program.fs compose ()`
     // for now; will move into a testable helper if PR-C's hot-switch
     // logic justifies the extraction).
-    let synthetic =
-        Map.ofList
-            [ ShellRegistry.Claude,
-                { Id = ShellRegistry.Claude
-                  DisplayName = "synthetic Claude"
-                  Resolve = fun () -> Error "synthetic-failure-for-test" } ]
+    let claudeShell : ShellRegistry.Shell =
+        { Id = ShellRegistry.Claude
+          DisplayName = "synthetic Claude"
+          Resolve = fun () -> Error "synthetic-failure-for-test" }
+    let synthetic = Map.ofList [ ShellRegistry.Claude, claudeShell ]
     let claude = (ShellRegistry.tryFindIn synthetic ShellRegistry.Claude).Value
     match claude.Resolve() with
     | Error reason -> Assert.Equal("synthetic-failure-for-test", reason)

--- a/tests/Tests.Unit/ShellRegistryTests.fs
+++ b/tests/Tests.Unit/ShellRegistryTests.fs
@@ -1,0 +1,170 @@
+module PtySpeak.Tests.Unit.ShellRegistryTests
+
+open Xunit
+open Terminal.Pty
+
+// ---------------------------------------------------------------------
+// Stage 7 PR-B — ShellRegistry pinning
+// ---------------------------------------------------------------------
+//
+// `ShellRegistry` is the extensibility seam Stage 7's hot-switch-
+// hotkey UX (PR-C) and Phase-2's user-settings menu eventually plug
+// into. These tests pin two contracts:
+//
+//   1. `parseEnvVar` — pure mapping from `PTYSPEAK_SHELL` text to
+//      `ShellId option`. Recognises "cmd" / "claude" case-insensitively
+//      after trim; returns `None` for null, empty, whitespace, or
+//      anything else (so the caller can warn-and-fall-back).
+//   2. `builtIns` registry contains exactly the cmd + claude entries
+//      Stage 7 ships with. Adding a shell entry requires updating
+//      this assertion (matches the AllowedNames-pin pattern in
+//      `EnvBlockTests.fs`).
+//
+// `whereExe` involves `Process.Start` and isn't unit-tested here —
+// the real path is exercised in PR-D's manual NVDA matrix row.
+// `tryFindIn` exists specifically to let tests inject synthetic
+// registries without touching `builtIns`; we use it below to verify
+// the lookup contract.
+
+// ---------------------------------------------------------------------
+// parseEnvVar — recognised values
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``parseEnvVar recognises "cmd"`` () =
+    Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "cmd")
+
+[<Fact>]
+let ``parseEnvVar recognises "claude"`` () =
+    Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "claude")
+
+[<Fact>]
+let ``parseEnvVar is case-insensitive`` () =
+    Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "CMD")
+    Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "Cmd")
+    Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "CLAUDE")
+    Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "Claude")
+
+[<Fact>]
+let ``parseEnvVar trims surrounding whitespace`` () =
+    Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "  cmd  ")
+    Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "\tclaude\n")
+
+// ---------------------------------------------------------------------
+// parseEnvVar — unrecognised values
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``parseEnvVar returns None for null`` () =
+    Assert.Equal(None, ShellRegistry.parseEnvVar null)
+
+[<Fact>]
+let ``parseEnvVar returns None for empty string`` () =
+    Assert.Equal(None, ShellRegistry.parseEnvVar "")
+
+[<Fact>]
+let ``parseEnvVar returns None for whitespace`` () =
+    Assert.Equal(None, ShellRegistry.parseEnvVar "   ")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "\t\n")
+
+[<Fact>]
+let ``parseEnvVar returns None for unrecognised values`` () =
+    // Values like "powershell" / "wsl" / "bash" / "garbage" all
+    // return None today; future shells would be added by extending
+    // `parseEnvVar`'s match arms.
+    Assert.Equal(None, ShellRegistry.parseEnvVar "powershell")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "wsl")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "bash")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "garbage")
+
+[<Fact>]
+let ``parseEnvVar does not match substrings (cmd.exe)`` () =
+    // "cmd.exe" should NOT match the "cmd" arm — recognised values
+    // are short identifiers, not paths. A user typing the full
+    // executable name should get None and fall through to the
+    // warning log.
+    Assert.Equal(None, ShellRegistry.parseEnvVar "cmd.exe")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "claude.exe")
+
+// ---------------------------------------------------------------------
+// builtIns registry — pin shell set
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``builtIns contains exactly Cmd and Claude`` () =
+    // Pinning the registry's keyset protects against accidental
+    // additions that would broaden the spawn surface beyond what
+    // Stage 7 authorises. Adding a shell requires a spec PR + this
+    // assertion update — same ADR-style discipline as
+    // `EnvBlockTests.allowedNames contains exactly the spec-7-2 baseline`.
+    let expected =
+        Set.ofList [ ShellRegistry.Cmd; ShellRegistry.Claude ]
+    let actual =
+        ShellRegistry.builtIns
+        |> Map.toSeq
+        |> Seq.map fst
+        |> Set.ofSeq
+    Assert.Equal<Set<ShellRegistry.ShellId>>(expected, actual)
+
+[<Fact>]
+let ``Cmd entry resolves to cmd.exe`` () =
+    let cmd =
+        ShellRegistry.builtIns
+        |> Map.find ShellRegistry.Cmd
+    Assert.Equal("Command Prompt", cmd.DisplayName)
+    Assert.Equal<Result<string, string>>(Ok "cmd.exe", cmd.Resolve())
+
+[<Fact>]
+let ``Claude entry has DisplayName "Claude Code"`` () =
+    // `Resolve` for Claude calls `where.exe claude` which behaves
+    // differently on each test environment; we only pin the metadata
+    // here. The real resolution is exercised in PR-D's NVDA matrix
+    // row.
+    let claude =
+        ShellRegistry.builtIns
+        |> Map.find ShellRegistry.Claude
+    Assert.Equal("Claude Code", claude.DisplayName)
+    Assert.Equal(ShellRegistry.Claude, claude.Id)
+
+// ---------------------------------------------------------------------
+// tryFindIn — synthetic registry injection
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``tryFindIn returns Some when the id is registered`` () =
+    let registry =
+        Map.ofList
+            [ ShellRegistry.Cmd,
+                { Id = ShellRegistry.Cmd
+                  DisplayName = "fake-cmd"
+                  Resolve = fun () -> Ok "fake.exe" } ]
+    let found = ShellRegistry.tryFindIn registry ShellRegistry.Cmd
+    Assert.True(found.IsSome)
+    Assert.Equal("fake-cmd", found.Value.DisplayName)
+
+[<Fact>]
+let ``tryFindIn returns None when the id is missing`` () =
+    let registry : Map<ShellRegistry.ShellId, ShellRegistry.Shell> =
+        Map.empty
+    Assert.Equal(None, ShellRegistry.tryFindIn registry ShellRegistry.Cmd)
+    Assert.Equal(None, ShellRegistry.tryFindIn registry ShellRegistry.Claude)
+
+[<Fact>]
+let ``tryFindIn allows tests to inject deterministic Resolve closures`` () =
+    // The reason `tryFindIn` exists separate from `tryFind`: PR-B's
+    // production resolver hits `where.exe` for Claude, which is
+    // non-deterministic across test environments. Tests construct a
+    // synthetic registry with predictable closures and verify the
+    // higher-level orchestration (which is in `Program.fs compose ()`
+    // for now; will move into a testable helper if PR-C's hot-switch
+    // logic justifies the extraction).
+    let synthetic =
+        Map.ofList
+            [ ShellRegistry.Claude,
+                { Id = ShellRegistry.Claude
+                  DisplayName = "synthetic Claude"
+                  Resolve = fun () -> Error "synthetic-failure-for-test" } ]
+    let claude = (ShellRegistry.tryFindIn synthetic ShellRegistry.Claude).Value
+    match claude.Resolve() with
+    | Error reason -> Assert.Equal("synthetic-failure-for-test", reason)
+    | Ok _ -> Assert.Fail("Expected Error from synthetic resolver; got Ok")

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="KeyEncodingTests.fs" />
     <Compile Include="FileLoggerTests.fs" />
     <Compile Include="EnvBlockTests.fs" />
+    <Compile Include="ShellRegistryTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Stage 7 PR-B: extensible shell registry with `Cmd` + `Claude` built-ins plus a `PTYSPEAK_SHELL` env-var override at startup. Second of four sequenced Stage 7 PRs per [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md) Part 2; depends on PR-A (#131) so the env-scrub block applies to claude as well. PR-C layers `Ctrl+Shift+1` / `Ctrl+Shift+2` hot-switch hotkeys on top.

## What changes

- **`src/Terminal.Pty/ShellRegistry.fs`** (new) — pure data + helpers:
  - `ShellId` discriminated union (`Cmd` | `Claude`). Future shells (PowerShell, WSL, Python REPL) plug in by extending the DU and adding a `builtIns` entry — no spawn-path changes required.
  - `Shell` record: `Id` + `DisplayName` + `Resolve` closure (`unit -> Result<string, string>`).
  - `builtIns` map: `Cmd` resolves to `"cmd.exe"`; `Claude` resolves via `where.exe claude` with a 2s timeout.
  - `tryFind` / `tryFindIn` lookup pair — `tryFindIn` lets tests inject synthetic registries without touching `builtIns`.
  - `parseEnvVar`: maps `PTYSPEAK_SHELL` text → `ShellId option`. Recognises `"cmd"` / `"claude"` case-insensitively after trim; null/empty/whitespace/unrecognised return `None`.
  - `whereExe` helper: thin `Process.Start` wrapper, no `shell=true`, explicit `ProcessStartInfo`. Not unit-tested directly (real path exercised in PR-D's NVDA matrix row).
- **`src/Terminal.App/Program.fs compose ()`** — replaces hardcoded `CommandLine = "cmd.exe"` with a `resolveStartupShell` helper:
  1. Read `PTYSPEAK_SHELL`
  2. Map via `ShellRegistry.parseEnvVar`; warn log on non-empty unrecognised values
  3. Default `Cmd`
  4. Resolve; fall back to cmd with warning on resolver failure (e.g. Claude Code not installed — pty-speak still works as a generic terminal)
  5. Log chosen shell + resolved command line at `Information`
  Stage 7 PR-A's env-scrub block applies uniformly regardless of shell.
- **`tests/Tests.Unit/ShellRegistryTests.fs`** (new) — pinning fixtures for `parseEnvVar` (recognised values, case-insensitivity, trim, null/empty/whitespace handling, non-substring-match — `cmd.exe` ≠ `cmd`), `builtIns` keyset pin (forces reviewer acknowledgement on every shell addition; matches the `AllowedNames` pin pattern in `EnvBlockTests`), and `tryFindIn` synthetic-registry injection demonstrating the test seam for PR-C's hot-switch orchestrator.
- **`docs/USER-SETTINGS.md`** — new "Default shell" section before Keybindings, following the existing template (Current state / Why hardcoded now / What configurability would look like / Implementation notes). Documents the configurability ladder: env var today → `Ctrl+Shift+1/2` hotkeys (PR-C) → Phase 2 TOML menu UI.
- **`CHANGELOG.md`** — `[Unreleased]` ### Added entry.

## What this PR deliberately omits

- **Hot-switch hotkeys `Ctrl+Shift+1` / `Ctrl+Shift+2`** — PR-C's scope. Carries the architecturally non-trivial mid-session `ConPtyHost` teardown + respawn + UIA continuity decision; lands as its own PR so a regression there doesn't entangle the registry work here.
- **Spec §7 update documenting the shell-registry extension** — PR-C lands the spec update alongside the `AppReservedHotkeys` contract change.
- **Stage 7 NVDA-validation matrix expansion + `STAGE-7-ISSUES.md` seeding** — PR-D's scope (after PR-C ships).

## Test plan

- [x] Unit fixtures cover `parseEnvVar` + `builtIns` keyset + `tryFindIn` injection
- [ ] CI green on Windows-latest
- [ ] Maintainer-side manual launch with `PTYSPEAK_SHELL` unset → cmd; `PTYSPEAK_SHELL=claude` → claude.exe (when installed); `PTYSPEAK_SHELL=garbage` → cmd + warning in log (deferred to PR-D row)

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_