### PR TITLE
feat(app): PR-J — PowerShell shell, liveness probe, inline diagnostic snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,68 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Stage 7-followup PR-J)
+
+- **PowerShell as third built-in shell + reordered hotkeys.**
+  `ShellRegistry` gains `PowerShell` (Windows PowerShell,
+  always available on Windows 10+) alongside `Cmd` and
+  `Claude`. The hot-switch hotkeys reorder to put PowerShell
+  next to cmd as the diagnostic control shell:
+  - `Ctrl+Shift+1` — switch to cmd (unchanged)
+  - `Ctrl+Shift+2` — switch to PowerShell (new; was claude in PR-C)
+  - `Ctrl+Shift+3` — switch to Claude (was Ctrl+Shift+2 in PR-C)
+
+  Rationale: the maintainer's NVDA validation pass on
+  2026-05-03 surfaced suspected shell-switch infrastructure
+  bugs that needed a diagnostic control shell to isolate.
+  PowerShell has zero auth, no terminal-capability
+  detection, and produces visible banner + prompt output
+  within milliseconds — making it the ideal control. Putting
+  it adjacent to cmd at slot 2 means the comparison "does
+  switching from cmd to PowerShell work?" is one keystroke
+  away. The `PTYSPEAK_SHELL` env var also recognises
+  `powershell` and `pwsh` (as aliases routing to the same
+  `PowerShell` ShellId).
+
+- **`Ctrl+Shift+H` liveness probe.** The health-check
+  announce now distinguishes "child running" from "child
+  exited". Each press calls
+  `Process.GetProcessById(currentShell.Pid)` (which throws
+  `ArgumentException` for a reaped/non-existent PID) and
+  announces "alive" / "dead" alongside the rest of the
+  state snapshot. Verdict heuristic gains a top-priority
+  "Child shell process N has exited." arm so a screen-
+  reader user gets the dispositive "the shell crashed"
+  signal without reading the log file. The 5s background
+  heartbeat (`runHeartbeat`) gains the same `Alive=`
+  field for log forensics — post-hoc grep for the moment
+  `Alive=False` first appears pinpoints the wedge
+  timestamp.
+
+- **`Ctrl+Shift+D` inline shell-process snapshot.** The
+  diagnostic launcher now announces a one-line process
+  enumeration BEFORE the cleanup-test PowerShell window
+  opens: "Diagnostic snapshot: 1 cmd, 0 powershell, 0
+  pwsh, 1 claude, 1 Terminal.App. Launching cleanup test."
+  Lets a screen-reader user (or a Claude session triaging
+  on their behalf) get the "what's currently running?"
+  answer in one keystroke, without losing their pty-speak
+  session to the close-and-recheck flow. The full
+  close-and-recheck flow still launches afterwards for
+  orphan-detection use cases. The bundled
+  `scripts/test-process-cleanup.ps1` gains a matching
+  `Get-ShellProcessSnapshot` helper that prints the same
+  vocabulary at script start + before/after each pass.
+
+- **CLAUDE.md "Diagnostic recipes" section + no-GUI rule.**
+  Adds explicit guidance for Claude sessions: `tasklist |
+  findstr /I` and `Get-Process` are the canonical "is the
+  child alive?" recipes; never propose GUI dialog walks
+  (System Properties / Task Manager / etc.) to a screen-
+  reader user. CLI / keyboard-only equivalents are listed
+  for the common cases (`setx`, `set`, `taskkill`, `reg
+  query`).
+
 ### Fixed (Stage 7-followup PR-I)
 
 - **Spurious "parser/reader loop: channel has been closed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,15 +397,31 @@ via `HandleAppLevelShortcut`.
 Currently shipped:
 
 - `Ctrl+Shift+U` — Velopack auto-update (Stage 11)
-- `Ctrl+Shift+D` — process-cleanup diagnostic launcher
+- `Ctrl+Shift+D` — process-cleanup diagnostic launcher (PR-J adds
+  inline shell-process snapshot announce before the script
+  window opens)
 - `Ctrl+Shift+R` — draft-a-new-release form launcher
 - `Ctrl+Shift+L` — open logs folder
 - `Ctrl+Shift+;` — copy active log to clipboard
+- `Ctrl+Shift+1` / `+2` / `+3` — hot-switch the spawned shell
+  (`+1` = cmd, `+2` = PowerShell, `+3` = Claude Code). PR-J
+  reordered: PowerShell sits in slot 2 deliberately so the
+  diagnostic control shell is one keystroke from cmd.
+- `Ctrl+Shift+G` — toggle FileLogger min-level between
+  Information and Debug at runtime (Stage 7-followup PR-E)
+- `Ctrl+Shift+H` — health-check announce: shell + PID + alive,
+  log level, reader staleness, queue depths (PR-F + PR-J
+  liveness probe)
+- `Ctrl+Shift+B` — incident marker: writes a clear
+  `=== INCIDENT MARKER {timestamp} ===` line into the active
+  log so post-hoc grep extracts the relevant slice (PR-F)
 
 Reserved (not yet bound):
 
 - `Ctrl+Shift+M` — Stage 9 earcon mute
 - `Alt+Shift+R` — Stage 10 review-mode toggle
+- `Ctrl+Shift+4` / `+5` / `+6` — additional shells (WSL, Python
+  REPL, etc.) per Phase 2 plans
 
 ### Accessibility (the non-negotiable rules)
 
@@ -436,18 +452,119 @@ canonical list. Highlights:
   `src/Terminal.Pty/Native.fs` — see CONTRIBUTING.md §"F# / P/Invoke
   conventions" for the full list.
 
+### The maintainer is a screen-reader user — no GUI dialog walks
+
+The maintainer uses NVDA. **Never** propose a fix or workflow that
+requires walking through a GUI dialog tree (System Properties →
+Advanced → Environment Variables → New…, Task Manager →
+Processes-tab chevron-expand, "right-click → Properties → Details
+tab", etc.). Every such suggestion is a multi-minute frustration
+sink because dialog trees are not always cleanly screen-reader-
+navigable, and the maintainer has explicitly called this out as
+unacceptable.
+
+Instead, surface keyboard- or shell-only equivalents:
+
+- Setting a user env var → `setx VAR value` from cmd. (Persists
+  across sessions; needs a fresh process to pick up.)
+- Setting a process-scoped env var → `set VAR=value` from cmd
+  before launching the child.
+- Inspecting running processes → `tasklist | findstr /I name`
+  from cmd, or
+  `Get-Process -Name name -ErrorAction SilentlyContinue` from
+  PowerShell. **Use these yourself first** before asking the
+  maintainer to check anything (see the diagnostic-recipes section
+  below).
+- Killing a stuck process → `taskkill /PID 1234 /F` from cmd, or
+  `Stop-Process -Id 1234 -Force` from PowerShell.
+- Inspecting / setting registry keys → `reg query` / `reg add`
+  from cmd, or `Get-ItemProperty` / `Set-ItemProperty` from
+  PowerShell.
+
+If a CLI / keyboard equivalent doesn't exist, say so explicitly
+and ask the maintainer how they want to proceed — don't paper
+over the gap with a dialog walk and hope.
+
+### Diagnostic recipes — triage without bothering the maintainer
+
+A standing problem in this codebase is "is the child shell
+actually running, or did it exit silently?". Before asking the
+maintainer to verify by hand, run these yourself via the user's
+existing `Ctrl+Shift+D` flow OR via direct CLI commands. Same
+recipes Ctrl+Shift+D uses internally.
+
+**Inline child-process check (the everyday triage tool):**
+
+The user can press `Ctrl+Shift+D` in pty-speak and NVDA reads back
+"Diagnostic snapshot: 1 cmd, 0 powershell, 0 pwsh, 1 claude, 1
+Terminal.App. Launching cleanup test." in one announcement —
+that's the inline enumeration the F# `enumerateShellProcesses`
+helper produces (`src/Terminal.App/Program.fs`). For Claude
+sessions reasoning about what the user might be seeing, the
+equivalent CLI commands are:
+
+```
+:: Enumerate shell processes by name (run in cmd)
+tasklist | findstr /I "cmd.exe powershell.exe pwsh.exe claude.exe Terminal.App.exe"
+
+:: Or in PowerShell:
+Get-Process -Name cmd, powershell, pwsh, claude, Terminal.App -ErrorAction SilentlyContinue |
+    Group-Object Name |
+    Select-Object @{Name='Name'; Expression='Name'}, Count
+```
+
+**Liveness probe for a specific PID:**
+
+`Ctrl+Shift+H` (PR-F + PR-J) announces the current child's PID
+and an `alive`/`dead` flag computed via
+`Process.GetProcessById(pid)`. The corresponding CLI form:
+
+```
+:: cmd
+tasklist /FI "PID eq 1234"
+:: PowerShell
+Get-Process -Id 1234 -ErrorAction SilentlyContinue
+```
+
+**Heartbeat trail:**
+
+The 5s background heartbeat
+(`runHeartbeat` in `Program.fs`) writes a line per tick to the
+active log including `Pid={Pid} Alive={Alive}`. When triaging
+"why did NVDA stop reading?" post-hoc, ask for the log slice
+covering that time window (`Ctrl+Shift+;` copies the active log)
+and grep `Heartbeat` to find the moment `Alive=False` first
+appears. That's the precise wedge timestamp.
+
+**Process tree diagnostic:**
+
+`Ctrl+Shift+D` launches `scripts/test-process-cleanup.ps1` in a
+new PowerShell window for the close-and-recheck flow. That
+script enumerates Terminal.App.exe + its parent-PID children +
+sibling shell counts (`Get-ShellProcessSnapshot`), then asks the
+user to close pty-speak via Alt+F4 / X-button and reports
+whether anything was orphaned. Use this when diagnosing Job
+Object cascade-kill regressions, NOT for "is the child alive
+right now?" — that's the inline check above.
+
 ## Current sequencing (May 2026)
 
 The cleanup cycle (Part 1 of the May-2026 plan) shipped 2026-05-03.
 Active sequence:
 
-- **Stage 7** = validation gate. Four sequenced PRs:
+- **Stage 7** = validation gate. Four sequenced PRs + followups:
   - **PR-A** — env-scrub PO-5 (shipped: PR #131)
   - **PR-B** — shell registry + `PTYSPEAK_SHELL` (shipped: PR #132)
   - **PR-C** — hot-switch hotkeys `Ctrl+Shift+1` / `Ctrl+Shift+2`
-    (next; depends on PR-B)
+    (shipped)
   - **PR-D** — NVDA validation matrix + `docs/STAGE-7-ISSUES.md`
-    seeding (after PR-C)
+    seeding (shipped)
+  - **PR-E…I** — diagnostic-surface + bug-fix followups from
+    NVDA-pass empirical findings (shipped)
+  - **PR-J** — PowerShell as third built-in shell + Ctrl+Shift+H
+    liveness probe + Ctrl+Shift+D inline child-process snapshot
+    (this PR; reorders hotkeys to `+1`=cmd / `+2`=PowerShell /
+    `+3`=Claude so the diagnostic control shell sits next to cmd)
 - **Output framework cycle** (Part 3, subsumes original Stages 8+9)
   — research → RFC → eight sub-stages, each with NVDA validation.
 - **Input framework cycle** (Part 4) — same shape.

--- a/README.md
+++ b/README.md
@@ -156,11 +156,17 @@ preserve this list per the app-reserved-hotkey contract in
 
 - **`Ctrl+Shift+U`** — self-update via Velopack (Stage 11). Checks
   GitHub Releases and applies the delta in ~2 seconds.
-- **`Ctrl+Shift+D`** — launch the bundled process-cleanup diagnostic
-  in a separate PowerShell window. Verifies that closing pty-speak
-  via Alt+F4 or the X button leaves no orphan `Terminal.App.exe` /
-  ConPTY child processes. Output is plain text NVDA reads aloud
-  naturally.
+- **`Ctrl+Shift+D`** — first announces an inline shell-process
+  snapshot via NVDA ("Diagnostic snapshot: 1 cmd, 0 powershell,
+  0 pwsh, 1 claude, 1 Terminal.App. Launching cleanup test.")
+  so a one-keystroke "what's currently running?" answer
+  doesn't require running the full close-and-recheck flow.
+  Then launches the bundled `test-process-cleanup.ps1` in a
+  separate PowerShell window for the close-and-recheck flow,
+  which verifies that closing pty-speak via Alt+F4 or the X
+  button leaves no orphan `Terminal.App.exe` / ConPTY child
+  processes. Output is plain text NVDA reads aloud naturally.
+  PR-J added the inline snapshot.
 - **`Ctrl+Shift+R`** — open the GitHub "draft a new release" form in
   your default browser. Maintainer shortcut — the normal release flow
   is to publish a release in the Releases UI (which creates the tag
@@ -183,13 +189,23 @@ preserve this list per the app-reserved-hotkey contract in
   spawns cmd in its place. NVDA announces "Switching to
   Command Prompt." → ~700ms pause → "Switched to Command
   Prompt." (Stage 7 PR-C).
-- **`Ctrl+Shift+2`** — switch the spawned shell to `claude.exe`
+- **`Ctrl+Shift+2`** — switch the spawned shell to
+  `powershell.exe` (Windows PowerShell, always available on
+  Windows 10+). Same teardown + respawn as `Ctrl+Shift+1`. NVDA
+  announces "Switching to PowerShell." → "Switched to
+  PowerShell." PowerShell sits in slot 2 deliberately as the
+  diagnostic control shell — always installed, no auth, no
+  terminal-capability detection — so isolating shell-switch
+  infrastructure bugs from claude-specific behaviour is one
+  keystroke from cmd (Stage 7-followup PR-J).
+- **`Ctrl+Shift+3`** — switch the spawned shell to `claude.exe`
   (resolved via `where.exe claude` per spec §7.1). Same teardown
   + respawn as `Ctrl+Shift+1`. NVDA announces "Switching to
   Claude Code." → "Switched to Claude Code." If Claude Code
   isn't on `PATH`, NVDA announces "Cannot switch to Claude
   Code: not found on PATH." and the existing shell keeps
-  running (Stage 7 PR-C).
+  running. Was `Ctrl+Shift+2` in PR-C; moved to slot 3 by PR-J
+  when PowerShell took slot 2.
 - **`Ctrl+Shift+G`** — toggle `FileLogger` min-level between
   `Information` (default) and `Debug` at runtime. Each press
   flips the level and NVDA announces the new state ("Debug
@@ -198,13 +214,18 @@ preserve this list per the app-reserved-hotkey contract in
   the previous env-var-and-relaunch workflow. Mnemonic: G for
   "loGging" (Stage 7-followup PR-E).
 - **`Ctrl+Shift+H`** — health check. Announces a one-line state
-  snapshot via NVDA: verdict ("Pty-speak healthy." / "Reader
-  appears wedged." / "Notification queue near capacity.") +
-  shell name + PID + log level + reader last-byte staleness +
-  channel queue depths. Lets a screen-reader user determine in
-  one keystroke whether pty-speak is functioning, instead of
-  inferring from "is NVDA reading anything?". Mnemonic: H for
-  "Health" (Stage 7-followup PR-F).
+  snapshot via NVDA: verdict ("Pty-speak healthy." / "Child
+  shell process N has exited." / "Reader appears wedged." /
+  "Notification queue near capacity.") + shell name + PID +
+  alive flag + log level + reader last-byte staleness +
+  channel queue depths. PR-J added the liveness probe (a
+  `Process.GetProcessById(pid)` call that throws if the kernel
+  no longer knows the PID) so the announce distinguishes
+  "child exited" from "child running but quiet" — a
+  distinction that previously required reading the log file.
+  Lets a screen-reader user determine in one keystroke whether
+  pty-speak is functioning. Mnemonic: H for "Health" (Stage
+  7-followup PR-F + PR-J).
 - **`Ctrl+Shift+B`** — incident marker. Logs a clear
   `=== INCIDENT MARKER {timestamp} ===` boundary line into the
   active log file and announces "Incident marker logged.
@@ -217,10 +238,11 @@ preserve this list per the app-reserved-hotkey contract in
 
 Reserved but not yet implemented: `Ctrl+Shift+M` (Stage 9 mute
 toggle), `Alt+Shift+R` (Stage 10 review-mode toggle).
-Higher digit slots (`Ctrl+Shift+3`, `Ctrl+Shift+4`, ...) are
-reserved for future shells (PowerShell, WSL, Python REPL)
-per the shell-registry extensibility model in
-[`spec/tech-plan.md`](spec/tech-plan.md) §7.5.
+Higher digit slots (`Ctrl+Shift+4`, `Ctrl+Shift+5`, ...) are
+reserved for future shells (WSL, Python REPL, bash) per the
+shell-registry extensibility model in
+[`spec/tech-plan.md`](spec/tech-plan.md) §7.5. Slots 1–3 are
+already taken (cmd / PowerShell / Claude per PR-J).
 
 The historical Stage 0 preview installer opens an empty window. Once
 the next preview is cut from the current `main`, the installer launches

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -268,10 +268,18 @@ defaults; they shouldn't be the only options.
 ### Current state
 
 Stage 7 PR-B added an extensible `ShellRegistry` in
-`src/Terminal.Pty/ShellRegistry.fs` exposing two built-in shells:
+`src/Terminal.Pty/ShellRegistry.fs`. PR-J added PowerShell as
+the third built-in (the diagnostic control shell). Current
+shipped set:
 
 - **`Cmd`** — Windows Command Prompt (`cmd.exe`). The Stage 7
   default; what new users see if they haven't configured anything.
+- **`PowerShell`** — Windows PowerShell (`powershell.exe`,
+  always available on Windows 10+). PR-J added; selected by
+  setting `PTYSPEAK_SHELL=powershell` or `=pwsh` (the `pwsh`
+  alias is for users who think of PowerShell as the
+  cross-platform `pwsh.exe`; both currently route to
+  `powershell.exe`).
 - **`Claude`** — Claude Code (`claude.exe`, resolved via
   `where.exe claude`). The maintainer's primary target workload;
   selected by setting `PTYSPEAK_SHELL=claude` (case-insensitive)
@@ -280,8 +288,9 @@ Stage 7 PR-B added an extensible `ShellRegistry` in
 Resolution lives in `compose ()` (`src/Terminal.App/Program.fs`):
 
 1. Read `PTYSPEAK_SHELL` env var. Recognised values: `cmd`,
-   `claude` (after trim, case-insensitive). Unrecognised non-empty
-   values produce a `LogWarning` and fall back to the default.
+   `claude`, `powershell`, `pwsh` (after trim, case-insensitive).
+   Unrecognised non-empty values produce a `LogWarning` and fall
+   back to the default.
 2. Default: `Cmd`.
 3. Resolve via `ShellRegistry.tryFind`. If the resolver returns
    `Error` (e.g. Claude Code not installed), log a warning at
@@ -298,8 +307,10 @@ Stage 7's job is to validate Claude Code under NVDA, not to ship
 a configuration UI. `PTYSPEAK_SHELL` is the smallest possible
 selection surface: an env var any user can set in their shell rc
 or via a desktop-shortcut "Run with environment" wrapper. Stage 7
-PR-C adds `Ctrl+Shift+1` / `Ctrl+Shift+2` hotkeys for in-session
-hot-switching (cmd ↔ claude); Phase 2 adds the menu / palette UI
+PR-C added `Ctrl+Shift+1` / `Ctrl+Shift+2` hotkeys for in-session
+hot-switching; PR-J added PowerShell + reordered the slots
+(`Ctrl+Shift+1` = cmd, `Ctrl+Shift+2` = PowerShell,
+`Ctrl+Shift+3` = Claude). Phase 2 adds the menu / palette UI
 that exposes the registry to the user without requiring shell
 literacy.
 
@@ -311,12 +322,14 @@ Three plausible levels of configurability, increasing in cost:
    Recognised names map to built-in registry entries. No file I/O,
    no parsing risk, easy to revert by unsetting.
 
-2. **Hotkey-driven hot-switch (Stage 7 PR-C).** `Ctrl+Shift+1`
-   selects cmd; `Ctrl+Shift+2` selects claude. The architectural
-   lift is mid-session `ConPtyHost` teardown + respawn, which PR-C
-   ships. Future shells claim higher digit slots (`Ctrl+Shift+3` for
-   PowerShell, etc.). `AppReservedHotkeys` contract + spec §6 update
-   land in PR-C.
+2. **Hotkey-driven hot-switch (Stage 7 PR-C, reordered + extended in PR-J).**
+   `Ctrl+Shift+1` selects cmd; `Ctrl+Shift+2` selects PowerShell;
+   `Ctrl+Shift+3` selects claude. The architectural lift is
+   mid-session `ConPtyHost` teardown + respawn, which PR-C
+   shipped. Future shells claim higher digit slots
+   (`Ctrl+Shift+4`, `+5`, ... for WSL / Python REPL / bash, etc.).
+   `AppReservedHotkeys` contract + spec §6 update land in PR-C
+   / PR-J.
 
 3. **Phase 2 TOML config + menu UI.** A `shells` table in the
    user-settings file lists shell-id + display-name + executable
@@ -332,7 +345,7 @@ Three plausible levels of configurability, increasing in cost:
   discriminated union, (b) adding an entry to `builtIns` with a
   resolver closure, (c) updating `parseEnvVar` to recognise the
   new name, and (d) updating
-  `tests/Tests.Unit/ShellRegistryTests.fs ``builtIns contains exactly Cmd and Claude```
+  `tests/Tests.Unit/ShellRegistryTests.fs ``builtIns contains exactly Cmd, Claude, and PowerShell```
   (the assertion intentionally pins the exact set so a reviewer is
   forced to acknowledge each addition).
 - `tryFindIn` exists separate from `tryFind` so tests can inject

--- a/scripts/test-process-cleanup.ps1
+++ b/scripts/test-process-cleanup.ps1
@@ -58,6 +58,23 @@ function Get-PtySpeakProcesses {
     }
 }
 
+# PR-J — enumerate live shell-related processes by NAME, not just
+# by parent-PID. Catches sibling instances (a separate cmd window
+# the user opened, an orphaned claude.exe from a previous crashed
+# pty-speak session) that the parent-PID query misses. Mirrors the
+# F# `enumerateShellProcesses` helper in
+# `src/Terminal.App/Program.fs` so the inline Ctrl+Shift+D announce
+# and the script's report use the same vocabulary.
+function Get-ShellProcessSnapshot {
+    $names = @('cmd', 'powershell', 'pwsh', 'claude', 'Terminal.App')
+    $parts = @()
+    foreach ($n in $names) {
+        $procs = @(Get-Process -Name $n -ErrorAction SilentlyContinue)
+        $parts += "$($procs.Count) $n"
+    }
+    return ($parts -join ', ')
+}
+
 function Wait-ForExit {
     param(
         [int]$TimeoutSeconds = 60
@@ -102,6 +119,7 @@ function Run-Pass {
     } else {
         Write-Host "    Child process count: 0"
     }
+    Write-Host "    Sibling snapshot: $(Get-ShellProcessSnapshot)"
 
     if ($running.Main.Count -eq 0) {
         Write-Host "FAIL: pty-speak failed to start. Aborting this pass."
@@ -130,6 +148,7 @@ function Run-Pass {
     Write-Host "Process state after close:"
     Write-Host "    Terminal.App.exe instances: $($after.Main.Count)"
     Write-Host "    Child process count: $($after.Children.Count)"
+    Write-Host "    Sibling snapshot: $(Get-ShellProcessSnapshot)"
 
     if ($after.Main.Count -eq 0 -and $after.Children.Count -eq 0) {
         Write-Host "RESULT: PASS"
@@ -149,6 +168,16 @@ Write-Host ""
 Write-Host "==========================================="
 Write-Host "  pty-speak process-cleanup baseline test"
 Write-Host "==========================================="
+Write-Host ""
+
+# PR-J — print the shell-process snapshot up front so a
+# screen-reader user (or a Claude session triaging on their
+# behalf) gets the "what's currently running" answer in one
+# scrollback page WITHOUT having to run the full close-and-recheck
+# flow. The two passes below still cover that flow for orphan
+# detection.
+Write-Host "Shell process snapshot (sibling counts by name):"
+Write-Host "    $(Get-ShellProcessSnapshot)"
 Write-Host ""
 
 $exePath = Find-PtySpeakInstall

--- a/spec/tech-plan.md
+++ b/spec/tech-plan.md
@@ -446,13 +446,21 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 >
 > Stage 7 PR-C additions (ADR-style amendment 2026-05-03,
 > maintainer-authorised — bundled with the shell registry +
-> hot-switch UX in §7.5 below):
+> hot-switch UX in §7.5 below). Stage 7-followup PR-J reordered
+> the slots and added PowerShell as a third built-in (the
+> diagnostic control shell — always installed, no auth, no
+> terminal-capability detection — sitting next to cmd at slot 2):
 >   - `Ctrl+Shift+1` — switch the spawned shell to cmd.exe.
 >     Bound in `setupShellSwitchKeybindings` in
 >     `src/Terminal.App/Program.fs`.
->   - `Ctrl+Shift+2` — switch the spawned shell to claude.exe
+>   - `Ctrl+Shift+2` — switch the spawned shell to powershell.exe
+>     (Windows PowerShell, always available; resolved as a
+>     constant `Ok "powershell.exe"` through PATH).
+>     Bound in the same setup function. Added by PR-J.
+>   - `Ctrl+Shift+3` — switch the spawned shell to claude.exe
 >     (resolved via `where.exe claude` per §7.1).
->     Bound in the same setup function.
+>     Bound in the same setup function. Was on slot 2 in PR-C;
+>     moved to slot 3 by PR-J.
 >
 > Stage 7-followup PR-E addition (ADR-style amendment 2026-05-03,
 > maintainer-authorised — diagnostic-workflow accessibility
@@ -505,9 +513,9 @@ The “spinner problem” is real (Claude Code’s Ink renderer redraws the same
 > when their owning stage ships):
 >   - `Ctrl+Shift+M` — Stage 9 earcon mute toggle.
 >   - `Alt+Shift+R` — Stage 10 review-mode toggle.
->   - `Ctrl+Shift+3` / `4` / `...` — additional shells
->     (PowerShell, WSL, Python REPL, etc.) per the §7.5
->     extensibility model.
+>   - `Ctrl+Shift+4` / `5` / `...` — additional shells (WSL,
+>     Python REPL, bash, etc.) per the §7.5 extensibility model.
+>     PowerShell took slot 2 and Claude moved to slot 3 in PR-J.
 >
 > Failure mode if violated: app-level hotkeys silently stop
 > working — `Ctrl+Shift+U` no longer triggers self-update,
@@ -676,7 +684,7 @@ On first invocation Claude Code will:
   - Red error text is announced as plain text → Stage 9.
   - No way to jump back through the response after focus moves → Stage 10.
 
-### 7.5 Shell registry + hot-switch UX (Stage 7 PR-B + PR-C)
+### 7.5 Shell registry + hot-switch UX (Stage 7 PR-B + PR-C + PR-J)
 
 > **ADR-style amendment 2026-05-03** — added per maintainer
 > authorisation (chat 2026-05-03; mirrors the chat-2026-05-03
@@ -700,7 +708,7 @@ without restarting pty-speak.
 resolver:
 
 ```fsharp
-type ShellId = | Cmd | Claude
+type ShellId = | Cmd | Claude | PowerShell
 type Shell =
     { Id: ShellId
       DisplayName: string
@@ -711,9 +719,20 @@ type Shell =
 Adding a shell requires (a) extending `ShellId`, (b) adding a
 `builtIns` entry with a resolver closure, (c) updating
 `parseEnvVar`'s recognised-values list, (d) updating
-`ShellRegistryTests.builtIns contains exactly Cmd and Claude` to
-pin the new keyset, and (e) adding a `Ctrl+Shift+N` hotkey if
-the new shell wants hot-switch participation.
+`ShellRegistryTests.builtIns contains exactly Cmd, Claude, and
+PowerShell` to pin the new keyset, and (e) adding a
+`Ctrl+Shift+N` hotkey if the new shell wants hot-switch
+participation.
+
+Stage 7-followup PR-J added `PowerShell` (Windows PowerShell,
+`powershell.exe`) as the third built-in. PowerShell-Core
+(`pwsh.exe`, the PowerShell 7+ rename) is intentionally NOT a
+separate case — it's an optional install; `powershell.exe` is
+the always-available baseline. The `parseEnvVar` arm accepts
+both `"powershell"` and `"pwsh"` as aliases that route to the
+same `PowerShell` ShellId; a Phase 2 user-settings TOML can
+split this into "PowerShell prefers pwsh.exe when present" if
+desired.
 
 `tryFind` and `tryFindIn` separate the production lookup
 (`tryFind`, delegates to `builtIns`) from the test seam
@@ -724,28 +743,40 @@ test.
 
 #### 7.5.2 Default + override (Stage 7 PR-B)
 
-Cmd is the default. `PTYSPEAK_SHELL=claude` (case-insensitive
-after trim) flips to claude at startup. Unrecognised non-empty
-values produce a `LogWarning` and fall back to cmd. Resolution
-failure (e.g. claude.exe not on PATH) likewise falls back to
-cmd with a warning.
+Cmd is the default. `PTYSPEAK_SHELL=claude` /
+`=powershell` / `=pwsh` (case-insensitive after trim) flips to
+the requested shell at startup. Unrecognised non-empty values
+produce a `LogWarning` and fall back to cmd. Resolution failure
+(e.g. claude.exe not on PATH) likewise falls back to cmd with a
+warning.
 
 Rationale: a fresh-install user without Claude Code installed
 should still see a working terminal. The maintainer-primary
 workload (Claude Code) is opt-in via the env var or the §7.5.3
-hotkey.
+hotkey. PowerShell is always-available on Windows 10+ so the
+`powershell` alias is reliable across all install configurations.
 
-#### 7.5.3 Hot-switch hotkeys (Stage 7 PR-C)
+#### 7.5.3 Hot-switch hotkeys (Stage 7 PR-C, reordered + extended in PR-J)
 
-`Ctrl+Shift+1` → cmd.exe; `Ctrl+Shift+2` → claude.exe. Both
-are reserved in `TerminalView.AppReservedHotkeys` per §6.
-Number-row digits, NOT numpad — numpad-with-NumLock-off
-carries NVDA review-cursor commands and must stay reachable.
+`Ctrl+Shift+1` → cmd.exe; `Ctrl+Shift+2` → powershell.exe;
+`Ctrl+Shift+3` → claude.exe. All three are reserved in
+`TerminalView.AppReservedHotkeys` per §6. Number-row digits, NOT
+numpad — numpad-with-NumLock-off carries NVDA review-cursor
+commands and must stay reachable.
 
-NVDA collision check: `Ctrl+Shift+1`/`Ctrl+Shift+2` have no
-default NVDA bindings. The bare `1`/`Shift+1` browse-mode
-heading-quick-nav doesn't fire in focus mode (which is what
-NVDA uses for terminal applications by default).
+PR-J reordered the slots and added PowerShell because the
+maintainer's NVDA validation pass on 2026-05-03 surfaced
+suspected shell-switch infrastructure bugs that needed a
+diagnostic control shell to isolate. PowerShell is always
+installed, has zero auth or terminal-capability detection, and
+produces visible banner + prompt output within milliseconds —
+making it the ideal control. Putting it adjacent to cmd at slot
+2 means the diagnostic comparison is one keystroke away.
+
+NVDA collision check: `Ctrl+Shift+1`/`+2`/`+3` have no default
+NVDA bindings. The bare `1`/`2`/`3` and `Shift+1`/`+2`/`+3`
+browse-mode heading-quick-nav doesn't fire in focus mode (which
+is what NVDA uses for terminal applications by default).
 
 Switch sequence (handler runs on the WPF dispatcher thread):
 
@@ -793,17 +824,26 @@ failure is mild (residual paint, not crash) and the
 architectural fix lives in Stage 4a's substrate / the framework
 cycles' RFC scope.
 
-#### 7.5.5 Validation (Stage 7 PR-C row in `docs/ACCESSIBILITY-TESTING.md`)
+#### 7.5.5 Validation (Stage 7 PR-C / PR-J rows in `docs/ACCESSIBILITY-TESTING.md`)
 
 - Launch pty-speak; default cmd shell is announced.
-- Press `Ctrl+Shift+2`; NVDA reads "Switching to Claude Code."
+- Press `Ctrl+Shift+3`; NVDA reads "Switching to Claude Code."
   → ~700ms pause → claude welcome screen reads.
 - Type a prompt; claude responds; review-cursor navigates the
   response.
 - Press `Ctrl+Shift+1`; NVDA reads "Switching to Command
   Prompt." → cmd prompt reads.
-- `Ctrl+Shift+D` (process-cleanup diagnostic) confirms no
-  orphan claude.exe processes after the switch.
+- Press `Ctrl+Shift+2`; NVDA reads "Switching to PowerShell."
+  → PowerShell banner + prompt read. Use this slot when
+  isolating shell-switch infrastructure bugs from claude-
+  specific behaviour.
+- `Ctrl+Shift+H` after each switch announces the new shell's
+  name + PID + alive flag — verifies the child is actually
+  running (PR-J liveness probe).
+- `Ctrl+Shift+D` announces the inline shell-process snapshot
+  (PR-J inline enumeration) before launching the cleanup
+  test window. Confirms no orphan claude/powershell/cmd
+  processes after a switch.
 - Press `Ctrl+Shift+2` when claude.exe isn't installed; NVDA
   reads the resolve-failure announcement; the existing cmd
   shell continues to work.

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -266,16 +266,75 @@ module Program =
     /// next to this one and routed through the same hotkey via
     /// a sub-menu, OR added as their own hotkeys following the
     /// app-reserved-hotkey contract in `spec/tech-plan.md` §6.
+    /// PR-J — enumerate the live shell-related processes and
+    /// return both a per-name count list and a one-line announce-
+    /// safe summary. Used by the Ctrl+Shift+D handler to report
+    /// state inline BEFORE launching the cleanup script — gives
+    /// the user (or a Claude session triaging on their behalf)
+    /// an immediate "what's currently running" snapshot without
+    /// the close-and-recheck round trip.
+    ///
+    /// Names checked: `cmd`, `powershell`, `pwsh`, `claude`,
+    /// `Terminal.App`. `Process.GetProcessesByName` is the supported
+    /// .NET API — case-insensitive, no `.exe` suffix in the name
+    /// argument. The returned `Process` objects are disposed
+    /// immediately; we only need the count.
+    ///
+    /// Logged at Information level too so post-hoc log analysis
+    /// captures the snapshot even if the user pressed Ctrl+Shift+D
+    /// without writing down what NVDA said.
+    let private enumerateShellProcesses () : string =
+        let names = [| "cmd"; "powershell"; "pwsh"; "claude"; "Terminal.App" |]
+        let counts =
+            names
+            |> Array.map (fun n ->
+                let count =
+                    try
+                        let procs = System.Diagnostics.Process.GetProcessesByName(n)
+                        for p in procs do
+                            try p.Dispose() with _ -> ()
+                        procs.Length
+                    with _ -> -1
+                n, count)
+        let parts =
+            counts
+            |> Array.map (fun (n, c) ->
+                if c < 0 then sprintf "%s ?" n
+                else sprintf "%d %s" c n)
+        String.concat ", " parts
+
     let private runDiagnostic (window: MainWindow) : unit =
         let scriptPath =
             System.IO.Path.Combine(
                 System.AppContext.BaseDirectory,
                 "test-process-cleanup.ps1")
+        // PR-J — inline process enumeration. The user's previous
+        // diagnostic ritual was "press Ctrl+Shift+D, close the
+        // window, watch what gets reaped" — fine for a deliberate
+        // close-and-recheck sweep but heavyweight for a quick "is
+        // anything weird running right now?" check. Enumerating
+        // up-front and announcing the counts means a screen-reader
+        // user gets the snapshot in one keystroke without losing
+        // their pty-speak session. Maintainer feedback 2026-05-03:
+        // "you should automatically check child processes when you
+        // launch diagnostics".
+        //
+        // The full close-and-recheck flow (PowerShell script in a
+        // separate window) STILL launches afterwards so the
+        // existing orphan-detection workflow continues working;
+        // the inline enumeration is purely additive.
+        let snapshot = enumerateShellProcesses ()
+        let log = Logger.get "Terminal.App.Program.runDiagnostic"
+        log.LogInformation(
+            "Diagnostic snapshot. ProcessCounts={Snapshot}",
+            snapshot)
         if not (System.IO.File.Exists scriptPath) then
             window.TerminalSurface.Announce(
                 sprintf
-                    "Diagnostic script not found at %s. Re-install pty-speak or report this as a packaging regression."
-                    scriptPath)
+                    "Diagnostic snapshot: %s. Cleanup script not found at %s."
+                    snapshot
+                    scriptPath,
+                ActivityIds.diagnostic)
         else
             // Announce FIRST so NVDA's speech queue holds the message
             // before focus shifts. The new PowerShell window's
@@ -287,16 +346,18 @@ module Program =
             // window's title). Pre-Stage-5 NVDA verification on
             // `v0.0.1-preview.NN` confirmed the regression.
             //
-            // Fix: announce a SHORT cue ("Launching diagnostic.") that
-            // NVDA can fully read in well under the focus-grab latency,
-            // wait ~700ms, then start the process. The PowerShell
-            // window's title takes over from there — which is the
-            // natural way for screen-reader users to confirm the new
-            // window arrived.
+            // PR-J prefixes the snapshot to the launch cue so a
+            // screen-reader user hears "1 cmd, 0 powershell, 0 pwsh,
+            // 1 claude, 1 Terminal.App. Launching diagnostic." in
+            // one announcement — strictly additive to the previous
+            // "Launching diagnostic." cue. The 700ms-then-spawn
+            // pattern below stays unchanged.
             // TODO Phase 2: the 700ms delay should come from a TOML
             // setting alongside the Stage 5 coalescer constants.
             window.TerminalSurface.Announce(
-                "Launching diagnostic.",
+                sprintf
+                    "Diagnostic snapshot: %s. Launching cleanup test."
+                    snapshot,
                 ActivityIds.diagnostic)
             let _ =
                 task {
@@ -997,11 +1058,12 @@ module Program =
 
         // Stage 7 PR-B — resolve which shell to spawn. cmd.exe stays
         // the default per maintainer instruction; `PTYSPEAK_SHELL=claude`
-        // (or any future menu UI) flips it. Unrecognised env-var values
-        // fall back to cmd with a warning log so the user isn't locked
-        // out of a working terminal by a typo. PR-C adds Ctrl+Shift+1
-        // (cmd) / Ctrl+Shift+2 (claude) hotkeys for mid-session
-        // hot-switching.
+        // / `=powershell` / `=pwsh` (or any future menu UI) flips it.
+        // Unrecognised env-var values fall back to cmd with a warning
+        // log so the user isn't locked out of a working terminal by a
+        // typo. PR-C added Ctrl+Shift+1 (cmd) / Ctrl+Shift+2 hotkeys;
+        // PR-J reordered: Ctrl+Shift+1 = cmd, +2 = PowerShell, +3 =
+        // claude.
         let resolveStartupShell () : ShellRegistry.Shell * string =
             let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
             // Distinguish "unset" from "set to garbage" so the
@@ -1019,7 +1081,7 @@ module Program =
                 | v when System.String.IsNullOrWhiteSpace(v) -> ()
                 | v ->
                     log.LogWarning(
-                        "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude.",
+                        "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude, powershell, pwsh.",
                         v)
             let requested =
                 match ShellRegistry.parseEnvVar envVar with
@@ -1136,19 +1198,50 @@ module Program =
                     match hostHandle with
                     | Some h -> int h.ProcessId
                     | None -> 0
+                // Stage 7-followup PR-J — liveness probe. The
+                // ConPtyHost handle's recorded PID is the value we
+                // captured at spawn; the OS may have already reaped
+                // the child (e.g. claude.exe exited silently after
+                // a terminal-capability handshake stalled, or
+                // PowerShell's startup banner threw). Check whether
+                // the kernel still knows about that PID via
+                // Process.GetProcessById, which throws
+                // ArgumentException for a reaped/non-existent PID.
+                // The result feeds both the verdict and the
+                // user-facing announce so a screen-reader user can
+                // distinguish "child exited" from "child running
+                // but quiet" — a distinction that previously
+                // required reading the log file.
+                let alive =
+                    if pid <= 0 then
+                        false
+                    else
+                        try
+                            use _ = System.Diagnostics.Process.GetProcessById(pid)
+                            true
+                        with _ -> false
                 let levelStr =
                     match loggerSink with
                     | Some s -> s.MinLevel.ToString()
                     | None -> "Unknown"
                 let notifDepth = notificationChannel.Reader.Count
                 let coalDepth = coalescedChannel.Reader.Count
-                // Verdict heuristic: reader-wedge if no bytes in
-                // 5+ seconds AND there's pending work; queue-near-
-                // capacity if the notification channel is past 95%
-                // (the DropOldest mode means past-capacity is silent
-                // data loss); otherwise healthy.
+                // Verdict heuristic, in priority order:
+                //   1. Child PID dead → "Child shell process has
+                //      exited." (highest signal — explains every
+                //      downstream symptom).
+                //   2. Reader wedge: no bytes in 5+ seconds AND
+                //      pending work in the notification queue.
+                //   3. Notification queue near capacity (95%) —
+                //      DropOldest means past-capacity is silent
+                //      data loss; warn before that.
+                //   4. Healthy.
                 let verdict =
-                    if staleness > 5000.0 && notifDepth > 0 then
+                    if pid > 0 && not alive then
+                        sprintf
+                            "Child shell process %d has exited."
+                            pid
+                    elif staleness > 5000.0 && notifDepth > 0 then
                         sprintf
                             "Reader appears wedged. Last byte %.0f seconds ago."
                             (staleness / 1000.0)
@@ -1158,12 +1251,14 @@ module Program =
                             notifDepth
                     else
                         "Pty-speak healthy."
+                let aliveStr = if alive then "alive" else "dead"
                 let summary =
                     sprintf
-                        "%s %s shell, PID %d, log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256. Coalesced queue %d of 16."
+                        "%s %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256. Coalesced queue %d of 16."
                         verdict
                         currentShell.DisplayName
                         pid
+                        aliveStr
                         levelStr
                         staleness
                         notifDepth
@@ -1204,6 +1299,19 @@ module Program =
                     match hostHandle with
                     | Some h -> int h.ProcessId
                     | None -> 0
+                // PR-J — same liveness probe as runHealthCheck.
+                // Logging the alive flag every 5s gives post-hoc
+                // log analysis a clean "child died at HH:MM:SS"
+                // breadcrumb without needing the user to press
+                // Ctrl+Shift+H at the right moment.
+                let alive =
+                    if pid <= 0 then
+                        false
+                    else
+                        try
+                            use _ = System.Diagnostics.Process.GetProcessById(pid)
+                            true
+                        with _ -> false
                 let level =
                     match loggerSink with
                     | Some s -> s.MinLevel
@@ -1211,9 +1319,10 @@ module Program =
                 let notifDepth = notificationChannel.Reader.Count
                 let coalDepth = coalescedChannel.Reader.Count
                 log.LogInformation(
-                    "Heartbeat. Shell={Shell} Pid={Pid} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap} CoalQueue={Coal}/{CoalCap}",
+                    "Heartbeat. Shell={Shell} Pid={Pid} Alive={Alive} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap} CoalQueue={Coal}/{CoalCap}",
                     currentShell.DisplayName,
                     pid,
+                    alive,
                     level,
                     staleness,
                     notifDepth,
@@ -1431,7 +1540,13 @@ module Program =
                         }
                     ()
 
-        // Wire `Ctrl+Shift+1` → cmd, `Ctrl+Shift+2` → claude.
+        // Wire `Ctrl+Shift+1` → cmd, `Ctrl+Shift+2` → PowerShell,
+        // `Ctrl+Shift+3` → claude. PR-J reordered the slots and
+        // added PowerShell as the diagnostic control shell (always
+        // installed, no auth, fast prompt) so isolating shell-switch
+        // infrastructure bugs from claude-specific issues is one
+        // keypress away.
+        //
         // Pattern matches `setupAutoUpdateKeybinding` etc.; same
         // window-level KeyBinding + RoutedCommand + CommandBinding
         // triple. The keys are listed in
@@ -1439,22 +1554,18 @@ module Program =
         // doesn't mark them Handled before InputBindings can fire.
         let setupShellSwitchKeybindings (window: MainWindow)
                                         (switchTo: ShellRegistry.ShellId -> unit) : unit =
-            let cmdRouted = RoutedCommand("SwitchToCmdShell", typeof<MainWindow>)
-            let cmdGesture = KeyGesture(Key.D1, ModifierKeys.Control ||| ModifierKeys.Shift)
-            window.InputBindings.Add(KeyBinding(cmdRouted, cmdGesture)) |> ignore
-            window.CommandBindings.Add(
-                CommandBinding(
-                    cmdRouted,
-                    ExecutedRoutedEventHandler(fun _ _ -> switchTo ShellRegistry.Cmd)))
-            |> ignore
-            let claudeRouted = RoutedCommand("SwitchToClaudeShell", typeof<MainWindow>)
-            let claudeGesture = KeyGesture(Key.D2, ModifierKeys.Control ||| ModifierKeys.Shift)
-            window.InputBindings.Add(KeyBinding(claudeRouted, claudeGesture)) |> ignore
-            window.CommandBindings.Add(
-                CommandBinding(
-                    claudeRouted,
-                    ExecutedRoutedEventHandler(fun _ _ -> switchTo ShellRegistry.Claude)))
-            |> ignore
+            let bind (name: string) (key: Key) (target: ShellRegistry.ShellId) : unit =
+                let routed = RoutedCommand(name, typeof<MainWindow>)
+                let gesture = KeyGesture(key, ModifierKeys.Control ||| ModifierKeys.Shift)
+                window.InputBindings.Add(KeyBinding(routed, gesture)) |> ignore
+                window.CommandBindings.Add(
+                    CommandBinding(
+                        routed,
+                        ExecutedRoutedEventHandler(fun _ _ -> switchTo target)))
+                |> ignore
+            bind "SwitchToCmdShell" Key.D1 ShellRegistry.Cmd
+            bind "SwitchToPowerShellShell" Key.D2 ShellRegistry.PowerShell
+            bind "SwitchToClaudeShell" Key.D3 ShellRegistry.Claude
 
         setupShellSwitchKeybindings window switchToShell
 

--- a/src/Terminal.Pty/ShellRegistry.fs
+++ b/src/Terminal.Pty/ShellRegistry.fs
@@ -31,11 +31,26 @@ module ShellRegistry =
     /// how to launch. Add cases here to extend the registry; each
     /// case needs a registration in `builtIns` below.
     ///
-    /// Future cases (Phase 2 territory): `PowerShell`, `Wsl of
-    /// distro: string`, `Python`, `Node`, `Bash`, etc.
+    /// Stage 7-followup PR-J added `PowerShell` (Windows
+    /// PowerShell, `powershell.exe`) as a third built-in
+    /// alongside `Cmd` and `Claude`. Diagnostic value: PowerShell
+    /// is always installed on Windows, has zero auth or
+    /// terminal-capability detection, and produces visible banner
+    /// + prompt output within milliseconds of launch — making it
+    /// an ideal control shell for isolating shell-switch bugs
+    /// from claude.exe-specific issues.
+    ///
+    /// Future cases (Phase 2 territory): `Wsl of distro: string`,
+    /// `Python`, `Node`, `Bash`, etc. PowerShell-Core (`pwsh.exe`,
+    /// the PowerShell 7+ rename) is intentionally NOT a separate
+    /// case — it's an optional install; `powershell.exe` is the
+    /// always-available baseline. A Phase 2 user-settings TOML
+    /// can let the `PowerShell` resolver prefer `pwsh.exe` when
+    /// present.
     type ShellId =
         | Cmd
         | Claude
+        | PowerShell
 
     /// The runtime descriptor for a shell. `Resolve` is called at
     /// most once per session by the composition root; tests inject
@@ -121,7 +136,17 @@ module ShellRegistry =
               Claude,
                 { Id = Claude
                   DisplayName = "Claude Code"
-                  Resolve = fun () -> whereExe "claude" } ]
+                  Resolve = fun () -> whereExe "claude" }
+              PowerShell,
+                { Id = PowerShell
+                  DisplayName = "PowerShell"
+                  // Windows PowerShell is always present on
+                  // Windows 10+; the bare command name resolves
+                  // through the parent's PATH (which our env-scrub
+                  // preserves). Not using `where.exe powershell`
+                  // because the bare resolution is faster and the
+                  // command is guaranteed available.
+                  Resolve = fun () -> Ok "powershell.exe" } ]
 
     /// Look up a shell in a registry. Production callers pass
     /// `builtIns`; tests pass a synthetic Map to inject
@@ -135,11 +160,19 @@ module ShellRegistry =
 
     /// Map a `PTYSPEAK_SHELL` env-var value to a `ShellId`.
     /// Recognised values (case-insensitive after trim): `"cmd"`,
-    /// `"claude"`. Returns `None` for unrecognised values so the
-    /// caller can log a warning + fall back to the default.
-    /// `null` and empty/whitespace are treated as "not set" (also
-    /// returns `None`); callers distinguish via the source-side
-    /// null check.
+    /// `"claude"`, `"powershell"` / `"pwsh"`. Returns `None` for
+    /// unrecognised values so the caller can log a warning + fall
+    /// back to the default. `null` and empty/whitespace are
+    /// treated as "not set" (also returns `None`); callers
+    /// distinguish via the source-side null check.
+    ///
+    /// `"pwsh"` is an alias for `PowerShell` because the
+    /// PowerShell Core 7+ executable is named `pwsh.exe` and
+    /// some users set `PTYSPEAK_SHELL=pwsh` thinking that's the
+    /// canonical name. Both currently route to
+    /// `powershell.exe` (Windows PowerShell, always available);
+    /// a Phase 2 user-settings TOML can split this into
+    /// "PowerShell prefers pwsh.exe when present" if desired.
     let parseEnvVar (value: string | null) : ShellId option =
         match value with
         | null -> None
@@ -148,4 +181,6 @@ module ShellRegistry =
             | "" -> None
             | "cmd" -> Some Cmd
             | "claude" -> Some Claude
+            | "powershell" -> Some PowerShell
+            | "pwsh" -> Some PowerShell
             | _ -> None

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -402,25 +402,36 @@ public class TerminalView : FrameworkElement
             (Key.OemSemicolon, ModifierKeys.Control | ModifierKeys.Shift, "Copy active log to clipboard"),
 
             // Stage 7 PR-C — hot-switch the spawned shell mid-session.
-            // `Ctrl+Shift+1` selects cmd.exe; `Ctrl+Shift+2` selects
-            // claude.exe. Designed extensibly so future shells
-            // (PowerShell, WSL, Python REPL) claim higher digits
-            // without breaking the contract. The handler tears down
-            // the running ConPtyHost, resolves the target via
-            // `ShellRegistry.tryFind`, spawns a new ConPtyHost, and
-            // re-wires `SetPtyHost` callbacks. Both digits are number-
-            // row (`Key.D1`/`Key.D2`), NOT numpad — numpad-with-
-            // NumLock-off carries NVDA review-cursor commands and
-            // must stay reachable per the accessibility non-
-            // negotiables in CONTRIBUTING.md. NVDA collision check:
-            // `Ctrl+Shift+1`/`Ctrl+Shift+2` have no default NVDA
-            // bindings (digit-only `1`/`Shift+1` browse-mode
-            // heading-quick-nav doesn't fire in focus mode, which is
-            // pty-speak's mode). Spec authority: §7.5 (added by
-            // this PR per chat 2026-05-03 maintainer authorisation
+            // PR-J (2026-05-03) reordered the slots and added
+            // PowerShell as a third built-in. Current assignment:
+            //   `Ctrl+Shift+1` → cmd.exe
+            //   `Ctrl+Shift+2` → powershell.exe (PowerShell)
+            //   `Ctrl+Shift+3` → claude.exe (Claude Code)
+            // PowerShell sits in slot 2 deliberately: it's the
+            // diagnostic control shell — always installed, no auth,
+            // no terminal-capability detection — so isolating
+            // shell-switch infrastructure bugs from claude-specific
+            // issues is one keypress away. Future shells (WSL,
+            // Python REPL, bash) claim higher digits without breaking
+            // the contract.
+            //
+            // The handler tears down the running ConPtyHost, resolves
+            // the target via `ShellRegistry.tryFind`, spawns a new
+            // ConPtyHost, and re-wires `SetPtyHost` callbacks. All
+            // three digits are number-row (`Key.D1`/`D2`/`D3`), NOT
+            // numpad — numpad-with-NumLock-off carries NVDA review-
+            // cursor commands and must stay reachable per the
+            // accessibility non-negotiables in CONTRIBUTING.md. NVDA
+            // collision check: `Ctrl+Shift+1`/`+2`/`+3` have no
+            // default NVDA bindings (digit-only `1`/`2`/`3` and
+            // `Shift+1`/`+2`/`+3` browse-mode heading-quick-nav
+            // doesn't fire in focus mode, which is pty-speak's
+            // mode). Spec authority: §7.5 (added by PR-C, extended
+            // by PR-J per chat 2026-05-03 maintainer authorisation
             // for shell registry + hot-switch UX).
             (Key.D1, ModifierKeys.Control | ModifierKeys.Shift, "Switch to cmd shell"),
-            (Key.D2, ModifierKeys.Control | ModifierKeys.Shift, "Switch to claude shell"),
+            (Key.D2, ModifierKeys.Control | ModifierKeys.Shift, "Switch to PowerShell shell"),
+            (Key.D3, ModifierKeys.Control | ModifierKeys.Shift, "Switch to claude shell"),
 
             // Stage 7-followup PR-E — toggle FileLogger min-level
             // between Information (default) and Debug at runtime,
@@ -462,8 +473,8 @@ public class TerminalView : FrameworkElement
             //    "Stage 9 earcon mute"),
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,
             //    "Stage 10 review-mode toggle"),
-            //   Higher Ctrl+Shift+digit slots (3, 4, 5, ...) reserved
-            //   for additional shells per Stage 7 PR-C.
+            //   Higher Ctrl+Shift+digit slots (4, 5, 6, ...) reserved
+            //   for additional shells per Stage 7 PR-C / PR-J.
         ];
 
     /// <summary>

--- a/tests/Tests.Unit/ShellRegistryTests.fs
+++ b/tests/Tests.Unit/ShellRegistryTests.fs
@@ -12,13 +12,14 @@ open Terminal.Pty
 // into. These tests pin two contracts:
 //
 //   1. `parseEnvVar` — pure mapping from `PTYSPEAK_SHELL` text to
-//      `ShellId option`. Recognises "cmd" / "claude" case-insensitively
-//      after trim; returns `None` for null, empty, whitespace, or
-//      anything else (so the caller can warn-and-fall-back).
-//   2. `builtIns` registry contains exactly the cmd + claude entries
-//      Stage 7 ships with. Adding a shell entry requires updating
-//      this assertion (matches the AllowedNames-pin pattern in
-//      `EnvBlockTests.fs`).
+//      `ShellId option`. Recognises "cmd" / "claude" / "powershell" /
+//      "pwsh" case-insensitively after trim; returns `None` for null,
+//      empty, whitespace, or anything else (so the caller can warn-
+//      and-fall-back). PR-J added the PowerShell + pwsh aliases.
+//   2. `builtIns` registry contains exactly the cmd + claude +
+//      PowerShell entries Stage 7 ships with after PR-J. Adding a
+//      shell entry requires updating this assertion (matches the
+//      AllowedNames-pin pattern in `EnvBlockTests.fs`).
 //
 // `whereExe` involves `Process.Start` and isn't unit-tested here —
 // the real path is exercised in PR-D's manual NVDA matrix row.
@@ -39,16 +40,32 @@ let ``parseEnvVar recognises "claude"`` () =
     Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "claude")
 
 [<Fact>]
+let ``parseEnvVar recognises "powershell"`` () =
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "powershell")
+
+[<Fact>]
+let ``parseEnvVar recognises "pwsh" as PowerShell alias`` () =
+    // `pwsh.exe` is the PowerShell Core 7+ executable name. PR-J
+    // routes both names to the same `PowerShell` ShellId for now;
+    // a Phase 2 user-settings TOML can split them into "prefer
+    // pwsh.exe when present" if desired.
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "pwsh")
+
+[<Fact>]
 let ``parseEnvVar is case-insensitive`` () =
     Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "CMD")
     Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "Cmd")
     Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "CLAUDE")
     Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "Claude")
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "PowerShell")
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "POWERSHELL")
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "PWSH")
 
 [<Fact>]
 let ``parseEnvVar trims surrounding whitespace`` () =
     Assert.Equal(Some ShellRegistry.Cmd, ShellRegistry.parseEnvVar "  cmd  ")
     Assert.Equal(Some ShellRegistry.Claude, ShellRegistry.parseEnvVar "\tclaude\n")
+    Assert.Equal(Some ShellRegistry.PowerShell, ShellRegistry.parseEnvVar "  pwsh  ")
 
 // ---------------------------------------------------------------------
 // parseEnvVar — unrecognised values
@@ -69,12 +86,13 @@ let ``parseEnvVar returns None for whitespace`` () =
 
 [<Fact>]
 let ``parseEnvVar returns None for unrecognised values`` () =
-    // Values like "powershell" / "wsl" / "bash" / "garbage" all
-    // return None today; future shells would be added by extending
-    // `parseEnvVar`'s match arms.
-    Assert.Equal(None, ShellRegistry.parseEnvVar "powershell")
+    // Values like "wsl" / "bash" / "node" / "garbage" all return
+    // None today; future shells would be added by extending
+    // `parseEnvVar`'s match arms. PR-J moved "powershell" / "pwsh"
+    // out of this list and into the recognised set.
     Assert.Equal(None, ShellRegistry.parseEnvVar "wsl")
     Assert.Equal(None, ShellRegistry.parseEnvVar "bash")
+    Assert.Equal(None, ShellRegistry.parseEnvVar "node")
     Assert.Equal(None, ShellRegistry.parseEnvVar "garbage")
 
 [<Fact>]
@@ -91,14 +109,18 @@ let ``parseEnvVar does not match substrings (cmd.exe)`` () =
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``builtIns contains exactly Cmd and Claude`` () =
+let ``builtIns contains exactly Cmd, Claude, and PowerShell`` () =
     // Pinning the registry's keyset protects against accidental
     // additions that would broaden the spawn surface beyond what
     // Stage 7 authorises. Adding a shell requires a spec PR + this
     // assertion update — same ADR-style discipline as
     // `EnvBlockTests.allowedNames contains exactly the spec-7-2 baseline`.
+    // PR-J added PowerShell as the third built-in.
     let expected =
-        Set.ofList [ ShellRegistry.Cmd; ShellRegistry.Claude ]
+        Set.ofList
+            [ ShellRegistry.Cmd
+              ShellRegistry.Claude
+              ShellRegistry.PowerShell ]
     let actual =
         ShellRegistry.builtIns
         |> Map.toSeq
@@ -125,6 +147,22 @@ let ``Claude entry has DisplayName "Claude Code"`` () =
         |> Map.find ShellRegistry.Claude
     Assert.Equal("Claude Code", claude.DisplayName)
     Assert.Equal(ShellRegistry.Claude, claude.Id)
+
+[<Fact>]
+let ``PowerShell entry resolves to powershell.exe`` () =
+    // Windows PowerShell is always present on Windows 10+ so the
+    // resolver returns a constant `Ok "powershell.exe"` and the
+    // bare command name resolves through the parent's PATH (which
+    // the env-scrub preserves). Pinning this protects against an
+    // accidental flip to `pwsh.exe` in the production registry —
+    // pwsh is an optional install and would break startup on
+    // machines without it.
+    let ps =
+        ShellRegistry.builtIns
+        |> Map.find ShellRegistry.PowerShell
+    Assert.Equal("PowerShell", ps.DisplayName)
+    Assert.Equal(ShellRegistry.PowerShell, ps.Id)
+    Assert.Equal<Result<string, string>>(Ok "powershell.exe", ps.Resolve())
 
 // ---------------------------------------------------------------------
 // tryFindIn — synthetic registry injection

--- a/tests/Tests.Unit/ShellSwitchTests.fs
+++ b/tests/Tests.Unit/ShellSwitchTests.fs
@@ -15,13 +15,16 @@ open Terminal.Pty
 // pieces the coordinator relies on:
 //
 //   1. The `ShellId` discriminated union shape — exhaustive
-//      pattern-match coverage for the two built-ins. A future
-//      addition (PowerShell, WSL) lights up the `_` arm and forces
-//      the contributor to update both the registry and the
-//      `Program.fs setupShellSwitchKeybindings` keybinding table.
+//      pattern-match coverage for the three built-ins (Cmd,
+//      Claude, PowerShell). A future addition (WSL, Python REPL)
+//      lights up the `_` arm and forces the contributor to update
+//      both the registry and the `Program.fs
+//      setupShellSwitchKeybindings` keybinding table.
 //   2. Hotkey-to-shell mapping — pinning that `Ctrl+Shift+1` maps
-//      to `Cmd` and `Ctrl+Shift+2` maps to `Claude`. The mapping
-//      lives in Program.fs as two `RoutedCommand` + `KeyBinding`
+//      to `Cmd`, `Ctrl+Shift+2` to `PowerShell`, and `Ctrl+Shift+3`
+//      to `Claude` (the order PR-J established for putting the
+//      diagnostic control shell next to cmd). The mapping lives
+//      in Program.fs as three `RoutedCommand` + `KeyBinding`
 //      pairs; this fixture documents the contract via a parallel
 //      table that the orchestrator's review must match.
 //   3. Synthetic-resolver behaviour — confirming that a registry
@@ -44,20 +47,22 @@ open Terminal.Pty
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``ShellId pattern match is exhaustive over Cmd and Claude`` () =
-    // If a future contributor adds a new ShellId case (e.g.
-    // PowerShell), this match becomes non-exhaustive and the
-    // compiler emits FS0025. Under TreatWarningsAsErrors=true,
-    // that fails the build — forcing the contributor to update
-    // both `ShellRegistry.builtIns` (the data) AND this fixture
-    // (the test contract) AND `Program.fs
-    // setupShellSwitchKeybindings` (the UX) in lockstep.
+let ``ShellId pattern match is exhaustive over Cmd, Claude, PowerShell`` () =
+    // If a future contributor adds a new ShellId case (e.g. Wsl,
+    // Python), this match becomes non-exhaustive and the compiler
+    // emits FS0025. Under TreatWarningsAsErrors=true, that fails
+    // the build — forcing the contributor to update both
+    // `ShellRegistry.builtIns` (the data) AND this fixture (the
+    // test contract) AND `Program.fs setupShellSwitchKeybindings`
+    // (the UX) in lockstep.
     let label (id: ShellRegistry.ShellId) : string =
         match id with
         | ShellRegistry.Cmd -> "cmd"
         | ShellRegistry.Claude -> "claude"
+        | ShellRegistry.PowerShell -> "powershell"
     Assert.Equal("cmd", label ShellRegistry.Cmd)
     Assert.Equal("claude", label ShellRegistry.Claude)
+    Assert.Equal("powershell", label ShellRegistry.PowerShell)
 
 // ---------------------------------------------------------------------
 // 2. Hotkey-to-shell mapping contract
@@ -65,12 +70,15 @@ let ``ShellId pattern match is exhaustive over Cmd and Claude`` () =
 //
 // Pins the map that `Program.fs setupShellSwitchKeybindings`
 // implements imperatively. The keys are documented as
-// `Key.D1` / `Key.D2` (number-row digits, NOT numpad) per the
-// AppReservedHotkeys table in `src/Views/TerminalView.cs`.
+// `Key.D1` / `Key.D2` / `Key.D3` (number-row digits, NOT numpad)
+// per the AppReservedHotkeys table in `src/Views/TerminalView.cs`.
+// PR-J reordered: cmd stays at +1; PowerShell takes +2 (the
+// diagnostic control shell sits next to cmd); claude moves to +3.
 
 let private hotkeyMapping : (string * ShellRegistry.ShellId) list =
     [ "Ctrl+Shift+1", ShellRegistry.Cmd
-      "Ctrl+Shift+2", ShellRegistry.Claude ]
+      "Ctrl+Shift+2", ShellRegistry.PowerShell
+      "Ctrl+Shift+3", ShellRegistry.Claude ]
 
 [<Fact>]
 let ``Ctrl+Shift+1 maps to Cmd shell`` () =
@@ -81,10 +89,18 @@ let ``Ctrl+Shift+1 maps to Cmd shell`` () =
     Assert.Equal(Some ShellRegistry.Cmd, target)
 
 [<Fact>]
-let ``Ctrl+Shift+2 maps to Claude shell`` () =
+let ``Ctrl+Shift+2 maps to PowerShell shell`` () =
     let target =
         hotkeyMapping
         |> List.tryFind (fun (g, _) -> g = "Ctrl+Shift+2")
+        |> Option.map snd
+    Assert.Equal(Some ShellRegistry.PowerShell, target)
+
+[<Fact>]
+let ``Ctrl+Shift+3 maps to Claude shell`` () =
+    let target =
+        hotkeyMapping
+        |> List.tryFind (fun (g, _) -> g = "Ctrl+Shift+3")
         |> Option.map snd
     Assert.Equal(Some ShellRegistry.Claude, target)
 
@@ -168,3 +184,12 @@ let ``Cmd DisplayName reads naturally as Command Prompt`` () =
 let ``Claude DisplayName reads naturally as Claude Code`` () =
     let claude = ShellRegistry.builtIns |> Map.find ShellRegistry.Claude
     Assert.Equal("Claude Code", claude.DisplayName)
+
+[<Fact>]
+let ``PowerShell DisplayName reads naturally as PowerShell`` () =
+    // Pinned because future "PowerShell Core" / "Windows
+    // PowerShell" naming churn could break NVDA's announce
+    // pronunciation; the bare "PowerShell" reads cleanly under
+    // the default eSpeak voice.
+    let ps = ShellRegistry.builtIns |> Map.find ShellRegistry.PowerShell
+    Assert.Equal("PowerShell", ps.DisplayName)


### PR DESCRIPTION
## Summary

Stage 7-followup. Three additions from the maintainer's NVDA validation pass on 2026-05-03 + the resulting "what's actually running?" debugging session:

1. **PowerShell as third built-in shell + reordered hotkeys.** PowerShell sits in slot 2 deliberately as the diagnostic control shell — always installed, no auth, fast prompt — so isolating shell-switch infrastructure bugs from claude-specific behaviour is one keystroke from cmd:
   - `Ctrl+Shift+1` → cmd (unchanged)
   - `Ctrl+Shift+2` → PowerShell (new; was claude in PR-C)
   - `Ctrl+Shift+3` → Claude (was Ctrl+Shift+2 in PR-C)

2. **`Ctrl+Shift+H` liveness probe + heartbeat alive flag.** Health-check announce now distinguishes "child running" from "child exited" via `Process.GetProcessById(pid)`; verdict gains "Child shell process N has exited." arm. The 5s background heartbeat gains the same `Alive=` log field so post-hoc grep pinpoints the wedge timestamp without needing the user to press Ctrl+Shift+H at the right moment.

3. **`Ctrl+Shift+D` inline shell-process snapshot.** Diagnostic launcher announces a one-line process enumeration BEFORE the cleanup-test window opens: "Diagnostic snapshot: 1 cmd, 0 powershell, 0 pwsh, 1 claude, 1 Terminal.App. Launching cleanup test." Lets a screen-reader user (or a Claude session triaging on their behalf) get the "what's currently running?" answer in one keystroke. The full close-and-recheck flow still launches afterwards. Maintainer's empirical guidance: "you should automatically check child processes when you launch diagnostics".

Plus CLAUDE.md gains a "Diagnostic recipes" section + a "no GUI dialog walks for screen-reader users" rule, with CLI equivalents for `setx`, `set`, `taskkill`, `tasklist`, `Get-Process`, `reg query`, etc.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest and passes (xUnit fixtures cover PowerShell parseEnvVar/builtIns/DU exhaustiveness/hotkey-mapping)
- [ ] Maintainer cuts a fresh preview build after merge
- [ ] Press `Ctrl+Shift+1` → cmd; NVDA reads "Switching to Command Prompt." → "Switched to Command Prompt."
- [ ] Press `Ctrl+Shift+2` → PowerShell; NVDA reads "Switching to PowerShell." → "Switched to PowerShell."; PowerShell banner + prompt audible
- [ ] Press `Ctrl+Shift+3` → claude; NVDA reads "Switching to Claude Code." → "Switched to Claude Code."
- [ ] After each switch, press `Ctrl+Shift+H`; NVDA announces the new shell name + PID + "alive"
- [ ] Press `Ctrl+Shift+D`; NVDA reads the inline shell-process snapshot before the cleanup-test window opens
- [ ] If a child shell crashes, `Ctrl+Shift+H` announces "Child shell process N has exited." within one keystroke

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_