### PR TITLE
fix(coalescer): PR-M — cross-row spinner gate + per-key static-row fix (Issue #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,77 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (PR-M, Issue #117)
+
+- **Coalescer cross-row spinner detection redesigned + per-key
+  static-row false-positive fixed.** The Stage 5 coalescer's
+  per-`(rowIdx, hash)` spinner gate uses a row-index-folded
+  hash, which means a spinner whose content moves between rows
+  (scrolling progress bar, Ink reconciler reflow) produces a
+  different `(rowIdx, hash)` key each frame and the gate sees
+  count=1 for each — never fires. The original Stage 5 design
+  included a generic "any-hash-anywhere" gate to catch this,
+  but its count-of-total-entries threshold was incompatible
+  with the per-row scan (every event added one entry per row,
+  so a 30-row screen instantly exceeded the 20-entry threshold
+  and silenced the channel permanently); it was removed in the
+  post-#114 fix.
+
+  Two bugs fixed:
+
+  1. **Cross-row gate restored**, redesigned per Issue #117.
+     New `HashHistory` dictionary tracks recurrences of the
+     CONTENT-only hash (no rowIdx fold) regardless of which
+     row it lands at. Within-frame dedup ensures a single
+     frame with N rows of identical content (e.g. blank
+     padding above a prompt) only contributes one Add per
+     frame, not N — the gate counts "this content appeared
+     in N FRAMES", not "N rows of one frame". Catches moving
+     spinners that the per-key gate misses; doesn't false-
+     positive on padded screens.
+
+  2. **Per-key static-row false-positive fixed.** The pre-PR-M
+     per-key gate `Add(now)`'d on every observation, so a
+     screen with N static rows added N entries per event. At
+     5+ events/sec (typing cadence), static-row keys
+     accumulated to threshold within ~5 events and tripped
+     suppression even when no spinner existed (the typing-
+     cadence false-positive flagged in the issue's
+     "Note on per-key gate interaction with static rows"
+     section).
+
+  Both gates now use **change-detection**: a per-row hash is
+  only `Add(now)`'d if the row's hash CHANGED since the
+  previous frame. Static rows contribute zero observations.
+  New `LastRowHashes: uint64[] voption` state field tracks
+  the comparison baseline; `onModeChanged` resets it to None
+  alongside the existing state reset (`PerRowHistory.Clear()`
+  + new `HashHistory.Clear()`).
+
+  Refactor: split `hashRow` into `hashRow` (row-index-folded;
+  used for frame-hash + per-key gate + change-detection key)
+  and `hashRowContent` (no fold; used for cross-row gate).
+  `hashRow` is now defined as `hashRowContent cells ^^^
+  (uint64 rowIdx * rowSwapMix)` so the existing semantics are
+  preserved bit-exactly; only the new code path uses the
+  unfolded form.
+
+  Pinned by 4 new `CoalescerTests` fixtures: cross-row gate
+  accumulates content-hash recurrence as spinner moves;
+  static rows do not trip per-key gate at fast typing
+  cadence; cross-row HashHistory ignores static blank rows;
+  ModeChanged resets LastRowHashes and HashHistory.
+
+  NVDA validation: maintainer runs the standard "type fast
+  in cmd" pass after merge; pre-PR-M behaviour was
+  intermittent typed-character silencing that was hard to
+  reproduce reliably; post-PR-M behaviour should be steady
+  speech for every keystroke. The new cross-row gate's
+  effects only show up under genuinely-spammy spinner-
+  shaped output (Claude Code progress indicators, Ink
+  reflows) where the user wants suppression; routine
+  typing + cmd output is unaffected.
+
 ### Documentation (Stage 7 wrap-up PR-L)
 
 - **`docs/DOC-MAP.md` (new).** Canonical "which doc owns what" index

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -38,19 +38,24 @@ open Microsoft.Extensions.Logging
 ///     Claude Ink's full-frame redraws — without this
 ///     layer, every row hash changes per redraw and
 ///     per-row dedup never fires).
-///   * **Spinner heuristic.** Sliding window keyed by
-///     `(rowIdx, hash)`. Suppresses repeated frames at high
-///     rate (e.g. spinners that overwrite the same row's
-///     content with cycling characters — `|/-\` etc.). The
-///     original Stage 5 design also included a generic
-///     "any-hash-anywhere" gate intended to catch cross-row
-///     spinners, but its count-of-total-entries threshold
-///     was fundamentally incompatible with the per-row scan
-///     (every event added one entry per row of the screen,
-///     and 30 rows instantly exceeded the 20-entry threshold,
-///     producing permanent silence). Removed in the post-#114
-///     fix; cross-row spinner detection is a future
-///     improvement tracked separately.
+///   * **Spinner heuristic — two gates.** Both gates use
+///     CHANGE-DETECTION (only count hash CHANGES at a row
+///     position, not observations) so a screen with N static
+///     rows doesn't trip suppression at high typing cadence.
+///     - **Per-`(rowIdx, hash)` gate.** Catches same-position
+///       cycling spinners (`|/-\`, `( *)`, etc.) — the same
+///       `(rowIdx, hash)` tuple recurs each cycle.
+///     - **Per-hash gate (any-hash-anywhere).** Catches moving
+///       spinners (scrolling progress bars, Ink reconciler
+///       reflows) where the same content lands at different
+///       rows each frame — the `(rowIdx, hash)` key is unique
+///       each frame so the per-key gate misses, but the bare
+///       hash recurs across rows. Issue #117 — the original
+///       Stage 5 design included this gate but its count-of-
+///       total-entries threshold was incompatible with the
+///       per-row scan; the redesigned gate counts unique-hash
+///       observations only on row-change.
+///     Either gate firing suppresses the whole frame.
 ///   * **Debounce.** Leading-edge + trailing-edge: first
 ///     event in an idle period (no flush in last 200ms)
 ///     emits immediately for fast single-event UX
@@ -94,9 +99,13 @@ module Coalescer =
     let private fnvPrime = 0x00000100000001B3UL
     let private rowSwapMix = 0x9E3779B97F4A7C15UL
 
-    /// FNV-1a 64-bit folded with the row index. See module
-    /// docstring §"Per-row hash".
-    let rec internal hashRow (rowIdx: int) (cells: Cell[]) : uint64 =
+    /// PR-M (Issue #117) — content-only FNV-1a 64-bit over the
+    /// cells, with NO row-index folding. Used by the cross-row
+    /// spinner gate, which needs to recognise the same content
+    /// landing at different rows across frames as the same hash.
+    /// `hashRow` (with row-index fold) is used everywhere else
+    /// for frame-hash computation + per-key spinner detection.
+    let rec internal hashRowContent (cells: Cell[]) : uint64 =
         let mutable h = fnvOffsetBasis
         for cell in cells do
             // Cell.Ch is a Rune (int code point).
@@ -115,7 +124,12 @@ module Coalescer =
             // h <- h * fnvPrime
             h <- h ^^^ hashAttrs cell.Attrs
             h <- h * fnvPrime
-        h ^^^ (uint64 rowIdx * rowSwapMix)
+        h
+
+    /// FNV-1a 64-bit folded with the row index. See module
+    /// docstring §"Per-row hash".
+    and internal hashRow (rowIdx: int) (cells: Cell[]) : uint64 =
+        hashRowContent cells ^^^ (uint64 rowIdx * rowSwapMix)
 
     /// Flatten SgrAttrs into a uint64 fingerprint. Stable
     /// across Cell instances with identical attrs.
@@ -206,45 +220,145 @@ module Coalescer =
           mutable LastFlushAt: DateTimeOffset voption
           mutable PendingFrame: Cell[][] voption
           mutable PendingHash: uint64 voption
-          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>> }
+          /// PR-M (Issue #117) — per-row hashes from the previous
+          /// frame, indexed by row. Feeds change-detection so the
+          /// two spinner gates only count hash CHANGES at a row
+          /// position, not observations. Without this, a screen
+          /// with N static rows added N entries per event to the
+          /// per-row history; at 5+ events/sec the static-row keys
+          /// tripped suppression even when no spinner existed.
+          /// `ValueNone` on first frame; `ValueSome` thereafter.
+          mutable LastRowHashes: uint64[] voption
+          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
+          /// PR-M (Issue #117) — per-hash recurrence history
+          /// independent of `rowIdx`. Catches CROSS-ROW spinners
+          /// that the per-`(rowIdx, hash)` gate misses: a moving
+          /// progress indicator scrolling vertically lands the
+          /// same content at a different row each frame, so each
+          /// `(rowIdx, hash)` key sees count = 1 and the per-key
+          /// gate never fires. The any-hash-anywhere gate sees
+          /// the recurring hash across rows and fires after
+          /// `spinnerThreshold` recurrences within `spinnerWindow`.
+          /// Like the per-key gate, only counts CHANGES (a row
+          /// transitioning TO this hash), so static content
+          /// doesn't accumulate.
+          HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
 
     let internal createState () : State =
         { LastFrameHash = ValueNone
           LastFlushAt = ValueNone
           PendingFrame = ValueNone
           PendingHash = ValueNone
-          PerRowHistory = Dictionary() }
+          LastRowHashes = ValueNone
+          PerRowHistory = Dictionary()
+          HashHistory = Dictionary() }
 
-    /// Trim history older than `spinnerWindow`. Mutates in
-    /// place. Called on every event arrival to keep histories
-    /// bounded.
+    /// Trim history older than `spinnerWindow` from BOTH
+    /// dictionaries. Mutates in place. Called on every event
+    /// arrival to keep histories bounded.
     let private gcHistory (state: State) (now: DateTimeOffset) =
         let cutoff = now - spinnerWindow
-        let staleKeys = ResizeArray()
+        let stalePerRow = ResizeArray()
         for kvp in state.PerRowHistory do
             kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
-            if kvp.Value.Count = 0 then staleKeys.Add(kvp.Key)
-        for k in staleKeys do
+            if kvp.Value.Count = 0 then stalePerRow.Add(kvp.Key)
+        for k in stalePerRow do
             state.PerRowHistory.Remove(k) |> ignore
+        let staleHash = ResizeArray()
+        for kvp in state.HashHistory do
+            kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
+            if kvp.Value.Count = 0 then staleHash.Add(kvp.Key)
+        for k in staleHash do
+            state.HashHistory.Remove(k) |> ignore
 
-    /// Test whether this frame should be suppressed by the
-    /// spinner heuristic. Records the timestamps even on
-    /// suppress so a long-running spinner stays suppressed.
+    /// PR-M (Issue #117) — walk all per-row hashes for the
+    /// current frame and decide whether either spinner gate
+    /// should suppress.
+    ///
+    /// **Change-detection.** For each row, only `Add(now)` an
+    /// observation to the gates if that row's hash CHANGED since
+    /// the previous frame. A static row contributes nothing to
+    /// either gate; a row that flips from blank to content
+    /// contributes once per transition. This protects high-
+    /// cadence typing scenarios (where many rows are static and
+    /// only the prompt-row changes per event) from tripping the
+    /// per-key gate via static-row recurrence.
+    ///
+    /// **Per-key gate** (existing): suppresses if the
+    /// `(rowIdx, hash)` tuple recurred ≥ `spinnerThreshold` times
+    /// in `spinnerWindow`. Catches same-position cycling
+    /// spinners (`|/-\`, `( *)( *)`).
+    ///
+    /// **Cross-row gate** (new): suppresses if any single hash
+    /// recurred ≥ `spinnerThreshold` times in `spinnerWindow`
+    /// REGARDLESS of which row it landed at. Catches moving
+    /// spinners (scrolling progress bars, Ink reconciler
+    /// reflows where the spinner content lands at different
+    /// rows each frame).
+    ///
+    /// Returns true if either gate fires. Caller is responsible
+    /// for updating `state.LastRowHashes` after this call so the
+    /// next frame's change-detection has the correct comparison
+    /// baseline.
     let private isSpinnerSuppressed
             (state: State)
             (now: DateTimeOffset)
-            (rowIdx: int)
-            (rowHash: uint64) : bool =
-        let key = (rowIdx, rowHash)
-        let history =
-            match state.PerRowHistory.TryGetValue key with
-            | true, h -> h
-            | false, _ ->
-                let h = ResizeArray()
-                state.PerRowHistory.[key] <- h
-                h
-        history.Add(now)
-        history.Count >= spinnerThreshold
+            (rowHashes: uint64[])
+            (contentHashes: uint64[]) : bool =
+        let mutable suppress = false
+        // PR-M: within-frame dedup for the cross-row gate. A
+        // screen with N rows of identical content (e.g. blank
+        // padding above the prompt) would otherwise contribute
+        // N Adds to HashHistory[content-hash] in a single frame,
+        // and a screen with ≥5 blank padding rows would trip
+        // the gate on the seed frame. The intent of the gate is
+        // "this content appeared in N FRAMES" (not "N rows of
+        // one frame"), so collapse within-frame duplicates.
+        let crossSeenThisFrame = HashSet<uint64>()
+        for i in 0 .. rowHashes.Length - 1 do
+            let rh = rowHashes.[i]
+            let changed =
+                match state.LastRowHashes with
+                | ValueNone -> true
+                | ValueSome arr when i >= arr.Length -> true
+                | ValueSome arr -> arr.[i] <> rh
+            if changed then
+                // Per-`(rowIdx, hash)` gate: uses the row-index-
+                // folded hash so the same content at different
+                // rows produces different keys. Catches cycling
+                // spinners that overwrite the same cell. No
+                // within-frame dedup needed: each (rowIdx, hash)
+                // tuple is naturally unique within a frame
+                // because rowIdx is unique.
+                let key = (i, rh)
+                let perRowHist =
+                    match state.PerRowHistory.TryGetValue key with
+                    | true, x -> x
+                    | false, _ ->
+                        let x = ResizeArray()
+                        state.PerRowHistory.[key] <- x
+                        x
+                perRowHist.Add(now)
+                if perRowHist.Count >= spinnerThreshold then
+                    suppress <- true
+                // Cross-row gate (within-frame deduped): uses
+                // the CONTENT-only hash so the same content
+                // moving between rows still maps to the same
+                // key. Catches scrolling progress bars and Ink
+                // reflows.
+                let ch = contentHashes.[i]
+                if crossSeenThisFrame.Add(ch) then
+                    let crossHist =
+                        match state.HashHistory.TryGetValue ch with
+                        | true, x -> x
+                        | false, _ ->
+                            let x = ResizeArray()
+                            state.HashHistory.[ch] <- x
+                            x
+                    crossHist.Add(now)
+                    if crossHist.Count >= spinnerThreshold then
+                        suppress <- true
+        suppress
 
     /// Decide what (if anything) to emit for an incoming
     /// `RowsChanged []` notification. Reads the current
@@ -270,7 +384,21 @@ module Coalescer =
         // produced enough log I/O at typing speed to lag the WPF
         // dispatcher visibly; demoted to Debug here.
         let logger = Logger.get "Terminal.Core.Coalescer.processRowsChanged"
-        let frameHash = hashFrame snapshot
+        // PR-M (Issue #117): compute per-row hashes ONCE and reuse
+        // for both frame-hash and spinner-gate checks. The
+        // pre-PR-M code walked snapshot twice (hashFrame + the
+        // suppress loop); the precompute is cheaper, and the
+        // change-detection logic in `isSpinnerSuppressed` needs
+        // the full array anyway.
+        let rowHashes =
+            Array.init snapshot.Length (fun i -> hashRow i snapshot.[i])
+        // PR-M: content-only hashes for the cross-row gate.
+        let contentHashes =
+            Array.init snapshot.Length (fun i -> hashRowContent snapshot.[i])
+        let frameHash =
+            let mutable h = 0UL
+            for rh in rowHashes do h <- h ^^^ rh
+            h
         // Frame-level dedup: identical content → suppress
         // entirely. This is the layer that composes with
         // Ink's full-frame redraws.
@@ -281,14 +409,18 @@ module Coalescer =
             []
         | _ ->
             gcHistory state now
-            // Spinner check: walk per-row hashes; if ANY row
-            // is in spinner-suppress and this is a fast
-            // repeat, suppress the whole frame.
-            let mutable suppress = false
-            for i in 0 .. snapshot.Length - 1 do
-                let rh = hashRow i snapshot.[i]
-                if isSpinnerSuppressed state now i rh then
-                    suppress <- true
+            // PR-M: spinner check now considers BOTH per-key
+            // (cycling-character spinners) AND cross-row (moving
+            // spinners) gates. Either gate firing suppresses the
+            // whole frame.
+            let suppress =
+                isSpinnerSuppressed state now rowHashes contentHashes
+            // PR-M: update LastRowHashes AFTER the suppress check
+            // (which read the previous values for change-detection)
+            // and BEFORE the early return so the next frame's
+            // change-detection has the correct baseline regardless
+            // of whether we emit.
+            state.LastRowHashes <- ValueSome rowHashes
             if suppress then
                 // Update LastFrameHash so we don't re-suppress
                 // when content actually changes again.
@@ -372,10 +504,16 @@ module Coalescer =
                 [ OutputBatch (renderRows snapshot) ]
             | ValueNone -> []
         // Reset coalescer state — the buffer just changed
-        // wholesale (alt-screen swap, etc.).
+        // wholesale (alt-screen swap, etc.). PR-M: also reset
+        // LastRowHashes (so post-mode-change first frame treats
+        // every row as changed and re-engages the gates) and
+        // HashHistory (the cross-row gate's accumulated counts
+        // are about a different screen).
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueSome now
+        state.LastRowHashes <- ValueNone
         state.PerRowHistory.Clear()
+        state.HashHistory.Clear()
         flushed @ [ ModeBarrier (flag, value) ]
 
     /// Pass-through for parser errors. No coalescing — errors

--- a/tests/Tests.Unit/CoalescerTests.fs
+++ b/tests/Tests.Unit/CoalescerTests.fs
@@ -195,6 +195,173 @@ let ``per-key spinner gate fires after threshold same-row-hash hits in window`` 
             suppressedCount emittedCount)
 
 [<Fact>]
+let ``cross-row gate accumulates content-hash recurrence as spinner moves between rows (PR-M, Issue #117)`` () =
+    // PR-M added the cross-row spinner gate. The pre-PR-M
+    // per-key gate uses a row-index-folded hash, so a spinner
+    // whose content moves between rows produces a different
+    // (rowIdx, hash) key each frame and the per-key gate sees
+    // count = 1 for each — never fires. The cross-row gate
+    // tracks recurrences of the CONTENT hash regardless of
+    // rowIdx, so a moving spinner accumulates count under one
+    // key and trips the threshold.
+    //
+    // This test asserts the gate's STATE directly (rather than
+    // observing emit-vs-suppress behaviour, which the debounce
+    // window would conflate with). Repro: BAR moves between
+    // rows 0..4 across 6 frames within the 1s spinner window;
+    // at the end, HashHistory[content-hash-of-BAR-row] should
+    // hold at least `spinnerThreshold` timestamps.
+    let state = Coalescer.createState ()
+    let cols = 10
+    let buildFrame (frameNum: int) (barRow: int) : Cell[][] =
+        let arr = Array.init 5 (fun i ->
+            if i = barRow then rowOf cols "BAR"
+            else rowOf cols (sprintf "PAD%d-%d" i frameNum))
+        arr
+    // Frame 0 is the seed (LastRowHashes = None initially;
+    // every row is "changed" relative to nothing).
+    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame 0 0)
+    // 5 more frames moving BAR through rows 1..4 and back to
+    // row 0, each with unique padding so the frame hash differs.
+    // Each frame's BAR row produces the SAME content hash
+    // (hashRowContent for "BAR" + cols-3 blanks).
+    let times = [| 100; 200; 300; 400; 500; 600 |]
+    let bars =  [|   1;   2;   3;   4;   0;   1 |]
+    for i in 0 .. times.Length - 1 do
+        let frame = buildFrame (i + 1) bars.[i]
+        let _ = Coalescer.processRowsChanged state (at times.[i]) frame
+        ()
+    // BAR's content hash should have accumulated 7 entries (the
+    // seed frame + 6 loop frames, all within the 1s spinnerWindow).
+    let barHash = Coalescer.hashRowContent (rowOf cols "BAR")
+    let barCount =
+        match state.HashHistory.TryGetValue barHash with
+        | true, h -> h.Count
+        | false, _ -> 0
+    Assert.True(barCount >= 5,
+        sprintf "Expected cross-row HashHistory[BAR] to have ≥%d entries; got %d"
+            5 barCount)
+    // Pre-PR-M behaviour check: the per-key gate's history would
+    // have a separate (i, hashRow_i_BAR) entry for each row BAR
+    // visited — count = 1 for each, never tripping the gate.
+    // Post-PR-M the per-key gate is unchanged for this scenario.
+    let perKeyBarKeys =
+        state.PerRowHistory.Keys
+        |> Seq.filter (fun (_, h) ->
+            // h is row-index-folded; BAR landed at 6 distinct rows
+            // (0, 1, 2, 3, 4, 0, 1) producing 5 unique
+            // (rowIdx, hashRow rowIdx BAR) keys.
+            true)
+        |> Seq.length
+    // Cross-row gate is the new contract; per-key would never
+    // fire here. Just sanity-check we have the per-key entries
+    // we expect.
+    Assert.True(perKeyBarKeys >= 5,
+        sprintf "Sanity: expected per-key gate to have entries from BAR at multiple rows; got %d"
+            perKeyBarKeys)
+
+[<Fact>]
+let ``static rows do not trip per-key gate at fast typing cadence (PR-M, Issue #117)`` () =
+    // PR-M added change-detection: the spinner gates only count
+    // hash CHANGES at a row position, not observations. Without
+    // it, a 30-row screen with 29 static rows added 29 entries
+    // per event to the per-row history; at 5+ events/sec the
+    // static rows trip the per-key threshold and false-positive
+    // suppress (the typing-cadence false-positive noted in the
+    // issue's "Note on per-key gate interaction with static
+    // rows" section).
+    //
+    // Repro: 30-row screen, only row 0 changes per event,
+    // 7 events at ~50ms intervals (well within spinnerWindow).
+    // The seed frame populates one entry per row (since
+    // LastRowHashes = None initially treats every row as
+    // changed); subsequent frames must NOT grow the static-row
+    // counts past 1.
+    let state = Coalescer.createState ()
+    let cols = 5
+    let buildFrame (typed: string) : Cell[][] =
+        let arr = Array.init 30 (fun _ -> blankRow cols)
+        arr.[0] <- rowOf cols typed
+        arr
+    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame "a")
+    // Pump 6 more frames at 50ms intervals; only row 0 changes
+    // each frame.
+    let typeSeq = [ "ab"; "abc"; "abcd"; "abcde"; "abcdef"; "abcdefg" ]
+    for i in 0 .. typeSeq.Length - 1 do
+        let _ = Coalescer.processRowsChanged state (at ((i + 1) * 50)) (buildFrame typeSeq.[i])
+        ()
+    // Static-row history counts should remain at 1 (only the
+    // seed frame contributed; no subsequent frame changed those
+    // rows). Pre-PR-M: each typing event would have added 30
+    // entries, so by event 5 the static-row keys would be at
+    // count 5 and the per-key gate would suppress.
+    let staticRowMaxCount =
+        state.PerRowHistory.Keys
+        |> Seq.filter (fun (rowIdx, _) -> rowIdx > 0)
+        |> Seq.map (fun key -> state.PerRowHistory.[key].Count)
+        |> Seq.fold max 0
+    Assert.True(staticRowMaxCount <= 1,
+        sprintf "Static-row entries should not grow past the seed frame's contribution; max count was %d"
+            staticRowMaxCount)
+    // Sanity: row 0 IS in the history with multiple entries
+    // (each typed string produced a unique hashRow for row 0).
+    let row0EntryCount =
+        state.PerRowHistory.Keys
+        |> Seq.filter (fun (rowIdx, _) -> rowIdx = 0)
+        |> Seq.length
+    Assert.True(row0EntryCount >= 5,
+        sprintf "Expected row 0 to accumulate multiple distinct hashes from typing; got %d" row0EntryCount)
+
+[<Fact>]
+let ``cross-row HashHistory ignores static blank rows (PR-M, Issue #117)`` () =
+    // Companion to the per-key static-row test. Without change
+    // detection, the cross-row HashHistory[blank-content-hash]
+    // would accumulate 29 entries per frame (one per static
+    // blank row) and trip the gate within 1 frame. With change
+    // detection, blank-rows-that-stay-blank contribute nothing.
+    let state = Coalescer.createState ()
+    let cols = 5
+    let buildFrame (typed: string) : Cell[][] =
+        let arr = Array.init 30 (fun _ -> blankRow cols)
+        arr.[0] <- rowOf cols typed
+        arr
+    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame "a")
+    for i in 0 .. 5 do
+        let _ = Coalescer.processRowsChanged state (at ((i + 1) * 50)) (buildFrame (sprintf "x%d" i))
+        ()
+    // The blank-content hash should have at most 1 entry (the
+    // initial seed frame, where every row was "changed"
+    // relative to None). Subsequent frames don't change the
+    // blank rows so they contribute nothing.
+    let blankHash = Coalescer.hashRowContent (blankRow cols)
+    let blankCount =
+        match state.HashHistory.TryGetValue blankHash with
+        | true, h -> h.Count
+        | false, _ -> 0
+    Assert.True(blankCount <= 1,
+        sprintf "Expected blank-content hash to have ≤1 entry post-seed; got %d" blankCount)
+
+[<Fact>]
+let ``ModeChanged resets LastRowHashes and HashHistory (PR-M, Issue #117)`` () =
+    // PR-M added LastRowHashes + HashHistory state. onModeChanged
+    // must reset both — otherwise post-mode-change the cross-row
+    // gate could carry forward stale recurrence counts from the
+    // previous buffer, and the change-detection's "changed?"
+    // check could falsely return false against pre-mode hashes.
+    let state = Coalescer.createState ()
+    let snap = snapshotOf 1 5 [ "hello" ]
+    let _ = Coalescer.processRowsChanged state (at 0) snap
+    Assert.True(state.LastRowHashes.IsSome,
+        "LastRowHashes should be populated after first frame")
+    Assert.True(state.HashHistory.Count > 0,
+        "HashHistory should be populated after first frame")
+    let _ = Coalescer.onModeChanged state (at 100) AltScreen true
+    Assert.True(state.LastRowHashes.IsNone,
+        "LastRowHashes should be reset to None after mode change")
+    Assert.Equal(0, state.HashHistory.Count)
+    Assert.Equal(0, state.PerRowHistory.Count)
+
+[<Fact>]
 let ``spinner per-key history is GC'd after spinnerWindow elapses`` () =
     // Once spinnerWindow of quiet has passed, the per-key
     // history is trimmed by gcHistory and a new frame can


### PR DESCRIPTION
## Summary

Closes #117. Two related coalescer bugs in the spinner-suppression heuristic:

1. **Cross-row spinner detection was missing.** The per-`(rowIdx, hash)` gate uses a row-index-folded hash, so a spinner whose content moves between rows produces a different `(rowIdx, hash)` key each frame and the gate never fires. The original Stage 5 design included an "any-hash-anywhere" gate to catch this, but its count-of-total-entries threshold was incompatible with the per-row scan and was removed in the post-#114 fix.

2. **Per-key static-row false-positive.** The pre-PR-M per-key gate `Add(now)`'d on every observation, so a 30-row screen added 30 entries per event. At 5+ events/sec (typing cadence), static-row keys accumulated to threshold and tripped suppression even when no spinner existed.

**Fix:**
- Both gates now use **change-detection** — only `Add(now)` if the row's hash actually CHANGED since the previous frame. New `LastRowHashes: uint64[] voption` state field tracks the baseline.
- **Cross-row gate restored** with a new `HashHistory` dictionary keyed on the CONTENT-only hash (no rowIdx fold). Within-frame dedup so a screen with N blank padding rows contributes one Add per frame, not N.
- **Refactor:** `hashRow` split into `hashRowContent` (no fold) + `hashRow` (folded). Bit-exact equivalence preserved for the existing folded form; only the new code path uses the unfolded version.
- `onModeChanged` resets the new state alongside the existing `PerRowHistory.Clear()`.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest and the 4 new fixtures pass:
  - `cross-row gate accumulates content-hash recurrence as spinner moves between rows (PR-M, Issue #117)`
  - `static rows do not trip per-key gate at fast typing cadence (PR-M, Issue #117)`
  - `cross-row HashHistory ignores static blank rows (PR-M, Issue #117)`
  - `ModeChanged resets LastRowHashes and HashHistory (PR-M, Issue #117)`
- [ ] All existing CoalescerTests still pass (the alternating A/B per-key spinner test relies on each frame changing row 0's hash, which change-detection still counts at the same rate — pre-existing behaviour preserved)
- [ ] Maintainer runs a fresh preview build and does a "type fast in cmd, watch for typed-character silencing" pass after merge. Pre-PR-M behaviour was intermittent silencing under fast typing; post-PR-M should be steady speech for every keystroke.
- [ ] If a Claude Code session is available with a moving spinner, confirm the cross-row gate actually engages (verbose readback from progress indicators should drop after ~1 second of recurrence).

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_