### PR TITLE
fix(app): Ctrl+Shift+; dispatcher deadlock from FlushPending(500).Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Stage 7-followup PR-G)
+
+- **`Ctrl+Shift+;` dispatcher deadlock.** Empirically confirmed in NVDA pass 2026-05-03:
+  pressing `Ctrl+Shift+;` (copy log to clipboard) while NVDA
+  had a long readout queued permanently wedged the WPF
+  dispatcher. The 5-second background heartbeat kept firing
+  (proving the runtime alive), but no further dispatcher
+  events processed — typing did nothing, Alt+F4 didn't close
+  the window, no other app-reserved hotkey produced an
+  announcement. Force-kill via Task Manager was the only way
+  out.
+
+  Root cause: `runCopyLatestLog` called
+  `sink.FlushPending(500).Result` synchronously on the
+  dispatcher. `FlushPending` is implemented as
+  `task { let! winner = Task.WhenAny(...) }` — the `let!`
+  captures the WPF dispatcher's `SynchronizationContext`. When
+  the dispatcher thread blocks on `.Result`, the task's
+  continuation can never resume because the dispatcher is
+  blocked. The 500ms timeout never fires because the timeout's
+  continuation also needs the dispatcher. Classic
+  sync-over-async deadlock. The bug has been latent since
+  PR #122 (Stage 5a's FlushPending introduction); only manifests
+  under sufficient dispatcher / NVDA-queue contention to expose
+  it, which the post-Stage-7-PR-D NVDA validation pass
+  reliably triggered.
+
+  Fix: run the entire `runCopyLatestLog` body in a `task` off
+  the dispatcher. `FlushPending` is awaited normally (no
+  `.Result`). The clipboard write itself runs on a dedicated
+  STA thread (`System.Windows.Clipboard.SetText` requires the
+  STA apartment, so we can't use the thread pool which is MTA)
+  with a 3-second timeout to bound clipboard contention with
+  NVDA's clipboard hooks / clipboard managers / antivirus
+  hooks. The announcement dispatches back to the WPF thread on
+  completion. The hotkey handler returns immediately; the
+  dispatcher never blocks regardless of clipboard or flush
+  state.
+
+  `docs/STAGE-7-ISSUES.md` records both this bug
+  (`[other]` tag, **Source: NVDA pass 2026-05-03; fixed in
+  PR-G**) and the empirical confirmation of the
+  `[output-stream]` verbose-readback prediction (concrete
+  numbers from this pass: 1316 / 1347-character announces
+  per cmd command, character-by-character announce growth on
+  typed input — the architectural fix remains in scope for
+  the Output framework cycle Part 3.2 RFC).
+
 ### Added
 
 - **Stage 7-followup PR-F — diagnostic surface: `Ctrl+Shift+H`

--- a/docs/STAGE-7-ISSUES.md
+++ b/docs/STAGE-7-ISSUES.md
@@ -122,6 +122,48 @@ predictions that don't reproduce empirically may indicate the
 substrate is more capable than the spec assumed, and the
 framework design adjusts accordingly.
 
+### [other] Ctrl+Shift+; dispatcher deadlock from FlushPending(500).Result
+
+**What broke.** Pressing `Ctrl+Shift+;` (copy log to clipboard)
+permanently wedges the WPF dispatcher. After the press: typing
+into pty-speak does nothing, Alt+F4 doesn't close the window,
+clicking the X button doesn't close it, no other app-reserved
+hotkey produces an NVDA announcement (Ctrl+Shift+H, Ctrl+Shift+G,
+etc. are all silent). The 5-second background heartbeat keeps
+firing so the runtime is alive — only the WPF dispatcher is
+seized up. Force-kill via Task Manager is the only way out.
+
+**Why it matters.** The user can no longer interact with
+pty-speak after pressing the very hotkey that exists to capture
+diagnostic logs. The diagnostic-capture workflow is broken at
+its terminal step.
+
+**Reproduction.** Launch pty-speak. Run any cmd command that
+produces enough output to keep NVDA reading for >30 seconds
+(e.g. several `dir /s` invocations or a single `set`). While
+NVDA is mid-readout, press `Ctrl+Shift+;` to copy the log.
+Window wedges; never recovers.
+
+**Hypothesised root cause.** Confirmed: `runCopyLatestLog`
+called `sink.FlushPending(500).Result` synchronously on the
+dispatcher. `FlushPending` is implemented as
+`task { let! winner = Task.WhenAny(...) }` — the `let!`
+captures the WPF dispatcher's `SynchronizationContext`. When
+the dispatcher thread blocks on `.Result`, the task's
+continuation can never resume because the dispatcher is
+blocked. The 500ms timeout never fires because the timeout's
+continuation also needs the dispatcher. Classic
+sync-over-async deadlock. PR-G fixes by running the whole
+operation in a Task off the dispatcher and using a dedicated
+STA thread for `Clipboard.SetText` (which can also hang on
+contention with NVDA's clipboard hooks; bounded by a 3s
+timeout in the fix).
+
+**Inventory date.** 2026-05-03; pty-speak post-PR-#137
+(`v0.0.1-preview.NN` to be cut); cmd.exe Windows 10.0.26200;
+NVDA version unrecorded. **Source: NVDA pass 2026-05-03;
+fixed in PR-G.**
+
 ### [output-stream] Verbose readback: whole-screen announcement on every emit
 
 **What broke.** Stage 5's generic `renderRows` coalescer
@@ -164,8 +206,20 @@ streaming-output workloads.
 **Source: design prediction** (per
 [`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 +
 [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) Stage 7 sketch
-"Known risks" §2). Empirical confirmation pending in
-maintainer NVDA pass.
+"Known risks" §2) **CONFIRMED empirically NVDA pass 2026-05-03**
+with concrete severity worse than predicted: confirmed even on
+plain `cmd.exe` interaction (not just Claude). Single-character
+typed input produced character-by-character announce growth
+`TextLen=140 → 141 → 142 → 143 → 145 → 146` — every keystroke
+re-announces the full rendered screen. Running `dir` (or
+similar) produced 1316 / 1347 / 847-character announces
+back-to-back; NVDA needed 30-45 seconds to read each one,
+during which any subsequent input queued behind. The terminal
+becomes effectively unusable for any workload that produces
+more than a few characters of output. Architectural fix
+remains in scope for Output framework cycle Part 3.2 RFC; a
+stopgap could cap announce length at the coalescer
+(post-PR-G follow-up if needed).
 
 ### [output-selection] Tool-use prompt reads as flat text instead of listbox
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -474,76 +474,130 @@ module Program =
                 "Logging is not initialised yet; nothing to copy.",
                 ActivityIds.error)
         | Some sink ->
-            try
-                // Wait briefly for any in-flight log entries to reach
-                // disk before reading. Without this, the bounded
-                // channel can hold ~milliseconds of recent entries
-                // that haven't been written yet — the clipboard
-                // would then capture a stale snapshot of the file.
-                // Bounded by 500ms so the dispatcher can't freeze
-                // for longer than that worst-case; if no flush
-                // completes (channel idle, nothing to flush), the
-                // file already contains everything the writer has
-                // produced, so the false-return path is benign.
-                let drained = sink.FlushPending(500).Result
-                if not drained then
-                    log.LogInformation(
-                        "FlushPending timed out after 500ms; clipboard may be missing entries enqueued in the last few hundred ms.")
-                let path = sink.ActiveLogPath
-                if not (System.IO.File.Exists path) then
-                    window.TerminalSurface.Announce(
-                        "Active log file does not exist yet; press a key or wait for an event first.",
-                        ActivityIds.error)
-                else
-                    // Read with FileShare.ReadWrite to match the
-                    // FileLogger writer's open mode. Using
-                    // File.ReadAllText here previously failed with
-                    // "The process cannot access the file because
-                    // it is being used by another process" — the
-                    // overload defaults to FileShare.Read, which
-                    // means "I tolerate other readers but no
-                    // writers." Since the writer IS holding the
-                    // file with write access, the OS rejected the
-                    // read open. FileShare.ReadWrite advertises
-                    // "I tolerate readers AND writers", which
-                    // matches the writer's policy and lets the
-                    // OS grant the handle.
-                    let content =
-                        use stream =
-                            new System.IO.FileStream(
-                                path,
-                                System.IO.FileMode.Open,
-                                System.IO.FileAccess.Read,
-                                System.IO.FileShare.ReadWrite)
-                        use reader =
-                            new System.IO.StreamReader(
-                                stream, System.Text.Encoding.UTF8)
-                        reader.ReadToEnd()
-                    // Clipboard.SetText must run on the WPF
-                    // dispatcher thread (STA). The hotkey
-                    // handler already runs there, so direct
-                    // call is safe. Wrap in try/catch because
-                    // Clipboard can transiently throw
-                    // COMException when the OS clipboard is
-                    // contended; one failed attempt is fine
-                    // — user retries.
-                    System.Windows.Clipboard.SetText(content)
-                    let bytes =
-                        System.Text.Encoding.UTF8.GetByteCount(content)
-                    log.LogInformation(
-                        "Copied active log to clipboard. Path={Path} Bytes={Bytes}",
-                        path, bytes)
-                    window.TerminalSurface.Announce(
-                        sprintf
-                            "Log copied to clipboard. %d bytes; ready to paste."
-                            bytes,
-                        ActivityIds.diagnostic)
-            with ex ->
-                let safe = AnnounceSanitiser.sanitise ex.Message
-                log.LogError(ex, "Failed to copy active log to clipboard.")
-                window.TerminalSurface.Announce(
-                    sprintf "Could not copy log: %s" safe,
-                    ActivityIds.error)
+            // Stage 7-followup PR-G — fix dispatcher deadlock that
+            // wedged the WPF window when this hotkey ran while NVDA
+            // had a long readout queued.
+            //
+            // The previous implementation called
+            // `sink.FlushPending(500).Result` on the dispatcher.
+            // `FlushPending` is `task { ... let! winner =
+            // Task.WhenAny(...) ... }`; the `let!` captures the
+            // WPF dispatcher's `SynchronizationContext`. When the
+            // dispatcher thread calls `.Result`, it blocks waiting
+            // for the task. The task's continuation needs to
+            // resume on the captured context — which is the
+            // dispatcher itself. Permanent deadlock; the 500ms
+            // timeout never fires because the timeout's
+            // continuation can't run on the wedged dispatcher.
+            // Empirical confirmation: 2026-05-03 NVDA pass log
+            // showed `Ctrl+Shift+;` entry-log fired at 19:13:51.861
+            // followed by zero subsequent dispatcher events for
+            // 2.5+ minutes (heartbeats kept firing on the
+            // background timer, confirming the runtime was alive
+            // but the WPF dispatcher was stuck).
+            //
+            // Additional concern: `Clipboard.SetText` requires the
+            // STA apartment AND can hang on contention with NVDA's
+            // clipboard hooks / antivirus / clipboard managers.
+            // Both issues are fixed by running the whole copy
+            // operation off the dispatcher in a Task: FlushPending
+            // is awaited normally (no `.Result`), the clipboard
+            // SetText runs on a dedicated STA thread with a 3s
+            // timeout, and the announcement dispatches back to the
+            // WPF thread on completion. The hotkey handler returns
+            // immediately; the dispatcher never blocks.
+            let _ =
+                task {
+                    try
+                        let! drained = sink.FlushPending(500)
+                        if not drained then
+                            log.LogInformation(
+                                "FlushPending timed out after 500ms; clipboard may be missing entries enqueued in the last few hundred ms.")
+                        let path = sink.ActiveLogPath
+                        if not (System.IO.File.Exists path) then
+                            let action () =
+                                window.TerminalSurface.Announce(
+                                    "Active log file does not exist yet; press a key or wait for an event first.",
+                                    ActivityIds.error)
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                        else
+                            // FileShare.ReadWrite matches the
+                            // FileLogger writer's open mode (the
+                            // writer holds the file with FileAccess.Write
+                            // + FileShare.ReadWrite, so a reader
+                            // with FileShare.ReadWrite is granted
+                            // by the OS).
+                            let content =
+                                use stream =
+                                    new System.IO.FileStream(
+                                        path,
+                                        System.IO.FileMode.Open,
+                                        System.IO.FileAccess.Read,
+                                        System.IO.FileShare.ReadWrite)
+                                use reader =
+                                    new System.IO.StreamReader(
+                                        stream, System.Text.Encoding.UTF8)
+                                reader.ReadToEnd()
+                            // System.Windows.Clipboard.SetText
+                            // requires STA apartment. Thread-pool
+                            // threads are MTA, so we spin up a
+                            // dedicated STA thread for this single
+                            // operation. Bounded by a 3s timeout
+                            // so clipboard contention can't hang
+                            // the workflow indefinitely.
+                            let setOk = TaskCompletionSource<bool>()
+                            let staBody = ThreadStart(fun () ->
+                                try
+                                    System.Windows.Clipboard.SetText(content)
+                                    setOk.TrySetResult(true) |> ignore
+                                with ex ->
+                                    log.LogWarning(
+                                        ex,
+                                        "Clipboard.SetText threw: {Message}",
+                                        ex.Message)
+                                    setOk.TrySetResult(false) |> ignore)
+                            let staThread = new Thread(staBody)
+                            staThread.SetApartmentState(ApartmentState.STA)
+                            staThread.IsBackground <- true
+                            staThread.Start()
+                            let! winner =
+                                Task.WhenAny(
+                                    setOk.Task :> Task,
+                                    Task.Delay(3000))
+                            let succeeded =
+                                obj.ReferenceEquals(winner, setOk.Task)
+                                && setOk.Task.Result
+                            let bytes =
+                                System.Text.Encoding.UTF8.GetByteCount(content)
+                            let msg, activityId =
+                                if succeeded then
+                                    log.LogInformation(
+                                        "Copied active log to clipboard. Path={Path} Bytes={Bytes}",
+                                        path, bytes)
+                                    sprintf
+                                        "Log copied to clipboard. %d bytes; ready to paste."
+                                        bytes,
+                                    ActivityIds.diagnostic
+                                else
+                                    log.LogWarning(
+                                        "Clipboard.SetText timed out or failed after 3s; clipboard may not contain log content.")
+                                    "Clipboard copy timed out. Try again, or open the logs folder via Ctrl+Shift+L.",
+                                    ActivityIds.error
+                            let action () =
+                                window.TerminalSurface.Announce(msg, activityId)
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        log.LogError(ex, "Failed to copy active log to clipboard.")
+                        let action () =
+                            window.TerminalSurface.Announce(
+                                sprintf "Could not copy log: %s" safe,
+                                ActivityIds.error)
+                        try
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                        with _ -> ()
+                }
+            ()
 
     /// Wire `Ctrl+Shift+;` to trigger `runCopyLatestLog`.
     let private setupCopyLatestLogKeybinding (window: MainWindow) : unit =

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -519,7 +519,7 @@ module Program =
                                 window.TerminalSurface.Announce(
                                     "Active log file does not exist yet; press a key or wait for an event first.",
                                     ActivityIds.error)
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
                         else
                             // FileShare.ReadWrite matches the
                             // FileLogger writer's open mode (the
@@ -585,7 +585,7 @@ module Program =
                                     ActivityIds.error
                             let action () =
                                 window.TerminalSurface.Announce(msg, activityId)
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
                     with ex ->
                         let safe = AnnounceSanitiser.sanitise ex.Message
                         log.LogError(ex, "Failed to copy active log to clipboard.")
@@ -594,7 +594,7 @@ module Program =
                                 sprintf "Could not copy log: %s" safe,
                                 ActivityIds.error)
                         try
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task :> Task
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
                         with _ -> ()
                 }
             ()


### PR DESCRIPTION
## Summary

**Hotfix for the dispatcher deadlock empirically confirmed in the 2026-05-03 NVDA pass.** Pressing `Ctrl+Shift+;` (copy log to clipboard) while NVDA had a long readout queued permanently wedged the WPF dispatcher. The 5-second background heartbeat kept firing (proving the runtime alive), but no further dispatcher events processed — typing did nothing, Alt+F4 didn't close the window, no other app-reserved hotkey produced an announcement. Force-kill via Task Manager was the only way out.

## Root cause

`runCopyLatestLog` called `sink.FlushPending(500).Result` synchronously on the dispatcher. `FlushPending` is implemented as `task { let! winner = Task.WhenAny(...) }` — the `let!` captures the WPF dispatcher's `SynchronizationContext`. When the dispatcher thread blocks on `.Result`, the task's continuation can never resume because the dispatcher is blocked. **The 500ms timeout never fires** because the timeout's continuation also needs the dispatcher. Classic sync-over-async deadlock.

The bug has been latent since PR #122 (Stage 5a's `FlushPending` introduction); only manifests under sufficient dispatcher / NVDA-queue contention to expose it, which the post-Stage-7-PR-D NVDA validation pass reliably triggered.

## Fix

Run the entire `runCopyLatestLog` body in a `task` off the dispatcher:
- `FlushPending` is awaited normally (no `.Result`)
- The clipboard write runs on a **dedicated STA thread** (`System.Windows.Clipboard.SetText` requires STA apartment; thread-pool threads are MTA and would fail) with a **3-second timeout** to bound clipboard contention with NVDA's clipboard hooks / clipboard managers / antivirus
- The announcement dispatches back to the WPF thread on completion via `Dispatcher.InvokeAsync`
- The hotkey handler returns immediately; the dispatcher never blocks regardless of clipboard or flush state

## What changes

- **`src/Terminal.App/Program.fs`** — `runCopyLatestLog` rewritten with the off-dispatcher pattern described above. Inline comments document the deadlock mechanism and the STA-thread requirement.
- **`docs/STAGE-7-ISSUES.md`** — new `[other]` entry pinning this bug with concrete reproduction steps, marked **Source: NVDA pass 2026-05-03; fixed in PR-G**. Existing `[output-stream]` verbose-readback entry flipped from `Source: design prediction` to `CONFIRMED empirically` with concrete numbers from this pass: 1316 / 1347-character announces per cmd command, character-by-character announce growth on typed input.
- **`CHANGELOG.md`** — `[Unreleased] ### Fixed` entry.

## What this PR deliberately omits

**Announce-length cap as a verbose-readback stopgap.** Today's NVDA pass empirically confirms the verbose-readback is severe (1347-char announces from trivial cmd interaction; 30-45 seconds of NVDA speech per command). A cap is a quick stopgap pending the Output framework cycle's Stream profile, but the threshold + truncation-cue UX is a separate decision from this deadlock fix. The maintainer asked about bundling it; my response is in the conversation transcript and the maintainer can choose: ship a follow-up PR-H, or address verbose-readback as part of the framework cycle proper.

## Test plan

- [x] No NUL bytes; diff-stat scope reasonable
- [ ] CI green
- [ ] Maintainer manual test:
  - [ ] Launch pty-speak; press `Ctrl+Shift+G` to enable debug logging
  - [ ] Run any command (e.g. `dir`) that produces output
  - [ ] **While NVDA is reading**, press `Ctrl+Shift+;`
  - [ ] Verify NVDA eventually says "Log copied to clipboard. N bytes; ready to paste." (or a timeout message) AND the window remains interactive
  - [ ] Press `Ctrl+Shift+H` — verify NVDA reads the health-check verdict (proves dispatcher is alive)
  - [ ] Type characters — verify they reach the cmd shell

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_