### PR TITLE
feat(app): Ctrl+Shift+G toggle debug logging at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,45 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 7-followup PR-E — `Ctrl+Shift+G` toggle debug logging
+  + announce state.** Eliminates the previous
+  `PTYSPEAK_LOG_LEVEL=Debug` env-var-and-relaunch workflow that
+  the maintainer (a screen-reader user) spent two hours fighting
+  to enable Debug-level logging. Each `Ctrl+Shift+G` press flips
+  the active `FileLoggerSink`'s min-level between `Information`
+  (default) and `Debug` and announces the new state via NVDA
+  ("Debug logging on." / "Debug logging off."). The toggle event
+  itself logs at `Information` level so the audit trail captures
+  every transition regardless of which state we just left.
+  New `ActivityIds.logToggle = "pty-speak.log-toggle"` so users
+  can configure NVDA's notification processing for diagnostic-
+  config announcements separately from streaming output. Wired
+  in `setupToggleDebugLogKeybinding`. Reserved in
+  `TerminalView.AppReservedHotkeys` so Stage 6's
+  `OnPreviewKeyDown` filter doesn't mark it `Handled = true`
+  before WPF's `InputBindings` machinery can fire. Mnemonic: G
+  for "loGging". No NVDA collision (default NVDA bindings don't
+  claim `Ctrl+Shift+G`).
+
+  Implementation: `FileLoggerSink.MinLevel` is now a runtime-
+  mutable read-out + `SetMinLevel` member (previously read-only
+  via the `options.MinLevel` immutable record field). Reads are
+  unsynchronised — the level is a 4-byte enum, atomic on x64,
+  and the hotkey-driven write happens on the WPF dispatcher
+  thread while reads happen on the Channel-drain thread; a
+  stale read for one entry is acceptable (worst case: one log
+  line at the previous level after a toggle).
+
+  Spec deviation: bundled spec update (§6 hotkey-list amendment)
+  per chat 2026-05-03 maintainer authorisation. Same ADR-style
+  retroactive-formalisation pattern as Stage 7 PR-C.
+
+  Followup to the Stage 7 sequence; addresses the diagnostic-
+  workflow accessibility gap surfaced when the maintainer
+  attempted manual NVDA validation per
+  `docs/ACCESSIBILITY-TESTING.md` Stage 7 row and could not
+  reliably enable Debug-level logging via env-var manipulation.
+
 - **Stage 7 PR-D — NVDA validation matrix expansion +
   `docs/STAGE-7-ISSUES.md` design-derived seed entries.**
   Closes the four-PR Stage 7 sequence per

--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ preserve this list per the app-reserved-hotkey contract in
   isn't on `PATH`, NVDA announces "Cannot switch to Claude
   Code: not found on PATH." and the existing shell keeps
   running (Stage 7 PR-C).
+- **`Ctrl+Shift+G`** — toggle `FileLogger` min-level between
+  `Information` (default) and `Debug` at runtime. Each press
+  flips the level and NVDA announces the new state ("Debug
+  logging on." / "Debug logging off."). Lets the maintainer
+  enable verbose debug logging from inside pty-speak without
+  the previous env-var-and-relaunch workflow. Mnemonic: G for
+  "loGging" (Stage 7-followup PR-E).
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute
 toggle), `Alt+Shift+R` (Stage 10 review-mode toggle).

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -454,6 +454,22 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 >     (resolved via `where.exe claude` per §7.1).
 >     Bound in the same setup function.
 >
+> Stage 7-followup PR-E addition (ADR-style amendment 2026-05-03,
+> maintainer-authorised — diagnostic-workflow accessibility
+> improvement after the maintainer spent two hours fighting
+> env-var manipulation to enable Debug-level logging):
+>   - `Ctrl+Shift+G` — toggle `FileLogger` min-level between
+>     `Information` (default) and `Debug` at runtime. Each press
+>     flips the level and announces the new state via NVDA
+>     ("Debug logging on." / "Debug logging off."). Eliminates
+>     the previous `PTYSPEAK_LOG_LEVEL=Debug` env-var-and-relaunch
+>     workflow that depended on shell-launch sequencing the
+>     screen-reader user couldn't reliably verify. Bound in
+>     `setupToggleDebugLogKeybinding` in
+>     `src/Terminal.App/Program.fs`. Mnemonic: G for "loGging".
+>     No NVDA collision (default NVDA bindings don't claim
+>     `Ctrl+Shift+G`).
+>
 > Future entries (declared as code comments today; activated
 > when their owning stage ships):
 >   - `Ctrl+Shift+M` — Stage 9 earcon mute toggle.

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -555,9 +555,64 @@ module Program =
         let gesture = KeyGesture(Key.L, ModifierKeys.Control ||| ModifierKeys.Shift)
         window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
         window.CommandBindings.Add(
+                CommandBinding(
+                    cmd,
+                    ExecutedRoutedEventHandler(fun _ _ -> runOpenLogs window)))
+        |> ignore
+
+    /// Stage 7-followup PR-E — toggle the active `FileLoggerSink`'s
+    /// min-level between Information (default) and Debug, and
+    /// announce the new state via NVDA. Lets the maintainer enable
+    /// verbose debug logging from inside pty-speak without an
+    /// env-var dance + relaunch (the previous workflow). Each
+    /// press flips the level; the level is persistent for the
+    /// lifetime of the session, but does NOT survive across
+    /// launches (a future Phase-2 user-settings TOML can persist
+    /// it if desired).
+    ///
+    /// The toggle event itself logs at `Information` level so the
+    /// audit trail captures every transition regardless of which
+    /// state we just left (Information passes both filters).
+    /// Announcement uses `ActivityIds.logToggle` so users can
+    /// configure NVDA's notification processing for diagnostic-
+    /// config announcements separately from streaming output.
+    let private runToggleDebugLog (window: MainWindow) : unit =
+        match loggerSink with
+        | None ->
+            let log = Logger.get "Terminal.App.Program.runToggleDebugLog"
+            log.LogWarning(
+                "Ctrl+Shift+G pressed but loggerSink is None; toggle skipped.")
+            window.TerminalSurface.Announce(
+                "Logger not initialised; toggle skipped.",
+                ActivityIds.error)
+        | Some sink ->
+            let log = Logger.get "Terminal.App.Program.runToggleDebugLog"
+            let next =
+                if sink.MinLevel = LogLevel.Debug then LogLevel.Information
+                else LogLevel.Debug
+            sink.SetMinLevel(next)
+            log.LogInformation(
+                "Ctrl+Shift+G pressed; FileLogger min-level toggled to {NewLevel}.",
+                next)
+            let cue =
+                match next with
+                | LogLevel.Debug -> "Debug logging on."
+                | _ -> "Debug logging off."
+            window.TerminalSurface.Announce(cue, ActivityIds.logToggle)
+
+    /// Wire `Ctrl+Shift+G` to trigger `runToggleDebugLog`. Same
+    /// pattern as the other reserved hotkeys above. The gesture
+    /// is reserved in `TerminalView.AppReservedHotkeys` so Stage 6's
+    /// `OnPreviewKeyDown` filter doesn't mark it `Handled = true`
+    /// before WPF's `InputBindings` machinery can fire.
+    let private setupToggleDebugLogKeybinding (window: MainWindow) : unit =
+        let cmd = RoutedCommand("ToggleDebugLog", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.G, ModifierKeys.Control ||| ModifierKeys.Shift)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
             CommandBinding(
                 cmd,
-                ExecutedRoutedEventHandler(fun _ _ -> runOpenLogs window)))
+                ExecutedRoutedEventHandler(fun _ _ -> runToggleDebugLog window)))
         |> ignore
 
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
@@ -612,6 +667,13 @@ module Program =
         // contents to the clipboard. Useful for sending the log
         // to a maintainer without navigating Explorer.
         setupCopyLatestLogKeybinding window
+
+        // Stage 7-followup PR-E — wire Ctrl+Shift+G to toggle the
+        // FileLogger min-level (Information ↔ Debug) at runtime,
+        // with an audible NVDA announcement of the new state. Lets
+        // the maintainer enable verbose debug logging without the
+        // env-var-and-relaunch dance.
+        setupToggleDebugLogKeybinding window
 
         // Direct dispatch via TerminalView.OnPreviewKeyDown is
         // kept as a defence-in-depth path because Window-level

--- a/src/Terminal.Core/FileLogger.fs
+++ b/src/Terminal.Core/FileLogger.fs
@@ -126,6 +126,18 @@ type FileLoggerSink (options: FileLoggerOptions) =
     /// folders.
     let launchUtc = DateTimeOffset.UtcNow
 
+    /// Stage 7-followup PR-E — runtime-mutable min-level so the
+    /// `Ctrl+Shift+G` hotkey can toggle Debug ↔ Information without
+    /// requiring an env-var + relaunch cycle. Initialised from
+    /// `options.MinLevel`; updated via `SetMinLevel`. Reads through
+    /// `currentMinLevel` are unsynchronised — the level is a single
+    /// `LogLevel` enum (4-byte read), atomic on x64, and the
+    /// hotkey-driven write happens on the WPF dispatcher thread
+    /// while reads happen on the Channel-drain thread; a stale read
+    /// for one entry is acceptable (worst case: one log line at the
+    /// previous level after a toggle).
+    let mutable currentMinLevel = options.MinLevel
+
     let channel =
         let opts =
             BoundedChannelOptions(options.ChannelCapacity,
@@ -329,7 +341,36 @@ type FileLoggerSink (options: FileLoggerOptions) =
             } :> Task)
 
     member _.IsEnabled (level: LogLevel) : bool =
-        level >= options.MinLevel
+        level >= currentMinLevel
+
+    /// Stage 7-followup PR-E — current min-level read-out. Used by
+    /// the `Ctrl+Shift+G` hotkey to announce the current state via
+    /// NVDA before/after toggling.
+    member _.MinLevel : LogLevel = currentMinLevel
+
+    /// Stage 7-followup PR-E — runtime-mutable min-level setter.
+    /// Wired to the `Ctrl+Shift+G` toggle hotkey in
+    /// `src/Terminal.App/Program.fs`. Effective for every TryWrite
+    /// call after this returns; the `currentMinLevel` field is a
+    /// 4-byte enum (atomic read on x64). Logs the change at
+    /// `Information` level so the audit trail captures every
+    /// transition regardless of the new state's filtering
+    /// (Information is always at-or-above the new min for the two
+    /// levels the hotkey toggles between).
+    member this.SetMinLevel (newLevel: LogLevel) : unit =
+        let prev = currentMinLevel
+        currentMinLevel <- newLevel
+        // Self-log via TryWrite so the transition appears in the
+        // log file even when downgrading from Debug to Information
+        // (the new-level filter passes Information).
+        let msg =
+            sprintf "FileLogger min-level changed: %A -> %A" prev newLevel
+        this.TryWrite(
+            DateTimeOffset.UtcNow,
+            LogLevel.Information,
+            "Terminal.Core.FileLoggerSink.SetMinLevel",
+            msg,
+            ValueNone)
 
     /// Enqueue an entry. Returns immediately. Drops silently if
     /// the channel is closed (post-shutdown).
@@ -339,7 +380,7 @@ type FileLoggerSink (options: FileLoggerOptions) =
              category: string,
              message: string,
              ex: exn voption) : unit =
-        if level >= options.MinLevel then
+        if level >= currentMinLevel then
             let entry =
                 { Timestamp = timestamp
                   Level = level

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -282,3 +282,12 @@ module ActivityIds =
     /// processing for shell-switch announcements separately
     /// from streaming output.
     let shellSwitch = "pty-speak.shell-switch"
+
+    /// Debug-logging toggle announcements (Stage 7-followup
+    /// PR-E `Ctrl+Shift+G`). Emits "Debug logging on." /
+    /// "Debug logging off." after each toggle so the user can
+    /// confirm the current state without checking a log file.
+    /// Distinct ActivityId so users can configure NVDA's
+    /// notification processing for diagnostic-config
+    /// announcements separately from streaming output.
+    let logToggle = "pty-speak.log-toggle"

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -422,6 +422,17 @@ public class TerminalView : FrameworkElement
             (Key.D1, ModifierKeys.Control | ModifierKeys.Shift, "Switch to cmd shell"),
             (Key.D2, ModifierKeys.Control | ModifierKeys.Shift, "Switch to claude shell"),
 
+            // Stage 7-followup PR-E — toggle FileLogger min-level
+            // between Information (default) and Debug at runtime,
+            // without requiring an env-var + relaunch cycle. Each
+            // press flips the level and announces the new state via
+            // NVDA so the user can confirm at any time. Mnemonic:
+            // G for "loGging". No NVDA collision (NVDA's
+            // `Ctrl+Shift+G` has no default binding; the
+            // letter-G family in NVDA is `NVDA+G` for object-nav
+            // graphics, which is a different modifier).
+            (Key.G, ModifierKeys.Control | ModifierKeys.Shift, "Toggle debug logging"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,


### PR DESCRIPTION
## Summary

Stage 7-followup. Adds **`Ctrl+Shift+G`** to toggle the active `FileLoggerSink`'s min-level between `Information` (default) and `Debug` at runtime. Each press flips the level and announces the new state via NVDA: **"Debug logging on."** or **"Debug logging off."**

## Why

The maintainer (a screen-reader user) spent two hours fighting `PTYSPEAK_LOG_LEVEL=Debug` env-var manipulation to enable Debug-level logging:
- Setting env vars via System Properties dialogs is hostile to screen-reader workflows.
- Setting them via PowerShell required execution-policy adjustments.
- Setting them via cmd `.bat` required knowing the install path Velopack chose.
- Even after setting, there was no in-app feedback confirming the level had actually been applied.

None of those friction points exist for an in-app keyboard hotkey with a spoken state announcement.

## What changes

- **`src/Terminal.Core/FileLogger.fs`** — `FileLoggerSink.MinLevel` is now a runtime-mutable read-out + `SetMinLevel` member. Previously read-only via `options.MinLevel`; now a `let mutable currentMinLevel` field is the source of truth. Reads are unsynchronised — the level is a 4-byte enum (atomic on x64) and the hotkey-driven write happens on the WPF dispatcher thread while reads happen on the Channel-drain thread; a stale read for one entry is acceptable. `SetMinLevel` self-logs at `Information` level so the audit trail captures every transition regardless of which state we left.
- **`src/Terminal.Core/Types.fs`** — new `ActivityIds.logToggle = "pty-speak.log-toggle"` for the announce strings; distinct from streaming output.
- **`src/Views/TerminalView.cs`** — adds `(Key.G, Ctrl+Shift)` to `AppReservedHotkeys`. NVDA collision check documented inline: `Ctrl+Shift+G` has no default NVDA binding.
- **`src/Terminal.App/Program.fs`** — `runToggleDebugLog` handler + `setupToggleDebugLogKeybinding`. Handler reads the sink's current level, flips between `Information` and `Debug`, calls `SetMinLevel`, logs at Information, announces via `TerminalSurface.Announce` with `ActivityIds.logToggle`. Unhappy-path (loggerSink is None) announces "Logger not initialised" via `ActivityIds.error`.
- **`spec/tech-plan.md`** — ADR-style amendment to §6 hotkey contract per chat 2026-05-03 maintainer authorisation.
- **`README.md`** — App-reserved hotkeys section adds the `Ctrl+Shift+G` entry.
- **`CHANGELOG.md`** — `[Unreleased]` ### Added entry.

## What this PR deliberately omits

- **Persistence across launches.** Each launch resets to `options.MinLevel` (Information by default). Phase 2 TOML can persist it if desired.
- **A separate "say current level" hotkey.** The toggle's announcement covers the use case; pressing once to check + flip back is two keystrokes vs. one for a query-only key, but acceptable for occasional checks.
- **Other diagnostic-workflow improvements** (incident-mode capture, state-announce hotkey, auto-archive on copy). I'll propose those as separate PRs in a follow-up message; this one stays single-concern.

## Test plan

- [x] No NUL bytes / binary-flagging chars
- [x] Internal links resolve
- [ ] CI green
- [ ] Maintainer manual NVDA validation:
  - [ ] Launch pty-speak; press `Ctrl+Shift+G`; NVDA reads "Debug logging on."
  - [ ] Verify `[DBG]` entries appear in the active session log (`Ctrl+Shift+;` to copy + check)
  - [ ] Press `Ctrl+Shift+G` again; NVDA reads "Debug logging off."
  - [ ] Verify new `[DBG]` entries stop appearing

## After this PR ships

I have **four more diagnostic-workflow ideas** in a follow-up message — happy to ship any/all if they help. They address: one-keystroke incident-mode capture, runtime state-announce hotkey, parser-error auto-snapshot, and a debug-launch script bundled into the Velopack install.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_