### PR TITLE
feat(app): 500-char announce-length cap (verbose-readback stopgap; closes #139 follow-up scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,53 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Stage 7-followup PR-H)
+
+- **500-character announce-length cap on streaming output.**
+  The drain task in `src/Terminal.App/Program.fs` now truncates
+  any `Coalescer.OutputBatch` announcement longer than 500
+  characters and appends a footer:
+  `"...announcement truncated; N more characters available — press Ctrl+Shift+; to copy full log."`
+  Only `OutputBatch` is affected; `ErrorPassthrough`,
+  `ModeBarrier`, and the diagnostic announcements (health
+  check, incident marker, log-toggle, shell-switch) pass
+  through unchanged.
+
+  **Why a cap.** The 2026-05-03 NVDA pass empirically confirmed
+  the `[output-stream]` verbose-readback prediction in
+  `docs/STAGE-7-ISSUES.md` with concrete numbers: trivial cmd
+  interaction (`dir`, `set`, single keystrokes) produced
+  1316 / 1347-character announces taking 30-45 seconds each
+  for NVDA to read, making the terminal effectively unusable.
+  500 characters ≈ 15-20 seconds — tolerable upper bound that
+  preserves enough content for the user to follow what's
+  happening while leaving the speech queue responsive enough
+  to keep up with new input.
+
+  **Why this number.** **Arbitrary.** No empirical evidence
+  yet that 500 is right vs 250 / 750 / 1000. Tracked in
+  [issue #139](https://github.com/KyleKeane/pty-speak/issues/139)
+  for tuning based on real-feel data from subsequent NVDA
+  passes, AND for surfacing as a user-configurable setting
+  (likely `audio.maxAnnounceChars` in Phase 2 TOML, or a
+  hotkey-cycled preset). Catalog entry in
+  `docs/USER-SETTINGS.md` "Verbosity / NVDA narration" →
+  "Stopgap: announce-length cap".
+
+  **Why this is a stopgap.** The proper architectural fix is
+  the Output framework cycle's Stream profile (per
+  `docs/PROJECT-PLAN-2026-05.md` Part 3.2 RFC) — suffix-diff
+  append-only emission eliminates the verbose-readback at its
+  source rather than capping its output. When Stream profile
+  ships, this cap + footer become redundant and should be
+  deleted. Issue #139 tracks that deletion at the ship
+  boundary.
+
+  Inline code comment in `Program.fs` documents the
+  arbitrary-threshold disclaimer + the issue reference + the
+  ship-boundary-delete contract so a future contributor
+  doesn't preserve the stopgap by accident.
+
 ### Added
 
 - **Stage 7-followup PR-F — diagnostic surface: `Ctrl+Shift+H`

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -608,6 +608,34 @@ is. Other power-user knobs:
   Stream profile during Part 3 Stage A; nothing in the
   pipeline (parser, screen, drain, peer) needs to move.
 
+### Stopgap: announce-length cap (Stage 7-followup PR-H)
+
+`src/Terminal.App/Program.fs`'s drain task currently caps every
+`Coalescer.OutputBatch` announcement at **500 characters**.
+When the announce text exceeds the cap, the head is preserved
+and a footer is appended:
+
+> `...announcement truncated; N more characters available — press Ctrl+Shift+; to copy full log.`
+
+**This is an arbitrary stopgap**, not the architectural fix.
+500 was chosen because it's roughly 15-20 seconds of NVDA
+speech at default rate — the empirical 2026-05-03 NVDA pass
+showed 1316 / 1347-character announces (30-45 seconds each)
+making the terminal effectively unusable. 500 trades some
+information loss for survivable speech-queue latency.
+
+**Tracked in [issue #139](https://github.com/KyleKeane/pty-speak/issues/139)**
+for revisiting both the threshold and whether to surface it as
+a user-configurable setting (likely `audio.maxAnnounceChars`
+in the Phase 2 TOML config, or a hotkey to cycle preset
+thresholds).
+
+When the Output framework cycle's Stream profile ships
+(suffix-diff append-only emission), this stopgap becomes
+redundant — the new emission strategy doesn't produce
+1000+-character announces in the first place. Issue #139
+also tracks the deletion of this cap at that ship boundary.
+
 ## Process for adding a new setting
 
 When the project moves from "hardcoded" to "user-configurable"

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -816,7 +816,41 @@ module Program =
                                     let msg, activityId =
                                         match peek with
                                         | Coalescer.OutputBatch text ->
-                                            text, ActivityIds.output
+                                            // Stage 7-followup PR-H — announce-length
+                                            // stopgap. The 500-character cap below is
+                                            // ARBITRARY: empirical NVDA pass 2026-05-03
+                                            // showed `dir`/`set`-class output produced
+                                            // 1316/1347-character announces taking
+                                            // 30-45 seconds of NVDA speech each, making
+                                            // the terminal effectively unusable. 500
+                                            // chars is approximately 15-20 seconds —
+                                            // tolerable upper bound balanced against
+                                            // information loss at the cut. Tracked in
+                                            // GitHub issue #139 for revisiting the
+                                            // threshold once the next NVDA pass yields
+                                            // real-feel data, AND for surfacing this
+                                            // as a user-configurable setting (catalog
+                                            // entry in `docs/USER-SETTINGS.md`).
+                                            //
+                                            // The proper architectural fix is the
+                                            // Output framework cycle's Stream profile
+                                            // (`docs/PROJECT-PLAN-2026-05.md` Part 3.2)
+                                            // — suffix-diff append-only emission
+                                            // eliminates the verbose-readback at its
+                                            // source rather than capping the output.
+                                            // Delete this cap + the footer cue when
+                                            // the Stream profile ships.
+                                            let limit = 500
+                                            let capped =
+                                                if text.Length <= limit then text
+                                                else
+                                                    let head = text.Substring(0, limit)
+                                                    let extra = text.Length - limit
+                                                    sprintf
+                                                        "%s ...announcement truncated; %d more characters available — press Ctrl+Shift+; to copy full log."
+                                                        head
+                                                        extra
+                                            capped, ActivityIds.output
                                         | Coalescer.ErrorPassthrough s ->
                                             sprintf "Terminal parser error: %s" s,
                                             ActivityIds.error


### PR DESCRIPTION
## Summary

**Stage 7-followup. Caps every `Coalescer.OutputBatch` announcement at 500 characters** in the drain task, with a footer appended on truncation:

> `...announcement truncated; N more characters available — press Ctrl+Shift+; to copy full log.`

Only `OutputBatch` is affected; `ErrorPassthrough`, `ModeBarrier`, and the diagnostic announcements pass through unchanged.

Closes the verbose-readback usability problem empirically confirmed in the 2026-05-03 NVDA pass.

## Why a cap

The NVDA pass observed 1316 / 1347-character announces from trivial cmd interaction (`dir`, `set`, single keystrokes) taking 30-45 seconds each for NVDA to read — effectively unusable. 500 chars ≈ 15-20 seconds of speech, tolerable upper bound balanced against information loss.

## Why 500

**Arbitrary.** No empirical evidence yet that 500 is right vs 250 / 750 / 1000. The threshold was a judgment call: long enough to preserve most useful content, short enough that NVDA's speech queue stays responsive.

**Tracked in [issue #139](https://github.com/KyleKeane/pty-speak/issues/139)** for:
1. Tuning the threshold based on real-feel data from subsequent NVDA passes.
2. Surfacing as a user-configurable setting (Phase 2 TOML or hotkey-cycled preset).
3. Deletion at Stream profile ship boundary.

## Why this is a stopgap

The proper architectural fix is the **Output framework cycle's Stream profile** ([`docs/PROJECT-PLAN-2026-05.md`](docs/PROJECT-PLAN-2026-05.md) Part 3.2 RFC) — suffix-diff append-only emission eliminates the verbose-readback at its source rather than capping its output. When Stream profile ships, this cap + footer become redundant and should be deleted.

The inline comment in `Program.fs` documents the arbitrary-threshold disclaimer + the issue reference + the ship-boundary-delete contract so a future contributor doesn't preserve the stopgap by accident.

## What changes

- **`src/Terminal.App/Program.fs`** — drain task's `OutputBatch` arm wraps `text` in a cap-then-truncate-with-footer pattern before emitting. Inline comment documents the contract.
- **`docs/USER-SETTINGS.md`** — "Verbosity / NVDA narration" section gains a "Stopgap: announce-length cap (Stage 7-followup PR-H)" subsection.
- **`CHANGELOG.md`** — `[Unreleased] ### Changed` entry above `### Added`.

## Independence from PR-G

This PR is **independent of PR #138** (the dispatcher-deadlock fix). Both touch `Program.fs` but in different sections (PR-G touches `runCopyLatestLog`; PR-H touches the drain task's `OutputBatch` arm). Either can merge first; if PR-G merges first, PR-H rebases cleanly.

## Test plan

- [x] No NUL bytes
- [ ] CI green
- [ ] Maintainer manual test:
  - [ ] Launch pty-speak; run a command producing >500 chars of output (e.g. `dir /s C:\Windows`)
  - [ ] Verify NVDA reads ~500 characters then the truncation footer
  - [ ] Press `Ctrl+Shift+;` (after PR-G merges) — verify the full log is still capturable

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_