### PR TITLE
test(views): PR-P — pin WPF adapter round-trip through KeyEncoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,65 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Pre-framework-cycle PR-P)
+
+- **WPF adapter round-trip pinned by unit-test fixtures.** The
+  C# adapter `TerminalView.TranslateKey` (WPF `Key` →
+  `KeyCode`) plus its companion `TranslateModifiers` had no
+  test coverage; a silent regression in either (e.g. a
+  cursor-key case dropped during a refactor) would NOT have
+  been caught by any existing test and would silently break
+  the future Input framework cycle's echo-correlation logic
+  (which depends on the WPF Key → encoded-bytes round-trip
+  being precise per `docs/STAGE-7-ISSUES.md` `[input-buffer]`
+  scope).
+
+  Pre-framework-cycle PR-P closes the test gap:
+
+  - **`TerminalView.TranslateKey` + `TerminalView.TranslateModifiers`
+    bumped from `private` to `internal`** so unit tests can
+    call them directly. `<InternalsVisibleTo
+    Include="PtySpeak.Tests.Unit" />` added to
+    `src/Views/Views.csproj` (modern SDK-style replacement
+    for an `AssemblyInfo.cs` attribute). Tests.Unit gains a
+    `ProjectReference` to PtySpeak.Views; the existing
+    `<UseWPF>true</UseWPF>` declaration on Tests.Unit
+    (originally added for Terminal.Accessibility's
+    word-boundary tests) covers the WPF reference set.
+  - **15 new fixtures in `tests/Tests.Unit/KeyEncodingTests.fs`**
+    (under "Pre-framework-cycle PR-P — WPF adapter
+    round-trip fixtures") cover the full WPF `Key` set
+    `TranslateKey` claims to handle:
+    * Round-trip pins: cursor keys (Up/Down/Left/Right),
+      editing keypad (Delete/Home/End/PageUp/PageDown/Insert),
+      whitespace + control (Tab/Enter/Escape/Back), function
+      keys F1-F12, all letters A-Z, all digits D0-D9, all
+      numpad digits NumPad0-NumPad9, Space. Each fixture
+      verifies `TranslateKey` produces a non-`Unhandled`
+      `KeyCode` and `KeyEncoding.encodeOrNull` produces a
+      non-empty byte sequence.
+    * KeyCode-output pins: specific `Key.X →
+      KeyCode.Y` mappings for cursor keys, editing keypad,
+      whitespace, function keys, letter / digit / numpad
+      `Char` cases (including the lowercase-folding
+      contract), and `KeyCode.Unhandled` for representative
+      OEM keys.
+    * `TranslateModifiers` pins: WPF flag → `KeyModifiers`
+      flag mappings for Ctrl / Shift / Alt and combinations,
+      plus the Windows-key silent-drop contract (Win+letter
+      is OS-shell territory; pty-speak doesn't forward it).
+  - The fixtures invoke the static `TranslateKey` /
+    `TranslateModifiers` methods directly. No WPF
+    dispatcher is required (both are pure static functions);
+    the test runs at the same speed as the existing
+    F#-side `KeyEncoding.encode` fixtures.
+
+  Net change: ~5 lines of `private` → `internal` + docstring
+  updates in `TerminalView.cs`; ~10 lines of `<InternalsVisibleTo>`
+  + `ProjectReference` config in the two .csproj/.fsproj files;
+  ~190 lines of new test fixtures + helper. Zero behavioural
+  change to production code; CI gates the round-trip pinning.
+
 ### Changed (Pre-framework-cycle PR-O)
 
 - **Hotkey handling unified through `HotkeyRegistry`.** The

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -840,7 +840,15 @@ public class TerminalView : FrameworkElement
     /// dropped — pty-speak doesn't forward it; Win+letter is OS-shell
     /// territory.
     /// </summary>
-    private static KeyModifiers TranslateModifiers(ModifierKeys m)
+    /// <remarks>
+    /// Pre-framework-cycle PR-P bumped this from <c>private</c> to
+    /// <c>internal</c> so
+    /// <c>tests/Tests.Unit/KeyEncodingTests.fs</c> can pin the WPF
+    /// adapter directly without a live dispatcher. The Input
+    /// framework cycle's echo-correlation logic depends on this
+    /// translation being precise.
+    /// </remarks>
+    internal static KeyModifiers TranslateModifiers(ModifierKeys m)
     {
         var result = KeyModifiers.None;
         if ((m & ModifierKeys.Shift) != 0) result |= KeyModifiers.Shift;
@@ -856,7 +864,19 @@ public class TerminalView : FrameworkElement
     /// the keystroke is dropped silently rather than crashing.
     /// New WPF Key values can ship without breaking us.
     /// </summary>
-    private static KeyCode TranslateKey(Key key)
+    /// <remarks>
+    /// Pre-framework-cycle PR-P bumped this from <c>private</c> to
+    /// <c>internal</c> so
+    /// <c>tests/Tests.Unit/KeyEncodingTests.fs</c> can pin the WPF
+    /// adapter directly without a live dispatcher. The Input
+    /// framework cycle's echo-correlation logic depends on the
+    /// WPF Key → <see cref="KeyCode"/> → encoded-bytes round-trip
+    /// being precise; a silent regression in this map would
+    /// silently break echo dedup. See the
+    /// "WPF adapter round-trip fixtures" section of that file
+    /// for the parametric coverage.
+    /// </remarks>
+    internal static KeyCode TranslateKey(Key key)
     {
         // Cursor keys.
         if (key == Key.Up) return KeyCode.Up;

--- a/src/Views/Views.csproj
+++ b/src/Views/Views.csproj
@@ -18,4 +18,17 @@
     <ProjectReference Include="..\Terminal.Accessibility\Terminal.Accessibility.fsproj" />
   </ItemGroup>
 
+  <!--
+    Pre-framework-cycle PR-P — exposes the `internal` static
+    `TranslateKey` and `TranslateModifiers` adapters in
+    `TerminalView.cs` to `tests/Tests.Unit/KeyEncodingTests.fs` so
+    the WPF Key → KeyCode → encoded-bytes round-trip is pinned by
+    fixtures without needing a live WPF dispatcher. See
+    `tests/Tests.Unit/KeyEncodingTests.fs` "WPF adapter round-trip
+    fixtures" section.
+  -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="PtySpeak.Tests.Unit" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Tests.Unit/KeyEncodingTests.fs
+++ b/tests/Tests.Unit/KeyEncodingTests.fs
@@ -314,3 +314,190 @@ let ``encodeOrNull returns bytes for handled keys`` () =
 let ``encodeOrNull returns null for Unhandled`` () =
     let result = KeyEncoding.encodeOrNull KeyCode.Unhandled KeyModifiers.None (modesNoneSet ())
     Assert.Null(result)
+
+// ---------------------------------------------------------------------
+// Pre-framework-cycle PR-P — WPF adapter round-trip fixtures
+// ---------------------------------------------------------------------
+//
+// `TerminalView.TranslateKey` (C#, in `src/Views/TerminalView.cs`)
+// adapts `System.Windows.Input.Key` to `KeyCode`; PR-P bumped it
+// (and `TranslateModifiers`) from `private` to `internal` and
+// added `<InternalsVisibleTo Include="PtySpeak.Tests.Unit" />` to
+// `src/Views/Views.csproj` so these fixtures can pin the adapter
+// directly without spinning up a WPF dispatcher.
+//
+// Why pin: the Input framework cycle's echo-correlation logic
+// depends on the WPF Key → KeyCode → encoded-bytes round-trip
+// being precise. A silent regression in the adapter (e.g. a case
+// dropped during refactor) would silently break echo dedup and
+// would NOT be caught by any existing test. These fixtures catch
+// the silent regression at unit-test level before it reaches NVDA
+// validation.
+//
+// Coverage strategy: parametric over the WPF `Key` set
+// `TranslateKey` claims to handle. Each case asserts both
+// (1) `TranslateKey` produces the expected `KeyCode`, and
+// (2) the resulting `KeyCode` encodes to non-empty bytes via
+// `encodeOrNull` (i.e. the encoder accepts the translation).
+
+open System.Windows.Input
+open PtySpeak.Views
+
+/// Helper: translate a WPF `Key`, then encode through the
+/// production path, asserting non-empty bytes. The WPF dispatcher
+/// is NOT required because `TranslateKey` and `encode` are both
+/// pure static functions.
+let private assertWpfKeyEncodes (wpfKey: Key) =
+    let kc = TerminalView.TranslateKey wpfKey
+    let bytes = KeyEncoding.encodeOrNull kc KeyModifiers.None (modesNoneSet ())
+    Assert.NotNull(bytes)
+    // Encoded bytes for any handled key are at least one byte
+    // (cursor keys = 3 bytes ESC [ X; F-keys = 3-5 bytes;
+    // letters = 1 byte; etc.).
+    Assert.True(
+        (nonNull bytes).Length > 0,
+        sprintf "Expected non-empty encoding for WPF Key.%A; got 0 bytes" wpfKey)
+
+[<Fact>]
+let ``TranslateKey: cursor keys round-trip through encode`` () =
+    assertWpfKeyEncodes Key.Up
+    assertWpfKeyEncodes Key.Down
+    assertWpfKeyEncodes Key.Left
+    assertWpfKeyEncodes Key.Right
+
+[<Fact>]
+let ``TranslateKey: editing-keypad keys round-trip through encode`` () =
+    assertWpfKeyEncodes Key.Delete
+    assertWpfKeyEncodes Key.Home
+    assertWpfKeyEncodes Key.End
+    assertWpfKeyEncodes Key.PageUp
+    assertWpfKeyEncodes Key.PageDown
+    // Note: Key.Insert is filtered upstream as a screen-reader
+    // candidate so the production OnPreviewKeyDown filter never
+    // calls TranslateKey for it. The adapter still maps Insert
+    // for completeness if the upstream filter is ever loosened;
+    // pin the adapter mapping here.
+    assertWpfKeyEncodes Key.Insert
+
+[<Fact>]
+let ``TranslateKey: whitespace + control keys round-trip through encode`` () =
+    assertWpfKeyEncodes Key.Tab
+    assertWpfKeyEncodes Key.Enter
+    assertWpfKeyEncodes Key.Escape
+    assertWpfKeyEncodes Key.Back
+
+[<Fact>]
+let ``TranslateKey: function keys F1-F12 round-trip through encode`` () =
+    assertWpfKeyEncodes Key.F1
+    assertWpfKeyEncodes Key.F2
+    assertWpfKeyEncodes Key.F3
+    assertWpfKeyEncodes Key.F4
+    assertWpfKeyEncodes Key.F5
+    assertWpfKeyEncodes Key.F6
+    assertWpfKeyEncodes Key.F7
+    assertWpfKeyEncodes Key.F8
+    assertWpfKeyEncodes Key.F9
+    assertWpfKeyEncodes Key.F10
+    assertWpfKeyEncodes Key.F11
+    assertWpfKeyEncodes Key.F12
+
+[<Fact>]
+let ``TranslateKey: letters A-Z round-trip through encode`` () =
+    let allLetters =
+        [ Key.A; Key.B; Key.C; Key.D; Key.E; Key.F; Key.G; Key.H
+          Key.I; Key.J; Key.K; Key.L; Key.M; Key.N; Key.O; Key.P
+          Key.Q; Key.R; Key.S; Key.T; Key.U; Key.V; Key.W; Key.X
+          Key.Y; Key.Z ]
+    for k in allLetters do
+        assertWpfKeyEncodes k
+
+[<Fact>]
+let ``TranslateKey: digits D0-D9 round-trip through encode`` () =
+    let allDigits =
+        [ Key.D0; Key.D1; Key.D2; Key.D3; Key.D4
+          Key.D5; Key.D6; Key.D7; Key.D8; Key.D9 ]
+    for k in allDigits do
+        assertWpfKeyEncodes k
+
+[<Fact>]
+let ``TranslateKey: numpad digits NumPad0-NumPad9 round-trip through encode`` () =
+    let allNumPad =
+        [ Key.NumPad0; Key.NumPad1; Key.NumPad2; Key.NumPad3; Key.NumPad4
+          Key.NumPad5; Key.NumPad6; Key.NumPad7; Key.NumPad8; Key.NumPad9 ]
+    for k in allNumPad do
+        assertWpfKeyEncodes k
+
+[<Fact>]
+let ``TranslateKey: Space round-trips through encode`` () =
+    assertWpfKeyEncodes Key.Space
+
+[<Fact>]
+let ``TranslateKey: cursor keys produce the expected KeyCode`` () =
+    Assert.Equal(KeyCode.Up, TerminalView.TranslateKey Key.Up)
+    Assert.Equal(KeyCode.Down, TerminalView.TranslateKey Key.Down)
+    Assert.Equal(KeyCode.Left, TerminalView.TranslateKey Key.Left)
+    Assert.Equal(KeyCode.Right, TerminalView.TranslateKey Key.Right)
+
+[<Fact>]
+let ``TranslateKey: editing-keypad produces the expected KeyCode`` () =
+    Assert.Equal(KeyCode.Delete, TerminalView.TranslateKey Key.Delete)
+    Assert.Equal(KeyCode.Home, TerminalView.TranslateKey Key.Home)
+    Assert.Equal(KeyCode.End, TerminalView.TranslateKey Key.End)
+    Assert.Equal(KeyCode.PageUp, TerminalView.TranslateKey Key.PageUp)
+    Assert.Equal(KeyCode.PageDown, TerminalView.TranslateKey Key.PageDown)
+    Assert.Equal(KeyCode.Insert, TerminalView.TranslateKey Key.Insert)
+
+[<Fact>]
+let ``TranslateKey: whitespace + control produce the expected KeyCode`` () =
+    Assert.Equal(KeyCode.Tab, TerminalView.TranslateKey Key.Tab)
+    Assert.Equal(KeyCode.Enter, TerminalView.TranslateKey Key.Enter)
+    Assert.Equal(KeyCode.Escape, TerminalView.TranslateKey Key.Escape)
+    Assert.Equal(KeyCode.Backspace, TerminalView.TranslateKey Key.Back)
+
+[<Fact>]
+let ``TranslateKey: function keys produce the expected KeyCode`` () =
+    Assert.Equal(KeyCode.F1, TerminalView.TranslateKey Key.F1)
+    Assert.Equal(KeyCode.F12, TerminalView.TranslateKey Key.F12)
+
+[<Fact>]
+let ``TranslateKey: lowercase Char for letter keys`` () =
+    // Adapter folds to lowercase; the encoder folds Shift back
+    // when assembling Ctrl-letter byte values upstream.
+    Assert.Equal(KeyCode.Char 'a', TerminalView.TranslateKey Key.A)
+    Assert.Equal(KeyCode.Char 'z', TerminalView.TranslateKey Key.Z)
+
+[<Fact>]
+let ``TranslateKey: digit Char for D0-D9 and NumPad0-NumPad9`` () =
+    Assert.Equal(KeyCode.Char '0', TerminalView.TranslateKey Key.D0)
+    Assert.Equal(KeyCode.Char '9', TerminalView.TranslateKey Key.D9)
+    Assert.Equal(KeyCode.Char '0', TerminalView.TranslateKey Key.NumPad0)
+    Assert.Equal(KeyCode.Char '9', TerminalView.TranslateKey Key.NumPad9)
+
+[<Fact>]
+let ``TranslateKey: unhandled keys produce KeyCode.Unhandled`` () =
+    // Punctuation / OEM / media keys flow through TextInput in
+    // production; the adapter returns Unhandled for them so the
+    // encoder bails out gracefully. Pin a few representative
+    // unhandled cases.
+    Assert.Equal(KeyCode.Unhandled, TerminalView.TranslateKey Key.OemSemicolon)
+    Assert.Equal(KeyCode.Unhandled, TerminalView.TranslateKey Key.OemPlus)
+    Assert.Equal(KeyCode.Unhandled, TerminalView.TranslateKey Key.OemMinus)
+
+[<Fact>]
+let ``TranslateModifiers: maps WPF flags to KeyModifiers flags`` () =
+    Assert.Equal(KeyModifiers.None, TerminalView.TranslateModifiers ModifierKeys.None)
+    Assert.Equal(KeyModifiers.Shift, TerminalView.TranslateModifiers ModifierKeys.Shift)
+    Assert.Equal(KeyModifiers.Alt, TerminalView.TranslateModifiers ModifierKeys.Alt)
+    Assert.Equal(KeyModifiers.Control, TerminalView.TranslateModifiers ModifierKeys.Control)
+    let all = ModifierKeys.Shift ||| ModifierKeys.Alt ||| ModifierKeys.Control
+    let expected = KeyModifiers.Shift ||| KeyModifiers.Alt ||| KeyModifiers.Control
+    Assert.Equal(expected, TerminalView.TranslateModifiers all)
+
+[<Fact>]
+let ``TranslateModifiers: silently drops the Windows key`` () =
+    // Win+letter is OS-shell territory; pty-speak doesn't forward it.
+    // Pin the silent-drop contract.
+    Assert.Equal(KeyModifiers.None, TerminalView.TranslateModifiers ModifierKeys.Windows)
+    Assert.Equal(
+        KeyModifiers.Control,
+        TerminalView.TranslateModifiers (ModifierKeys.Windows ||| ModifierKeys.Control))

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -65,6 +65,19 @@
       declaration PR-C added to Terminal.Accessibility.
     -->
     <ProjectReference Include="..\..\src\Terminal.Accessibility\Terminal.Accessibility.fsproj" />
+    <!--
+      Pre-framework-cycle PR-P added PtySpeak.Views so
+      KeyEncodingTests can reach `TerminalView.TranslateKey` and
+      `TerminalView.TranslateModifiers` (both bumped from
+      private to internal in PR-P) via the
+      `<InternalsVisibleTo Include="PtySpeak.Tests.Unit" />`
+      declaration in `src/Views/Views.csproj`. The Input
+      framework cycle's echo-correlation logic depends on the
+      WPF Key → KeyCode → encoded-bytes round-trip being
+      precise; pinning the adapter at unit-test level catches
+      silent regressions before NVDA validation.
+    -->
+    <ProjectReference Include="..\..\src\Views\Views.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Pre-framework-cycle audit bundle (3 of 3, final). Plan: `/root/.claude/plans/hello-i-lost-my-velvet-deer.md`.

**Pins the WPF adapter round-trip (`Key` → `KeyCode` → encoded bytes) with unit-test fixtures** so the future Input framework cycle's echo-correlation logic (per `docs/STAGE-7-ISSUES.md` `[input-buffer]` scope) can rely on the precision of the adapter without surprises.

`TerminalView.TranslateKey` and `TerminalView.TranslateModifiers` had no test coverage. A silent regression in either (e.g. a cursor-key case dropped during refactor) would silently break echo dedup.

**Three changes:**
- `TranslateKey` / `TranslateModifiers` bumped from `private static` → `internal static` in `TerminalView.cs`.
- `<InternalsVisibleTo Include="PtySpeak.Tests.Unit" />` added to `Views.csproj` (modern SDK-style); Tests.Unit gains a `ProjectReference` to PtySpeak.Views.
- 15 new fixtures in `tests/Tests.Unit/KeyEncodingTests.fs`:
  - **Round-trip pins** for cursor / editing keypad / whitespace / F1-F12 / A-Z / D0-D9 / NumPad0-NumPad9 / Space. Each verifies `TranslateKey` returns a non-Unhandled `KeyCode` AND `KeyEncoding.encodeOrNull` produces non-empty bytes.
  - **KeyCode-output pins** for specific `Key.X → KeyCode.Y` mappings, including the lowercase-fold contract for letters and the `KeyCode.Unhandled` contract for OEM keys.
  - **`TranslateModifiers` pins** for WPF flag → `KeyModifiers` flag mappings + the Windows-key silent-drop contract.

Zero behavioural change to production code; CI gates the round-trip pinning. The fixtures invoke the static methods directly — no WPF dispatcher needed.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest and the 15 new fixtures pass alongside existing 100+ fixtures
- [ ] Workflow lint + Markdown link check pass

## Sequencing

PR-P of 3 in the pre-framework-cycle bundle (final). PR-N (#146, doc-fix + framework-contract docstrings) and PR-O (#147, HotkeyRegistry refactor) shipped earlier. Pre-framework-cycle work is complete after this PR merges; the **Output framework cycle research phase** (Part 3 of `docs/PROJECT-PLAN-2026-05.md`) is the next active stream.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_