### PR TITLE
docs: Stage 7 PR-D — NVDA validation matrix + STAGE-7-ISSUES seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,95 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 7 PR-D — NVDA validation matrix expansion +
+  `docs/STAGE-7-ISSUES.md` design-derived seed entries.**
+  Closes the four-PR Stage 7 sequence per
+  `docs/PROJECT-PLAN-2026-05.md` Part 2; depends on PR-A
+  (#131, env-scrub PO-5), PR-B (#132, shell registry +
+  `PTYSPEAK_SHELL`), and PR-C (#134, hot-switch hotkeys
+  `Ctrl+Shift+1` / `Ctrl+Shift+2`).
+
+  `docs/ACCESSIBILITY-TESTING.md` "Stage 7 — Claude Code
+  roundtrip" row expanded from 4 tests to 14, covering:
+  default-shell launch (PR-B), env-scrub empirical check via
+  `set` enumeration confirming deny-list strips (PR-A),
+  Claude-shell launch via `PTYSPEAK_SHELL=claude` (PR-B),
+  welcome screen + prompt → response (Claude), review-cursor
+  navigation of streaming response (`Caps Lock+Numpad 7/8/9`),
+  spinner-flood guard, tool-use prompt (Edit/Yes/Always/No),
+  hot-switch cmd → claude + claude → cmd (PR-C), hot-switch
+  resolve failure announcement when claude.exe isn't on PATH,
+  process-cleanup verification post-switch via `Ctrl+Shift+D`
+  diagnostic (Job Object `KILL_ON_JOB_CLOSE` cascade), clean
+  quit via `/exit` / `exit` / `Ctrl+D`, and
+  `PTYSPEAK_SHELL=garbage` unrecognised-value fallback. Each
+  test row specifies the exact procedure + expected NVDA
+  announcement so the maintainer's manual pass is mechanically
+  reproducible.
+
+  Diagnostic-decoder section expanded with new failure-mode
+  entries: env-scrub leak indicating `EnvBlock.isDenied`
+  regression (security-class), allow-list missing var
+  indicating spec §7.2 sync drift, hot-switch silent-announce
+  indicating `AppReservedHotkeys` table or filter-ordering
+  regression, hot-switch orphan-child accumulation indicating
+  `ConPtyHost.Dispose` race with the new spawn (Job Object
+  cascade is the safety net), hot-switch announce-but-no-shell
+  indicating `wirePostSpawn` not invoked or `SetPtyHost`
+  callbacks not re-bound. Each decoder names the specific
+  source file or test fixture to triage against.
+
+  `docs/STAGE-7-ISSUES.md` status header flipped from
+  "stub created in PR #129; no entries yet" to "Stage 7
+  substrate shipped via PRs #131 / #132 / #134; PR-D this
+  PR; empirical NVDA validation maintainer-driven." The
+  inventory body pre-seeded with **four design-derived
+  entries** sourced from `spec/tech-plan.md` §7.4 "Known
+  issues you'll hit (drives next stages)" plus the headline
+  architectural finding from `docs/SESSION-HANDOFF.md` Stage
+  7 sketch "Known risks":
+
+  - `[output-stream]` Verbose readback: whole-screen
+    announcement on every Ink frame redraw — the first
+    foundational architecture decision the Output framework
+    cycle (Part 3) addresses; framework cycle's Stream
+    profile with suffix-diff append-only emission resolves.
+  - `[output-selection]` Tool-use prompt
+    (Edit/Yes/Always/No) reads as flat text instead of
+    listbox — original Stage 8 scope, folded into the
+    Output framework cycle's Selection profile.
+  - `[output-earcon]` Red error text reads as plain text
+    with no severity signal — original Stage 9 scope,
+    folded into the Output framework cycle's Earcons
+    presentation-sink layer.
+  - `[review-mode]` No quick-nav after focus moves past a
+    response — Stage 10 scope; depends on the
+    semantic-event taxonomy landing in the parser →
+    semantic-mapper layer first.
+
+  Each entry is marked **Source: design prediction** at the
+  bottom; the maintainer's empirical NVDA pass either
+  confirms with concrete reproduction steps + version pins,
+  refines the prediction, or marks as not-reproducible (in
+  which case the substrate is more capable than the spec
+  assumed and the framework cycle adjusts accordingly).
+  Entries surfaced empirically use the **Source: NVDA pass
+  YYYY-MM-DD** marker instead. The distinction matters for
+  the Output framework cycle's research phase
+  (`docs/research/OUTPUT-FRAMEWORK-PRIOR-ART.md`) which
+  reads this inventory as design input.
+
+  Per the May-2026 plan: **don't fix anything from the
+  inventory in Stage 7; that's framework-cycle work.** PR-D's
+  merge gate is the matrix being green for the rows that
+  should be green and the inventory documenting (not solving)
+  the rows that aren't.
+
+  After PR-D ships, the doc-purpose audit queued in
+  `docs/SESSION-HANDOFF.md` "Queued before Output framework
+  cycle starts" runs as the transition-window work before
+  the Output framework cycle's Phase 3.1 research begins.
+
 - **Stage 7 PR-C — hot-switch hotkeys `Ctrl+Shift+1` (cmd) /
   `Ctrl+Shift+2` (claude).** Mid-session shell switching via WPF
   `KeyBinding` -> `RoutedCommand` -> orchestrator closure in

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -372,12 +372,35 @@ pattern at the right element.
 
 ### Stage 7 — Claude Code roundtrip
 
+Stage 7 ships across four sequenced PRs (per
+[`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) Part 2):
+PR-A (env-scrub PO-5; #131), PR-B (shell registry +
+`PTYSPEAK_SHELL`; #132), PR-C (hot-switch hotkeys
+`Ctrl+Shift+1`/`Ctrl+Shift+2`; #134), and PR-D (this matrix
+expansion + `docs/STAGE-7-ISSUES.md` seeding). The matrix below
+exercises the full surface end-to-end. Per
+[`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) "Stage 7
+implementation sketch (next)" §5, **gaps surfaced during this
+matrix go into [`docs/STAGE-7-ISSUES.md`](STAGE-7-ISSUES.md)
+with framework-taxonomy category tags — Stage 7's job is to
+surface, not solve.**
+
 | Test                              | Procedure                                       | Expected behaviour                                               |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| Welcome screen                    | Launch `claude`                                 | NVDA reads the welcome screen                                    |
-| Prompt → response                 | Type "Say hi", Enter                            | Claude responds; NVDA reads the response                         |
-| Spinner does not flood            | Trigger a long-thinking response                | Spinner is announced at most once or as a periodic earcon; NVDA never freezes |
-| Quitting cleanly                  | `/exit` or Ctrl+D                               | Process exits; NVDA announces it; terminal returns to host shell |
+| **Default-shell launch (PR-B)**     | Launch pty-speak with `PTYSPEAK_SHELL` unset    | cmd.exe spawns; NVDA reads the cmd prompt; log line "Startup shell: Command Prompt (command line: cmd.exe)" appears in the active session log (`Ctrl+Shift+L` → today's folder) |
+| **Env-scrub empirical check (PR-A)** | At the cmd prompt, type `set` and press Enter | Output enumerates the child's env block. Confirm sensitive vars from the deny-list are ABSENT: `GITHUB_TOKEN`, `OPENAI_API_KEY` (any `*_TOKEN`/`*_SECRET`/`*_PASSWORD`/non-Anthropic `*_KEY`). Confirm allow-list vars are PRESENT: `PATH`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `HOME`, `TERM=xterm-256color`, `COLORTERM=truecolor`. Active session log includes "Env-scrub: stripped {N} variables before child spawn." (count only; never names or values) |
+| **Claude-shell launch (PR-B)**      | Quit pty-speak; relaunch with `PTYSPEAK_SHELL=claude` (or with claude.exe on PATH and PR-C's hotkey approach below) | claude.exe spawns; NVDA reads the welcome screen; log line "Startup shell: Claude Code (command line: <resolved path>)" |
+| **Welcome screen (Claude)**         | After Claude spawns, listen                     | NVDA reads the welcome screen                                    |
+| **Prompt → response (Claude)**      | Type "Say hi", Enter                            | Claude responds; NVDA reads the streaming response               |
+| **Review-cursor navigation**        | After Claude's response completes, press `Caps Lock + Numpad 7` / `Numpad 8` / `Numpad 9` (or `Insert + Up/Down/Left/Right` depending on NVDA layout) | NVDA's review cursor moves through the response by line / current-line / next-line; NVDA reads the line under the review cursor |
+| **Spinner does not flood**          | Trigger a long-thinking response                | Spinner is announced at most once or as a periodic earcon; NVDA never freezes |
+| **Tool-use prompt (Claude)**        | Ask Claude to edit a file in the current dir; when "Edit / Yes / Always / No" prompt appears, accept a choice | NVDA reads the prompt text. (Reads as flat text in PR-D; Stage 8 / Output framework's Selection profile fixes this — log the failure mode in `STAGE-7-ISSUES.md` with `[output-selection]` tag.) Pressing Enter accepts; Claude proceeds |
+| **Hot-switch cmd → claude (PR-C)**  | At the cmd prompt, press `Ctrl+Shift+2`         | NVDA announces "Switching to Claude Code." → ~700ms pause → "Switched to Claude Code." → claude welcome reads. Active session log includes "Shell-switch: spawning Claude Code. CommandLine=<path>" |
+| **Hot-switch claude → cmd (PR-C)**  | After claude is running, press `Ctrl+Shift+1`   | NVDA announces "Switching to Command Prompt." → ~700ms pause → "Switched to Command Prompt." → cmd prompt reads. Brief alt-screen residue is acceptable for v1 — log severity to `STAGE-7-ISSUES.md` with `[output-tui]` tag if it confuses the read |
+| **Hot-switch resolve failure (PR-C)** | On a machine WITHOUT claude.exe on PATH, press `Ctrl+Shift+2` | NVDA announces "Cannot switch to Claude Code: not found on PATH." (sanitised). The existing cmd shell continues to work; the user is NOT dropped into a dead window |
+| **Process-cleanup after switch (PR-C)** | After at least one Ctrl+Shift+1 / Ctrl+Shift+2 cycle, press `Ctrl+Shift+D` (process-cleanup diagnostic) | Diagnostic confirms no orphan `claude.exe` / cmd.exe / Terminal.App processes from the previous host. (Job Object's `KILL_ON_JOB_CLOSE` is the kernel-enforced cleanup.) |
+| **Quitting cleanly**                | `/exit` (Claude), `exit` (cmd), or Ctrl+D       | Process exits; NVDA announces it; terminal returns to host shell or window closes |
+| **PTYSPEAK_SHELL unrecognised value** | Launch pty-speak with `PTYSPEAK_SHELL=garbage` | cmd.exe still spawns (fallback); active session log includes "PTYSPEAK_SHELL=\"garbage\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude." NVDA-bound behaviour is identical to default-shell launch |
 
 **Diagnostic decoder for Stage 7:**
 
@@ -385,7 +408,10 @@ pattern at the right element.
   Check `tests/fixtures/claude-thinking.txt` replay through
   Stage 5's coalescing path; if the unit tests pass, the
   semantic-layer hashing is fine and the regression is in how
-  Stage 7's spinner detector classifies the row.
+  Stage 7's spinner detector classifies the row. **This is also
+  the headline finding the Output framework cycle's research
+  phase consumes from `STAGE-7-ISSUES.md`** — log it with
+  `[output-stream]` even if you also fix the regression.
 - **Welcome screen silent** → Claude's TUI emits its first paint
   in a way that bypasses our coalescing entry point. Compare against
   Stage 5's `dir` test — if `dir` works but `claude` doesn't, the
@@ -394,6 +420,38 @@ pattern at the right element.
 - **`/exit` leaves orphaned `claude` process** → Same class as
   Stage 3b's "orphan cmd.exe" — the ConPTY shutdown isn't
   signalling the child correctly.
+- **Env-scrub empirical check shows a `*_TOKEN`/`*_SECRET` leak**
+  → `EnvBlock.isDenied` regression. Re-run
+  `tests/Tests.Unit/EnvBlockTests.fs` first; if the suffix-match
+  fixture passes, the leak is in the parent-env collection step
+  (the env var name didn't reach the deny-list). Symptom is
+  PO-5-class — file as a security regression, not an inventory
+  entry.
+- **Allow-list var missing from `set` output** → `EnvBlock.allowedNames`
+  edit landed without the spec-§7.2 sync. Cross-check
+  `EnvBlockTests.allowedNames contains exactly the spec-7-2 baseline`
+  fixture; if that passes, the parent process didn't have the
+  expected var set in the first place (sandbox / launcher
+  environment issue, not an env-scrub regression).
+- **Hot-switch announce is silent** → `Ctrl+Shift+1`/`Ctrl+Shift+2`
+  not in `TerminalView.AppReservedHotkeys`, OR `OnPreviewKeyDown`
+  marked `Handled = true` before `InputBindings` fired. Same
+  diagnosis path as the Stage 6 `Ctrl+V` paste regression: check
+  the `AppReservedHotkeys` table first, then the filter ordering.
+- **Hot-switch produces orphan child after several switches** →
+  `ConPtyHost.Dispose` race with the new spawn. Job Object's
+  `KILL_ON_JOB_CLOSE` should still cascade-kill on the next
+  switch (each switch creates a new Job, closing the previous
+  Job's last handle), but if `Ctrl+Shift+D` shows accumulating
+  orphans across many switches, file as `[other]` with the
+  exact sequence to reproduce.
+- **Hot-switch announce reads but new shell never appears** →
+  `wirePostSpawn` not invoked OR `SetPtyHost` callbacks not
+  re-bound. Check the active session log for "ConPTY child
+  spawned. Pid=<N>" + "Env-scrub: stripped {N}..." — if both
+  are present but no shell output reaches NVDA, the reader
+  loop didn't restart. If neither is present,
+  `ConPtyHost.start` failed.
 
 ### Stage 8 — selection lists
 

--- a/docs/STAGE-7-ISSUES.md
+++ b/docs/STAGE-7-ISSUES.md
@@ -10,11 +10,31 @@ end-to-end and **surface every gap that NVDA validation reveals** —
 not solve them. Each gap below becomes a framework requirement that
 the corresponding cycle's RFC must address.
 
-> **Status:** stub created in PR #129 (final-handoff audit). **No
-> entries yet** — Stage 7 implementation hasn't started. The next
-> session that picks up Part 2 / Stage 7 fills this file as it
-> validates Claude Code under NVDA. Don't try to fix anything from
-> the inventory in Stage 7; that's framework-cycle work.
+> **Status:** Stage 7 substrate **shipped** across four sequenced
+> PRs (per
+> [`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md)
+> Part 2):
+>
+> - **PR #131 (PR-A)** — env-scrub PO-5 (closes
+>   [`SECURITY.md`](../SECURITY.md) row PO-5).
+> - **PR #132 (PR-B)** — extensible shell registry +
+>   `PTYSPEAK_SHELL` startup override.
+> - **PR #134 (PR-C)** — hot-switch hotkeys
+>   `Ctrl+Shift+1` / `Ctrl+Shift+2`.
+> - **PR-D (this PR)** — manual NVDA-validation matrix expansion
+>   in [`docs/ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md)
+>   "Stage 7 — Claude Code roundtrip" + this inventory's first
+>   pre-seeded entries.
+>
+> **Empirical NVDA validation is maintainer-driven.** This PR
+> ships the validation matrix + the design-derived inventory
+> entries below; the maintainer runs the matrix, confirms or
+> refines the predicted entries, and adds any additional gaps
+> surfaced empirically. Per the May-2026 plan: **don't fix
+> anything from the inventory in Stage 7; that's framework-cycle
+> work.** The Output framework cycle (Part 3) consumes this
+> inventory as design input for its research phase
+> (`docs/research/OUTPUT-FRAMEWORK-PRIOR-ART.md`).
 
 ## How to use this file
 
@@ -81,11 +101,175 @@ API).
 
 ## Entries
 
-_(empty — Stage 7 NVDA validation hasn't started yet. First entry
-arrives when the next session ships Stage 7 and runs the
-`docs/ACCESSIBILITY-TESTING.md` Stage 7 manual matrix row.)_
+The four entries below are **design-derived** from
+[`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 "Known issues
+you'll hit (drives next stages)" + the headline architectural
+finding logged in
+[`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) Stage 7 sketch
+"Known risks". They predict what NVDA validation will surface
+based on the architectural shape of the shipped substrate. The
+maintainer's empirical NVDA pass either (a) confirms each
+prediction with concrete reproduction steps + version pins, or
+(b) refines the prediction (or marks it as not-reproducible if
+the substrate behaves better than predicted), or (c) adds
+additional empirically-surfaced entries below.
 
-### Template (delete when first real entry lands)
+Each entry below is marked **Source: design prediction** at the
+bottom; entries the maintainer adds during NVDA validation will
+be marked **Source: NVDA pass YYYY-MM-DD** instead. The
+distinction matters for the framework cycles' research phase:
+predictions that don't reproduce empirically may indicate the
+substrate is more capable than the spec assumed, and the
+framework design adjusts accordingly.
+
+### [output-stream] Verbose readback: whole-screen announcement on every emit
+
+**What broke.** Stage 5's generic `renderRows` coalescer
+announces the **entire rendered screen** on every emit. Claude
+Code's Ink reconciler drives whole-frame redraws ~10 Hz during
+streaming response generation
+([`spec/tech-plan.md`](../spec/tech-plan.md) §7.3). The
+combination produces so much speech that NVDA's speech queue
+falls behind and the user can't keep up — even with the
+spinner-row dedup in place, the bulk of the response text is
+re-announced on every Ink frame.
+
+**Why it matters.** This is the first foundational architecture
+decision the Output framework cycle (Part 3) addresses. Per
+[`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) Stage 7 sketch
+"Known risks" §2: the right fix isn't a verbosity-tuning knob
+on the generic coalescer — it's a per-content-paradigm
+presentation strategy (Stream / REPL / TUI / Form / Selection)
+where each paradigm has its own announcement model.
+[`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md) Part
+3.2's RFC owns the design.
+
+**Reproduction.** Set `PTYSPEAK_SHELL=claude` and launch (or
+`Ctrl+Shift+2` after launch). Ask Claude a multi-paragraph
+question ("Explain how ConPTY works in 200 words"). Listen
+for the speech-queue lag pattern: NVDA continues reading the
+beginning of the response while later paragraphs scroll past
+on screen.
+
+**Hypothesised root cause.** `Coalescer.fs`'s
+`processRowsChanged` flushes the full visible row range on each
+debounce window. Claude's per-Ink-frame redraw bumps the
+sequence number and triggers a flush; the flush re-announces
+already-spoken rows because their hash differs from the
+preceding flush by a single character (e.g. cursor advanced).
+The framework cycle resolves this by introducing a Stream
+profile with suffix-diff append-only emission for
+streaming-output workloads.
+
+**Source: design prediction** (per
+[`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 +
+[`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) Stage 7 sketch
+"Known risks" §2). Empirical confirmation pending in
+maintainer NVDA pass.
+
+### [output-selection] Tool-use prompt reads as flat text instead of listbox
+
+**What broke.** Claude's tool-use confirmation prompt
+("Edit / Yes / Always / No") is rendered as a vertical list of
+text items, one of which carries a distinct background colour
+indicating selection. NVDA reads it as a paragraph instead of
+a listbox: "Edit Yes Always No" with no list semantics, no
+"item N of M" announcement, no arrow-key list navigation.
+
+**Why it matters.** The user can't tell which item is currently
+selected without inferring from background colour, which the
+substrate doesn't surface to the screen reader. Arrow keys
+move the highlight on screen but NVDA doesn't announce the
+movement. Pressing Enter accepts whatever is highlighted —
+usable only if the user can guess.
+
+**Reproduction.** Set `PTYSPEAK_SHELL=claude`. Ask Claude to
+edit a file in the current directory. When the
+"Edit / Yes / Always / No" prompt appears, press the down
+arrow. Listen for an announcement of the selection change.
+None will arrive (predicted).
+
+**Hypothesised root cause.** No selection-list detection layer
+in the parser → screen → UIA peer pipeline. The substrate
+exposes the prompt as part of the Document text view; UIA's
+List + ListItem control types aren't published. Original
+spec Stage 8 ("Interactive list detection + UIA List
+provider") owns the fix; the May-2026 plan folds Stage 8 into
+the Output framework cycle's Selection profile.
+
+**Source: design prediction** (per
+[`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 known issue
+#2 → Stage 8). Empirical confirmation pending.
+
+### [output-earcon] Red error text reads as plain text (no severity signal)
+
+**What broke.** Claude (and other shells) emits red-coloured
+text via SGR `\x1b[31m...\x1b[0m` to indicate errors / warnings.
+NVDA reads the text but conveys no colour or severity
+information. The user can't tell from the announcement that
+they just read an error message vs. a normal output line.
+
+**Why it matters.** Errors in compiled output, test failures,
+git conflict markers, and Claude's own error messages all
+become indistinguishable from normal text. Sighted users
+process severity at a glance from colour; blind users currently
+have no equivalent channel.
+
+**Reproduction.** At a cmd or claude prompt, run a command
+that produces red error output (e.g. ask Claude to deliberately
+introduce a syntax error and run a build, or run
+`git diff` on a file with conflict markers). Listen for any
+audible cue distinguishing the error text from surrounding
+output. None will arrive (predicted).
+
+**Hypothesised root cause.** Stage 9 (earcons) hasn't shipped.
+The May-2026 plan folds Stage 9 into the Output framework
+cycle's Earcons presentation-sink layer. Frequency mapping
+(red=220 Hz square alarm, yellow=440 Hz triangle warn, etc.)
+is documented in spec §9.3 but not yet implemented.
+
+**Source: design prediction** (per
+[`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 known issue
+#3 → Stage 9). Empirical confirmation pending.
+
+### [review-mode] No quick-nav after focus moves past response
+
+**What broke.** Once the cursor moves past Claude's response
+(user types a follow-up prompt, or the next tool-use prompt
+arrives), there's no way to jump back to the previous
+response and re-read a specific section. NVDA's review cursor
+can move line-by-line via `Caps Lock + Numpad 8` etc., but
+moving from "current screen line 30" back to "the start of
+the response three exchanges ago" requires line-by-line
+backwards navigation through every intervening line.
+
+**Why it matters.** Long Claude sessions accumulate dozens of
+exchanges; the user needs random-access navigation to
+previous responses. Quick-nav letters (`e` for next error,
+`o` for next output block, `c` for next command) are the
+canonical screen-reader pattern (NVDA's browse-mode shortcut
+keys); pty-speak doesn't yet expose them.
+
+**Reproduction.** Have a multi-exchange Claude session
+(3–4 exchanges). Try to jump back to the second response's
+specific paragraph without using line-by-line review-cursor
+navigation. No quick-nav is available (predicted).
+
+**Hypothesised root cause.** Stage 10 (review mode +
+quick-nav letters) hasn't shipped. The semantic-event taxonomy
+(error / warning / command / output block / interactive
+element / prompt) needs to land in the parser → semantic-mapper
+layer first; review mode then consumes that taxonomy via
+quick-nav letters. Spec §10 has the full design;
+[`docs/PROJECT-PLAN-2026-05.md`](PROJECT-PLAN-2026-05.md)
+Part 5 sequences Stage 10 as the first non-built-in consumer
+of the Output / Input framework taxonomies.
+
+**Source: design prediction** (per
+[`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 known issue
+#4 → Stage 10). Empirical confirmation pending.
+
+### Template (use for new entries surfaced during NVDA validation)
 
 ```markdown
 ### [tag-1] [tag-2] One-line summary of the gap


### PR DESCRIPTION
## Summary

**Closes the four-PR Stage 7 sequence** per [`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md) Part 2; depends on PR-A (#131, env-scrub PO-5), PR-B (#132, shell registry + `PTYSPEAK_SHELL`), and PR-C (#134, hot-switch hotkeys `Ctrl+Shift+1` / `Ctrl+Shift+2`).

Docs-only — no code changes. Two artefacts:

1. The manual NVDA-validation matrix the maintainer runs to verify the substrate.
2. The Stage 7 issues inventory pre-seeded with design-derived predictions; the maintainer's empirical NVDA pass confirms / refines / supplements them, and the Output framework cycle's research phase consumes the inventory as design input.

## What changes

- **`docs/ACCESSIBILITY-TESTING.md`** "Stage 7 — Claude Code roundtrip" row expanded from 4 tests to **14**, exercising the full PR-A/B/C surface end-to-end:
  - **Default-shell launch (PR-B)** — cmd.exe spawns; log line `"Startup shell: Command Prompt"`.
  - **Env-scrub empirical check (PR-A)** — `set` enumeration confirms deny-list strips (`*_TOKEN`, `*_SECRET`, `*_PASSWORD`, non-Anthropic `*_KEY`) and allow-list preserves (`PATH`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `HOME` plus always-set `TERM=xterm-256color` + `COLORTERM=truecolor`).
  - **Claude-shell launch (PR-B)** — `PTYSPEAK_SHELL=claude` or PR-C hotkey.
  - **Welcome screen + prompt → response (Claude)**.
  - **Review-cursor navigation** — `Caps Lock+Numpad 7/8/9`.
  - **Spinner-flood guard**.
  - **Tool-use prompt (Edit/Yes/Always/No)**.
  - **Hot-switch cmd ↔ claude (PR-C)**.
  - **Hot-switch resolve failure** when claude.exe isn't on PATH.
  - **Process-cleanup verification post-switch** via `Ctrl+Shift+D` diagnostic (Job Object `KILL_ON_JOB_CLOSE` cascade).
  - **Clean quit** via `/exit` / `exit` / `Ctrl+D`.
  - **PTYSPEAK_SHELL=garbage** unrecognised-value fallback.
- **`docs/ACCESSIBILITY-TESTING.md`** diagnostic-decoder section expanded with new failure-mode entries: env-scrub leak (security-class), allow-list missing var (spec §7.2 sync drift), hot-switch silent-announce (`AppReservedHotkeys` / filter-ordering regression), hot-switch orphan-child accumulation (`ConPtyHost.Dispose` race), hot-switch announce-but-no-shell (`wirePostSpawn` not invoked / `SetPtyHost` not re-bound). Each decoder names the source file or test fixture to triage against.
- **`docs/STAGE-7-ISSUES.md`** status header flipped from `"stub created in PR #129; no entries yet"` to `"Stage 7 substrate shipped via PRs #131 / #132 / #134; PR-D this PR; empirical NVDA validation maintainer-driven."`
- **`docs/STAGE-7-ISSUES.md`** inventory body pre-seeded with **four design-derived entries** sourced from `spec/tech-plan.md` §7.4 + `docs/SESSION-HANDOFF.md` Stage 7 sketch "Known risks":
  - **`[output-stream]` Verbose readback** — whole-screen announcement on every Ink frame redraw. The first foundational architecture decision the Output framework cycle (Part 3) addresses.
  - **`[output-selection]` Tool-use prompt reads as flat text** — original Stage 8 scope, folded into the Output framework cycle's Selection profile.
  - **`[output-earcon]` Red error text reads as plain text** — original Stage 9 scope, folded into the Output framework cycle's Earcons presentation-sink layer.
  - **`[review-mode]` No quick-nav after focus moves past response** — Stage 10 scope; depends on the semantic-event taxonomy.
  - Each entry marked **Source: design prediction**; maintainer's empirical pass uses **Source: NVDA pass YYYY-MM-DD** for confirmed/refined/new entries. The distinction matters for the framework cycle's research phase.
- **`CHANGELOG.md`** `[Unreleased]` ### Added entry (above PR-C; chronological).

## What this PR deliberately omits

- **Solving any of the four pre-seeded gaps.** Per the May-2026 plan: *don't fix anything from the inventory in Stage 7; that's framework-cycle work.* PR-D's merge gate is the matrix being green for the rows that should be green and the inventory documenting (not solving) the rows that aren't.
- **Empirical NVDA validation (matrix execution).** I cannot run NVDA from the dev sandbox; the maintainer's manual pass produces the empirical entries that confirm, refine, or replace the design predictions.
- **Refinements to the doc-purpose audit** queued in [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md) "Queued before Output framework cycle starts" — that's the next transition-window PR after Stage 7 closes.

## Test plan

- [x] Both docs are plain UTF-8 / ASCII (no NUL bytes verified)
- [x] Internal links resolve to existing files / sections
- [x] Inventory entries follow the template structure (One-line summary / What broke / Why it matters / Reproduction / Hypothesised root cause / Source)
- [x] Matrix rows specify exact procedure + expected NVDA announcement
- [ ] CI green
- [ ] Maintainer review of matrix scope + inventory predictions

## After this PR ships

Stage 7 closes. The next work is the **doc-purpose audit** queued in `docs/SESSION-HANDOFF.md` "Queued before Output framework cycle starts" — the transition-window deliverable before the Output framework cycle's Phase 3.1 research begins. This inventory becomes the design input that research phase reads.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_