### PR TITLE
fix(app): PR-I — silent reader-loop shutdown + currentShell tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,64 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Stage 7-followup PR-I)
+
+- **Spurious "parser/reader loop: channel has been closed"
+  announce on shell hot-switch.** Empirically confirmed in
+  NVDA pass 2026-05-03: every `Ctrl+Shift+1` / `Ctrl+Shift+2`
+  press produced an unwanted `ActivityIds.error` announce
+  ("Terminal parser error: Parser/reader loop: The channel
+  has been closed.", 71 characters) firing in between the
+  "Switching to {target}." and "Switched to {target}." cues.
+  The switch itself succeeded — the new `ConPtyHost` spawned
+  and took over correctly — but the spurious error
+  announcement made the switch sound broken to the user.
+
+  Root cause: when `switchToShell` disposes the old
+  `ConPtyHost`, the host's internal stdout channel completes
+  (`chan.Writer.TryComplete()` runs in `Dispose`). The reader
+  loop's `host.Stdout.ReadAsync(ct)` then throws
+  `ChannelClosedException` — which is NOT
+  `OperationCanceledException` — so the catch-all `| ex ->`
+  arm in `startReaderLoop` mis-classifies it as a real
+  parser/reader fault and writes a `ParserError` to the
+  SHARED notification channel. The drain task announces
+  it via `ActivityIds.error`.
+
+  Fix: add silent-shutdown arms for
+  `System.Threading.Channels.ChannelClosedException`,
+  `System.IO.IOException`, and `ObjectDisposedException` to
+  the reader-loop catch chain. All three indicate intentional
+  pipe/channel teardown (channel completed; pipe handle
+  closed mid-read; FileStream/SafeFileHandle disposed
+  mid-read). Other exception types still surface as parser
+  errors.
+
+  `docs/STAGE-7-ISSUES.md` records this as
+  `[other]` tag, **Source: NVDA pass 2026-05-03; fixed in
+  PR-I**.
+
+- **Heartbeat + health-check reported stale shell name after
+  hot-switch.** Same NVDA pass log showed
+  `Heartbeat. Shell=Command Prompt Pid=2596` after the user
+  had switched to claude.exe. Cosmetic for the user
+  (`Ctrl+Shift+H` health-check verdict said "Command Prompt
+  shell" instead of "Claude Code shell"); confusing for log
+  analysis (the wrong shell name in heartbeats made
+  post-mortem triage harder).
+
+  Root cause: `chosenShell` was captured at startup and never
+  updated. Heartbeat and health-check closures both read
+  `chosenShell.DisplayName` directly.
+
+  Fix: new `let mutable currentShell` field in `compose ()`;
+  `switchToShell` updates it after a successful spawn; both
+  heartbeat and health-check read from `currentShell`
+  instead of `chosenShell`.
+
+  `docs/STAGE-7-ISSUES.md` records this as a follow-on
+  `[other]` entry from the same NVDA pass.
+
 ### Changed (Stage 7-followup PR-H)
 
 - **500-character announce-length cap on streaming output.**

--- a/docs/STAGE-7-ISSUES.md
+++ b/docs/STAGE-7-ISSUES.md
@@ -122,6 +122,85 @@ predictions that don't reproduce empirically may indicate the
 substrate is more capable than the spec assumed, and the
 framework design adjusts accordingly.
 
+### [other] Spurious "parser/reader loop" error announce on shell hot-switch
+
+**What broke.** Pressing `Ctrl+Shift+1` (cmd) or `Ctrl+Shift+2`
+(claude) reliably produced this NVDA announcement sequence:
+
+1. "Switching to Claude Code." (or "...Command Prompt.")
+2. ~700ms pause
+3. **"Terminal parser error: Parser/reader loop: The channel
+   has been closed."** ← spurious; sounds like a fatal error
+4. "Switched to Claude Code." (or "...Command Prompt.")
+
+The switch itself succeeded (the new ConPtyHost spawned and
+took over input/output), but the spurious error message in
+between made the switch sound broken to a screen-reader user.
+Combined with claude's quiet welcome screen and the persisting
+cmd screen contents (the documented `[output-tui]` no-screen-
+reset limitation), the user perceived the switch as "didn't
+work."
+
+**Why it matters.** The shell-switch UX (`Ctrl+Shift+1` /
+`Ctrl+Shift+2` per Stage 7 PR-C) is unusable when every press
+generates a fake error announcement.
+
+**Reproduction.** Launch pty-speak; let it settle in cmd. Press
+`Ctrl+Shift+2`. NVDA announces all four lines including the
+parser-error one. Empirically confirmed in the 2026-05-03
+NVDA pass; full log slice available with the inventory entry.
+
+**Hypothesised root cause.** Confirmed: when `switchToShell`
+disposes the old `ConPtyHost`, the host's internal stdout
+channel completes (`chan.Writer.TryComplete()` runs in
+`Dispose`). The reader loop's `host.Stdout.ReadAsync(ct)` then
+throws `ChannelClosedException` — which is NOT
+`OperationCanceledException` — so the catch-all `| ex ->` arm
+in `startReaderLoop` mis-classifies it as a real parser
+fault and writes a `ParserError` to the SHARED notification
+channel. The drain task announces it via `ActivityIds.error`
+in the gap between "Switching..." and "Switched..." cues.
+PR-I fixes by adding silent-shutdown arms for
+`ChannelClosedException`, `IOException`, and
+`ObjectDisposedException` to the reader-loop catch chain
+(all three indicate intentional pipe/channel teardown).
+
+**Inventory date.** 2026-05-03; pty-speak post-PR-#140
+(Velopack preview cut between Stage 7 PR-D and PR-I);
+NVDA version unrecorded. **Source: NVDA pass 2026-05-03;
+fixed in PR-I.**
+
+### [other] Heartbeat + health-check report stale shell name after hot-switch
+
+**What broke.** After a successful `Ctrl+Shift+1` or
+`Ctrl+Shift+2` hot-switch, the 5-second heartbeat log line +
+the `Ctrl+Shift+H` health-check announcement continued to
+report `Shell=Command Prompt` even when the running shell
+had switched to claude.exe (and vice versa). Cosmetic — the
+PID was correct (heartbeat showed `Pid=2596` after the
+switch to claude.exe), but the shell-name field was wrong.
+
+**Why it matters.** Mostly affects post-mortem log analysis:
+the 2026-05-03 NVDA pass log alone, without the explicit
+`Shell-switch: spawning Claude Code` event line, would not
+have made it obvious that claude was the active shell during
+heartbeats — making the wrong shell name a source of
+confusion when triaging future issues. For the user, the
+health-check announcement is also wrong-but-not-dangerously-so.
+
+**Reproduction.** Same as above: launch, press `Ctrl+Shift+2`,
+press `Ctrl+Shift+H`. Verdict text says "Command Prompt
+shell" instead of "Claude Code shell".
+
+**Hypothesised root cause.** Confirmed: `chosenShell` is
+captured at startup and never updated. PR-I adds a
+`mutable currentShell` field that `switchToShell` sets
+after a successful spawn; heartbeat and health-check both
+read from `currentShell` instead of `chosenShell`.
+
+**Inventory date.** 2026-05-03; same release as the entry
+above. **Source: NVDA pass 2026-05-03; fixed in PR-I.**
+
 ### [other] Ctrl+Shift+; dispatcher deadlock from FlushPending(500).Result
 
 **What broke.** Pressing `Ctrl+Shift+;` (copy log to clipboard)

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -106,6 +106,32 @@ module Program =
                                 ()
                 with
                 | :? OperationCanceledException -> ()
+                // Stage 7-followup PR-I — clean-shutdown exceptions
+                // from the underlying ConPTY pipe / channel shouldn't
+                // be reported as parser errors. The empirical NVDA
+                // pass on 2026-05-03 surfaced a spurious "Terminal
+                // parser error: ...the channel has been closed."
+                // announcement firing every time the user pressed
+                // Ctrl+Shift+1 / Ctrl+Shift+2 (shell hot-switch),
+                // because `switchToShell` disposes the old
+                // ConPtyHost — completing its internal stdout
+                // channel — and `host.Stdout.ReadAsync(ct)` then
+                // throws ChannelClosedException, which the
+                // catch-all arm below mis-classifies as a real
+                // parser/reader fault.
+                //
+                // The three exception types caught here all indicate
+                // the pipe / channel was intentionally shut down:
+                //   * ChannelClosedException — channel completed
+                //     (host.Dispose calls chan.Writer.TryComplete()).
+                //   * IOException — underlying pipe handle was
+                //     closed while a read was in flight.
+                //   * ObjectDisposedException — the FileStream /
+                //     SafeFileHandle was disposed mid-read.
+                // Treat all three as silent shutdown.
+                | :? System.Threading.Channels.ChannelClosedException -> ()
+                | :? System.IO.IOException -> ()
+                | :? ObjectDisposedException -> ()
                 | ex ->
                     // Audit-cycle SR-2: sanitise ex.Message before
                     // it reaches NVDA via the notification channel.
@@ -1034,6 +1060,19 @@ module Program =
             chosenShell.DisplayName,
             commandLine)
 
+        // Stage 7-followup PR-I — `chosenShell` is the value chosen
+        // at startup and never changes. Hot-switching shells
+        // (`Ctrl+Shift+1` / `Ctrl+Shift+2`) updates `currentShell`
+        // below; the heartbeat + health-check both read this for
+        // their state snapshots. The empirical NVDA pass on
+        // 2026-05-03 surfaced this as a follow-on finding: the
+        // post-switch heartbeat continued reporting
+        // "Shell=Command Prompt" after the user had switched to
+        // claude.exe, because `chosenShell.DisplayName` was the
+        // captured-at-startup value. Cosmetic for the user but
+        // confusing for log analysis.
+        let mutable currentShell : ShellRegistry.Shell = chosenShell
+
         let cfg : PtyConfig =
             { Cols = int16 ScreenCols
               Rows = int16 ScreenRows
@@ -1123,7 +1162,7 @@ module Program =
                     sprintf
                         "%s %s shell, PID %d, log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256. Coalesced queue %d of 16."
                         verdict
-                        chosenShell.DisplayName
+                        currentShell.DisplayName
                         pid
                         levelStr
                         staleness
@@ -1173,7 +1212,7 @@ module Program =
                 let coalDepth = coalescedChannel.Reader.Count
                 log.LogInformation(
                     "Heartbeat. Shell={Shell} Pid={Pid} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap} CoalQueue={Coal}/{CoalCap}",
-                    chosenShell.DisplayName,
+                    currentShell.DisplayName,
                     pid,
                     level,
                     staleness,
@@ -1360,6 +1399,20 @@ module Program =
                                             ActivityIds.error)
                                     | Ok newHost ->
                                         hostHandle <- Some newHost
+                                        // Stage 7-followup PR-I — update
+                                        // currentShell so subsequent
+                                        // heartbeats + health checks
+                                        // report the post-switch shell
+                                        // identity. Captured-at-startup
+                                        // `chosenShell` was never
+                                        // updated previously; the
+                                        // 2026-05-03 NVDA pass log
+                                        // showed
+                                        // "Heartbeat. Shell=Command Prompt Pid=2596"
+                                        // after switching to claude
+                                        // (cosmetic but confusing for
+                                        // log analysis).
+                                        currentShell <- shell
                                         wirePostSpawn newHost
                                         window.TerminalSurface.Announce(
                                             sprintf "Switched to %s." shell.DisplayName,


### PR DESCRIPTION
## Summary

Stage 7-followup. Two fixes from the empirical 2026-05-03 NVDA pass on the post-PR-H build. The user reported *"everything worked as expected except being able to switch between command prompt and Claude code"* — the switch ITSELF succeeded but a spurious parser-error announce in between made it sound broken.

## Fix 1 — spurious "channel has been closed" announce on shell switch

When `switchToShell` disposes the old `ConPtyHost`, the host's internal stdout channel completes (`chan.Writer.TryComplete()` runs in `Dispose`). The reader loop's `host.Stdout.ReadAsync(ct)` then throws `ChannelClosedException` — which is **not** `OperationCanceledException` — so the catch-all `| ex ->` arm in `startReaderLoop` mis-classifies it as a real parser/reader fault and writes a `ParserError` to the SHARED notification channel. The drain announces it as `"Terminal parser error: Parser/reader loop: The channel has been closed."` (71 characters; matches the user's NVDA-pass log byte-for-byte).

Fix: add silent-shutdown arms to `startReaderLoop`'s catch chain for the three exception types that indicate intentional pipe/channel teardown:

```fsharp
| :? System.Threading.Channels.ChannelClosedException -> ()
| :? System.IO.IOException -> ()
| :? ObjectDisposedException -> ()
```

Other exception types still surface as `ParserError` to preserve the post-Stage-6 diagnostic safety net for genuine reader-loop crashes.

## Fix 2 — heartbeat + health-check reported stale shell name

Same NVDA pass log: `"Heartbeat. Shell=Command Prompt Pid=2596"` appeared after the user switched to claude.exe. PID correct; `Shell=` was the captured-at-startup value. Cosmetic for the user, but confusing for log analysis.

Fix: new `let mutable currentShell` field in `compose ()`; `switchToShell` sets it after a successful spawn; both heartbeat and health-check closures read from `currentShell.DisplayName` instead of `chosenShell.DisplayName`.

## What this PR deliberately omits

- **Screen state reset on switch** — the documented `[output-tui]` limitation. Switching from cmd to claude STILL leaves cmd's screen contents visible until claude produces enough output to overwrite them. claude's quiet welcome screen means the visual mix can persist indefinitely. Architectural fix is in the Output framework cycle.
- **Post-switch child-tree cleanup verification** — the Job Object `KILL_ON_JOB_CLOSE` cascade should already work; an empirical `Ctrl+Shift+D` check after multiple switches is part of the manual NVDA matrix in PR-D, not this hotfix.

## Test plan

After PR-I ships, the maintainer cuts a fresh preview and runs:

- [ ] `Ctrl+Shift+2` from cmd. NVDA should announce only:
  1. *"Switching to Claude Code."*
  2. ~700ms pause
  3. *"Switched to Claude Code."*
  No "parser error" in between.
- [ ] Press `Ctrl+Shift+H` after the switch. Verdict text should say *"Claude Code shell"* (not "Command Prompt shell").
- [ ] Active log: `Heartbeat. Shell=Claude Code Pid=...` (correct shell name post-switch).

## Cross-references

- `docs/STAGE-7-ISSUES.md` — two new `[other]` entries (Source: NVDA pass 2026-05-03; fixed in PR-I).

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_