### PR TITLE
feat(app): hot-switch hotkeys Ctrl+Shift+1 (cmd) / Ctrl+Shift+2 (claude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,85 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 7 PR-C — hot-switch hotkeys `Ctrl+Shift+1` (cmd) /
+  `Ctrl+Shift+2` (claude).** Mid-session shell switching via WPF
+  `KeyBinding` -> `RoutedCommand` -> orchestrator closure in
+  `src/Terminal.App/Program.fs compose ()`. The orchestrator
+  resolves the target via `ShellRegistry.tryFind`, announces
+  "Switching to {target}." with the existing 700ms
+  announce-before-launch delay (matches Stage 4b's diagnostic-
+  launcher pattern), tears down the running ConPtyHost (cancels
+  reader, terminates immediate child via `TerminateProcess`,
+  closes pipes; `KILL_ON_JOB_CLOSE` on the Job Object cascade-
+  kills any grandchildren the previous shell spawned), spawns
+  a new `ConPtyHost.start` with the same grid dimensions and
+  the resolved command line, re-wires keyboard / paste / focus
+  / resize callbacks via the extracted `wirePostSpawn` helper,
+  and announces "Switched to {target}." Resolve failure (e.g.
+  Claude Code not installed) keeps the existing host running
+  and announces the failure rather than dropping the user
+  into a dead window.
+
+  Both hotkeys are reserved in
+  `TerminalView.AppReservedHotkeys` so Stage 6's
+  `OnPreviewKeyDown` filter doesn't mark them `Handled = true`
+  before WPF's `InputBindings` machinery can fire.
+  Number-row digits (`Key.D1` / `Key.D2`), NOT numpad —
+  numpad-with-NumLock-off carries NVDA review-cursor commands
+  per the accessibility non-negotiables. NVDA collision check:
+  `Ctrl+Shift+1` / `Ctrl+Shift+2` have no default NVDA
+  bindings (the digit-only `1` / `Shift+1` browse-mode
+  heading-quick-nav doesn't fire in focus mode, which is what
+  NVDA uses for terminal applications).
+
+  New `ActivityIds.shellSwitch = "pty-speak.shell-switch"` for
+  the announce strings; tagged distinctly so users can
+  configure NVDA's notification processing for shell-switch
+  announcements separately from streaming output.
+
+  `wirePostSpawn` extraction: the post-spawn wiring (env-scrub
+  count log, reader-loop start, `SetPtyHost` callbacks) was
+  factored out of the initial-spawn `window.Loaded.Add` block
+  so the shell-switch coordinator reuses the exact same
+  wiring without duplication. Both spawn paths converge on
+  `wirePostSpawn host`.
+
+  Spec deviation: bundled spec update (§6 hotkey-list
+  amendment + new §7.5 "Shell registry + hot-switch UX")
+  per chat 2026-05-03 maintainer authorisation. Mirrors the
+  ADR-style retroactive-formalisation pattern that landed
+  Stages 4a / 4b / 5a.
+
+  Pinned by `tests/Tests.Unit/ShellSwitchTests.fs`: ShellId
+  exhaustive pattern coverage (FS0025 forces lockstep updates
+  when shells are added), `Ctrl+Shift+1`-to-`Cmd` /
+  `Ctrl+Shift+2`-to-`Claude` mapping, registry/hotkey keyset
+  parity check (every registered shell has a hotkey),
+  Resolver-Result shape (no exception leak), DisplayName
+  natural-language check (announce strings read aloud).
+
+  Known limitations (deferred to follow-up PRs if NVDA
+  validation flags them in PR-D):
+  - Screen state is NOT reset across switches; new shell's
+    first paint overlays the previous screen. cmd -> claude
+    is clean (`?1049h` enters alt-screen); claude -> cmd may
+    briefly show alt-screen residue.
+  - Parser state is NOT reset; mid-CSI/OSC bytes from the
+    dying shell may parse oddly until the new shell sends a
+    complete sequence.
+  - UIA peer ranges are NOT invalidated; NVDA's review cursor
+    may briefly point at stale text until the new shell's
+    first announce-bound output triggers a fresh
+    Notification event.
+
+  Each is acceptable for v1; the framework cycles' RFC scope
+  owns the architectural fixes.
+
+  Third of four sequenced Stage 7 PRs per
+  `docs/PROJECT-PLAN-2026-05.md` Part 2; depends on PR-B
+  (#132) for the `ShellRegistry` registry. PR-D (NVDA
+  validation matrix + STAGE-7-ISSUES seeding) follows.
+
 - **Stage 7 PR-B — extensible shell registry + `PTYSPEAK_SHELL`
   startup override.** New `Terminal.Pty.ShellRegistry` module
   (`src/Terminal.Pty/ShellRegistry.fs`) exposes two built-in shells

--- a/README.md
+++ b/README.md
@@ -176,9 +176,26 @@ preserve this list per the app-reserved-hotkey contract in
   and paste. The fastest way to send a session log to a
   maintainer. See [`docs/LOGGING.md`](docs/LOGGING.md) for what
   is and isn't logged.
+- **`Ctrl+Shift+1`** — switch the spawned shell to `cmd.exe`
+  mid-session. Tears down the running ConPTY child (kernel
+  `KILL_ON_JOB_CLOSE` cascade kills any grandchildren) and
+  spawns cmd in its place. NVDA announces "Switching to
+  Command Prompt." → ~700ms pause → "Switched to Command
+  Prompt." (Stage 7 PR-C).
+- **`Ctrl+Shift+2`** — switch the spawned shell to `claude.exe`
+  (resolved via `where.exe claude` per spec §7.1). Same teardown
+  + respawn as `Ctrl+Shift+1`. NVDA announces "Switching to
+  Claude Code." → "Switched to Claude Code." If Claude Code
+  isn't on `PATH`, NVDA announces "Cannot switch to Claude
+  Code: not found on PATH." and the existing shell keeps
+  running (Stage 7 PR-C).
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute
 toggle), `Alt+Shift+R` (Stage 10 review-mode toggle).
+Higher digit slots (`Ctrl+Shift+3`, `Ctrl+Shift+4`, ...) are
+reserved for future shells (PowerShell, WSL, Python REPL)
+per the shell-registry extensibility model in
+[`spec/tech-plan.md`](spec/tech-plan.md) §7.5.
 
 The historical Stage 0 preview installer opens an empty window. Once
 the next preview is cut from the current `main`, the installer launches

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -444,10 +444,23 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 >     bound in `setupAutoUpdateKeybinding` in
 >     `src/Terminal.App/Program.fs`).
 >
+> Stage 7 PR-C additions (ADR-style amendment 2026-05-03,
+> maintainer-authorised — bundled with the shell registry +
+> hot-switch UX in §7.5 below):
+>   - `Ctrl+Shift+1` — switch the spawned shell to cmd.exe.
+>     Bound in `setupShellSwitchKeybindings` in
+>     `src/Terminal.App/Program.fs`.
+>   - `Ctrl+Shift+2` — switch the spawned shell to claude.exe
+>     (resolved via `where.exe claude` per §7.1).
+>     Bound in the same setup function.
+>
 > Future entries (declared as code comments today; activated
 > when their owning stage ships):
 >   - `Ctrl+Shift+M` — Stage 9 earcon mute toggle.
 >   - `Alt+Shift+R` — Stage 10 review-mode toggle.
+>   - `Ctrl+Shift+3` / `4` / `...` — additional shells
+>     (PowerShell, WSL, Python REPL, etc.) per the §7.5
+>     extensibility model.
 >
 > Failure mode if violated: app-level hotkeys silently stop
 > working — `Ctrl+Shift+U` no longer triggers self-update,
@@ -615,6 +628,138 @@ On first invocation Claude Code will:
   - Selection prompt (“Edit / Yes / Always / No”) is announced as flat text, not as a listbox → Stage 8.
   - Red error text is announced as plain text → Stage 9.
   - No way to jump back through the response after focus moves → Stage 10.
+
+### 7.5 Shell registry + hot-switch UX (Stage 7 PR-B + PR-C)
+
+> **ADR-style amendment 2026-05-03** — added per maintainer
+> authorisation (chat 2026-05-03; mirrors the chat-2026-05-03
+> retroactive-formalisation pattern that landed §4a / §4b /
+> §5a). The original §7 launch story assumed a single
+> shell-per-launch (the `PTYSPEAK_SHELL` env var); this section
+> formalises the registry abstraction + the mid-session
+> hot-switch UX that landed in PR-B and PR-C of the Stage 7
+> sequence.
+
+**Goal.** Make the spawned shell pluggable (no hardcoded
+"cmd or claude" branching in the spawn path) and reachable
+mid-session via a screen-reader-accessible hotkey gesture, so
+the user can flip between cmd / claude (and future shells)
+without restarting pty-speak.
+
+#### 7.5.1 Registry shape (Stage 7 PR-B)
+
+`Terminal.Pty.ShellRegistry` exposes a discriminated union
+`ShellId` plus a `Shell` record carrying display name + lazy
+resolver:
+
+```fsharp
+type ShellId = | Cmd | Claude
+type Shell =
+    { Id: ShellId
+      DisplayName: string
+      Resolve: unit -> Result<string, string> }
+```
+
+`builtIns: Map<ShellId, Shell>` is the single source of truth.
+Adding a shell requires (a) extending `ShellId`, (b) adding a
+`builtIns` entry with a resolver closure, (c) updating
+`parseEnvVar`'s recognised-values list, (d) updating
+`ShellRegistryTests.builtIns contains exactly Cmd and Claude` to
+pin the new keyset, and (e) adding a `Ctrl+Shift+N` hotkey if
+the new shell wants hot-switch participation.
+
+`tryFind` and `tryFindIn` separate the production lookup
+(`tryFind`, delegates to `builtIns`) from the test seam
+(`tryFindIn`, accepts an injected registry). Tests construct
+synthetic registries with deterministic resolvers so
+`Process.Start("where.exe", ...)` doesn't leak into the unit
+test.
+
+#### 7.5.2 Default + override (Stage 7 PR-B)
+
+Cmd is the default. `PTYSPEAK_SHELL=claude` (case-insensitive
+after trim) flips to claude at startup. Unrecognised non-empty
+values produce a `LogWarning` and fall back to cmd. Resolution
+failure (e.g. claude.exe not on PATH) likewise falls back to
+cmd with a warning.
+
+Rationale: a fresh-install user without Claude Code installed
+should still see a working terminal. The maintainer-primary
+workload (Claude Code) is opt-in via the env var or the §7.5.3
+hotkey.
+
+#### 7.5.3 Hot-switch hotkeys (Stage 7 PR-C)
+
+`Ctrl+Shift+1` → cmd.exe; `Ctrl+Shift+2` → claude.exe. Both
+are reserved in `TerminalView.AppReservedHotkeys` per §6.
+Number-row digits, NOT numpad — numpad-with-NumLock-off
+carries NVDA review-cursor commands and must stay reachable.
+
+NVDA collision check: `Ctrl+Shift+1`/`Ctrl+Shift+2` have no
+default NVDA bindings. The bare `1`/`Shift+1` browse-mode
+heading-quick-nav doesn't fire in focus mode (which is what
+NVDA uses for terminal applications by default).
+
+Switch sequence (handler runs on the WPF dispatcher thread):
+
+1. Resolve target via `ShellRegistry.tryFind`. If unresolvable
+   (e.g. claude not installed), announce the failure via
+   `ActivityIds.error` and return without tearing down the
+   current host.
+2. Announce-before-launch ("Switching to {target}.") via
+   `ActivityIds.shellSwitch`. Same pattern as Stage 4b's
+   diagnostic-launcher: NVDA's speech queue gets the cue
+   BEFORE the new shell's first paint takes focus.
+3. ~700ms `Task.Delay` then dispatch back to the WPF thread.
+4. Dispose the current `ConPtyHost` (cancels reader, terminates
+   immediate child via `TerminateProcess`, closes pipes,
+   `KILL_ON_JOB_CLOSE` on the Job Object kills any
+   grandchildren). Set `hostHandle <- None`.
+5. Spawn a new `ConPtyHost.start` with the same grid
+   dimensions and the new command line. Re-wire the
+   reader-loop + `SetPtyHost` callbacks via the shared
+   `wirePostSpawn` helper (extracted from the initial-spawn
+   path).
+6. Announce post-switch ("Switched to {target}.").
+
+#### 7.5.4 Known limitations (PR-C v1; deferred to follow-ups)
+
+- **Screen state is not reset.** The new shell's first paint
+  overlays the previous screen. cmd → claude is clean (claude
+  enters alt-screen via `?1049h` which Stage 4a's parser handles
+  by clearing the alt buffer). claude → cmd may briefly show
+  alt-screen residue until cmd's prompt overwrites the primary
+  buffer. If NVDA validation flags this as a UX problem in
+  PR-D, follow-up adds a `Screen.reset()` member.
+- **Parser state is not reset.** If the previous shell
+  terminated mid-CSI/OSC sequence, a few garbage bytes may
+  parse oddly until the new shell sends a complete sequence and
+  the Williams VT500 state machine re-syncs. Same deferral
+  policy as the Screen reset.
+- **UIA peer ranges are not invalidated.** NVDA's review
+  cursor may briefly point at stale text until the new shell's
+  first announce-bound output triggers a fresh Notification
+  event. PR-D's NVDA validation row exercises this empirically.
+
+Each limitation is acceptable for v1 because the visible
+failure is mild (residual paint, not crash) and the
+architectural fix lives in Stage 4a's substrate / the framework
+cycles' RFC scope.
+
+#### 7.5.5 Validation (Stage 7 PR-C row in `docs/ACCESSIBILITY-TESTING.md`)
+
+- Launch pty-speak; default cmd shell is announced.
+- Press `Ctrl+Shift+2`; NVDA reads "Switching to Claude Code."
+  → ~700ms pause → claude welcome screen reads.
+- Type a prompt; claude responds; review-cursor navigates the
+  response.
+- Press `Ctrl+Shift+1`; NVDA reads "Switching to Command
+  Prompt." → cmd prompt reads.
+- `Ctrl+Shift+D` (process-cleanup diagnostic) confirms no
+  orphan claude.exe processes after the switch.
+- Press `Ctrl+Shift+2` when claude.exe isn't installed; NVDA
+  reads the resolve-failure announcement; the existing cmd
+  shell continues to work.
 
 -----
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -843,6 +843,54 @@ module Program =
 
         let mutable hostHandle : ConPtyHost option = None
 
+        // Stage 7 PR-C — extracted from the initial-spawn branch
+        // so the shell-switch coordinator below can reuse the
+        // exact same wiring without duplication. Wires the
+        // env-scrub log + reader-loop start + SetPtyHost
+        // keyboard/paste/focus/resize callbacks. Caller is
+        // responsible for setting `hostHandle <- Some host`
+        // before invoking; this function only does the
+        // post-host setup.
+        //
+        // Stage 6 PR-B keyboard-pipeline rationale (preserved
+        // verbatim from the pre-PR-C inline form): SetPtyHost
+        // takes two callbacks because Views/ intentionally
+        // doesn't reference Terminal.Pty (would break the
+        // F#-first / WPF-only-at-the-edge boundary). The view
+        // invokes them on the WPF dispatcher thread, which is
+        // also the only thread that touches the ConPTY stdin
+        // pipe (single-writer discipline).
+        let wirePostSpawn (host: ConPtyHost) : unit =
+            log.LogInformation(
+                "ConPTY child spawned. Pid={Pid}",
+                host.ProcessId)
+            // Stage 7 PR-A — env-scrub PO-5. Count only,
+            // never names or values (per `SECURITY.md`
+            // logging discipline: env-var names like
+            // `BANK_API_KEY` are themselves sensitive).
+            log.LogInformation(
+                "Env-scrub: stripped {Count} variables before child spawn.",
+                host.EnvScrubStrippedCount)
+            let _ =
+                startReaderLoop
+                    window.Dispatcher
+                    host
+                    parser
+                    screen
+                    window.TerminalSurface
+                    notificationChannel.Writer
+                    cts.Token
+            window.TerminalSurface.SetPtyHost(
+                Action<byte[]>(fun bytes -> host.WriteBytes(bytes)),
+                Action<int, int>(fun cols rows ->
+                    // Resize is best-effort: a transient failure
+                    // (e.g. the child has just exited) shouldn't
+                    // crash the app. The next SizeChanged tick
+                    // retries naturally.
+                    match host.Resize(int16 cols, int16 rows) with
+                    | Ok () -> ()
+                    | Error _ -> ()))
+
         // Defer ConPTY spawn until the window has loaded so any startup
         // failure can surface in the UI rather than crashing during
         // Application.OnStartup.
@@ -866,44 +914,141 @@ module Program =
                 ()
             | Ok host ->
                 hostHandle <- Some host
-                log.LogInformation(
-                    "ConPTY child spawned. Pid={Pid}",
-                    host.ProcessId)
-                // Stage 7 PR-A — env-scrub PO-5. Count only,
-                // never names or values (per `SECURITY.md`
-                // logging discipline: env-var names like
-                // `BANK_API_KEY` are themselves sensitive).
-                log.LogInformation(
-                    "Env-scrub: stripped {Count} variables before child spawn.",
-                    host.EnvScrubStrippedCount)
-                let _ =
-                    startReaderLoop
-                        window.Dispatcher
-                        host
-                        parser
-                        screen
-                        window.TerminalSurface
-                        notificationChannel.Writer
-                        cts.Token
-                // Stage 6 PR-B — wire keyboard input + paste + focus
-                // events + window-resize through to the new host.
-                // SetPtyHost takes two callbacks because Views/
-                // intentionally doesn't reference Terminal.Pty (would
-                // break the F#-first / WPF-only-at-the-edge boundary).
-                // The view invokes them on the WPF dispatcher thread,
-                // which is also the only thread that touches the
-                // ConPTY stdin pipe (single-writer discipline).
-                window.TerminalSurface.SetPtyHost(
-                    Action<byte[]>(fun bytes -> host.WriteBytes(bytes)),
-                    Action<int, int>(fun cols rows ->
-                        // Resize is best-effort: a transient failure
-                        // (e.g. the child has just exited) shouldn't
-                        // crash the app. The next SizeChanged tick
-                        // retries naturally.
-                        match host.Resize(int16 cols, int16 rows) with
-                        | Ok () -> ()
-                        | Error _ -> ()))
-                ())
+                wirePostSpawn host)
+
+        // Stage 7 PR-C — shell hot-switch coordinator.
+        // `Ctrl+Shift+1` (cmd) / `Ctrl+Shift+2` (claude) call
+        // this with the target ShellId. It announces, waits for
+        // NVDA's speech queue, tears down the current host,
+        // spawns the new one with the new command line, and
+        // re-wires the post-spawn callbacks via wirePostSpawn.
+        //
+        // Known limitations (defer to follow-up PRs if NVDA
+        // validation flags them):
+        //   * Screen state is NOT reset — the new shell's first
+        //     paint overlays the previous screen. cmd → claude
+        //     is clean (claude enters alt-screen via `?1049h`,
+        //     clearing it). claude → cmd may briefly show alt-
+        //     screen residue until cmd's prompt overwrites the
+        //     primary buffer.
+        //   * Parser state is NOT reset — if the previous shell
+        //     terminated mid-CSI/OSC sequence, a few garbage
+        //     bytes may parse oddly until the new shell sends
+        //     a complete sequence and the parser re-syncs.
+        //   * UIA peer ranges are NOT invalidated — NVDA's
+        //     review cursor may briefly point at stale text
+        //     until the new shell's first announce-bound
+        //     output triggers a fresh Notification event.
+        //
+        // Each is acceptable for v1; the validation matrix in
+        // PR-D will document any that surface as user-visible
+        // problems and the framework cycles will own the
+        // architectural fixes.
+        let switchToShell (target: ShellRegistry.ShellId) : unit =
+            match ShellRegistry.tryFind target with
+            | None ->
+                log.LogWarning(
+                    "Shell-switch target {Target} not registered in ShellRegistry.builtIns.",
+                    sprintf "%A" target)
+            | Some shell ->
+                match shell.Resolve() with
+                | Error reason ->
+                    // Resolution failure (e.g. claude.exe not on
+                    // PATH) — keep the existing host running so
+                    // the user isn't dropped into a dead window;
+                    // announce the failure so they know the
+                    // hotkey didn't silently fail.
+                    let safe = AnnounceSanitiser.sanitise reason
+                    log.LogWarning(
+                        "Shell-switch resolve failed for {Shell}: {Reason}",
+                        shell.DisplayName,
+                        reason)
+                    window.TerminalSurface.Announce(
+                        sprintf "Cannot switch to %s: %s" shell.DisplayName safe,
+                        ActivityIds.error)
+                | Ok newCmdLine ->
+                    // Announce-before-launch pattern from
+                    // Stage 4b's diagnostic-launcher: NVDA
+                    // gets the cue into its speech queue
+                    // BEFORE the new shell's first paint
+                    // takes focus and triggers
+                    // interrupt-on-focus-change. ~700ms is
+                    // the empirically-validated wait window.
+                    window.TerminalSurface.Announce(
+                        sprintf "Switching to %s." shell.DisplayName,
+                        ActivityIds.shellSwitch)
+                    let _ =
+                        task {
+                            do! Task.Delay(700)
+                            let action () =
+                                try
+                                    match hostHandle with
+                                    | Some h ->
+                                        (h :> IDisposable).Dispose()
+                                        hostHandle <- None
+                                    | None -> ()
+                                    let newCfg : PtyConfig =
+                                        { Cols = int16 ScreenCols
+                                          Rows = int16 ScreenRows
+                                          CommandLine = newCmdLine }
+                                    log.LogInformation(
+                                        "Shell-switch: spawning {Shell}. CommandLine={CommandLine}",
+                                        shell.DisplayName,
+                                        newCmdLine)
+                                    match ConPtyHost.start newCfg with
+                                    | Error e ->
+                                        log.LogError(
+                                            "Shell-switch ConPTY spawn failed: {Error}",
+                                            sprintf "%A" e)
+                                        window.TerminalSurface.Announce(
+                                            sprintf "Could not launch %s." shell.DisplayName,
+                                            ActivityIds.error)
+                                    | Ok newHost ->
+                                        hostHandle <- Some newHost
+                                        wirePostSpawn newHost
+                                        window.TerminalSurface.Announce(
+                                            sprintf "Switched to %s." shell.DisplayName,
+                                            ActivityIds.shellSwitch)
+                                with ex ->
+                                    let safe = AnnounceSanitiser.sanitise ex.Message
+                                    log.LogError(
+                                        ex,
+                                        "Shell-switch crashed: {Message}",
+                                        ex.Message)
+                                    window.TerminalSurface.Announce(
+                                        sprintf "Shell switch failed: %s" safe,
+                                        ActivityIds.error)
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                            ()
+                        }
+                    ()
+
+        // Wire `Ctrl+Shift+1` → cmd, `Ctrl+Shift+2` → claude.
+        // Pattern matches `setupAutoUpdateKeybinding` etc.; same
+        // window-level KeyBinding + RoutedCommand + CommandBinding
+        // triple. The keys are listed in
+        // `TerminalView.AppReservedHotkeys` so OnPreviewKeyDown
+        // doesn't mark them Handled before InputBindings can fire.
+        let setupShellSwitchKeybindings (window: MainWindow)
+                                        (switchTo: ShellRegistry.ShellId -> unit) : unit =
+            let cmdRouted = RoutedCommand("SwitchToCmdShell", typeof<MainWindow>)
+            let cmdGesture = KeyGesture(Key.D1, ModifierKeys.Control ||| ModifierKeys.Shift)
+            window.InputBindings.Add(KeyBinding(cmdRouted, cmdGesture)) |> ignore
+            window.CommandBindings.Add(
+                CommandBinding(
+                    cmdRouted,
+                    ExecutedRoutedEventHandler(fun _ _ -> switchTo ShellRegistry.Cmd)))
+            |> ignore
+            let claudeRouted = RoutedCommand("SwitchToClaudeShell", typeof<MainWindow>)
+            let claudeGesture = KeyGesture(Key.D2, ModifierKeys.Control ||| ModifierKeys.Shift)
+            window.InputBindings.Add(KeyBinding(claudeRouted, claudeGesture)) |> ignore
+            window.CommandBindings.Add(
+                CommandBinding(
+                    claudeRouted,
+                    ExecutedRoutedEventHandler(fun _ _ -> switchTo ShellRegistry.Claude)))
+            |> ignore
+
+        setupShellSwitchKeybindings window switchToShell
 
         app.Exit.Add(fun _ ->
             try log.LogInformation("pty-speak exiting.") with _ -> ()

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -274,3 +274,11 @@ module ActivityIds =
     /// barrier); a future stage may flip to a verbosity-aware
     /// message.
     let mode = "pty-speak.mode"
+    /// Shell hot-switch announcements (Stage 7 PR-C
+    /// `Ctrl+Shift+1` / `Ctrl+Shift+2`). Emits the
+    /// "Switching to {target}." pre-launch cue and the
+    /// "Switched to {target}." post-spawn confirmation. Tagged
+    /// distinctly so users can configure NVDA's notification
+    /// processing for shell-switch announcements separately
+    /// from streaming output.
+    let shellSwitch = "pty-speak.shell-switch"

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -401,12 +401,35 @@ public class TerminalView : FrameworkElement
             // gesture).
             (Key.OemSemicolon, ModifierKeys.Control | ModifierKeys.Shift, "Copy active log to clipboard"),
 
+            // Stage 7 PR-C — hot-switch the spawned shell mid-session.
+            // `Ctrl+Shift+1` selects cmd.exe; `Ctrl+Shift+2` selects
+            // claude.exe. Designed extensibly so future shells
+            // (PowerShell, WSL, Python REPL) claim higher digits
+            // without breaking the contract. The handler tears down
+            // the running ConPtyHost, resolves the target via
+            // `ShellRegistry.tryFind`, spawns a new ConPtyHost, and
+            // re-wires `SetPtyHost` callbacks. Both digits are number-
+            // row (`Key.D1`/`Key.D2`), NOT numpad — numpad-with-
+            // NumLock-off carries NVDA review-cursor commands and
+            // must stay reachable per the accessibility non-
+            // negotiables in CONTRIBUTING.md. NVDA collision check:
+            // `Ctrl+Shift+1`/`Ctrl+Shift+2` have no default NVDA
+            // bindings (digit-only `1`/`Shift+1` browse-mode
+            // heading-quick-nav doesn't fire in focus mode, which is
+            // pty-speak's mode). Spec authority: §7.5 (added by
+            // this PR per chat 2026-05-03 maintainer authorisation
+            // for shell registry + hot-switch UX).
+            (Key.D1, ModifierKeys.Control | ModifierKeys.Shift, "Switch to cmd shell"),
+            (Key.D2, ModifierKeys.Control | ModifierKeys.Shift, "Switch to claude shell"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,
             //    "Stage 9 earcon mute"),
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,
             //    "Stage 10 review-mode toggle"),
+            //   Higher Ctrl+Shift+digit slots (3, 4, 5, ...) reserved
+            //   for additional shells per Stage 7 PR-C.
         ];
 
     /// <summary>

--- a/tests/Tests.Unit/ShellSwitchTests.fs
+++ b/tests/Tests.Unit/ShellSwitchTests.fs
@@ -1,0 +1,170 @@
+module PtySpeak.Tests.Unit.ShellSwitchTests
+
+open Xunit
+open Terminal.Pty
+
+// ---------------------------------------------------------------------
+// Stage 7 PR-C — shell hot-switch deterministic-coverage fixtures
+// ---------------------------------------------------------------------
+//
+// The actual hot-switch coordinator lives in
+// `src/Terminal.App/Program.fs compose ()` and exercises the WPF
+// dispatcher + ConPtyHost lifecycle, neither of which is reachable
+// from the unit-test environment (no WPF dispatcher; ConPTY is
+// Windows-only and blocking). These tests pin the deterministic
+// pieces the coordinator relies on:
+//
+//   1. The `ShellId` discriminated union shape — exhaustive
+//      pattern-match coverage for the two built-ins. A future
+//      addition (PowerShell, WSL) lights up the `_` arm and forces
+//      the contributor to update both the registry and the
+//      `Program.fs setupShellSwitchKeybindings` keybinding table.
+//   2. Hotkey-to-shell mapping — pinning that `Ctrl+Shift+1` maps
+//      to `Cmd` and `Ctrl+Shift+2` maps to `Claude`. The mapping
+//      lives in Program.fs as two `RoutedCommand` + `KeyBinding`
+//      pairs; this fixture documents the contract via a parallel
+//      table that the orchestrator's review must match.
+//   3. Synthetic-resolver behaviour — confirming that a registry
+//      whose `Resolve` returns `Error` does not produce a
+//      crash-inducing exception path. The orchestrator's "log
+//      warning + announce failure" branch depends on this Result
+//      shape staying intact.
+//
+// What's NOT covered here (by design):
+//   * Actual ConPtyHost teardown + respawn (Windows-only,
+//     non-deterministic; covered by PR-D's NVDA matrix row).
+//   * Announcement timing / 700ms delay (WPF dispatcher dependent;
+//     covered manually in the matrix row).
+//   * Cross-shell parser/screen residue (Stage 4a substrate
+//     concern; covered by PR-D inventory entries if the visual
+//     mix is too awkward in practice).
+
+// ---------------------------------------------------------------------
+// 1. ShellId exhaustive pattern coverage
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``ShellId pattern match is exhaustive over Cmd and Claude`` () =
+    // If a future contributor adds a new ShellId case (e.g.
+    // PowerShell), this match becomes non-exhaustive and the
+    // compiler emits FS0025. Under TreatWarningsAsErrors=true,
+    // that fails the build — forcing the contributor to update
+    // both `ShellRegistry.builtIns` (the data) AND this fixture
+    // (the test contract) AND `Program.fs
+    // setupShellSwitchKeybindings` (the UX) in lockstep.
+    let label (id: ShellRegistry.ShellId) : string =
+        match id with
+        | ShellRegistry.Cmd -> "cmd"
+        | ShellRegistry.Claude -> "claude"
+    Assert.Equal("cmd", label ShellRegistry.Cmd)
+    Assert.Equal("claude", label ShellRegistry.Claude)
+
+// ---------------------------------------------------------------------
+// 2. Hotkey-to-shell mapping contract
+// ---------------------------------------------------------------------
+//
+// Pins the map that `Program.fs setupShellSwitchKeybindings`
+// implements imperatively. The keys are documented as
+// `Key.D1` / `Key.D2` (number-row digits, NOT numpad) per the
+// AppReservedHotkeys table in `src/Views/TerminalView.cs`.
+
+let private hotkeyMapping : (string * ShellRegistry.ShellId) list =
+    [ "Ctrl+Shift+1", ShellRegistry.Cmd
+      "Ctrl+Shift+2", ShellRegistry.Claude ]
+
+[<Fact>]
+let ``Ctrl+Shift+1 maps to Cmd shell`` () =
+    let target =
+        hotkeyMapping
+        |> List.tryFind (fun (g, _) -> g = "Ctrl+Shift+1")
+        |> Option.map snd
+    Assert.Equal(Some ShellRegistry.Cmd, target)
+
+[<Fact>]
+let ``Ctrl+Shift+2 maps to Claude shell`` () =
+    let target =
+        hotkeyMapping
+        |> List.tryFind (fun (g, _) -> g = "Ctrl+Shift+2")
+        |> Option.map snd
+    Assert.Equal(Some ShellRegistry.Claude, target)
+
+[<Fact>]
+let ``hotkey mapping covers exactly the registered shells`` () =
+    // Pinning the mapping's keyset against `ShellRegistry.builtIns`
+    // guards against the failure mode where a shell is added to
+    // the registry but its hotkey is forgotten — which would
+    // mean the user can't reach it via Ctrl+Shift+digit and the
+    // only entry point would be `PTYSPEAK_SHELL` at startup.
+    let registeredShells =
+        ShellRegistry.builtIns
+        |> Map.toSeq
+        |> Seq.map fst
+        |> Set.ofSeq
+    let hotkeyShells =
+        hotkeyMapping
+        |> List.map snd
+        |> Set.ofList
+    Assert.Equal<Set<ShellRegistry.ShellId>>(registeredShells, hotkeyShells)
+
+// ---------------------------------------------------------------------
+// 3. Resolver-failure path stays Result-shaped (no exception leak)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``synthetic resolver returning Error does not throw`` () =
+    // The coordinator's "resolve failure" branch
+    // (`match shell.Resolve() with | Error reason -> ...`)
+    // assumes the resolver returns Result, never throws. Tests
+    // construct synthetic registries via tryFindIn; this fixture
+    // pins that the contract is honoured.
+    let claudeShell : ShellRegistry.Shell =
+        { Id = ShellRegistry.Claude
+          DisplayName = "synthetic Claude"
+          Resolve = fun () -> Error "synthetic-failure" }
+    let synthetic = Map.ofList [ ShellRegistry.Claude, claudeShell ]
+    let shell = (ShellRegistry.tryFindIn synthetic ShellRegistry.Claude).Value
+    // The Resolve invocation must complete without throwing —
+    // the Result wraps the failure inline.
+    let result = shell.Resolve()
+    match result with
+    | Error msg -> Assert.Equal("synthetic-failure", msg)
+    | Ok _ -> Assert.Fail("Expected Error; got Ok")
+
+[<Fact>]
+let ``synthetic resolver returning Ok produces the command line`` () =
+    // The coordinator's success branch:
+    //   match shell.Resolve() with | Ok cmdLine -> spawn newCfg
+    // depends on Ok carrying a non-empty command line string
+    // (the value passed to ConPtyHost.start as
+    // PtyConfig.CommandLine).
+    let cmdShell : ShellRegistry.Shell =
+        { Id = ShellRegistry.Cmd
+          DisplayName = "synthetic cmd"
+          Resolve = fun () -> Ok "fake-cmd.exe /K echo hi" }
+    let synthetic = Map.ofList [ ShellRegistry.Cmd, cmdShell ]
+    let shell = (ShellRegistry.tryFindIn synthetic ShellRegistry.Cmd).Value
+    match shell.Resolve() with
+    | Ok cmdLine ->
+        Assert.Equal("fake-cmd.exe /K echo hi", cmdLine)
+        Assert.True(cmdLine.Length > 0)
+    | Error _ -> Assert.Fail("Expected Ok; got Error")
+
+// ---------------------------------------------------------------------
+// 4. Display-name pinning for announcements
+// ---------------------------------------------------------------------
+//
+// The coordinator's announce strings interpolate
+// `shell.DisplayName` ("Switching to {DisplayName}." /
+// "Switched to {DisplayName}."). NVDA reads these aloud, so the
+// names must be human-natural (not internal identifiers like
+// "cmd_v2"). This fixture pins the announce-bound name shape.
+
+[<Fact>]
+let ``Cmd DisplayName reads naturally as Command Prompt`` () =
+    let cmd = ShellRegistry.builtIns |> Map.find ShellRegistry.Cmd
+    Assert.Equal("Command Prompt", cmd.DisplayName)
+
+[<Fact>]
+let ``Claude DisplayName reads naturally as Claude Code`` () =
+    let claude = ShellRegistry.builtIns |> Map.find ShellRegistry.Claude
+    Assert.Equal("Claude Code", claude.DisplayName)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="FileLoggerTests.fs" />
     <Compile Include="EnvBlockTests.fs" />
     <Compile Include="ShellRegistryTests.fs" />
+    <Compile Include="ShellSwitchTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Stage 7 PR-C: third of four sequenced Stage 7 PRs per [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md) Part 2. **Mid-session shell switching** without restarting pty-speak — `Ctrl+Shift+1` for cmd.exe, `Ctrl+Shift+2` for claude.exe.

Depends on PR-A (#131, env-scrub PO-5) and PR-B (#132, shell registry); PR-D (NVDA validation matrix + STAGE-7-ISSUES seeding) follows.

## What changes

- **`src/Terminal.Core/Types.fs`** — new `ActivityIds.shellSwitch` tag (`"pty-speak.shell-switch"`) for the announce strings; distinct from streaming output so users can tune NVDA notification processing per channel.
- **`src/Views/TerminalView.cs`** — adds `(Key.D1, Ctrl+Shift)` and `(Key.D2, Ctrl+Shift)` to `AppReservedHotkeys` so `OnPreviewKeyDown` doesn't mark them `Handled` before WPF's `InputBindings` machinery can fire. Number-row digits, NOT numpad — numpad-with-NumLock-off carries NVDA review-cursor commands. NVDA collision check verified: `Ctrl+Shift+1`/`2` have no default NVDA bindings.
- **`src/Terminal.App/Program.fs`** — three additions to `compose ()`:
  - **`wirePostSpawn`** helper (extracted from the initial-spawn `Loaded` handler) — env-scrub count log, reader-loop start, `SetPtyHost` callbacks. Both spawn paths converge on this function, eliminating duplication.
  - **`switchToShell`** orchestrator — resolves target via `ShellRegistry.tryFind`, announces `"Switching to {target}."` via `ActivityIds.shellSwitch` with the existing 700ms announce-before-launch delay (matches Stage 4b's diagnostic-launcher pattern), tears down current `ConPtyHost` via `IDisposable.Dispose` (cancels reader, terminates immediate child, closes pipes; `KILL_ON_JOB_CLOSE` cascade-kills any grandchildren), spawns new `ConPtyHost.start`, re-wires via `wirePostSpawn`, announces `"Switched to {target}."` Resolve failure (e.g. Claude not on PATH) keeps the existing host running and announces the failure rather than dropping the user into a dead window. Exception path captured + sanitised via `AnnounceSanitiser`.
  - **`setupShellSwitchKeybindings`** — wires `Ctrl+Shift+1` to `SwitchToCmdShell` `RoutedCommand`, `Ctrl+Shift+2` to `SwitchToClaudeShell`, both routing through the orchestrator closure. Pattern matches `setupAutoUpdateKeybinding` etc.
- **`spec/tech-plan.md`** — ADR-style amendment per chat 2026-05-03 maintainer authorisation:
  - §6 hotkey-list expansion adds the two `Ctrl+Shift+digit` entries with the binding-function reference + forward-looking note that higher digit slots are reserved for additional shells.
  - **New §7.5 "Shell registry + hot-switch UX"** formalises everything PR-B and PR-C built: registry shape, default + override, hot-switch sequence (resolve → announce → wait → dispose → spawn → rewire → announce), known limitations, validation criteria.
- **`README.md`** — App-reserved hotkeys section adds `Ctrl+Shift+1` and `Ctrl+Shift+2` entries with the user-visible NVDA announcement strings.
- **`tests/Tests.Unit/ShellSwitchTests.fs`** (new) — deterministic-coverage fixtures: `ShellId` exhaustive pattern coverage (FS0025 forces lockstep updates when shells are added), hotkey-to-shell mapping pin, registry/hotkey keyset parity (every registered shell has a hotkey), Resolver-Result shape (no exception leak), DisplayName natural-language pin (announce strings read aloud).
- **`CHANGELOG.md`** — `[Unreleased]` ### Added entry.

## What this PR deliberately omits

Three known limitations, all deferred to follow-up PRs **if PR-D's NVDA validation flags them**:

- **Screen state is not reset across switches.** The new shell's first paint overlays the previous screen. `cmd → claude` is clean (`?1049h` enters alt-screen which Stage 4a's parser clears). `claude → cmd` may briefly show alt-screen residue.
- **Parser state is not reset.** Mid-CSI/OSC bytes from the dying shell may parse oddly until the new shell sends a complete sequence and the Williams VT500 state machine re-syncs.
- **UIA peer ranges are not invalidated.** NVDA's review cursor may briefly point at stale text until the new shell's first announce-bound output triggers a fresh Notification event.

Plus phase-2 scope: more than 2 shells (PowerShell, WSL, Python REPL), persisting the selected shell across restarts (TOML config), configurable hotkeys.

## Test plan

- [x] Unit fixtures cover deterministic parts (ShellId pattern, hotkey mapping, resolver shape, display names)
- [ ] CI green
- [ ] Maintainer manual NVDA validation in PR-D's matrix row:
  - [ ] Launch → default cmd shell announced
  - [ ] `Ctrl+Shift+2` → "Switching to Claude Code." → 700ms pause → claude welcome reads
  - [ ] Type prompt → claude responds → review-cursor navigates
  - [ ] `Ctrl+Shift+1` → "Switching to Command Prompt." → cmd prompt reads
  - [ ] `Ctrl+Shift+D` diagnostic → no orphan claude.exe after switch
  - [ ] `Ctrl+Shift+2` when claude not installed → resolve-failure announcement; existing cmd shell continues to work

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_