### PR TITLE
feat(app): diagnostic surface — health check + incident marker + heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,85 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ### Added
 
+- **Stage 7-followup PR-F — diagnostic surface: `Ctrl+Shift+H`
+  health check, `Ctrl+Shift+B` incident marker, background
+  heartbeat.** Closes the in-app debug-capture workflow alongside
+  PR-E's `Ctrl+Shift+G` toggle. The maintainer's two-hour
+  env-var-debug ordeal is the trigger; the goal is to make
+  "capture and send a diagnostic log" achievable in three
+  keystrokes (G to enable Debug logging, B to mark the incident,
+  ; to copy the log to clipboard) without any out-of-app
+  manipulation.
+
+  **`Ctrl+Shift+H` — health check.** Announces a one-line state
+  snapshot via NVDA: verdict ("Pty-speak healthy." / "Reader
+  appears wedged. Last byte N seconds ago." / "Notification
+  queue near capacity (N of 256).") + shell name + PID + log
+  level + reader last-byte staleness + notification-channel
+  depth + coalesced-channel depth. Lets a screen-reader user
+  determine in one keystroke whether pty-speak is functioning,
+  instead of inferring from "is NVDA reading anything?". Verdict
+  heuristic: reader-wedge if staleness > 5000ms AND notification
+  queue non-empty; queue-near-capacity if notification queue at
+  ≥244/256 (DropOldest mode means past-capacity is silent data
+  loss); otherwise healthy. Wired in
+  `setupHealthCheckKeybinding` with the closure
+  `runHealthCheck` constructed inside `compose ()` (captures
+  compose-local state — `lastReadUtc`, `hostHandle`, channels,
+  `chosenShell`).
+
+  **`Ctrl+Shift+B` — incident marker.** Writes a clear
+  `=== INCIDENT MARKER {timestamp} === (Ctrl+Shift+B)`
+  boundary line into the active log at `Information` level via
+  the standard `ILogger` path, then announces via NVDA:
+  "Incident marker logged. Reproduce your issue, then press
+  Ctrl+Shift+; to copy the log." The user reproduces the issue,
+  then copies the full log via `Ctrl+Shift+;`; server-side grep
+  for the marker extracts the relevant slice. Wired in
+  `setupIncidentMarkerKeybinding` with `runIncidentMarker`
+  closure inside `compose ()`.
+
+  **Background heartbeat (no hotkey).** A
+  `System.Threading.Timer` ticks every 5 seconds and logs an
+  `Information`-level "Heartbeat" line with the same fields as
+  the health-check announcement (shell, PID, level, last-read
+  staleness, channel queues). Heartbeats stopping in the log
+  are a clean wedge timestamp for post-mortem triage. Runs on
+  the timer thread pool (NOT the WPF dispatcher), so heartbeats
+  keep emitting even if the dispatcher is wedged — the gap
+  between the last successful heartbeat and the next captured
+  event localises the problem. Initialised in `compose ()`;
+  disposed in `app.Exit` BEFORE the logger is disposed (so the
+  timer doesn't fire one last entry into a closed channel and
+  log a confusing exception).
+
+  **Last-read timestamp threading.** `startReaderLoop` now takes
+  an `onChunkRead: int -> unit` callback parameter that the
+  reader fires on every non-empty chunk. `compose ()` passes
+  `(fun _ -> lastReadUtc <- DateTimeOffset.UtcNow)` to share
+  the timestamp across the heartbeat + health-check + every
+  reader (initial spawn AND each shell hot-switch — the
+  callback is captured in the closure, not the host).
+  Unsynchronised reads are acceptable for a diagnostic; one
+  weird-looking entry occasionally is OK.
+
+  Two new `ActivityIds` for the announcements:
+  `healthCheck = "pty-speak.health-check"`,
+  `incidentMarker = "pty-speak.incident-marker"`. Distinct so
+  diagnostic-config announcements stay configurable separately
+  from streaming output.
+
+  Spec deviation: bundled spec update (§6 hotkey-list amendment)
+  per chat 2026-05-03 maintainer authorisation. Same ADR-style
+  retroactive-formalisation pattern as PR-C and PR-E.
+
+  Followup to the Stage 7 sequence; closes the diagnostic-
+  workflow accessibility gap that surfaced when the maintainer
+  attempted manual NVDA validation per
+  `docs/ACCESSIBILITY-TESTING.md` Stage 7 row and could not
+  reliably enable Debug-level logging or capture an in-progress
+  hang.
+
 - **Stage 7-followup PR-E — `Ctrl+Shift+G` toggle debug logging
   + announce state.** Eliminates the previous
   `PTYSPEAK_LOG_LEVEL=Debug` env-var-and-relaunch workflow that

--- a/README.md
+++ b/README.md
@@ -197,6 +197,23 @@ preserve this list per the app-reserved-hotkey contract in
   enable verbose debug logging from inside pty-speak without
   the previous env-var-and-relaunch workflow. Mnemonic: G for
   "loGging" (Stage 7-followup PR-E).
+- **`Ctrl+Shift+H`** — health check. Announces a one-line state
+  snapshot via NVDA: verdict ("Pty-speak healthy." / "Reader
+  appears wedged." / "Notification queue near capacity.") +
+  shell name + PID + log level + reader last-byte staleness +
+  channel queue depths. Lets a screen-reader user determine in
+  one keystroke whether pty-speak is functioning, instead of
+  inferring from "is NVDA reading anything?". Mnemonic: H for
+  "Health" (Stage 7-followup PR-F).
+- **`Ctrl+Shift+B`** — incident marker. Logs a clear
+  `=== INCIDENT MARKER {timestamp} ===` boundary line into the
+  active log file and announces "Incident marker logged.
+  Reproduce your issue, then press Ctrl+Shift+; to copy the
+  log." Pair with `Ctrl+Shift+G` (debug logging on) and
+  `Ctrl+Shift+;` (copy log to clipboard) for a complete
+  three-keystroke debug-capture workflow that doesn't require
+  any env-var manipulation. Mnemonic: B for "Bug" (Stage
+  7-followup PR-F).
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute
 toggle), `Alt+Shift+R` (Stage 10 review-mode toggle).

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -470,6 +470,37 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 >     No NVDA collision (default NVDA bindings don't claim
 >     `Ctrl+Shift+G`).
 >
+> Stage 7-followup PR-F additions (ADR-style amendment 2026-05-03,
+> maintainer-authorised — diagnostic-surface bundle that completes
+> the in-app debug-capture workflow alongside `Ctrl+Shift+G`):
+>   - `Ctrl+Shift+H` — health check: announce a one-line state
+>     snapshot (shell + PID, log level, reader last-byte
+>     staleness, channel queue depths) with a verdict prefix
+>     ("Pty-speak healthy." / "Reader appears wedged." /
+>     "Notification queue near capacity."). Lets a screen-reader
+>     user determine in one keystroke whether pty-speak is
+>     functional. Bound in `setupHealthCheckKeybinding` in
+>     `src/Terminal.App/Program.fs`. Mnemonic: H for "Health".
+>   - `Ctrl+Shift+B` — incident marker: log a
+>     `=== INCIDENT MARKER {timestamp} ===` boundary line at
+>     `Information` level and announce. The user reproduces the
+>     issue, then copies the log via `Ctrl+Shift+;` — server-side
+>     grep for the marker extracts the relevant slice. Replaces
+>     the env-var-and-relaunch debug-capture workflow with three
+>     keystrokes (G, B, ;) entirely inside pty-speak. Bound in
+>     `setupIncidentMarkerKeybinding`. Mnemonic: B for "Bug".
+>   - **Background heartbeat (no hotkey).** A
+>     `System.Threading.Timer` ticks every 5 seconds and logs an
+>     `Information`-level state snapshot (same fields as the
+>     health-check announcement). Heartbeats stopping in the log
+>     are a clean wedge timestamp for post-mortem triage.
+>     Initialised in `compose ()`; disposed in `app.Exit`.
+>   - All three are independent: the heartbeat runs on the timer
+>     thread regardless of dispatcher liveness; the hotkeys run
+>     on the dispatcher (so a wedged dispatcher would stop them,
+>     but the heartbeat's silence in the log captures that
+>     condition).
+>
 > Future entries (declared as code comments today; activated
 > when their owning stage ships):
 >   - `Ctrl+Shift+M` — Stage 9 earcon mute toggle.

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -57,6 +57,7 @@ module Program =
             (screen: Screen)
             (view: TerminalView)
             (notifications: System.Threading.Channels.ChannelWriter<ScreenNotification>)
+            (onChunkRead: int -> unit)
             (ct: CancellationToken) : Task =
         Task.Run(fun () ->
             task {
@@ -65,6 +66,13 @@ module Program =
                     while not ct.IsCancellationRequested do
                         let! chunk = host.Stdout.ReadAsync(ct).AsTask()
                         if chunk.Length > 0 then
+                            // Stage 7-followup PR-F — record the
+                            // moment of last live PTY activity. The
+                            // heartbeat timer + Ctrl+Shift+H health
+                            // check both read this to detect reader
+                            // staleness (a wedged reader vs a quiet
+                            // shell).
+                            onChunkRead chunk.Length
                             let events = Parser.feedArray parser chunk
                             if events.Length > 0 then
                                 let action () =
@@ -615,6 +623,46 @@ module Program =
                 ExecutedRoutedEventHandler(fun _ _ -> runToggleDebugLog window)))
         |> ignore
 
+    /// Stage 7-followup PR-F — wire `Ctrl+Shift+H` to a caller-
+    /// supplied health-check callback. The callback is a closure
+    /// constructed inside `compose ()` that reads compose-local
+    /// state (host, channel queue depths, last-byte timestamp,
+    /// log level) and announces a one-line summary via NVDA.
+    /// Same closure-passing pattern as
+    /// `setupShellSwitchKeybindings` (which takes
+    /// `ShellId -> unit`); keeps this setup function pure
+    /// boilerplate.
+    let private setupHealthCheckKeybinding
+            (window: MainWindow)
+            (run: unit -> unit) : unit =
+        let cmd = RoutedCommand("HealthCheck", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.H, ModifierKeys.Control ||| ModifierKeys.Shift)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
+            CommandBinding(
+                cmd,
+                ExecutedRoutedEventHandler(fun _ _ -> run ())))
+        |> ignore
+
+    /// Stage 7-followup PR-F — wire `Ctrl+Shift+B` to a caller-
+    /// supplied incident-marker callback. The callback writes a
+    /// clear "=== INCIDENT MARKER {timestamp} ===" line into the
+    /// active log + announces. Replaces the env-var-and-relaunch
+    /// debug-capture workflow with three keystrokes
+    /// (`Ctrl+Shift+G`, `Ctrl+Shift+B`, `Ctrl+Shift+;`) entirely
+    /// inside pty-speak.
+    let private setupIncidentMarkerKeybinding
+            (window: MainWindow)
+            (run: unit -> unit) : unit =
+        let cmd = RoutedCommand("IncidentMarker", typeof<MainWindow>)
+        let gesture = KeyGesture(Key.B, ModifierKeys.Control ||| ModifierKeys.Shift)
+        window.InputBindings.Add(KeyBinding(cmd, gesture)) |> ignore
+        window.CommandBindings.Add(
+            CommandBinding(
+                cmd,
+                ExecutedRoutedEventHandler(fun _ _ -> run ())))
+        |> ignore
+
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
     /// in here. For Stage 3b we just hold references to the long-lived
     /// pieces and ensure they're disposed on Application.Exit.
@@ -905,6 +953,162 @@ module Program =
 
         let mutable hostHandle : ConPtyHost option = None
 
+        // Stage 7-followup PR-F — last-byte timestamp shared across
+        // every reader (initial spawn + each shell hot-switch). The
+        // heartbeat timer + Ctrl+Shift+H health check both read
+        // this to derive reader-loop staleness ("how long since the
+        // PTY produced output"), which is the single most useful
+        // signal for distinguishing "pty-speak is wedged" from
+        // "the shell is just idle waiting for input". Updates are
+        // unsynchronised — DateTimeOffset is 16 bytes (torn read
+        // possible) but the heartbeat is a diagnostic; one
+        // weird-looking entry occasionally is acceptable.
+        let mutable lastReadUtc = DateTimeOffset.UtcNow
+
+        // Stage 7-followup PR-F — incident-marker handler. Single
+        // press writes a clear "=== INCIDENT MARKER {timestamp} ==="
+        // boundary line to the active log via the standard
+        // ILogger/FileLogger path, then announces via NVDA. The
+        // user reproduces the issue, then copies the log via
+        // Ctrl+Shift+;; server-side grep for the marker extracts
+        // the relevant slice from the full log. Replaces the
+        // env-var-and-relaunch debug-capture workflow with three
+        // keystrokes (G, B, ;) entirely inside pty-speak.
+        let runIncidentMarker () : unit =
+            try
+                let timestamp =
+                    DateTimeOffset.UtcNow.ToString(
+                        "yyyy-MM-ddTHH:mm:ss.fffZ")
+                let markerLog = Logger.get "Terminal.App.IncidentMarker"
+                markerLog.LogInformation(
+                    "=== INCIDENT MARKER {Timestamp} === (Ctrl+Shift+B)",
+                    timestamp)
+                window.TerminalSurface.Announce(
+                    "Incident marker logged. Reproduce your issue, then press Ctrl+Shift+; to copy the log.",
+                    ActivityIds.incidentMarker)
+            with ex ->
+                let safe = AnnounceSanitiser.sanitise ex.Message
+                log.LogError(ex, "Incident marker raised exception.")
+                window.TerminalSurface.Announce(
+                    sprintf "Incident marker failed: %s" safe,
+                    ActivityIds.error)
+
+        // Stage 7-followup PR-F — health-check handler. Reads
+        // current runtime state (shell + PID, log level, last-byte
+        // staleness, channel queue depths) and announces a one-line
+        // summary. The summary opens with a status verdict
+        // (healthy / queue-near-capacity / reader-wedged) so a
+        // screen-reader user can determine in one keystroke whether
+        // pty-speak is functioning, instead of inferring from "is
+        // NVDA reading anything?".
+        let runHealthCheck () : unit =
+            try
+                let now = DateTimeOffset.UtcNow
+                let staleness = (now - lastReadUtc).TotalMilliseconds
+                let pid =
+                    match hostHandle with
+                    | Some h -> int h.ProcessId
+                    | None -> 0
+                let levelStr =
+                    match loggerSink with
+                    | Some s -> s.MinLevel.ToString()
+                    | None -> "Unknown"
+                let notifDepth = notificationChannel.Reader.Count
+                let coalDepth = coalescedChannel.Reader.Count
+                // Verdict heuristic: reader-wedge if no bytes in
+                // 5+ seconds AND there's pending work; queue-near-
+                // capacity if the notification channel is past 95%
+                // (the DropOldest mode means past-capacity is silent
+                // data loss); otherwise healthy.
+                let verdict =
+                    if staleness > 5000.0 && notifDepth > 0 then
+                        sprintf
+                            "Reader appears wedged. Last byte %.0f seconds ago."
+                            (staleness / 1000.0)
+                    elif notifDepth >= 244 then
+                        sprintf
+                            "Notification queue near capacity (%d of 256)."
+                            notifDepth
+                    else
+                        "Pty-speak healthy."
+                let summary =
+                    sprintf
+                        "%s %s shell, PID %d, log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256. Coalesced queue %d of 16."
+                        verdict
+                        chosenShell.DisplayName
+                        pid
+                        levelStr
+                        staleness
+                        notifDepth
+                        coalDepth
+                log.LogInformation("Health check requested. {Summary}", summary)
+                window.TerminalSurface.Announce(
+                    summary,
+                    ActivityIds.healthCheck)
+            with ex ->
+                let safe = AnnounceSanitiser.sanitise ex.Message
+                log.LogError(ex, "Health check raised exception.")
+                window.TerminalSurface.Announce(
+                    sprintf "Health check failed: %s" safe,
+                    ActivityIds.error)
+
+        // Stage 7-followup PR-F — wire Ctrl+Shift+H and Ctrl+Shift+B
+        // through the standard reserved-hotkey machinery. Both
+        // closures capture compose-local state (lastReadUtc,
+        // hostHandle, channels, chosenShell) so they're built
+        // here rather than as module-level handlers like the
+        // Ctrl+Shift+G toggle (which only needs loggerSink).
+        setupHealthCheckKeybinding window runHealthCheck
+        setupIncidentMarkerKeybinding window runIncidentMarker
+
+        // Stage 7-followup PR-F — background heartbeat. Every 5
+        // seconds, log a single Information-level "Heartbeat" line
+        // capturing the same state the health check announces.
+        // Heartbeats stopping appear as a clean wedge timestamp in
+        // the log when troubleshooting later. Runs on the
+        // System.Threading.Timer thread pool — does NOT touch the
+        // WPF dispatcher, so the heartbeat keeps emitting even if
+        // the dispatcher is wedged.
+        let runHeartbeat () : unit =
+            try
+                let now = DateTimeOffset.UtcNow
+                let staleness = (now - lastReadUtc).TotalMilliseconds
+                let pid =
+                    match hostHandle with
+                    | Some h -> int h.ProcessId
+                    | None -> 0
+                let level =
+                    match loggerSink with
+                    | Some s -> s.MinLevel
+                    | None -> LogLevel.Information
+                let notifDepth = notificationChannel.Reader.Count
+                let coalDepth = coalescedChannel.Reader.Count
+                log.LogInformation(
+                    "Heartbeat. Shell={Shell} Pid={Pid} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap} CoalQueue={Coal}/{CoalCap}",
+                    chosenShell.DisplayName,
+                    pid,
+                    level,
+                    staleness,
+                    notifDepth,
+                    256,
+                    coalDepth,
+                    16)
+            with ex ->
+                // Don't let heartbeat crashes propagate to the
+                // timer thread — log and continue.
+                try
+                    log.LogWarning(
+                        ex,
+                        "Heartbeat raised exception: {Message}",
+                        ex.Message)
+                with _ -> ()
+        let heartbeatTimer =
+            new System.Threading.Timer(
+                callback = TimerCallback(fun _ -> runHeartbeat ()),
+                state = null,
+                dueTime = TimeSpan.FromSeconds(5.0),
+                period = TimeSpan.FromSeconds(5.0))
+
         // Stage 7 PR-C — extracted from the initial-spawn branch
         // so the shell-switch coordinator below can reuse the
         // exact same wiring without duplication. Wires the
@@ -941,6 +1145,7 @@ module Program =
                     screen
                     window.TerminalSurface
                     notificationChannel.Writer
+                    (fun _ -> lastReadUtc <- DateTimeOffset.UtcNow)
                     cts.Token
             window.TerminalSurface.SetPtyHost(
                 Action<byte[]>(fun bytes -> host.WriteBytes(bytes)),
@@ -1115,6 +1320,11 @@ module Program =
         app.Exit.Add(fun _ ->
             try log.LogInformation("pty-speak exiting.") with _ -> ()
             try cts.Cancel() with _ -> ()
+            // Stage 7-followup PR-F — stop the heartbeat timer
+            // before the logger is disposed so the timer doesn't
+            // fire one last entry into a closed channel and log a
+            // confusing exception.
+            try heartbeatTimer.Dispose() with _ -> ()
             // Complete both writers so the coalescer and drain
             // tasks exit cleanly when their channels run dry.
             try notificationChannel.Writer.TryComplete() |> ignore with _ -> ()

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -291,3 +291,23 @@ module ActivityIds =
     /// notification processing for diagnostic-config
     /// announcements separately from streaming output.
     let logToggle = "pty-speak.log-toggle"
+
+    /// Health-check announcements (Stage 7-followup PR-F
+    /// `Ctrl+Shift+H`). Emits a one-line state snapshot — shell
+    /// name + PID, log level, reader liveness (last-byte
+    /// staleness), notification-channel and coalesced-channel
+    /// queue depths. Lets a screen-reader user determine in one
+    /// keystroke whether pty-speak is healthy or wedged, instead
+    /// of inferring from "is NVDA reading anything?". Distinct
+    /// ActivityId so diagnostic-config announcements stay
+    /// configurable separately from streaming output.
+    let healthCheck = "pty-speak.health-check"
+
+    /// Incident-marker announcements (Stage 7-followup PR-F
+    /// `Ctrl+Shift+B`). Emits a confirmation that the user just
+    /// dropped a marker line into the active log file, plus the
+    /// instruction to reproduce the issue and copy the log via
+    /// `Ctrl+Shift+;`. Distinct ActivityId so the marker
+    /// announcement isn't suppressed by streaming-output
+    /// processing.
+    let incidentMarker = "pty-speak.incident-marker"

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -433,6 +433,29 @@ public class TerminalView : FrameworkElement
             // graphics, which is a different modifier).
             (Key.G, ModifierKeys.Control | ModifierKeys.Shift, "Toggle debug logging"),
 
+            // Stage 7-followup PR-F — diagnostic-surface hotkeys.
+            //
+            // Ctrl+Shift+H — health check: announce a one-line
+            // state snapshot (shell + PID, log level, reader
+            // last-byte staleness, channel queue depths). Lets a
+            // screen-reader user determine in one keystroke whether
+            // pty-speak is healthy or wedged, instead of inferring
+            // from "is NVDA reading anything?".
+            //
+            // Ctrl+Shift+B — incident marker: write a clear
+            // "=== INCIDENT MARKER {timestamp} ===" line into the
+            // active log + announce. The user reproduces the issue,
+            // then copies the log via Ctrl+Shift+; — server-side
+            // grep for the marker extracts the relevant slice.
+            // Replaces the env-var-and-relaunch debug capture
+            // workflow with three keystrokes (G, B, ;) entirely
+            // inside pty-speak.
+            //
+            // No NVDA collisions: Ctrl+Shift+H and Ctrl+Shift+B
+            // are not default NVDA bindings.
+            (Key.H, ModifierKeys.Control | ModifierKeys.Shift, "Health check"),
+            (Key.B, ModifierKeys.Control | ModifierKeys.Shift, "Incident marker"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,


### PR DESCRIPTION
## Summary

Stage 7-followup. **Closes the in-app debug-capture workflow** alongside PR-E's `Ctrl+Shift+G` toggle. Goal: make "capture and send a diagnostic log" achievable in three keystrokes (G to enable Debug logging, B to mark the incident, `;` to copy to clipboard) without any out-of-app manipulation. The maintainer's two-hour env-var-debug ordeal earlier this session is the trigger.

## What changes

Three independent diagnostic features:

### `Ctrl+Shift+H` — Health check

Announces a one-line state snapshot via NVDA: **verdict** ("Pty-speak healthy." / "Reader appears wedged. Last byte N seconds ago." / "Notification queue near capacity (N of 256).") + shell name + PID + log level + reader last-byte staleness + channel queue depths. Lets a screen-reader user determine in one keystroke whether pty-speak is functioning, instead of inferring from "is NVDA reading anything?".

Verdict heuristic:
| Condition | Verdict |
|---|---|
| staleness > 5000ms AND notif queue > 0 | Reader wedged |
| notif queue ≥ 244 of 256 | Queue near capacity |
| otherwise | Healthy |

(244 = 95% of the 256-capacity DropOldest channel; past capacity is silent data loss.)

### `Ctrl+Shift+B` — Incident marker

Writes `=== INCIDENT MARKER {timestamp} === (Ctrl+Shift+B)` to the active log at `Information` level via the standard `ILogger` path, then announces *"Incident marker logged. Reproduce your issue, then press Ctrl+Shift+; to copy the log."* The user reproduces the issue, copies the full log via `Ctrl+Shift+;`; server-side grep for the marker extracts the relevant slice.

### Background heartbeat (no hotkey)

A `System.Threading.Timer` ticks every 5 seconds and logs an `Information`-level "Heartbeat" line with the same fields as the health-check announcement. Runs on the timer thread pool (NOT the WPF dispatcher), so heartbeats keep emitting even if the dispatcher is wedged — the gap between the last successful heartbeat and the next captured event localises the problem.

## Three-keystroke debug-capture workflow

This PR + PR-E together enable:

1. `Ctrl+Shift+G` → NVDA: *"Debug logging on."*
2. *(reproduce issue)*
3. `Ctrl+Shift+B` → NVDA: *"Incident marker logged. Reproduce your issue, then press Ctrl+Shift+; to copy the log."*
4. `Ctrl+Shift+;` → NVDA announces byte count; log on clipboard
5. Paste into chat / email / issue.

**No env-var manipulation. No System Properties dialogs. No PowerShell execution policies. No knowing the EXE install path.**

## Implementation notes

- `startReaderLoop` gains an `onChunkRead: int -> unit` callback parameter so `compose ()` can track `lastReadUtc` (a shared mutable across initial spawn AND every shell hot-switch). Unsynchronised reads are acceptable for diagnostics.
- `runHealthCheck`, `runIncidentMarker`, `runHeartbeat` are all closures inside `compose ()` capturing local state (`hostHandle`, channels, `chosenShell`, `lastReadUtc`). Two new module-level setup functions (`setupHealthCheckKeybinding`, `setupIncidentMarkerKeybinding`) wire the closures via the standard `RoutedCommand` + `KeyBinding` + `CommandBinding` triple, matching the closure-passing pattern from PR-C's `setupShellSwitchKeybindings`.
- `heartbeatTimer.Dispose()` runs in `app.Exit` BEFORE the logger is disposed so the timer doesn't fire one last entry into a closed channel.
- Two new `ActivityIds`: `healthCheck = "pty-speak.health-check"`, `incidentMarker = "pty-speak.incident-marker"`. Distinct so diagnostic-config announcements stay configurable separately from streaming output.

## What this PR deliberately omits

- **Dispatcher-wedge detector** (separate timer pinging WPF dispatcher with a threshold). The heartbeat covers most of the same ground passively: heartbeat silence in the log = wedged background runtime; dispatcher silence while heartbeats continue = wedged dispatcher.
- **Auto-snapshot on parser/reader exception** (PR-H in the earlier proposal). Lower priority now that incident-marker + heartbeat exist.
- **Velopack debug-launch shortcut** (PR-I). Redundant once `Ctrl+Shift+G` is wired — debug logging is one keystroke from any normal launch.

## Test plan

- [x] No NUL bytes verified
- [x] Internal links resolve
- [ ] CI green
- [ ] Maintainer manual NVDA validation:
  - [ ] `Ctrl+Shift+H` announces verdict + state. Verify announcement quality against actual conditions.
  - [ ] `Ctrl+Shift+B` announces marker confirmation. Verify the marker line appears in the log.
  - [ ] After 30+ seconds, verify the log contains 6+ "Heartbeat" lines at 5-second intervals.
  - [ ] **The full debug-capture workflow:** `G` → reproduce hang → `B` → `;` → paste log to chat. Verify the resulting log slice contains the incident marker + the events around it.

After this PR ships and validates, the next planned work is the doc-purpose audit queued in `docs/SESSION-HANDOFF.md` "Queued before Output framework cycle starts".

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_