### PR TITLE
feat(terminal-core): Stage 8b — Coalescer absorbs as the Stream profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,139 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Stage 8b — Coalescer absorbs as the Stream profile)
+
+The Stage-7 `Coalescer.runLoop` orchestrator and its module-level
+constants (debounceWindow / spinnerWindow / spinnerThreshold)
+move into the Stream profile, completing what the PR-N
+substrate-cleanup contract anticipated. The Coalescer's
+algorithms and `State` record are unchanged — they're now
+hosted in `src/Terminal.Core/StreamProfile.fs` rather than
+`Coalescer.fs`. The pipeline thread model is rewritten: the
+two-channel `notificationChannel + Coalescer.runLoop +
+coalescedChannel + drain` chain collapses to a one-channel
+`notificationChannel + TranslatorPump + OutputDispatcher.dispatch`
++ a concurrent `TickPump` that calls
+`OutputDispatcher.dispatchTick(now)` every 50ms.
+
+Behaviour is identical to the post-8a release build: same
+debounce / spinner-suppress / mode-barrier / parser-error /
+500-char-cap defaults, same NVDA reading. The 8b refactor moves
+constants to per-instance `StreamProfile.Parameters` fields
+without changing their values; the next sub-stage (8b.2) adds a
+TOML loader that overrides them per the `[profile.stream]`
+section.
+
+**Substrate API extensions** (deliberate, called out for spec
+follow-up):
+
+- **`Profile.Tick: DateTimeOffset → (OutputEvent *
+  ChannelDecision[])[]`** — new field for time-driven flush.
+  Profiles that don't accumulate (Selection, Earcon, the future
+  Form / TUI / REPL profiles) supply
+  `Tick = fun _ -> [||]` — zero-cost no-op. The Stream profile
+  uses Tick to release pending stream content when the debounce
+  window elapses with no new event arriving (the Stage-7
+  trailing-edge flush).
+- **`Profile.Apply: OutputEvent → (OutputEvent *
+  ChannelDecision[])[]`** — return type changed from
+  `ChannelDecision[]` to a multi-pair array. Each pair is
+  `(effectiveEvent, decisionsForThatEvent)`: the effectiveEvent
+  is what the channel's `Send` receives. Most profiles return a
+  single pair; the Stream profile may return two pairs when an
+  incoming mode-change forces a flush (one pair for the flushed
+  pending stream content, one for the mode barrier itself, each
+  with its own Semantic so NvdaChannel routes via the right
+  ActivityId).
+- **`OutputDispatcher.dispatchTick(now)`** — new dispatcher
+  entry point. The composition root's TickPump task runs a
+  `PeriodicTimer(50ms)` and calls dispatchTick on each tick.
+
+The spec (`spec/event-and-output-framework.md` Part B.3) is
+silent on time-driven flush + multi-pair Apply; 8b adds these
+as substrate extensions. A focused doc-only PR will update the
+spec after maintainer approval.
+
+**Files modified:**
+
+- `src/Terminal.Core/OutputEventTypes.fs` — Profile record gains
+  `Tick` field; Apply return type changes to multi-pair shape.
+- `src/Terminal.Core/StreamProfile.fs` — full rewrite. Adds
+  `Parameters` record, `defaultParameters`, internal `State`
+  record + algorithm functions (`processRowsChanged`,
+  `onTimerTick`, `onModeChanged`, `onParserError`,
+  `createState`), and `create` that captures parameters +
+  screen + state in the Profile's Apply / Tick / Reset
+  closures. The 500-char announce cap (PR-H, GitHub issue
+  #139) lifts from the Stage-7 drain into the Stream profile's
+  `capAnnounce` helper, parameterised by
+  `Parameters.MaxAnnounceChars`.
+- `src/Terminal.Core/Coalescer.fs` — gutted to ~140 lines. Keeps
+  the `CoalescedNotification` DU (algorithm intermediate type)
+  and the five pure helpers (`hashRowContent`, `hashRow`,
+  `hashAttrs`, `hashFrame`, `renderRows`). Re-anchors the PR-N
+  substrate-cleanup contract pointing at `StreamProfile.Parameters`.
+- `src/Terminal.Core/OutputDispatcher.fs` — adds `dispatchTick`
+  (mirrors `dispatch` for the Tick path); `dispatch` updated
+  for the new Apply pair shape.
+- `src/Terminal.Core/OutputEventBuilder.fs` — rewritten.
+  Translates raw `ScreenNotification → OutputEvent` (the 8a
+  `fromCoalescedNotification` is removed; the new
+  `fromScreenNotification` runs BEFORE the Stream profile's
+  Apply rather than AFTER coalescing). Producer ID changes from
+  `"drain"` to `"translator"` to match the new pipeline location.
+- `src/Terminal.App/Program.fs` — pipeline composition rewritten.
+  `coalescedChannel` removed. `Coalescer.runLoop` call removed.
+  Stage-8a drain task replaced by **TranslatorPump** (reads
+  ScreenNotification, calls `OutputEventBuilder.fromScreenNotification`,
+  calls `OutputDispatcher.dispatch`) and **TickPump** (50ms
+  PeriodicTimer, calls `OutputDispatcher.dispatchTick`). Both
+  pumps share the existing `cts.Token` for cancellation. The
+  diagnostic Debug log line + post-Stage-6 drain-crash safety
+  net are preserved (in adjusted form).
+
+**Tests changed:**
+
+- `tests/Tests.Unit/CoalescerTests.fs` → `StreamProfileTests.fs`.
+  Module rename + mechanical rename of `Coalescer.X state` to
+  `StreamProfile.X StreamProfile.defaultParameters state` for
+  the four algorithm functions + `Coalescer.createState ()` to
+  `StreamProfile.createState ()`. The 30 algorithm tests (incl.
+  the 4 PR-M #145 cross-row spinner gate pins on `:198`,
+  `:264`, `:316`, `:345`) preserve their assertions verbatim;
+  the algorithm logic is unchanged. Three `Coalescer.runLoop`
+  end-to-end tests are removed — the orchestrator is now in
+  Program.fs (composition root); composition-root logic isn't
+  unit-tested in this codebase. References to
+  `Coalescer.OutputBatch`, `Coalescer.ErrorPassthrough`,
+  `Coalescer.ModeBarrier`, and the pure helpers stay (those
+  types + helpers remain in `Coalescer.fs`).
+- `tests/Tests.Unit/OutputEventTests.fs` — builder tests
+  updated for the new `fromScreenNotification` shape.
+  ScreenNotification inputs replace CoalescedNotification
+  inputs. New test pins the producer ID change (`"drain"` →
+  `"translator"`) and the sanitisation of ParserError messages
+  before wrapping.
+- `tests/Tests.Unit/OutputDispatcherTests.fs` — replaces
+  StreamProfile.create() calls (which now require parameters +
+  screen) with a synthetic `passthroughProfile` test helper.
+  Adds new tests for `dispatchTick` (no-op when no profiles /
+  empty Tick / routes Tick decisions / fans out across
+  profiles) and for the multi-pair Apply path.
+- `tests/Tests.Unit/Tests.Unit.fsproj` — `<Compile Include>`
+  entry renamed `CoalescerTests.fs → StreamProfileTests.fs`.
+
+### Open question
+
+Spec D.2 maps `ParserError → Background`, where Background is
+"suppressed at profile layer" per B.5.2. The 8b Stream profile
+does NOT suppress Background events (preserves the post-8a
+release build's behaviour). Reconciliation deferred per the
+8a CHANGELOG entry below; the maintainer can pick (A) suppress
+in NVDA + log only, (B) reclassify ParserError as Assertive
+in spec D.2, (C) add a fifth Diagnostic priority. Captured in
+inline comments in `StreamProfile.fs` + `OutputEventBuilder.fs`.
+
 ### Added (Stage 8a — OutputEvent + Channel + NVDA-channel retrofit)
 
 The first concrete implementation work after the post-Stage-7

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -833,25 +833,35 @@ module Program =
         window.TerminalSurface.SetCopyLogToClipboardHandler(
             Action(fun () -> runCopyLatestLog window))
 
-        // Stage 5 — two-channel pipeline:
+        // Stage 8b — single-channel pipeline:
         //
         //   parser thread → notificationChannel (256, DropOldest)
         //                       ↓
-        //                 Coalescer.runLoop (one Task)
+        //                 TranslatorPump (one Task)
         //                       ↓
-        //                 coalescedChannel (16, Wait)
+        //                 OutputEventBuilder.fromScreenNotification
         //                       ↓
-        //                 drain task → window.TerminalSurface.Announce(msg, activityId)
+        //                 OutputDispatcher.dispatch (raw event)
+        //                       ↓
+        //                 StreamProfile.Apply (coalesces internally)
+        //                       ↓
+        //                 ChannelDecision[] → NvdaChannel.Send
         //
-        // The DropOldest source channel means a flooding parser
-        // can't grow the backlog without bound; the coalescer
-        // applies debounce + hash dedup + spinner suppression
-        // and emits at most one CoalescedNotification per
-        // ~200ms window. The downstream channel is small +
-        // Wait because the drain marshals to the WPF
-        // dispatcher per item and we want backpressure on
-        // pathological emit rates rather than dropping
-        // already-coalesced notifications.
+        // + concurrent TickPump (one Task):
+        //   PeriodicTimer(50ms) → OutputDispatcher.dispatchTick(now)
+        //                       ↓
+        //                 StreamProfile.Tick (trailing-edge flush)
+        //                       ↓
+        //                 ChannelDecision[] → NvdaChannel.Send
+        //
+        // The Stage 7 `coalescedChannel + Coalescer.runLoop +
+        // drain task` triplet collapses to two pumps both reading
+        // from the unchanged `notificationChannel`. The
+        // DropOldest source channel still bounds the parser-side
+        // backlog. The Stream profile owns the per-instance
+        // debounce + spinner-suppress + 500-char cap, all per
+        // `StreamProfile.Parameters` (Stage 7 defaults preserved
+        // via `StreamProfile.defaultParameters`).
         let notificationChannel =
             let opts =
                 System.Threading.Channels.BoundedChannelOptions(256,
@@ -859,88 +869,47 @@ module Program =
                         System.Threading.Channels.BoundedChannelFullMode.DropOldest)
             System.Threading.Channels.Channel.CreateBounded<ScreenNotification>(opts)
 
-        let coalescedChannel =
-            let opts =
-                System.Threading.Channels.BoundedChannelOptions(16,
-                    FullMode =
-                        System.Threading.Channels.BoundedChannelFullMode.Wait)
-            System.Threading.Channels.Channel.CreateBounded<Coalescer.CoalescedNotification>(opts)
-
         // Bridge Screen.ModeChanged events into the parser-side
-        // channel so the coalescer can use them as flush
-        // barriers (alt-screen swap, etc.) and pass them
-        // through as ModeBarrier announcements. The screen
-        // fires this AFTER releasing its internal lock, so
-        // pushing to a Channel here is non-blocking and
-        // deadlock-free.
+        // channel so the Stream profile can use them as flush
+        // barriers (alt-screen swap, etc.). The screen fires
+        // this AFTER releasing its internal lock, so pushing to
+        // a Channel here is non-blocking and deadlock-free.
         screen.ModeChanged.Add(fun (flag, value) ->
             notificationChannel.Writer.TryWrite(ModeChanged (flag, value)) |> ignore)
 
-        // Start the coalescer with the SHARED cts.Token so
-        // shutdown cancels reader, coalescer, and drain in
-        // unison. Production passes TimeProvider.System;
-        // unit tests inject FakeTimeProvider directly into
-        // Coalescer.processRowsChanged / onTimerTick.
-        let _ =
-            Coalescer.runLoop
-                notificationChannel.Reader
-                coalescedChannel.Writer
-                screen
-                TimeProvider.System
-                cts.Token
-
-        // Stage 8a — output framework substrate.
+        // Stage 8b — output framework substrate composition.
         //
-        // Compose the dispatcher: register the NVDA channel
-        // (with its WPF-dispatcher-marshalled announce
-        // callback), register the Stream profile (a
-        // pass-through stub in 8a; 8b absorbs the Coalescer's
-        // debounce / spinner-suppress / max-chars logic), and
-        // set the active profile set so the drain's per-event
-        // dispatch finds it. The framework is behaviour-identical
-        // in 8a: every CoalescedNotification still produces the
-        // same (message, activityId) pair, the NVDA channel
-        // still calls `TerminalSurface.Announce(msg, activityId)`
-        // (the 2-arg overload that picks ImportantAll for
-        // streaming output and MostRecent for everything else
-        // per `src/Views/TerminalView.cs:292-298`), and the
-        // 500-char announce-length cap from PR-H stays where
-        // it is — until 8b lifts it into
-        // `StreamProfile.Parameters.MaxAnnounceChars`.
-        //
-        // See `spec/event-and-output-framework.md` Part D for
-        // the retrofit specifics.
         // The marshal callback uses synchronous `Dispatcher.Invoke`
-        // so the drain task blocks on each Announce until the WPF
+        // so the drain blocks on each Announce until the WPF
         // dispatch completes — same effective backpressure as
         // Stage 7's `let! _ = InvokeAsync(...).Task` await. The
-        // drain runs on a thread-pool worker (not the UI thread),
-        // so blocking is safe; UI thread never waits on the drain
-        // worker. Behaviour-identical to Stage 7 in throughput +
-        // ordering.
+        // pumps run on thread-pool workers (not the UI thread),
+        // so blocking is safe; UI thread never waits on a pump
+        // worker. Behaviour-identical to Stage 7 / Stage 8a in
+        // throughput + ordering.
         let nvdaChannel =
             NvdaChannel.create (fun (msg, activityId) ->
                 let action () =
                     window.TerminalSurface.Announce(msg, activityId)
                 window.Dispatcher.Invoke(Action(action)))
         OutputDispatcher.ChannelRegistry.register nvdaChannel
-        let streamProfile = StreamProfile.create ()
+        let streamProfile =
+            StreamProfile.create StreamProfile.defaultParameters screen
         OutputDispatcher.ProfileRegistry.register streamProfile
         OutputDispatcher.ProfileRegistry.setActiveProfileSet [ streamProfile ]
 
-        // Drain the coalesced channel into the framework
-        // dispatcher. The 500-char cap (PR-H, GitHub issue
-        // #139) stays here in 8a; 8b moves it into
-        // StreamProfile.Apply once the profile owns the
-        // `MaxAnnounceChars` parameter. The diagnostic Debug
-        // log line is preserved for streaming-silence triage
-        // continuity (`Ctrl+Shift+;` clipboard-copy + grep).
+        // TranslatorPump — read raw ScreenNotifications, build
+        // OutputEvents, dispatch through the active profile set.
+        // Replaces Stage 8a's drain task. The diagnostic Debug
+        // log line is preserved (in adjusted form) for
+        // streaming-silence triage continuity (`Ctrl+Shift+;`
+        // clipboard-copy + grep).
         let _ =
             Task.Run(fun () ->
                 task {
-                    let drainLog = Logger.get "Terminal.App.Program.drain"
+                    let pumpLog = Logger.get "Terminal.App.Program.translatorPump"
                     try
-                        let reader = coalescedChannel.Reader
+                        let reader = notificationChannel.Reader
                         let mutable keepGoing = true
                         while keepGoing && not cts.Token.IsCancellationRequested do
                             let! got = reader.WaitToReadAsync(cts.Token).AsTask()
@@ -948,74 +917,80 @@ module Program =
                                 keepGoing <- false
                             else
                                 let mutable peek =
-                                    Unchecked.defaultof<Coalescer.CoalescedNotification>
+                                    Unchecked.defaultof<ScreenNotification>
                                 while reader.TryRead(&peek) do
-                                    // 500-char cap stays in the drain in 8a per
-                                    // the PR-H stopgap rationale; OutputBatch is
-                                    // the only case affected. The capped text
-                                    // becomes the OutputEvent.Payload that flows
-                                    // through StreamProfile + NvdaChannel.
-                                    let capped =
-                                        match peek with
-                                        | Coalescer.OutputBatch text ->
-                                            let limit = 500
-                                            if text.Length <= limit then
-                                                Coalescer.OutputBatch text
-                                            else
-                                                let head = text.Substring(0, limit)
-                                                let extra = text.Length - limit
-                                                let footer =
-                                                    sprintf
-                                                        "%s ...announcement truncated; %d more characters available — press Ctrl+Shift+; to copy full log."
-                                                        head
-                                                        extra
-                                                Coalescer.OutputBatch footer
-                                        | other -> other
                                     let event =
-                                        OutputEventBuilder.fromCoalescedNotification capped
-                                    if event.Payload <> "" then
-                                        drainLog.LogDebug(
-                                            "Drain → Dispatch. Semantic={Semantic} Priority={Priority} PayloadLen={PayloadLen}",
-                                            event.Semantic, event.Priority, event.Payload.Length)
-                                    else
-                                        drainLog.LogDebug(
-                                            "Drain dispatched empty-payload event. Semantic={Semantic}",
-                                            event.Semantic)
+                                        OutputEventBuilder.fromScreenNotification peek
+                                    pumpLog.LogDebug(
+                                        "TranslatorPump → Dispatch. Semantic={Semantic} Priority={Priority}",
+                                        event.Semantic, event.Priority)
                                     OutputDispatcher.dispatch event
                     with
                     | :? OperationCanceledException -> ()
                     | ex ->
-                        // Post-Stage-6 diagnostic safety net.
-                        // Previously this was `| _ -> ()` — any
-                        // exception killed the drain task silently
-                        // and streaming announcements stopped
-                        // forever with no clue why. Surfacing the
-                        // exception via one final
-                        // `Announce(..., pty-speak.error)` lets a
-                        // user (or maintainer) hear that something
-                        // went wrong before the task exits.
-                        // Sanitise the message through SR-2's
+                        // Post-Stage-6 diagnostic safety net,
+                        // preserved across the 8b reorganisation.
+                        // Surface the exception via one last
+                        // direct `Announce(..., pty-speak.error)`
+                        // — direct call (not through the
+                        // dispatcher) because the framework
+                        // substrate may itself be the exception
+                        // source. Sanitise through SR-2's
                         // chokepoint so PTY-originated control
-                        // bytes can't reach NVDA verbatim. Direct
-                        // call to `Announce` here (not through the
-                        // dispatcher) — the framework substrate
-                        // may itself be the source of the
-                        // exception, so going through it for the
-                        // last-ditch announce would risk a
-                        // re-entrant crash.
+                        // bytes can't reach NVDA verbatim.
                         try
                             log.LogError(
                                 ex,
-                                "Drain task crashed; streaming announcements halted.")
+                                "TranslatorPump crashed; streaming announcements halted.")
                             let safe =
                                 AnnounceSanitiser.sanitise ex.Message
                             let action () =
                                 window.TerminalSurface.Announce(
                                     sprintf
-                                        "Drain task exception: %s"
+                                        "TranslatorPump exception: %s"
                                         safe,
                                     ActivityIds.error)
                             window.Dispatcher.Invoke(Action(action))
+                        with _ -> ()
+                } :> Task)
+
+        // TickPump — periodic timer for the Stream profile's
+        // trailing-edge flush. The 50ms cadence is the
+        // dispatcher-tick rate, NOT the debounce window (200ms).
+        // The Stream profile's Tick checks the elapsed-since-
+        // last-flush internally and emits zero or one
+        // ChannelDecision per call. Faster ticks = lower
+        // worst-case latency on trailing-edge flush; the cost
+        // is negligible (each Tick that returns [||] is a
+        // pure-function call).
+        let _ =
+            Task.Run(fun () ->
+                task {
+                    try
+                        use tickTimer =
+                            new System.Threading.PeriodicTimer(
+                                TimeSpan.FromMilliseconds 50.0)
+                        let mutable keepGoing = true
+                        while keepGoing && not cts.Token.IsCancellationRequested do
+                            let! tickFired = tickTimer.WaitForNextTickAsync(cts.Token).AsTask()
+                            if not tickFired then
+                                keepGoing <- false
+                            else
+                                OutputDispatcher.dispatchTick (DateTimeOffset.UtcNow)
+                    with
+                    | :? OperationCanceledException -> ()
+                    | ex ->
+                        try
+                            log.LogError(
+                                ex,
+                                "TickPump crashed; trailing-edge flushes halted.")
+                            // No user-facing announce here —
+                            // TickPump failure is silent
+                            // degradation (Apply still fires for
+                            // every event; only the trailing-edge
+                            // flush stops). The error is logged
+                            // for `Ctrl+Shift+;` post-hoc
+                            // diagnosis.
                         with _ -> ()
                 } :> Task)
 
@@ -1188,7 +1163,6 @@ module Program =
                     | Some s -> s.MinLevel.ToString()
                     | None -> "Unknown"
                 let notifDepth = notificationChannel.Reader.Count
-                let coalDepth = coalescedChannel.Reader.Count
                 // Verdict heuristic, in priority order:
                 //   1. Child PID dead → "Child shell process has
                 //      exited." (highest signal — explains every
@@ -1199,6 +1173,11 @@ module Program =
                 //      DropOldest means past-capacity is silent
                 //      data loss; warn before that.
                 //   4. Healthy.
+                //
+                // Stage 8b: the coalescedChannel was removed when
+                // the Coalescer absorbed into the Stream profile;
+                // queue-depth reporting now covers only the
+                // notification channel.
                 let verdict =
                     if pid > 0 && not alive then
                         sprintf
@@ -1217,7 +1196,7 @@ module Program =
                 let aliveStr = if alive then "alive" else "dead"
                 let summary =
                     sprintf
-                        "%s %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256. Coalesced queue %d of 16."
+                        "%s %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256."
                         verdict
                         currentShell.DisplayName
                         pid
@@ -1225,7 +1204,6 @@ module Program =
                         levelStr
                         staleness
                         notifDepth
-                        coalDepth
                 log.LogInformation("Health check requested. {Summary}", summary)
                 window.TerminalSurface.Announce(
                     summary,
@@ -1280,18 +1258,15 @@ module Program =
                     | Some s -> s.MinLevel
                     | None -> LogLevel.Information
                 let notifDepth = notificationChannel.Reader.Count
-                let coalDepth = coalescedChannel.Reader.Count
                 log.LogInformation(
-                    "Heartbeat. Shell={Shell} Pid={Pid} Alive={Alive} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap} CoalQueue={Coal}/{CoalCap}",
+                    "Heartbeat. Shell={Shell} Pid={Pid} Alive={Alive} Level={Level} LastReadAgoMs={Staleness:F0} NotifQueue={Notif}/{NotifCap}",
                     currentShell.DisplayName,
                     pid,
                     alive,
                     level,
                     staleness,
                     notifDepth,
-                    256,
-                    coalDepth,
-                    16)
+                    256)
             with ex ->
                 // Don't let heartbeat crashes propagate to the
                 // timer thread — log and continue.
@@ -1553,10 +1528,13 @@ module Program =
             // fire one last entry into a closed channel and log a
             // confusing exception.
             try heartbeatTimer.Dispose() with _ -> ()
-            // Complete both writers so the coalescer and drain
-            // tasks exit cleanly when their channels run dry.
+            // Complete the notification-channel writer so the
+            // TranslatorPump task exits cleanly when the channel
+            // runs dry. Stage 8b removed the coalescedChannel
+            // (the Coalescer absorbed into the Stream profile);
+            // the TickPump exits via its own
+            // `cts.Token.IsCancellationRequested` check.
             try notificationChannel.Writer.TryComplete() |> ignore with _ -> ()
-            try coalescedChannel.Writer.TryComplete() |> ignore with _ -> ()
             match hostHandle with
             | Some h -> (h :> IDisposable).Dispose()
             | None -> ()

--- a/src/Terminal.Core/Coalescer.fs
+++ b/src/Terminal.Core/Coalescer.fs
@@ -1,157 +1,66 @@
 namespace Terminal.Core
 
-open System
 open System.Collections.Generic
 open System.Text
-open System.Threading
-open System.Threading.Channels
-open System.Threading.Tasks
-// Logging-PR — needed for the LogInformation / LogError
-// extension methods on ILogger (defined in the
-// LoggerExtensions static class in this namespace).
-open Microsoft.Extensions.Logging
 
-/// Stage 5 — streaming-output coalescer.
+/// Stage 5 — streaming-output coalescer (originally), now a
+/// thin library of pure helpers + the `CoalescedNotification`
+/// intermediate DU.
 ///
-/// Sits between the parser-side `notificationChannel`
-/// (`Channel<ScreenNotification>`, capacity 256, DropOldest)
-/// and the existing UIA drain task in `Program.fs compose ()`.
-/// Reads every `ScreenNotification` the parser publishes,
-/// coalesces them via debounce + dedup + frame-hash, and
-/// emits at most one `ScreenNotification` per ~200ms window
-/// to a downstream `coalescedChannel`.
+/// **Stage 8b restructuring (2026-05-04).** The Coalescer's
+/// `State` record + four algorithm functions
+/// (`processRowsChanged`, `onTimerTick`, `onModeChanged`,
+/// `onParserError`) + `runLoop` orchestrator + per-instance
+/// constants (`debounceWindow`, `spinnerWindow`,
+/// `spinnerThreshold`) all moved into
+/// `src/Terminal.Core/StreamProfile.fs` per the PR-N
+/// substrate-cleanup contract. The constants became
+/// `StreamProfile.Parameters` fields. The algorithms were
+/// preserved verbatim — only their host module changed.
 ///
-/// The drain task is unchanged — it reads the downstream
-/// channel and calls `TerminalSurface.Announce(message,
-/// activityId)` per item.
+/// What this file retains:
+/// - The `CoalescedNotification` DU. Used as the algorithms'
+///   intermediate output type; the StreamProfile module
+///   converts these to `(OutputEvent, ChannelDecision[])` pairs
+///   for dispatch routing.
+/// - Five pure hash + rendering helpers (`hashRowContent`,
+///   `hashRow`, `hashAttrs`, `hashFrame`, `renderRows`). These
+///   are stateless utilities the StreamProfile algorithms call;
+///   they're named "Coalescer" by historical accident and kept
+///   here for git-blame continuity. Future cleanup PR may rename
+///   to a more neutral `StreamHelpers.fs` if the maintainer
+///   prefers.
 ///
-/// Algorithms in detail:
-///
-///   * **Per-row hash.** FNV-1a 64-bit over each cell
-///     (`Cell.Ch.Value` + `Cell.Width` + flattened
-///     `SgrAttrs`), folded with the row index so a row
-///     swap doesn't alias.
-///   * **Frame hash.** XOR of per-row hashes. Two
-///     consecutive `RowsChanged` events with identical
-///     screen content produce identical frame hashes
-///     and the second is suppressed (composes with
-///     Claude Ink's full-frame redraws — without this
-///     layer, every row hash changes per redraw and
-///     per-row dedup never fires).
-///   * **Spinner heuristic — two gates.** Both gates use
-///     CHANGE-DETECTION (only count hash CHANGES at a row
-///     position, not observations) so a screen with N static
-///     rows doesn't trip suppression at high typing cadence.
-///     - **Per-`(rowIdx, hash)` gate.** Catches same-position
-///       cycling spinners (`|/-\`, `( *)`, etc.) — the same
-///       `(rowIdx, hash)` tuple recurs each cycle.
-///     - **Per-hash gate (any-hash-anywhere).** Catches moving
-///       spinners (scrolling progress bars, Ink reconciler
-///       reflows) where the same content lands at different
-///       rows each frame — the `(rowIdx, hash)` key is unique
-///       each frame so the per-key gate misses, but the bare
-///       hash recurs across rows. Issue #117 — the original
-///       Stage 5 design included this gate but its count-of-
-///       total-entries threshold was incompatible with the
-///       per-row scan; the redesigned gate counts unique-hash
-///       observations only on row-change.
-///     Either gate firing suppresses the whole frame.
-///   * **Debounce.** Leading-edge + trailing-edge: first
-///     event in an idle period (no flush in last 200ms)
-///     emits immediately for fast single-event UX
-///     (`echo hello`); subsequent events accumulate and
-///     drain on the next 200ms timer tick.
-///   * **Alt-screen flush barrier.** `ModeChanged
-///     (AltScreen, _)` events flush the pending
-///     accumulator first, reset frame-hash + spinner
-///     state, then pass through the `ModeChanged`
-///     itself so the drain can announce the transition.
-///   * **Sanitisation.** Every emit text passes through
-///     `AnnounceSanitiser.sanitise` so PTY-originated
-///     control chars can't reach NVDA's notification
-///     handler.
-///
-/// Threading: the coalescer runs as a single
-/// `Task.Run` reader loop; the input channel is
-/// SPSC (parser → coalescer); the output channel is
-/// SPSC (coalescer → drain). The coalescer is
-/// pure-state otherwise (no Dispatcher dependency,
-/// no UI thread requirement).
+/// **PR-N substrate-cleanup contract (re-anchored 2026-05-04
+/// in StreamProfile.fs):** the constants that USED to live here
+/// at module scope are now on `StreamProfile.Parameters` —
+/// `DebounceWindowMs`, `SpinnerWindowMs`, `SpinnerThreshold`,
+/// `MaxAnnounceChars`. Caller-supplied at construction time;
+/// `StreamProfile.defaultParameters` carries the Stage-7
+/// values; the 9c TOML loader will override per
+/// `[profile.stream]` when present.
 module Coalescer =
-
-    // PR-N substrate-cleanup contract (2026-05-04). The three
-    // constants below — `debounceWindow`, `spinnerWindow`,
-    // `spinnerThreshold` — are **Stream-profile defaults**, not
-    // universal terminal-output tuning knobs. The Output framework
-    // cycle (Part 3 of `docs/PROJECT-PLAN-2026-05.md`) introduces
-    // per-profile presentation strategies (Stream / Form /
-    // Selection / TUI / REPL / Earcon); each profile is expected
-    // to construct its own `Coalescer.State` instance with
-    // caller-supplied thresholds rather than reading these module
-    // globals. Today's Coalescer IS the Stream profile — the
-    // current values reflect that role's defaults. When the
-    // framework lands, these values stay as Stream-profile
-    // fallbacks; new profiles override via their own
-    // construction parameters and pass their own thresholds
-    // through the gate functions. Phase 2's TOML config will
-    // expose these per the USER-SETTINGS.md "Verbosity / NVDA
-    // narration" candidate; the framework refactor is the
-    // intermediate seam, not the user-config surface.
-
-    /// Stream-profile default; Phase 2 TOML candidate. See
-    /// PR-N substrate-cleanup contract above.
-    let internal debounceWindow = TimeSpan.FromMilliseconds 200.0
-
-    /// Stream-profile default; Phase 2 TOML candidate. See
-    /// PR-N substrate-cleanup contract above.
-    let internal spinnerWindow = TimeSpan.FromMilliseconds 1000.0
-
-    /// Stream-profile default. Suppress an `(rowIdx, hash)` if
-    /// it appeared this many times within `spinnerWindow`. Five
-    /// flips per second (e.g. `|/-\` cycle) is the textbook
-    /// spinner. Phase 2 TOML candidate. See PR-N substrate-
-    /// cleanup contract above.
-    let internal spinnerThreshold = 5
 
     let private fnvOffsetBasis = 0xcbf29ce484222325UL
     let private fnvPrime = 0x00000100000001B3UL
     let private rowSwapMix = 0x9E3779B97F4A7C15UL
 
-    /// PR-M (Issue #117) — content-only FNV-1a 64-bit over the
-    /// cells, with NO row-index folding. Used by the cross-row
-    /// spinner gate, which needs to recognise the same content
-    /// landing at different rows across frames as the same hash.
-    /// `hashRow` (with row-index fold) is used everywhere else
-    /// for frame-hash computation + per-key spinner detection.
-    let rec internal hashRowContent (cells: Cell[]) : uint64 =
-        let mutable h = fnvOffsetBasis
-        for cell in cells do
-            // Cell.Ch is a Rune (int code point).
-            h <- h ^^^ uint64 cell.Ch.Value
-            h <- h * fnvPrime
-            // Defensive against future Cell.Width additions
-            // (Cell type today has no Width field; if Stage
-            // 5+ adds wide-char support, this branch begins
-            // to mix it in). Until then, this is a constant
-            // contribution and mathematically a no-op for
-            // dedup purposes.
-            //
-            // Stage 5 ships without Width; commented out
-            // until the Cell type grows that field.
-            // h <- h ^^^ uint64 cell.Width
-            // h <- h * fnvPrime
-            h <- h ^^^ hashAttrs cell.Attrs
-            h <- h * fnvPrime
-        h
+    /// Output type from the Stream profile's algorithm functions.
+    /// `OutputBatch` carries post-debounce, post-spinner-suppress,
+    /// post-cap announcement text. `ErrorPassthrough` carries a
+    /// sanitised parser-error message. `ModeBarrier` signals a
+    /// mode transition (alt-screen, etc.). The Stream profile's
+    /// dispatch wrapper converts each into one or more
+    /// `(OutputEvent, ChannelDecision[])` pairs the
+    /// `OutputDispatcher` routes to channels.
+    type CoalescedNotification =
+        | OutputBatch of text: string
+        | ErrorPassthrough of message: string
+        | ModeBarrier of flag: TerminalModeFlag * value: bool
 
-    /// FNV-1a 64-bit folded with the row index. See module
-    /// docstring §"Per-row hash".
-    and internal hashRow (rowIdx: int) (cells: Cell[]) : uint64 =
-        hashRowContent cells ^^^ (uint64 rowIdx * rowSwapMix)
-
-    /// Flatten SgrAttrs into a uint64 fingerprint. Stable
-    /// across Cell instances with identical attrs.
-    and internal hashAttrs (attrs: SgrAttrs) : uint64 =
+    /// Flatten SgrAttrs into a uint64 fingerprint. Stable across
+    /// Cell instances with identical attrs.
+    let internal hashAttrs (attrs: SgrAttrs) : uint64 =
         let colorHash (c: ColorSpec) : uint64 =
             match c with
             | Default -> 0UL
@@ -171,9 +80,29 @@ module Coalescer =
         h <- h ^^^ flags
         h * fnvPrime
 
+    /// PR-M (Issue #117) — content-only FNV-1a 64-bit over the
+    /// cells, with NO row-index folding. Used by the cross-row
+    /// spinner gate, which needs to recognise the same content
+    /// landing at different rows across frames as the same hash.
+    /// `hashRow` (with row-index fold) is used everywhere else
+    /// for frame-hash computation + per-key spinner detection.
+    let internal hashRowContent (cells: Cell[]) : uint64 =
+        let mutable h = fnvOffsetBasis
+        for cell in cells do
+            h <- h ^^^ uint64 cell.Ch.Value
+            h <- h * fnvPrime
+            h <- h ^^^ hashAttrs cell.Attrs
+            h <- h * fnvPrime
+        h
+
+    /// FNV-1a 64-bit folded with the row index. Used by frame-hash
+    /// computation + per-key spinner detection.
+    let internal hashRow (rowIdx: int) (cells: Cell[]) : uint64 =
+        hashRowContent cells ^^^ (uint64 rowIdx * rowSwapMix)
+
     /// Compose row hashes into a frame hash. Order-independent
-    /// XOR is correct here because each row hash already
-    /// encodes its index via `^^^ (uint64 rowIdx * rowSwapMix)`.
+    /// XOR is correct here because each row hash already encodes
+    /// its index via `^^^ (uint64 rowIdx * rowSwapMix)`.
     let internal hashFrame (rows: Cell[][]) : uint64 =
         let mutable h = 0UL
         for i in 0 .. rows.Length - 1 do
@@ -187,8 +116,8 @@ module Coalescer =
     /// then joined with `\n`. The separator is added AFTER
     /// sanitisation so the row structure survives — sanitise
     /// strips `\n` as a C0 control, which would otherwise
-    /// collapse multi-line output into a single line and
-    /// defeat NVDA's per-line speech pause.
+    /// collapse multi-line output into a single line and defeat
+    /// NVDA's per-line speech pause.
     let internal renderRows (rows: Cell[][]) : string =
         let sb = StringBuilder()
         // Drop trailing all-blank rows so a half-full screen
@@ -209,470 +138,3 @@ module Coalescer =
                 rowSb.Append(row.[c].Ch.ToString()) |> ignore
             sb.Append(AnnounceSanitiser.sanitise (rowSb.ToString())) |> ignore
         sb.ToString()
-
-    /// One emitted announcement: the text plus the
-    /// `activityId` the drain passes to
-    /// `RaiseNotificationEvent`. Stage 5 always uses
-    /// `ActivityIds.output` for streaming text;
-    /// `ActivityIds.error` for parser errors;
-    /// `ActivityIds.mode` for mode-change barriers.
-    type CoalescedNotification =
-        | OutputBatch of text: string
-        | ErrorPassthrough of message: string
-        | ModeBarrier of flag: TerminalModeFlag * value: bool
-
-    /// Spinner-suppression key: the per-row hash plus the row
-    /// index it came from. A spinner that overwrites the same
-    /// cell with cycling characters (`|/-\` etc.) generates
-    /// the same `(rowIdx, hash)` tuple repeatedly across each
-    /// cycle, which the per-key history catches once the
-    /// recurrence count crosses the threshold.
-    type private SpinnerKey = int * uint64
-
-    /// Coalescer's mutable state. Owned by the single reader
-    /// loop task; no concurrent access. Tests construct one
-    /// directly and drive it via `tryEmit` to assert
-    /// algorithmic behaviour without spinning a real loop.
-    type State =
-        { mutable LastFrameHash: uint64 voption
-          mutable LastFlushAt: DateTimeOffset voption
-          mutable PendingFrame: Cell[][] voption
-          mutable PendingHash: uint64 voption
-          /// PR-M (Issue #117) — per-row hashes from the previous
-          /// frame, indexed by row. Feeds change-detection so the
-          /// two spinner gates only count hash CHANGES at a row
-          /// position, not observations. Without this, a screen
-          /// with N static rows added N entries per event to the
-          /// per-row history; at 5+ events/sec the static-row keys
-          /// tripped suppression even when no spinner existed.
-          /// `ValueNone` on first frame; `ValueSome` thereafter.
-          mutable LastRowHashes: uint64[] voption
-          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
-          /// PR-M (Issue #117) — per-hash recurrence history
-          /// independent of `rowIdx`. Catches CROSS-ROW spinners
-          /// that the per-`(rowIdx, hash)` gate misses: a moving
-          /// progress indicator scrolling vertically lands the
-          /// same content at a different row each frame, so each
-          /// `(rowIdx, hash)` key sees count = 1 and the per-key
-          /// gate never fires. The any-hash-anywhere gate sees
-          /// the recurring hash across rows and fires after
-          /// `spinnerThreshold` recurrences within `spinnerWindow`.
-          /// Like the per-key gate, only counts CHANGES (a row
-          /// transitioning TO this hash), so static content
-          /// doesn't accumulate.
-          HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
-
-    let internal createState () : State =
-        { LastFrameHash = ValueNone
-          LastFlushAt = ValueNone
-          PendingFrame = ValueNone
-          PendingHash = ValueNone
-          LastRowHashes = ValueNone
-          PerRowHistory = Dictionary()
-          HashHistory = Dictionary() }
-
-    /// Trim history older than `spinnerWindow` from BOTH
-    /// dictionaries. Mutates in place. Called on every event
-    /// arrival to keep histories bounded.
-    let private gcHistory (state: State) (now: DateTimeOffset) =
-        let cutoff = now - spinnerWindow
-        let stalePerRow = ResizeArray()
-        for kvp in state.PerRowHistory do
-            kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
-            if kvp.Value.Count = 0 then stalePerRow.Add(kvp.Key)
-        for k in stalePerRow do
-            state.PerRowHistory.Remove(k) |> ignore
-        let staleHash = ResizeArray()
-        for kvp in state.HashHistory do
-            kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
-            if kvp.Value.Count = 0 then staleHash.Add(kvp.Key)
-        for k in staleHash do
-            state.HashHistory.Remove(k) |> ignore
-
-    /// PR-M (Issue #117) — walk all per-row hashes for the
-    /// current frame and decide whether either spinner gate
-    /// should suppress.
-    ///
-    /// **Change-detection.** For each row, only `Add(now)` an
-    /// observation to the gates if that row's hash CHANGED since
-    /// the previous frame. A static row contributes nothing to
-    /// either gate; a row that flips from blank to content
-    /// contributes once per transition. This protects high-
-    /// cadence typing scenarios (where many rows are static and
-    /// only the prompt-row changes per event) from tripping the
-    /// per-key gate via static-row recurrence.
-    ///
-    /// **Per-key gate** (existing): suppresses if the
-    /// `(rowIdx, hash)` tuple recurred ≥ `spinnerThreshold` times
-    /// in `spinnerWindow`. Catches same-position cycling
-    /// spinners (`|/-\`, `( *)( *)`).
-    ///
-    /// **Cross-row gate** (new): suppresses if any single hash
-    /// recurred ≥ `spinnerThreshold` times in `spinnerWindow`
-    /// REGARDLESS of which row it landed at. Catches moving
-    /// spinners (scrolling progress bars, Ink reconciler
-    /// reflows where the spinner content lands at different
-    /// rows each frame).
-    ///
-    /// Returns true if either gate fires. Caller is responsible
-    /// for updating `state.LastRowHashes` after this call so the
-    /// next frame's change-detection has the correct comparison
-    /// baseline.
-    let private isSpinnerSuppressed
-            (state: State)
-            (now: DateTimeOffset)
-            (rowHashes: uint64[])
-            (contentHashes: uint64[]) : bool =
-        let mutable suppress = false
-        // PR-M: within-frame dedup for the cross-row gate. A
-        // screen with N rows of identical content (e.g. blank
-        // padding above the prompt) would otherwise contribute
-        // N Adds to HashHistory[content-hash] in a single frame,
-        // and a screen with ≥5 blank padding rows would trip
-        // the gate on the seed frame. The intent of the gate is
-        // "this content appeared in N FRAMES" (not "N rows of
-        // one frame"), so collapse within-frame duplicates.
-        let crossSeenThisFrame = HashSet<uint64>()
-        for i in 0 .. rowHashes.Length - 1 do
-            let rh = rowHashes.[i]
-            let changed =
-                match state.LastRowHashes with
-                | ValueNone -> true
-                | ValueSome arr when i >= arr.Length -> true
-                | ValueSome arr -> arr.[i] <> rh
-            if changed then
-                // Per-`(rowIdx, hash)` gate: uses the row-index-
-                // folded hash so the same content at different
-                // rows produces different keys. Catches cycling
-                // spinners that overwrite the same cell. No
-                // within-frame dedup needed: each (rowIdx, hash)
-                // tuple is naturally unique within a frame
-                // because rowIdx is unique.
-                let key = (i, rh)
-                let perRowHist =
-                    match state.PerRowHistory.TryGetValue key with
-                    | true, x -> x
-                    | false, _ ->
-                        let x = ResizeArray()
-                        state.PerRowHistory.[key] <- x
-                        x
-                perRowHist.Add(now)
-                if perRowHist.Count >= spinnerThreshold then
-                    suppress <- true
-                // Cross-row gate (within-frame deduped): uses
-                // the CONTENT-only hash so the same content
-                // moving between rows still maps to the same
-                // key. Catches scrolling progress bars and Ink
-                // reflows.
-                let ch = contentHashes.[i]
-                if crossSeenThisFrame.Add(ch) then
-                    let crossHist =
-                        match state.HashHistory.TryGetValue ch with
-                        | true, x -> x
-                        | false, _ ->
-                            let x = ResizeArray()
-                            state.HashHistory.[ch] <- x
-                            x
-                    crossHist.Add(now)
-                    if crossHist.Count >= spinnerThreshold then
-                        suppress <- true
-        suppress
-
-    /// Decide what (if anything) to emit for an incoming
-    /// `RowsChanged []` notification. Reads the current
-    /// screen snapshot, computes hashes, applies dedup +
-    /// spinner + debounce, returns the `CoalescedNotification`
-    /// list to push downstream (zero or one item).
-    ///
-    /// Public for unit testability — production code calls
-    /// this from the `runLoop` reader task; tests drive it
-    /// directly with a `FakeTimeProvider`.
-    let processRowsChanged
-            (state: State)
-            (now: DateTimeOffset)
-            (snapshot: Cell[][]) : CoalescedNotification list =
-        // Streaming-path instrumentation. Per-event entries are
-        // emitted at Debug so the production default (Information)
-        // sees no per-frame I/O. Set the min-level to Debug via
-        // env-var override when reproducing a streaming-silence
-        // bug; the trail then distinguishes "Coalescer dropped
-        // the event by design" from "Coalescer didn't see the
-        // event" from "Coalescer emitted but Drain didn't pick
-        // up". Information-level was tried in PR #109 but
-        // produced enough log I/O at typing speed to lag the WPF
-        // dispatcher visibly; demoted to Debug here.
-        let logger = Logger.get "Terminal.Core.Coalescer.processRowsChanged"
-        // PR-M (Issue #117): compute per-row hashes ONCE and reuse
-        // for both frame-hash and spinner-gate checks. The
-        // pre-PR-M code walked snapshot twice (hashFrame + the
-        // suppress loop); the precompute is cheaper, and the
-        // change-detection logic in `isSpinnerSuppressed` needs
-        // the full array anyway.
-        let rowHashes =
-            Array.init snapshot.Length (fun i -> hashRow i snapshot.[i])
-        // PR-M: content-only hashes for the cross-row gate.
-        let contentHashes =
-            Array.init snapshot.Length (fun i -> hashRowContent snapshot.[i])
-        let frameHash =
-            let mutable h = 0UL
-            for rh in rowHashes do h <- h ^^^ rh
-            h
-        // Frame-level dedup: identical content → suppress
-        // entirely. This is the layer that composes with
-        // Ink's full-frame redraws.
-        match state.LastFrameHash with
-        | ValueSome prev when prev = frameHash ->
-            logger.LogDebug(
-                "Suppressed (frame-dedup). FrameHash=0x{Hash:X16}", frameHash)
-            []
-        | _ ->
-            gcHistory state now
-            // PR-M: spinner check now considers BOTH per-key
-            // (cycling-character spinners) AND cross-row (moving
-            // spinners) gates. Either gate firing suppresses the
-            // whole frame.
-            let suppress =
-                isSpinnerSuppressed state now rowHashes contentHashes
-            // PR-M: update LastRowHashes AFTER the suppress check
-            // (which read the previous values for change-detection)
-            // and BEFORE the early return so the next frame's
-            // change-detection has the correct baseline regardless
-            // of whether we emit.
-            state.LastRowHashes <- ValueSome rowHashes
-            if suppress then
-                // Update LastFrameHash so we don't re-suppress
-                // when content actually changes again.
-                state.LastFrameHash <- ValueSome frameHash
-                logger.LogDebug(
-                    "Suppressed (spinner). FrameHash=0x{Hash:X16}", frameHash)
-                []
-            else
-                // Debounce decision: leading-edge or queue?
-                let elapsed =
-                    match state.LastFlushAt with
-                    | ValueNone -> debounceWindow + debounceWindow
-                    | ValueSome t -> now - t
-                if elapsed >= debounceWindow then
-                    // Leading-edge: emit immediately.
-                    state.LastFrameHash <- ValueSome frameHash
-                    state.LastFlushAt <- ValueSome now
-                    state.PendingFrame <- ValueNone
-                    state.PendingHash <- ValueNone
-                    let rendered = renderRows snapshot
-                    // INFO — emit entries are bounded by the
-                    // 200ms debounce (~5/sec max) and are the
-                    // primary signal that the streaming pipeline
-                    // is alive. Suppress / accumulate entries
-                    // stay at Debug.
-                    logger.LogInformation(
-                        "Emit OutputBatch (leading-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
-                        frameHash, rendered.Length)
-                    [ OutputBatch rendered ]
-                else
-                    // Within debounce: accumulate; trailing
-                    // edge will flush.
-                    state.PendingFrame <- ValueSome snapshot
-                    state.PendingHash <- ValueSome frameHash
-                    logger.LogDebug(
-                        "Accumulated (within debounce window). FrameHash=0x{Hash:X16}",
-                        frameHash)
-                    []
-
-    /// Trailing-edge timer tick. If anything is pending and
-    /// the debounce window has elapsed, emit it.
-    let onTimerTick
-            (state: State)
-            (now: DateTimeOffset) : CoalescedNotification list =
-        let logger = Logger.get "Terminal.Core.Coalescer.onTimerTick"
-        match state.PendingFrame, state.PendingHash with
-        | ValueSome snapshot, ValueSome hash ->
-            let elapsed =
-                match state.LastFlushAt with
-                | ValueNone -> debounceWindow
-                | ValueSome t -> now - t
-            if elapsed >= debounceWindow then
-                state.LastFrameHash <- ValueSome hash
-                state.LastFlushAt <- ValueSome now
-                state.PendingFrame <- ValueNone
-                state.PendingHash <- ValueNone
-                let rendered = renderRows snapshot
-                logger.LogInformation(
-                    "Emit OutputBatch (trailing-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
-                    hash, rendered.Length)
-                [ OutputBatch rendered ]
-            else
-                []
-        | _ -> []
-
-    /// Mode-change barrier: flush any pending accumulator
-    /// (synthesising a snapshot from the saved pending
-    /// frame), reset frame-hash + spinner state, then
-    /// pass through the ModeChanged signal so the drain
-    /// can announce the transition.
-    ///
-    /// **Framework-cycle contract (PR-N).** Profile-detection
-    /// logic (Output framework cycle, Part 3 of
-    /// `docs/PROJECT-PLAN-2026-05.md`) MUST NOT assume screen
-    /// content is stable across a mode change. ModeChanged
-    /// signals that the semantic context has shifted (alt-screen
-    /// toggle, cursor-key mode change, etc.); the screen buffer
-    /// behind the next read may be the alternate-buffer's
-    /// pre-existing state, blank, or the previous primary
-    /// buffer — none of which are reliable indicators of the
-    /// new profile. Profiles must wait for the first
-    /// post-`ModeBarrier` `RowsChanged` to inspect content; a
-    /// profile-classifier reading the snapshot at the
-    /// `ModeBarrier` itself will see stale visual state and
-    /// mis-classify.
-    let onModeChanged
-            (state: State)
-            (now: DateTimeOffset)
-            (flag: TerminalModeFlag)
-            (value: bool) : CoalescedNotification list =
-        let flushed =
-            match state.PendingFrame with
-            | ValueSome snapshot ->
-                state.PendingFrame <- ValueNone
-                state.PendingHash <- ValueNone
-                [ OutputBatch (renderRows snapshot) ]
-            | ValueNone -> []
-        // Reset coalescer state — the buffer just changed
-        // wholesale (alt-screen swap, etc.). PR-M: also reset
-        // LastRowHashes (so post-mode-change first frame treats
-        // every row as changed and re-engages the gates) and
-        // HashHistory (the cross-row gate's accumulated counts
-        // are about a different screen).
-        state.LastFrameHash <- ValueNone
-        state.LastFlushAt <- ValueSome now
-        state.LastRowHashes <- ValueNone
-        state.PerRowHistory.Clear()
-        state.HashHistory.Clear()
-        flushed @ [ ModeBarrier (flag, value) ]
-
-    /// Pass-through for parser errors. No coalescing — errors
-    /// are immediate by design (they signal something the
-    /// user needs to know about now).
-    let onParserError (message: string) : CoalescedNotification list =
-        [ ErrorPassthrough (AnnounceSanitiser.sanitise message) ]
-
-    /// Production reader loop. Drains the input channel,
-    /// dispatches each notification through the appropriate
-    /// `process*` function, and writes resulting
-    /// `CoalescedNotification`s to the output channel. Runs
-    /// the trailing-edge timer in parallel via
-    /// `Task.WhenAny` over the read + the timer task.
-    let runLoop
-            (input: ChannelReader<ScreenNotification>)
-            (output: ChannelWriter<CoalescedNotification>)
-            (screen: Screen)
-            (timeProvider: TimeProvider)
-            (ct: CancellationToken) : Task =
-        Task.Run(fun () ->
-            task {
-                let logger = Logger.get "Terminal.Core.Coalescer"
-                logger.LogInformation(
-                    "runLoop starting. debounceWindow={Debounce} spinnerWindow={Spinner} spinnerThreshold={Threshold}",
-                    debounceWindow,
-                    spinnerWindow,
-                    spinnerThreshold)
-                let state = createState ()
-                let mutable lastSnapshotSeq = -1L
-                use timer = new PeriodicTimer(debounceWindow, timeProvider)
-                let writeOne (notification: CoalescedNotification) =
-                    task {
-                        let! _ = output.WriteAsync(notification, ct).AsTask()
-                        return ()
-                    }
-                let writeAll (xs: CoalescedNotification list) =
-                    task {
-                        for n in xs do
-                            do! writeOne n
-                    }
-                let processNotification (n: ScreenNotification) =
-                    task {
-                        let now = timeProvider.GetUtcNow()
-                        match n with
-                        | RowsChanged _ ->
-                            // RowsChanged carries no row-info
-                            // today; the coalescer reads the
-                            // snapshot itself and dedups via
-                            // sequence number + frame hash.
-                            let seq, snapshot = screen.SnapshotRows(0, screen.Rows)
-                            if seq <> lastSnapshotSeq then
-                                lastSnapshotSeq <- seq
-                                let emits = processRowsChanged state now snapshot
-                                do! writeAll emits
-                        | ParserError msg ->
-                            do! writeAll (onParserError msg)
-                        | ModeChanged (flag, value) ->
-                            do! writeAll (onModeChanged state now flag value)
-                    }
-                try
-                    let! _ = input.WaitToReadAsync(ct).AsTask()
-                    let mutable keepGoing = true
-                    // PeriodicTimer.WaitForNextTickAsync throws
-                    // InvalidOperationException ("Operation is not
-                    // valid due to the state of the object") if
-                    // called concurrently — a second call before the
-                    // previous returns. Each loop iteration's
-                    // Task.WhenAny wins on EITHER timer or reader; if
-                    // the reader wins, the timer's wait is still
-                    // pending. Without this state-tracking, the next
-                    // iteration would invoke WaitForNextTickAsync
-                    // again on a still-pending timer and crash.
-                    //
-                    // Fix: keep the pending timer task across
-                    // iterations. Only start a new
-                    // WaitForNextTickAsync after the previous one
-                    // has fired.
-                    let mutable pendingTimerWait : Task | null = null
-                    while keepGoing && not ct.IsCancellationRequested do
-                        // Drain everything currently available.
-                        let mutable peek = Unchecked.defaultof<ScreenNotification>
-                        while input.TryRead(&peek) do
-                            do! processNotification peek
-                        // Reuse the still-pending timer task from a
-                        // previous reader-wins iteration; otherwise
-                        // start a fresh wait.
-                        let timerWait : Task =
-                            match pendingTimerWait with
-                            | null -> timer.WaitForNextTickAsync(ct).AsTask() :> Task
-                            | t -> t
-                        pendingTimerWait <- timerWait
-                        let readWait = input.WaitToReadAsync(ct).AsTask()
-                        let! winner = Task.WhenAny(timerWait, readWait :> Task)
-                        if obj.ReferenceEquals(winner, timerWait) then
-                            // Timer tick fired: clear the pending
-                            // slot so the next iteration starts a
-                            // fresh wait, and flush any pending
-                            // accumulator.
-                            pendingTimerWait <- null
-                            let now = timeProvider.GetUtcNow()
-                            let emits = onTimerTick state now
-                            do! writeAll emits
-                        else
-                            // Reader won; timer wait stays in
-                            // pendingTimerWait for next iteration.
-                            // Did the channel close?
-                            let! got = readWait
-                            if not got then keepGoing <- false
-                with
-                | :? OperationCanceledException ->
-                    logger.LogInformation("runLoop cancelled cleanly.")
-                | ex ->
-                    // Log the FULL exception (type, message, stack
-                    // trace, inner exception chain) BEFORE the
-                    // sanitised user-facing announcement. This is
-                    // the diagnostic path for the post-Stage-6
-                    // intermittent crash.
-                    logger.LogError(
-                        ex,
-                        "Coalescer runLoop crashed at lastSnapshotSeq={LastSeq}.",
-                        lastSnapshotSeq)
-                    // Surface as parser-error so the user hears
-                    // about coalescer-internal failures rather
-                    // than the channel just going silent.
-                    do! writeOne (ErrorPassthrough
-                        (sprintf "Coalescer crashed: %s"
-                            (AnnounceSanitiser.sanitise ex.Message)))
-            } :> Task)

--- a/src/Terminal.Core/OutputDispatcher.fs
+++ b/src/Terminal.Core/OutputDispatcher.fs
@@ -1,6 +1,9 @@
 namespace Terminal.Core
 
-/// Stage 8a — output framework dispatcher + registries.
+open System
+
+/// Stage 8a — output framework dispatcher + registries (extended
+/// in 8b with `dispatchTick` for time-driven flush).
 ///
 /// One file holds three submodules so the abstraction surface
 /// stays small. The shape mirrors the canonical extensibility
@@ -93,21 +96,49 @@ module OutputDispatcher =
                 profiles <- Map.empty
                 activeProfileSet <- [])
 
+    /// Route a `(effectiveEvent, decisions)` pair to its
+    /// channels. Each ChannelDecision is sent to the channel
+    /// resolved by `ChannelRegistry.lookup`; the channel's
+    /// `Send` receives the effectiveEvent for activity-ID /
+    /// notification-processing decisions, and the Render for
+    /// the actual emission. Decisions referencing an
+    /// unregistered channel are silently dropped.
+    let private routePair (effectiveEvent: OutputEvent) (decisions: ChannelDecision[]) : unit =
+        for decision in decisions do
+            match ChannelRegistry.lookup decision.Channel with
+            | Some channel -> channel.Send effectiveEvent decision.Render
+            | None -> ()
+
     /// Dispatch one `OutputEvent` through the active profile set
-    /// and into each profile-decided channel. Channels are
-    /// invoked sequentially in `ChannelDecision[]` order; each
-    /// channel's own `Send` is responsible for any internal
-    /// queueing or dispatcher-thread marshalling. Decisions
-    /// referencing an unregistered channel are silently dropped.
-    ///
-    /// 8a profile contract: the Stream profile returns one
-    /// decision per event (NVDA channel + `RenderText`). 8b/8c/8d
-    /// add fan-out; the dispatcher is unchanged.
+    /// and into each profile-decided channel. Each profile's
+    /// `Apply` returns an array of `(effectiveEvent, decisions)`
+    /// pairs (most profiles return one pair carrying the input
+    /// event verbatim; the Stream profile may return two pairs
+    /// when a mode-change forces a pending-stream flush). The
+    /// dispatcher routes each pair through `routePair`.
     let dispatch (event: OutputEvent) : unit =
         let profileSet = ProfileRegistry.getActiveProfileSet ()
         for profile in profileSet do
-            let decisions = profile.Apply event
-            for decision in decisions do
-                match ChannelRegistry.lookup decision.Channel with
-                | Some channel -> channel.Send event decision.Render
-                | None -> ()
+            let pairs = profile.Apply event
+            for (effectiveEvent, decisions) in pairs do
+                routePair effectiveEvent decisions
+
+    /// Dispatch a time-driven tick. Called by the composition
+    /// root's TickPump task on each `PeriodicTimer` tick. Each
+    /// active profile's `Tick` returns `(effectiveEvent,
+    /// decisions)` pairs the same way `Apply` does; profiles
+    /// that don't accumulate (Selection, Earcon, the future
+    /// Form / TUI / REPL profiles) supply
+    /// `Tick = fun _ -> [||]`, and `dispatchTick` then calls
+    /// `routePair` zero times for them.
+    ///
+    /// Stage 8b adds this. The Stream profile uses it to release
+    /// pending stream content when the debounce window elapses
+    /// with no new event arriving (the Stage-7 trailing-edge
+    /// flush).
+    let dispatchTick (now: DateTimeOffset) : unit =
+        let profileSet = ProfileRegistry.getActiveProfileSet ()
+        for profile in profileSet do
+            let pairs = profile.Tick now
+            for (effectiveEvent, decisions) in pairs do
+                routePair effectiveEvent decisions

--- a/src/Terminal.Core/OutputEventBuilder.fs
+++ b/src/Terminal.Core/OutputEventBuilder.fs
@@ -1,74 +1,73 @@
 namespace Terminal.Core
 
-/// Stage 8a — translation from the existing
-/// `Coalescer.CoalescedNotification` DU to the new framework
-/// `OutputEvent`. The drain task in
-/// `src/Terminal.App/Program.fs` calls into this module instead
-/// of constructing the `(message, activityId)` tuple inline.
+/// Stage 8b — translation from raw `ScreenNotification` to raw
+/// `OutputEvent`. The `TranslatorPump` task in
+/// `src/Terminal.App/Program.fs` reads ScreenNotifications from
+/// the parser-side `notificationChannel` and calls into this
+/// module to build the OutputEvents the dispatcher routes.
 ///
-/// Mapping per spec
-/// `spec/event-and-output-framework.md` Part D.2 (with `OutputBatch`
-/// taking the `RowsChanged` slot, since the Coalescer in 8a is
-/// the producer of post-debounce `OutputBatch` events that 8b
-/// will absorb into the Stream profile):
+/// **Pre-coalesce, post-translation.** Stage 8a's translator
+/// ran AFTER the Coalescer (`fromCoalescedNotification`); the
+/// CoalescedNotification carried post-debounce, post-cap text.
+/// Stage 8b's translator runs BEFORE coalescing — the Stream
+/// profile's `Apply` is now the producer of post-coalesce
+/// events. So the OutputEvents this module builds carry minimal
+/// payloads:
 ///
-/// | `CoalescedNotification` | `Semantic` | `Priority` |
-/// |---|---|---|
-/// | `OutputBatch text` | `StreamChunk` | `Polite` |
-/// | `ErrorPassthrough s` | `ParserError` | `Background` |
-/// | `ModeBarrier(AltScreen, true)` | `AltScreenEntered` | `Assertive` |
-/// | `ModeBarrier(AltScreen, false)` | `ModeBarrier` | `Assertive` |
-/// | `ModeBarrier(other, _)` | `ModeBarrier` | `Polite` |
+/// | `ScreenNotification` | `Semantic` | `Priority` | `Payload` |
+/// |---|---|---|---|
+/// | `RowsChanged _` | `StreamChunk` | `Polite` | `""` (empty — Stream profile reads the screen) |
+/// | `ParserError msg` | `ParserError` | `Background` | sanitised + wrapped error message |
+/// | `ModeChanged(AltScreen, true)` | `AltScreenEntered` | `Assertive` | `""` |
+/// | `ModeChanged(AltScreen, false)` | `ModeBarrier` | `Assertive` | `""` |
+/// | `ModeChanged(other, _)` | `ModeBarrier` | `Polite` | `""` |
 ///
-/// Note: spec D.2 maps `ParserError → Background`, where
-/// Background is "suppressed at profile layer; never emitted as
-/// UIA notification" per spec B.5.2. Stage 8a's Stream profile
-/// is a pass-through and does NOT honour that suppression — see
-/// `OutputEventTypes.fs` `Priority` documentation. This means
-/// 8a behaviour is identical to Stage 7: parser errors continue
-/// to reach NVDA via `pty-speak.error`. The Background contract
-/// activates in 8b/8c when profiles + channels start consulting
-/// `Priority`.
+/// **Sanitisation.** ParserError text is sanitised through
+/// `AnnounceSanitiser.sanitise` before placement in Payload —
+/// the producer-responsibility chokepoint per spec B.2.4 step 5
+/// + the PR-N entry-gate contract. The Stream profile's
+/// `Apply`/`Tick` flushes preserve the same sanitisation
+/// invariant via `Coalescer.renderRows` per-row sanitising.
 ///
-/// All payloads are already sanitised by the time they reach
-/// this builder: `OutputBatch` text comes from
-/// `Coalescer.renderRows` which sanitises per-row, and
-/// `ErrorPassthrough` text comes from `Coalescer.onParserError`
-/// which sanitises. The builder just adds the spec D.2 metadata.
+/// **Spec D.2 ParserError → Background note.** Carried over
+/// from 8a: spec D.2 maps ParserError to Background, where
+/// Background is "suppressed at profile layer" per B.5.2. The
+/// 8b Stream profile's Apply does NOT suppress Background
+/// events — it dispatches a ChannelDecision that announces via
+/// NVDA. So 8b's behaviour matches Stage 7 (parser errors reach
+/// NVDA via ActivityIds.error). The Background contract
+/// activates when a future stage's profile or channel starts
+/// honouring it.
 module OutputEventBuilder =
 
-    /// Stable producer identifier the framework dispatch path
-    /// records on every event the drain emits. 8a producer is
-    /// "drain"; 8b moves this to "stream" when the Coalescer
-    /// absorbs as the Stream profile.
-    let internal producerId = "drain"
+    /// Stable producer identifier for translator-built events.
+    /// 8b producer is "translator"; the StreamProfile's
+    /// post-coalesce events use producer "stream" (set inside
+    /// `StreamProfile.create`'s Apply / Tick closures).
+    let internal producerId = "translator"
 
-    /// Translate a `CoalescedNotification` into an `OutputEvent`.
-    /// Caller (Program.fs drain) passes the post-cap text for
-    /// `OutputBatch` so the 500-char announce stopgap stays in
-    /// the drain (where it lives today). 8b moves the cap into
-    /// `StreamProfile.Apply` once the profile owns the
-    /// max-announce-chars parameter.
-    let fromCoalescedNotification
-        (coalesced: Coalescer.CoalescedNotification)
-        : OutputEvent
-        =
-        match coalesced with
-        | Coalescer.OutputBatch text ->
+    /// Translate a raw `ScreenNotification` into a raw
+    /// `OutputEvent` the dispatcher can route through the active
+    /// profile set. The Stream profile's Apply matches on the
+    /// resulting Semantic and either accumulates (StreamChunk),
+    /// produces an immediate decision (ParserError), or flushes +
+    /// emits a barrier (AltScreenEntered / ModeBarrier).
+    let fromScreenNotification (notification: ScreenNotification) : OutputEvent =
+        match notification with
+        | RowsChanged _ ->
             OutputEvent.create
                 SemanticCategory.StreamChunk
                 Priority.Polite
                 producerId
-                text
-        | Coalescer.ErrorPassthrough s ->
-            // Preserves the Stage 7 drain's exact wrapping so
-            // NVDA reads the same text post-retrofit.
+                ""
+        | ParserError msg ->
             OutputEvent.create
                 SemanticCategory.ParserError
                 Priority.Background
                 producerId
-                (sprintf "Terminal parser error: %s" s)
-        | Coalescer.ModeBarrier (flag, value) ->
+                (sprintf "Terminal parser error: %s"
+                    (AnnounceSanitiser.sanitise msg))
+        | ModeChanged (flag, value) ->
             let semantic, priority =
                 match flag, value with
                 | TerminalModeFlag.AltScreen, true ->
@@ -77,9 +76,4 @@ module OutputEventBuilder =
                     SemanticCategory.ModeBarrier, Priority.Assertive
                 | _ ->
                     SemanticCategory.ModeBarrier, Priority.Polite
-            // Stage 5's mode-barrier announcement is the empty
-            // string — see `Types.fs:290-294` (`ActivityIds.mode`).
-            // The empty payload survives behaviour-identically;
-            // a future stage may flip this to a verbosity-aware
-            // description.
             OutputEvent.create semantic priority producerId ""

--- a/src/Terminal.Core/OutputEventTypes.fs
+++ b/src/Terminal.Core/OutputEventTypes.fs
@@ -1,5 +1,6 @@
 namespace Terminal.Core
 
+open System
 open System.Collections.Generic
 
 /// Stage 8a — output framework substrate types.
@@ -264,14 +265,51 @@ type Channel =
     { Id: ChannelId
       Send: OutputEvent -> RenderInstruction -> unit }
 
-/// A profile is a pure function `OutputEvent → ChannelDecision[]`
-/// with per-instance state. `Reset` is invoked when the active
-/// shell changes (8f) so the profile can clear any
-/// per-shell-session caches; 8a's pass-through Stream profile
-/// has no state to reset, but the contract is in place.
+/// A profile is a pure function with per-instance state. `Apply`
+/// is the per-event entry point; `Tick` is the time-driven flush
+/// for profiles that accumulate across a debounce / window cycle;
+/// `Reset` is invoked when the active shell changes (8f) so the
+/// profile can clear any per-shell-session caches.
+///
+/// Both `Apply` and `Tick` return
+/// `(OutputEvent * ChannelDecision[])[]` — an array of
+/// `(effectiveEvent, decisionsForThatEvent)` pairs:
+///
+/// - `effectiveEvent` is the OutputEvent the channel's `Send`
+///   receives. For pass-through profiles it equals the input
+///   event; for synthesised emits (Stream's debounce flush, or
+///   the flushed-pending-stream produced when a mode-change
+///   triggers a barrier) it's a synthesised event with the
+///   appropriate Semantic / Priority / Payload that drives the
+///   channel's per-event mapping (e.g. NvdaChannel's
+///   Semantic → ActivityId).
+/// - `decisionsForThatEvent` is the array of channel-render
+///   decisions for that event.
+///
+/// **Multi-pair Apply.** Most profiles return a single pair.
+/// The Stream profile may return two pairs when an incoming
+/// mode-change forces a flush: one pair for the flushed-pending
+/// stream content (Semantic = StreamChunk → ActivityIds.output)
+/// and one for the mode barrier itself (Semantic =
+/// AltScreenEntered or ModeBarrier → ActivityIds.mode). Each
+/// pair carries its own effectiveEvent so the channel's
+/// per-event activity mapping picks the right ActivityId.
+///
+/// **Tick contract.** Profiles that don't accumulate (Selection,
+/// Earcon, the future Form / TUI / REPL profiles) supply
+/// `Tick = fun _ -> [||]` — zero-cost no-op. The dispatcher's
+/// `OutputDispatcher.dispatchTick` is the caller; a `TickPump`
+/// task in the composition root runs a `PeriodicTimer(50ms)` and
+/// invokes `dispatchTick` on each tick.
+///
+/// See `spec/event-and-output-framework.md` Part B.3. The spec
+/// is silent on time-driven flush + multi-pair Apply; 8b adds
+/// these as substrate extensions; a focused doc-only PR will
+/// update the spec after maintainer approval.
 type Profile =
     { Id: ProfileId
-      Apply: OutputEvent -> ChannelDecision[]
+      Apply: OutputEvent -> (OutputEvent * ChannelDecision[])[]
+      Tick: DateTimeOffset -> (OutputEvent * ChannelDecision[])[]
       Reset: unit -> unit }
 
 /// 8a OutputEvent default — convenient constructor for the

--- a/src/Terminal.Core/StreamProfile.fs
+++ b/src/Terminal.Core/StreamProfile.fs
@@ -1,42 +1,467 @@
 namespace Terminal.Core
 
-/// Stage 8a — Stream profile (pass-through stub).
+open System
+open System.Collections.Generic
+open Microsoft.Extensions.Logging
+
+/// Stage 8b — Stream profile (Coalescer absorbs as a Profile
+/// instance).
 ///
-/// 8a's Stream profile is the substrate seam between the
-/// existing Coalescer drain and the new framework: every
-/// `OutputEvent` produces exactly one `ChannelDecision`
-/// targeting the NVDA channel with a `RenderText` of the
-/// event's payload. No debounce, no spinner-suppress, no
-/// max-announce-chars cap — those still live in the existing
-/// `Coalescer.runLoop` + drain caller in 8a.
+/// The four algorithms (per-row hash + frame-hash dedup, the
+/// per-`(rowIdx, hash)` and cross-row spinner gates, leading-
+/// and trailing-edge debounce, alt-screen flush barrier) move
+/// out of `Coalescer.fs` and into this module. Constants that
+/// were Stage 7 module globals (debounceWindow / spinnerWindow
+/// / spinnerThreshold / maxAnnounceChars) become per-instance
+/// parameters per the PR-N substrate-cleanup contract previously
+/// docstring'd at `Coalescer.fs:82-99`.
 ///
-/// **8b absorbs the Coalescer.** When stage 8b lands, this
-/// module gains the `Parameters` record (DebounceWindowMs /
-/// SpinnerWindowMs / SpinnerThreshold / MaxAnnounceChars per
-/// the PR-N docstring contract in `Coalescer.fs:82-114`) and
-/// `Apply` becomes the real coalescing logic. The `create`
-/// signature evolves to take parameters; the 8a no-arg
-/// constructor remains for backward-compat where the absent
-/// args read the PR-N module-default constants.
+/// `Coalescer.fs` retains: the `CoalescedNotification` DU
+/// (algorithm intermediate type), and the five pure helpers
+/// (`hashRowContent`, `hashRow`, `hashAttrs`, `hashFrame`,
+/// `renderRows`). Tests that pin the algorithm internals
+/// (`tests/Tests.Unit/StreamProfileTests.fs`, renamed from
+/// `CoalescerTests.fs`) call `StreamProfile.processRowsChanged`
+/// / `onTimerTick` / `onModeChanged` / `onParserError` directly
+/// against a fresh State + explicit Parameters; the Profile
+/// record's `Apply` + `Tick` are constructed in `create` and
+/// wire those algorithms to the dispatcher.
 ///
 /// **Spec reference.** `spec/event-and-output-framework.md`
-/// Part B.3.2 (the "Stream profile" row of the v1 profile
-/// table).
+/// Part B.3 (Profile abstraction). The spec is silent on
+/// time-driven flush; 8b adds `Profile.Tick` and a multi-pair
+/// `Apply` return type as substrate extensions per the
+/// `OutputEventTypes.fs` Profile docstring.
 module StreamProfile =
 
-    /// Stable profile identifier registered with the
-    /// dispatcher's `ProfileRegistry`. The TOML
-    /// `[profile.stream]` section in 9c keys on this string.
+    /// Stable profile identifier registered with the dispatcher's
+    /// `ProfileRegistry`. The 9c TOML config keys
+    /// `[profile.stream]` on this string.
     [<Literal>]
     let id: ProfileId = "stream"
 
-    /// Construct a Stream profile instance. 8a takes no
-    /// parameters; 8b adds the `Parameters` record argument
-    /// when the Coalescer absorbs.
-    let create () : Profile =
+    /// Per-instance Stream-profile parameters. Caller-supplied
+    /// at construction time so different callers (test harness,
+    /// future per-shell mappings, the next sub-stage's TOML
+    /// loader) can override the defaults independently. The PR-N
+    /// substrate-cleanup contract: these were Stage 7 module
+    /// globals; Stage 8b lifts them to per-instance parameters
+    /// without changing the values themselves. The 9c TOML loader
+    /// will override these per the `[profile.stream]` section
+    /// when it ships.
+    type Parameters =
+        { DebounceWindowMs: int
+          SpinnerWindowMs: int
+          SpinnerThreshold: int
+          MaxAnnounceChars: int }
+
+    /// Stage 7 / PR-N defaults. Stage 8b ships behaviour-identical
+    /// with these values; 8b.2's TOML loader will override per
+    /// `[profile.stream]` when present.
+    let defaultParameters: Parameters =
+        { DebounceWindowMs = 200
+          SpinnerWindowMs = 1000
+          SpinnerThreshold = 5
+          MaxAnnounceChars = 500 }
+
+    /// Spinner-suppression key: the per-row hash plus the row
+    /// index it came from. A spinner that overwrites the same
+    /// cell with cycling characters (`|/-\` etc.) generates the
+    /// same `(rowIdx, hash)` tuple repeatedly across each cycle,
+    /// which the per-key history catches once the recurrence
+    /// count crosses the threshold.
+    type private SpinnerKey = int * uint64
+
+    /// The Stream profile's mutable state. One instance per
+    /// `create` call (per shell session in production); no
+    /// concurrent access (the WPF Dispatcher serialises Apply
+    /// + Tick invocations on the drain task / TickPump task).
+    /// PR-M's `LastRowHashes` + `HashHistory` are preserved
+    /// verbatim — the cross-row spinner gate logic is unchanged
+    /// across the 8b refactor.
+    type State =
+        { mutable LastFrameHash: uint64 voption
+          mutable LastFlushAt: DateTimeOffset voption
+          mutable PendingFrame: Cell[][] voption
+          mutable PendingHash: uint64 voption
+          mutable LastRowHashes: uint64[] voption
+          PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
+          HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
+
+    /// Construct a fresh State with all mutables `ValueNone` and
+    /// empty dictionaries.
+    let internal createState () : State =
+        { LastFrameHash = ValueNone
+          LastFlushAt = ValueNone
+          PendingFrame = ValueNone
+          PendingHash = ValueNone
+          LastRowHashes = ValueNone
+          PerRowHistory = Dictionary()
+          HashHistory = Dictionary() }
+
+    /// Trim history older than `parameters.SpinnerWindowMs` from
+    /// BOTH dictionaries. Mutates in place.
+    let private gcHistory
+            (parameters: Parameters)
+            (state: State)
+            (now: DateTimeOffset)
+            : unit =
+        let cutoff =
+            now - TimeSpan.FromMilliseconds(float parameters.SpinnerWindowMs)
+        let stalePerRow = ResizeArray()
+        for kvp in state.PerRowHistory do
+            kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
+            if kvp.Value.Count = 0 then stalePerRow.Add(kvp.Key)
+        for k in stalePerRow do
+            state.PerRowHistory.Remove(k) |> ignore
+        let staleHash = ResizeArray()
+        for kvp in state.HashHistory do
+            kvp.Value.RemoveAll(fun ts -> ts < cutoff) |> ignore
+            if kvp.Value.Count = 0 then staleHash.Add(kvp.Key)
+        for k in staleHash do
+            state.HashHistory.Remove(k) |> ignore
+
+    /// Walk all per-row hashes and decide whether either spinner
+    /// gate should suppress. PR-M change-detection: only count
+    /// observations on row-hash CHANGES, not on every row.
+    let private isSpinnerSuppressed
+            (parameters: Parameters)
+            (state: State)
+            (now: DateTimeOffset)
+            (rowHashes: uint64[])
+            (contentHashes: uint64[])
+            : bool =
+        let mutable suppress = false
+        let crossSeenThisFrame = HashSet<uint64>()
+        for i in 0 .. rowHashes.Length - 1 do
+            let rh = rowHashes.[i]
+            let changed =
+                match state.LastRowHashes with
+                | ValueNone -> true
+                | ValueSome arr when i >= arr.Length -> true
+                | ValueSome arr -> arr.[i] <> rh
+            if changed then
+                let key = (i, rh)
+                let perRowHist =
+                    match state.PerRowHistory.TryGetValue key with
+                    | true, x -> x
+                    | false, _ ->
+                        let x = ResizeArray()
+                        state.PerRowHistory.[key] <- x
+                        x
+                perRowHist.Add(now)
+                if perRowHist.Count >= parameters.SpinnerThreshold then
+                    suppress <- true
+                let ch = contentHashes.[i]
+                if crossSeenThisFrame.Add(ch) then
+                    let crossHist =
+                        match state.HashHistory.TryGetValue ch with
+                        | true, x -> x
+                        | false, _ ->
+                            let x = ResizeArray()
+                            state.HashHistory.[ch] <- x
+                            x
+                    crossHist.Add(now)
+                    if crossHist.Count >= parameters.SpinnerThreshold then
+                        suppress <- true
+        suppress
+
+    /// Apply the announce-length cap (Stage 7 PR-H stopgap, GitHub
+    /// issue #139). 8b lifts the cap from the Stage 7 drain
+    /// (Program.fs ~916-950) into the Stream profile per the PR-N
+    /// docstring contract; the threshold remains user-configurable
+    /// via Parameters.MaxAnnounceChars in the 9c TOML loader.
+    let private capAnnounce (parameters: Parameters) (text: string) : string =
+        let limit = parameters.MaxAnnounceChars
+        if text.Length <= limit then
+            text
+        else
+            let head = text.Substring(0, limit)
+            let extra = text.Length - limit
+            sprintf
+                "%s ...announcement truncated; %d more characters available — press Ctrl+Shift+; to copy full log."
+                head
+                extra
+
+    /// Decide what (if anything) to emit for an incoming
+    /// `RowsChanged` snapshot. Computes hashes, applies dedup +
+    /// spinner + debounce, returns 0 or 1 `CoalescedNotification`.
+    /// Public-internal for the test harness — production code
+    /// reaches it via `create`'s `Apply` closure.
+    let internal processRowsChanged
+            (parameters: Parameters)
+            (state: State)
+            (now: DateTimeOffset)
+            (snapshot: Cell[][])
+            : Coalescer.CoalescedNotification list =
+        let logger = Logger.get "Terminal.Core.StreamProfile.processRowsChanged"
+        let rowHashes =
+            Array.init snapshot.Length (fun i -> Coalescer.hashRow i snapshot.[i])
+        let contentHashes =
+            Array.init snapshot.Length (fun i -> Coalescer.hashRowContent snapshot.[i])
+        let frameHash =
+            let mutable h = 0UL
+            for rh in rowHashes do h <- h ^^^ rh
+            h
+        match state.LastFrameHash with
+        | ValueSome prev when prev = frameHash ->
+            logger.LogDebug(
+                "Suppressed (frame-dedup). FrameHash=0x{Hash:X16}", frameHash)
+            []
+        | _ ->
+            gcHistory parameters state now
+            let suppress =
+                isSpinnerSuppressed parameters state now rowHashes contentHashes
+            state.LastRowHashes <- ValueSome rowHashes
+            if suppress then
+                state.LastFrameHash <- ValueSome frameHash
+                logger.LogDebug(
+                    "Suppressed (spinner). FrameHash=0x{Hash:X16}", frameHash)
+                []
+            else
+                let debounceWindow =
+                    TimeSpan.FromMilliseconds(float parameters.DebounceWindowMs)
+                let elapsed =
+                    match state.LastFlushAt with
+                    | ValueNone -> debounceWindow + debounceWindow
+                    | ValueSome t -> now - t
+                if elapsed >= debounceWindow then
+                    state.LastFrameHash <- ValueSome frameHash
+                    state.LastFlushAt <- ValueSome now
+                    state.PendingFrame <- ValueNone
+                    state.PendingHash <- ValueNone
+                    let rendered = Coalescer.renderRows snapshot |> capAnnounce parameters
+                    logger.LogInformation(
+                        "Emit OutputBatch (leading-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
+                        frameHash, rendered.Length)
+                    [ Coalescer.OutputBatch rendered ]
+                else
+                    state.PendingFrame <- ValueSome snapshot
+                    state.PendingHash <- ValueSome frameHash
+                    logger.LogDebug(
+                        "Accumulated (within debounce window). FrameHash=0x{Hash:X16}",
+                        frameHash)
+                    []
+
+    /// Trailing-edge timer tick. If anything is pending and the
+    /// debounce window has elapsed, emit it.
+    let internal onTimerTick
+            (parameters: Parameters)
+            (state: State)
+            (now: DateTimeOffset)
+            : Coalescer.CoalescedNotification list =
+        let logger = Logger.get "Terminal.Core.StreamProfile.onTimerTick"
+        match state.PendingFrame, state.PendingHash with
+        | ValueSome snapshot, ValueSome hash ->
+            let debounceWindow =
+                TimeSpan.FromMilliseconds(float parameters.DebounceWindowMs)
+            let elapsed =
+                match state.LastFlushAt with
+                | ValueNone -> debounceWindow
+                | ValueSome t -> now - t
+            if elapsed >= debounceWindow then
+                state.LastFrameHash <- ValueSome hash
+                state.LastFlushAt <- ValueSome now
+                state.PendingFrame <- ValueNone
+                state.PendingHash <- ValueNone
+                let rendered = Coalescer.renderRows snapshot |> capAnnounce parameters
+                logger.LogInformation(
+                    "Emit OutputBatch (trailing-edge). FrameHash=0x{Hash:X16} TextLen={Len}",
+                    hash, rendered.Length)
+                [ Coalescer.OutputBatch rendered ]
+            else
+                []
+        | _ -> []
+
+    /// Mode-change barrier: flush any pending accumulator
+    /// (synthesising a snapshot from the saved pending frame),
+    /// reset frame-hash + spinner state, then pass through the
+    /// ModeChanged signal so the channel can announce the
+    /// transition. Algorithm preserved verbatim from the Stage 7
+    /// `Coalescer.onModeChanged`; the per-instance `parameters`
+    /// argument is unused here today (no parameter influences
+    /// mode-barrier semantics) but the signature is kept aligned
+    /// with the other algorithm functions for symmetry.
+    let internal onModeChanged
+            (parameters: Parameters)
+            (state: State)
+            (now: DateTimeOffset)
+            (flag: TerminalModeFlag)
+            (value: bool)
+            : Coalescer.CoalescedNotification list =
+        let flushed =
+            match state.PendingFrame with
+            | ValueSome snapshot ->
+                state.PendingFrame <- ValueNone
+                state.PendingHash <- ValueNone
+                let rendered =
+                    Coalescer.renderRows snapshot |> capAnnounce parameters
+                [ Coalescer.OutputBatch rendered ]
+            | ValueNone -> []
+        state.LastFrameHash <- ValueNone
+        state.LastFlushAt <- ValueSome now
+        state.LastRowHashes <- ValueNone
+        state.PerRowHistory.Clear()
+        state.HashHistory.Clear()
+        flushed @ [ Coalescer.ModeBarrier (flag, value) ]
+
+    /// Pass-through for parser errors. No coalescing — errors are
+    /// immediate by design (they signal something the user needs
+    /// to know about now).
+    let internal onParserError (message: string) : Coalescer.CoalescedNotification list =
+        [ Coalescer.ErrorPassthrough (AnnounceSanitiser.sanitise message) ]
+
+    /// Build a streaming-output OutputEvent for a flushed batch
+    /// of post-coalesce text. The synthesized event carries
+    /// `Semantic = StreamChunk` so the NvdaChannel routes it to
+    /// `ActivityIds.output` regardless of which input event
+    /// triggered the flush (a normal RowsChanged, a mode change
+    /// flushing pending content, or a Tick-driven trailing-edge
+    /// flush).
+    let private streamOutputEvent (text: string) : OutputEvent =
+        OutputEvent.create
+            SemanticCategory.StreamChunk
+            Priority.Polite
+            id
+            text
+
+    /// Build a parser-error OutputEvent.
+    let private parserErrorEvent (sanitised: string) : OutputEvent =
+        OutputEvent.create
+            SemanticCategory.ParserError
+            Priority.Background
+            id
+            (sprintf "Terminal parser error: %s" sanitised)
+
+    /// Build a NVDA-channel decision rendering the supplied text.
+    let private nvdaTextDecision (text: string) : ChannelDecision =
+        { Channel = NvdaChannel.id
+          Render = RenderText text }
+
+    /// Translate a `CoalescedNotification` into an
+    /// `(effectiveEvent, ChannelDecision[])` pair the dispatcher
+    /// can route. The effectiveEvent is the synthesised
+    /// OutputEvent that NvdaChannel reads `Semantic` from for
+    /// activity-ID mapping.
+    let private coalescedToPair
+            (inputEvent: OutputEvent)
+            (coalesced: Coalescer.CoalescedNotification)
+            : OutputEvent * ChannelDecision[] =
+        match coalesced with
+        | Coalescer.OutputBatch text ->
+            let event = streamOutputEvent text
+            event, [| nvdaTextDecision text |]
+        | Coalescer.ErrorPassthrough s ->
+            let event = parserErrorEvent s
+            event, [| nvdaTextDecision event.Payload |]
+        | Coalescer.ModeBarrier _ ->
+            // The mode barrier reuses the input event's Semantic
+            // / Priority (AltScreenEntered / ModeBarrier with the
+            // appropriate Priority) so NvdaChannel routes via
+            // `ActivityIds.mode`. Stage 5's barrier announcement
+            // is the empty string per `Types.fs:290-294`; the
+            // empty payload survives behaviour-identically.
+            inputEvent, [| nvdaTextDecision "" |]
+
+    /// Construct a Stream profile instance. `screen` is captured
+    /// in the closure so `Apply` can call `screen.SnapshotRows`
+    /// when handling raw `StreamChunk` events. `parameters` is
+    /// captured so the algorithm functions read consistent
+    /// thresholds even if the Parameters record is later mutated
+    /// (today nothing mutates it, but the closure-capture seals
+    /// the contract).
+    let create (parameters: Parameters) (screen: Screen) : Profile =
+        let state = createState ()
+        let lastSnapshotSeq = ref -1L
         { Id = id
           Apply =
             fun event ->
-                [| { Channel = NvdaChannel.id
-                     Render = RenderText event.Payload } |]
-          Reset = fun () -> () }
+                let now = DateTimeOffset.UtcNow
+                match event.Semantic with
+                | SemanticCategory.StreamChunk ->
+                    // Raw rows-changed input: read the screen,
+                    // dedup by sequence number, run the algorithm.
+                    let seq, snapshot = screen.SnapshotRows(0, screen.Rows)
+                    if seq = lastSnapshotSeq.Value then
+                        [||]
+                    else
+                        lastSnapshotSeq.Value <- seq
+                        let coalesced =
+                            processRowsChanged parameters state now snapshot
+                        coalesced
+                        |> List.map (coalescedToPair event)
+                        |> List.toArray
+                | SemanticCategory.ParserError ->
+                    // Parser errors come through pre-sanitised
+                    // (the producer in Program.fs's TranslatorPump
+                    // sanitises before building the OutputEvent).
+                    // Apply produces the error decision directly
+                    // — no internal coalescing.
+                    [|
+                        event,
+                        [| nvdaTextDecision event.Payload |]
+                    |]
+                | SemanticCategory.AltScreenEntered
+                | SemanticCategory.ModeBarrier ->
+                    // Mode change: flush pending stream content
+                    // + emit the barrier. The flag/value passed
+                    // to onModeChanged are SYNTHETIC — the
+                    // original (TerminalModeFlag, bool) was lost
+                    // in the spec-D.2 mapping in TranslatorPump.
+                    // The reset behaviour is the same regardless
+                    // of which mode flipped, so any synthetic
+                    // value works; we use (AltScreen, true) for
+                    // AltScreenEntered and (AltScreen, false)
+                    // for ModeBarrier.
+                    let flag = TerminalModeFlag.AltScreen
+                    let value = event.Semantic = SemanticCategory.AltScreenEntered
+                    let coalesced =
+                        onModeChanged parameters state now flag value
+                    coalesced
+                    |> List.map (coalescedToPair event)
+                    |> List.toArray
+                | _ ->
+                    // Other semantic categories (SelectionShown /
+                    // BellRang / etc.) don't have a Stream-profile
+                    // producer in 8b. Pass through with a single
+                    // pair containing the input event and a
+                    // matching RenderText decision. Future profiles
+                    // (8d Earcon, 8e Selection) will produce these
+                    // and the Stream profile will return [||] for
+                    // them (so they don't double-up on NVDA).
+                    [|
+                        event,
+                        [| nvdaTextDecision event.Payload |]
+                    |]
+          Tick =
+            fun now ->
+                let coalesced = onTimerTick parameters state now
+                coalesced
+                |> List.map (fun c ->
+                    // Tick only emits OutputBatch (trailing-edge
+                    // flush of pending stream content), but we
+                    // pattern-match defensively. The synthesised
+                    // event for OutputBatch carries Semantic =
+                    // StreamChunk so NvdaChannel routes via
+                    // ActivityIds.output.
+                    match c with
+                    | Coalescer.OutputBatch text ->
+                        let event = streamOutputEvent text
+                        event, [| nvdaTextDecision text |]
+                    | Coalescer.ErrorPassthrough _
+                    | Coalescer.ModeBarrier _ ->
+                        // Tick never produces these; defensive
+                        // fall-through.
+                        let event = streamOutputEvent ""
+                        event, [||])
+                |> List.toArray
+          Reset =
+            fun () ->
+                state.LastFrameHash <- ValueNone
+                state.LastFlushAt <- ValueNone
+                state.PendingFrame <- ValueNone
+                state.PendingHash <- ValueNone
+                state.LastRowHashes <- ValueNone
+                state.PerRowHistory.Clear()
+                state.HashHistory.Clear()
+                lastSnapshotSeq.Value <- -1L }

--- a/tests/Tests.Unit/OutputDispatcherTests.fs
+++ b/tests/Tests.Unit/OutputDispatcherTests.fs
@@ -1,12 +1,14 @@
 module PtySpeak.Tests.Unit.OutputDispatcherTests
 
+open System
 open Xunit
 open Terminal.Core
 
-/// Stage 8a — pins the OutputDispatcher's
-/// `OutputEvent → Profile.Apply → ChannelDecision[] →
-/// Channel.Send` end-to-end path. The dispatcher implementation
-/// lives at `src/Terminal.Core/OutputDispatcher.fs`.
+/// Stage 8a/8b — pins the OutputDispatcher's
+/// `OutputEvent → Profile.Apply → (effectiveEvent,
+/// ChannelDecision[])[] → Channel.Send` end-to-end path. The
+/// dispatcher implementation lives at
+/// `src/Terminal.Core/OutputDispatcher.fs`.
 ///
 /// **Test isolation.** ChannelRegistry + ProfileRegistry hold
 /// process-wide mutable state (single-thread-init pattern; see
@@ -14,6 +16,16 @@ open Terminal.Core
 /// calls `clearForTests` in its setup and restores the empty
 /// state on the way out so test runs don't leak registrations
 /// across each other.
+///
+/// **Stage 8b changes (2026-05-04).** Profile.Apply now returns
+/// `(OutputEvent * ChannelDecision[])[]` — pairs of (effective
+/// event, decisions). Profile.Tick is new (same shape).
+/// dispatchTick is the dispatcher entry point for time-driven
+/// flush. StreamProfile.create takes Parameters + Screen.
+///
+/// Most StreamProfile-specific behaviour pins live in
+/// `StreamProfileTests.fs`; this file uses a synthetic
+/// pass-through profile for testing the dispatcher itself.
 
 let private resetRegistries () : unit =
     OutputDispatcher.ChannelRegistry.clearForTests ()
@@ -28,6 +40,42 @@ let private recordingChannel (channelId: ChannelId) : Channel * ResizeArray<Outp
 
 let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEvent =
     OutputEvent.create semantic Priority.Polite "test" payload
+
+/// Synthetic pass-through profile for dispatcher tests. Apply
+/// returns one pair containing the input event + a single
+/// RenderText decision targeting the supplied channel ID. Tick
+/// is a no-op. The pattern mirrors what the 8a StreamProfile did
+/// before 8b's Coalescer absorption.
+let private passthroughProfile (profileId: ProfileId) (channelId: ChannelId) : Profile =
+    { Id = profileId
+      Apply =
+        fun event ->
+            [|
+                event,
+                [| { Channel = channelId; Render = RenderText event.Payload } |]
+            |]
+      Tick = fun _ -> [||]
+      Reset = fun () -> () }
+
+/// Synthetic Tick-emitting profile. Apply is a no-op; Tick
+/// returns one pair containing a synthesised event with the
+/// supplied payload + a single RenderText decision. Used to
+/// pin dispatchTick's routing.
+let private tickEmittingProfile
+        (profileId: ProfileId)
+        (channelId: ChannelId)
+        (payload: string)
+        : Profile =
+    { Id = profileId
+      Apply = fun _ -> [||]
+      Tick =
+        fun _ ->
+            let event = buildEvent SemanticCategory.StreamChunk payload
+            [|
+                event,
+                [| { Channel = channelId; Render = RenderText payload } |]
+            |]
+      Reset = fun () -> () }
 
 // ---- ChannelRegistry -------------------------------------------
 
@@ -56,9 +104,6 @@ let ``ChannelRegistry register is idempotent on the same Id`` () =
     OutputDispatcher.ChannelRegistry.register second
     let found = OutputDispatcher.ChannelRegistry.lookup "ch"
     Assert.True(found.IsSome)
-    // Re-registering replaces; we can't compare `Channel` records
-    // directly because they hold function values, but Id staying
-    // "ch" + the lookup returning Some is the registered contract.
     Assert.Equal("ch", found.Value.Id)
     resetRegistries ()
 
@@ -67,11 +112,11 @@ let ``ChannelRegistry register is idempotent on the same Id`` () =
 [<Fact>]
 let ``ProfileRegistry register then lookup returns the registered Profile`` () =
     resetRegistries ()
-    let profile = StreamProfile.create ()
+    let profile = passthroughProfile "test-prof" NvdaChannel.id
     OutputDispatcher.ProfileRegistry.register profile
-    let found = OutputDispatcher.ProfileRegistry.lookup StreamProfile.id
+    let found = OutputDispatcher.ProfileRegistry.lookup "test-prof"
     Assert.True(found.IsSome)
-    Assert.Equal(StreamProfile.id, found.Value.Id)
+    Assert.Equal("test-prof", found.Value.Id)
     resetRegistries ()
 
 [<Fact>]
@@ -83,67 +128,21 @@ let ``ProfileRegistry getActiveProfileSet defaults to empty list`` () =
 [<Fact>]
 let ``ProfileRegistry setActiveProfileSet round-trips through getActiveProfileSet`` () =
     resetRegistries ()
-    let profile = StreamProfile.create ()
+    let profile = passthroughProfile "test-prof" NvdaChannel.id
     OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
     let active = OutputDispatcher.ProfileRegistry.getActiveProfileSet ()
     Assert.Equal(1, active.Length)
-    Assert.Equal(StreamProfile.id, active.[0].Id)
+    Assert.Equal("test-prof", active.[0].Id)
     resetRegistries ()
 
-// ---- StreamProfile (8a pass-through stub) ----------------------
+// ---- End-to-end dispatch (Apply path) --------------------------
 
 [<Fact>]
-let ``StreamProfile.Apply emits exactly one ChannelDecision targeting nvda`` () =
-    let profile = StreamProfile.create ()
-    let event = buildEvent SemanticCategory.StreamChunk "ls"
-    let decisions = profile.Apply event
-    Assert.Equal(1, decisions.Length)
-    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
-
-[<Fact>]
-let ``StreamProfile.Apply emits a RenderText with the event's Payload`` () =
-    let profile = StreamProfile.create ()
-    let event = buildEvent SemanticCategory.StreamChunk "ls -la"
-    let decisions = profile.Apply event
-    match decisions.[0].Render with
-    | RenderText text -> Assert.Equal("ls -la", text)
-    | other -> Assert.Fail(sprintf "expected RenderText, got %A" other)
-
-[<Fact>]
-let ``StreamProfile.Apply passes through ParserError event without suppression`` () =
-    // 8a's pass-through Stream profile does NOT honour
-    // Background-suppression yet (per the OutputEventTypes
-    // Priority docstring + the spec D.2 reconciliation note in
-    // OutputEventBuilder.fs). Background events still produce
-    // ChannelDecisions; the channel decides what to do.
-    let profile = StreamProfile.create ()
-    let event =
-        OutputEvent.create
-            SemanticCategory.ParserError
-            Priority.Background
-            "test"
-            "boom"
-    let decisions = profile.Apply event
-    Assert.Equal(1, decisions.Length)
-
-[<Fact>]
-let ``StreamProfile.Reset is a no-op in 8a`` () =
-    let profile = StreamProfile.create ()
-    profile.Reset ()
-    // No state to verify; the contract is "Reset doesn't throw"
-    // until 8b absorbs the Coalescer and Reset clears
-    // per-shell-session state.
-    Assert.True(true)
-
-// ---- End-to-end dispatch ---------------------------------------
-
-[<Fact>]
-let ``dispatch routes a StreamChunk through StreamProfile to a registered NVDA test channel`` () =
+let ``dispatch routes a StreamChunk through a passthrough profile to a registered NVDA test channel`` () =
     resetRegistries ()
     let nvda, calls = recordingChannel NvdaChannel.id
     OutputDispatcher.ChannelRegistry.register nvda
-    let profile = StreamProfile.create ()
-    OutputDispatcher.ProfileRegistry.register profile
+    let profile = passthroughProfile "test" NvdaChannel.id
     OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
     let event = buildEvent SemanticCategory.StreamChunk "hello"
     OutputDispatcher.dispatch event
@@ -160,16 +159,14 @@ let ``dispatch silently drops decisions whose channel is not registered`` () =
     // Drop instead of throw: a profile may emit decisions for a
     // channel that's deferred / disabled / not yet shipped (e.g.
     // an EarconChannel reference before 8d lands). Silent drop
-    // keeps the dispatcher from blowing up the drain task.
+    // keeps the dispatcher from blowing up the pump task.
     resetRegistries ()
-    let profile = StreamProfile.create ()
-    OutputDispatcher.ProfileRegistry.register profile
+    let profile = passthroughProfile "test" NvdaChannel.id
     OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
-    // Note: NO channel registered. The Stream profile wants nvda;
+    // Note: NO channel registered. The profile wants nvda;
     // lookup returns None; dispatch is a no-op.
     let event = buildEvent SemanticCategory.StreamChunk "hello"
     OutputDispatcher.dispatch event
-    // No exception, no panic. Reaching this assertion is the test.
     Assert.True(true)
     resetRegistries ()
 
@@ -178,7 +175,6 @@ let ``dispatch with no active profile set is a no-op`` () =
     resetRegistries ()
     let nvda, calls = recordingChannel NvdaChannel.id
     OutputDispatcher.ChannelRegistry.register nvda
-    // No profiles registered or active.
     let event = buildEvent SemanticCategory.StreamChunk "hello"
     OutputDispatcher.dispatch event
     Assert.Equal(0, calls.Count)
@@ -189,12 +185,100 @@ let ``dispatch fans out across multiple profiles producing combined ChannelDecis
     resetRegistries ()
     let nvda, calls = recordingChannel NvdaChannel.id
     OutputDispatcher.ChannelRegistry.register nvda
-    let stream1 = StreamProfile.create ()
-    let stream2 = StreamProfile.create ()
-    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ stream1; stream2 ]
+    let p1 = passthroughProfile "p1" NvdaChannel.id
+    let p2 = passthroughProfile "p2" NvdaChannel.id
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ p1; p2 ]
     let event = buildEvent SemanticCategory.StreamChunk "x"
     OutputDispatcher.dispatch event
-    // Two profiles each emit one decision targeting the same
-    // channel. The dispatcher invokes Send twice.
+    Assert.Equal(2, calls.Count)
+    resetRegistries ()
+
+[<Fact>]
+let ``dispatch with multi-pair Apply routes each pair's effectiveEvent to channel.Send`` () =
+    // A profile may return multiple (effectiveEvent,
+    // decisions) pairs from Apply — e.g., the Stream profile
+    // when a mode-change forces a flush of pending stream
+    // content. Each pair carries its own effectiveEvent so
+    // NvdaChannel's Semantic → ActivityId mapping picks the
+    // right ID for that pair.
+    resetRegistries ()
+    let nvda, calls = recordingChannel NvdaChannel.id
+    OutputDispatcher.ChannelRegistry.register nvda
+    let multiPairProfile : Profile =
+        { Id = "multi"
+          Apply =
+            fun event ->
+                let streamEvent =
+                    OutputEvent.create
+                        SemanticCategory.StreamChunk
+                        Priority.Polite
+                        "test"
+                        "flushed"
+                [|
+                    streamEvent,
+                    [| { Channel = NvdaChannel.id
+                         Render = RenderText "flushed" } |]
+                    event,
+                    [| { Channel = NvdaChannel.id
+                         Render = RenderText "barrier" } |]
+                |]
+          Tick = fun _ -> [||]
+          Reset = fun () -> () }
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ multiPairProfile ]
+    let event = buildEvent SemanticCategory.AltScreenEntered ""
+    OutputDispatcher.dispatch event
+    Assert.Equal(2, calls.Count)
+    let event0, _ = calls.[0]
+    let event1, _ = calls.[1]
+    Assert.Equal(SemanticCategory.StreamChunk, event0.Semantic)
+    Assert.Equal(SemanticCategory.AltScreenEntered, event1.Semantic)
+    resetRegistries ()
+
+// ---- End-to-end dispatchTick (Tick path) -----------------------
+
+[<Fact>]
+let ``dispatchTick is a no-op when no profiles are active`` () =
+    resetRegistries ()
+    let nvda, calls = recordingChannel NvdaChannel.id
+    OutputDispatcher.ChannelRegistry.register nvda
+    OutputDispatcher.dispatchTick DateTimeOffset.UtcNow
+    Assert.Equal(0, calls.Count)
+    resetRegistries ()
+
+[<Fact>]
+let ``dispatchTick is a no-op for profiles whose Tick returns empty array`` () =
+    resetRegistries ()
+    let nvda, calls = recordingChannel NvdaChannel.id
+    OutputDispatcher.ChannelRegistry.register nvda
+    let profile = passthroughProfile "p" NvdaChannel.id
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    OutputDispatcher.dispatchTick DateTimeOffset.UtcNow
+    Assert.Equal(0, calls.Count)
+    resetRegistries ()
+
+[<Fact>]
+let ``dispatchTick routes Tick decisions through ChannelRegistry`` () =
+    resetRegistries ()
+    let nvda, calls = recordingChannel NvdaChannel.id
+    OutputDispatcher.ChannelRegistry.register nvda
+    let profile = tickEmittingProfile "tick-prof" NvdaChannel.id "tick-payload"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    OutputDispatcher.dispatchTick DateTimeOffset.UtcNow
+    Assert.Equal(1, calls.Count)
+    let _, render = calls.[0]
+    match render with
+    | RenderText text -> Assert.Equal("tick-payload", text)
+    | other -> Assert.Fail(sprintf "expected RenderText, got %A" other)
+    resetRegistries ()
+
+[<Fact>]
+let ``dispatchTick fans out across multiple Tick-emitting profiles`` () =
+    resetRegistries ()
+    let nvda, calls = recordingChannel NvdaChannel.id
+    OutputDispatcher.ChannelRegistry.register nvda
+    let p1 = tickEmittingProfile "p1" NvdaChannel.id "a"
+    let p2 = tickEmittingProfile "p2" NvdaChannel.id "b"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ p1; p2 ]
+    OutputDispatcher.dispatchTick DateTimeOffset.UtcNow
     Assert.Equal(2, calls.Count)
     resetRegistries ()

--- a/tests/Tests.Unit/OutputEventTests.fs
+++ b/tests/Tests.Unit/OutputEventTests.fs
@@ -124,71 +124,97 @@ let ``OutputEvent.create preserves Payload verbatim`` () =
             "hello world"
     Assert.Equal("hello world", event.Payload)
 
-// ---- Builder mapping per spec D.2 ------------------------------
+// ---- Builder mapping (Stage 8b: ScreenNotification → OutputEvent) ----
+//
+// Stage 8a's translator ran AFTER coalescing; the test inputs were
+// CoalescedNotifications carrying post-debounce text. Stage 8b's
+// translator runs BEFORE coalescing, so the test inputs are now raw
+// ScreenNotifications and the OutputEvent payloads are minimal — the
+// Stream profile produces post-coalesce text inside its Apply / Tick
+// closures (covered by StreamProfileTests.fs).
 
 [<Fact>]
-let ``fromCoalescedNotification maps OutputBatch to StreamChunk + Polite`` () =
+let ``fromScreenNotification maps RowsChanged to StreamChunk + Polite`` () =
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.OutputBatch "ls -la output")
+        OutputEventBuilder.fromScreenNotification (RowsChanged [ 0; 1 ])
     Assert.Equal(SemanticCategory.StreamChunk, event.Semantic)
     Assert.Equal(Priority.Polite, event.Priority)
-    Assert.Equal("ls -la output", event.Payload)
 
 [<Fact>]
-let ``fromCoalescedNotification maps ErrorPassthrough to ParserError + Background`` () =
+let ``fromScreenNotification RowsChanged carries empty Payload`` () =
+    // The Stream profile reads the screen at Apply time; the
+    // OutputEvent itself doesn't ferry row content. Empty Payload
+    // is the contract.
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ErrorPassthrough "boom")
+        OutputEventBuilder.fromScreenNotification (RowsChanged [])
+    Assert.Equal("", event.Payload)
+
+[<Fact>]
+let ``fromScreenNotification maps ParserError to ParserError + Background`` () =
+    let event =
+        OutputEventBuilder.fromScreenNotification (ParserError "boom")
     Assert.Equal(SemanticCategory.ParserError, event.Semantic)
     Assert.Equal(Priority.Background, event.Priority)
 
 [<Fact>]
-let ``fromCoalescedNotification preserves the Stage 7 ErrorPassthrough wrapping`` () =
+let ``fromScreenNotification preserves the Stage 7 ErrorPassthrough wrapping`` () =
     // The Stage 7 drain produced "Terminal parser error: <msg>";
     // the framework retrofit must keep the same wrapping so the
     // NVDA reading is identical post-retrofit.
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ErrorPassthrough "decoder failed")
+        OutputEventBuilder.fromScreenNotification (ParserError "decoder failed")
     Assert.Equal("Terminal parser error: decoder failed", event.Payload)
 
 [<Fact>]
-let ``fromCoalescedNotification maps ModeBarrier AltScreen true to AltScreenEntered + Assertive`` () =
+let ``fromScreenNotification ParserError sanitises the message`` () =
+    // The translator sanitises through AnnounceSanitiser.sanitise
+    // before wrapping (the producer-responsibility chokepoint per
+    // spec B.2.4 step 5 + the PR-N entry-gate contract). The C0
+    // BEL (0x07) in the input must be stripped from the Payload.
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ModeBarrier (TerminalModeFlag.AltScreen, true))
+        OutputEventBuilder.fromScreenNotification (ParserError "boom\x07!")
+    Assert.Equal("Terminal parser error: boom!", event.Payload)
+
+[<Fact>]
+let ``fromScreenNotification maps ModeChanged AltScreen true to AltScreenEntered + Assertive`` () =
+    let event =
+        OutputEventBuilder.fromScreenNotification (
+            ModeChanged (TerminalModeFlag.AltScreen, true))
     Assert.Equal(SemanticCategory.AltScreenEntered, event.Semantic)
     Assert.Equal(Priority.Assertive, event.Priority)
 
 [<Fact>]
-let ``fromCoalescedNotification maps ModeBarrier AltScreen false to ModeBarrier + Assertive`` () =
+let ``fromScreenNotification maps ModeChanged AltScreen false to ModeBarrier + Assertive`` () =
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ModeBarrier (TerminalModeFlag.AltScreen, false))
+        OutputEventBuilder.fromScreenNotification (
+            ModeChanged (TerminalModeFlag.AltScreen, false))
     Assert.Equal(SemanticCategory.ModeBarrier, event.Semantic)
     Assert.Equal(Priority.Assertive, event.Priority)
 
 [<Fact>]
-let ``fromCoalescedNotification maps non-AltScreen ModeBarrier to ModeBarrier + Polite`` () =
+let ``fromScreenNotification maps non-AltScreen ModeChanged to ModeBarrier + Polite`` () =
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ModeBarrier (TerminalModeFlag.BracketedPaste, true))
+        OutputEventBuilder.fromScreenNotification (
+            ModeChanged (TerminalModeFlag.BracketedPaste, true))
     Assert.Equal(SemanticCategory.ModeBarrier, event.Semantic)
     Assert.Equal(Priority.Polite, event.Priority)
 
 [<Fact>]
-let ``fromCoalescedNotification ModeBarrier carries empty Payload`` () =
+let ``fromScreenNotification ModeChanged carries empty Payload`` () =
     // Stage 5 mode-barrier announcement is the empty string — see
     // ActivityIds.mode docstring at Types.fs:290-294.
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.ModeBarrier (TerminalModeFlag.AltScreen, true))
+        OutputEventBuilder.fromScreenNotification (
+            ModeChanged (TerminalModeFlag.AltScreen, true))
     Assert.Equal("", event.Payload)
 
 [<Fact>]
-let ``fromCoalescedNotification stamps drain as the producer`` () =
+let ``fromScreenNotification stamps translator as the producer`` () =
+    // Stage 8a producer was "drain" (the post-coalesce drain task);
+    // Stage 8b producer is "translator" (pre-coalesce
+    // ScreenNotification → OutputEvent translation). The Stream
+    // profile's Apply re-stamps post-coalesce events with producer
+    // "stream" (covered in StreamProfileTests).
     let event =
-        OutputEventBuilder.fromCoalescedNotification (
-            Coalescer.OutputBatch "x")
-    Assert.Equal("drain", event.Source.Producer)
+        OutputEventBuilder.fromScreenNotification (RowsChanged [])
+    Assert.Equal("translator", event.Source.Producer)

--- a/tests/Tests.Unit/StreamProfileTests.fs
+++ b/tests/Tests.Unit/StreamProfileTests.fs
@@ -1,12 +1,6 @@
-module PtySpeak.Tests.Unit.CoalescerTests
+module PtySpeak.Tests.Unit.StreamProfileTests
 
 open System
-open System.Collections.Generic
-open System.Text
-open System.Threading
-open System.Threading.Channels
-open System.Threading.Tasks
-open Microsoft.Extensions.Time.Testing
 open Xunit
 open Terminal.Core
 
@@ -18,7 +12,7 @@ open Terminal.Core
 // frame hash, sliding-window spinner suppression, leading- +
 // trailing-edge debounce, and an alt-screen flush barrier).
 // These tests pin each algorithm independently and a few of
-// the interactions, driving `Coalescer.processRowsChanged` /
+// the interactions, driving `StreamProfile.processRowsChanged` /
 // `onTimerTick` / `onModeChanged` directly with explicit
 // `now` timestamps so debounce assertions are deterministic
 // without spinning the production reader loop.
@@ -95,20 +89,20 @@ let ``hashFrame is order-independent for blank suffix rows`` () =
 
 [<Fact>]
 let ``two identical RowsChanged frames in a row → only first emits`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap = snapshotOf 3 5 [ "hello" ]
-    let first = Coalescer.processRowsChanged state (at 0) snap
+    let first = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap
     Assert.Equal(1, first.Length)
-    let second = Coalescer.processRowsChanged state (at 500) snap
+    let second = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 500) snap
     Assert.Equal(0, second.Length)
 
 [<Fact>]
 let ``frame dedup releases when content actually changes`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap1 = snapshotOf 3 5 [ "hello" ]
     let snap2 = snapshotOf 3 5 [ "world" ]
-    let _ = Coalescer.processRowsChanged state (at 0) snap1
-    let next = Coalescer.processRowsChanged state (at 500) snap2
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap1
+    let next = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 500) snap2
     Assert.Equal(1, next.Length)
 
 // ---------------------------------------------------------------------
@@ -117,12 +111,12 @@ let ``frame dedup releases when content actually changes`` () =
 
 [<Fact>]
 let ``first event in idle period emits immediately (leading edge)`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     // Width must accommodate the full string; the rowOf helper
     // truncates at cols-1 and renderRows trims trailing blanks,
     // so a 5-col screen would render "echo hello" as "echo".
     let snap = snapshotOf 3 20 [ "echo hello" ]
-    let result = Coalescer.processRowsChanged state (at 0) snap
+    let result = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap
     Assert.Equal(1, result.Length)
     match result.[0] with
     | Coalescer.OutputBatch text -> Assert.Contains("echo hello", text)
@@ -130,21 +124,21 @@ let ``first event in idle period emits immediately (leading edge)`` () =
 
 [<Fact>]
 let ``burst of events within debounce window collapses to leading + trailing emit`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap1 = snapshotOf 3 5 [ "a" ]
     let snap2 = snapshotOf 3 5 [ "ab" ]
     let snap3 = snapshotOf 3 5 [ "abc" ]
     // Leading edge.
-    let r1 = Coalescer.processRowsChanged state (at 0) snap1
+    let r1 = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap1
     Assert.Equal(1, r1.Length)
     // Within 200ms — should accumulate, NOT emit.
-    let r2 = Coalescer.processRowsChanged state (at 50) snap2
+    let r2 = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 50) snap2
     Assert.Equal(0, r2.Length)
-    let r3 = Coalescer.processRowsChanged state (at 100) snap3
+    let r3 = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 100) snap3
     Assert.Equal(0, r3.Length)
     // Trailing-edge timer tick at 200ms+ flushes the
     // last accumulated frame.
-    let tick = Coalescer.onTimerTick state (at 250)
+    let tick = StreamProfile.onTimerTick StreamProfile.defaultParameters state (at 250)
     Assert.Equal(1, tick.Length)
     match tick.[0] with
     | Coalescer.OutputBatch text -> Assert.Contains("abc", text)
@@ -152,11 +146,11 @@ let ``burst of events within debounce window collapses to leading + trailing emi
 
 [<Fact>]
 let ``trailing-edge tick with nothing pending is a no-op`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap = snapshotOf 3 5 [ "x" ]
-    let _ = Coalescer.processRowsChanged state (at 0) snap
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap
     // No accumulator built up; tick should emit nothing.
-    let tick = Coalescer.onTimerTick state (at 250)
+    let tick = StreamProfile.onTimerTick StreamProfile.defaultParameters state (at 250)
     Assert.Equal(0, tick.Length)
 
 // ---------------------------------------------------------------------
@@ -170,15 +164,15 @@ let ``per-key spinner gate fires after threshold same-row-hash hits in window`` 
     // the spinner per-key gate accumulate hits for B's
     // (row=0, hash) key. After threshold hits within the
     // 1s window, the next B frame is spinner-suppressed.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let frameA = snapshotOf 1 1 [ "A" ]
     let frameB = snapshotOf 1 1 [ "B" ]
-    let _ = Coalescer.processRowsChanged state (at 0) frameA
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) frameA
     let mutable suppressedCount = 0
     let mutable emittedCount = 0
     for i in 1 .. 14 do
         let frame = if i % 2 = 1 then frameB else frameA
-        let result = Coalescer.processRowsChanged state (at (i * 60)) frame
+        let result = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at (i * 60)) frame
         // Frame-dedup'd A's also return [] but DO NOT count
         // as spinner suppression — distinguish by checking
         // whether this is a B frame (the one whose history
@@ -211,7 +205,7 @@ let ``cross-row gate accumulates content-hash recurrence as spinner moves betwee
     // rows 0..4 across 6 frames within the 1s spinner window;
     // at the end, HashHistory[content-hash-of-BAR-row] should
     // hold at least `spinnerThreshold` timestamps.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let cols = 10
     let buildFrame (frameNum: int) (barRow: int) : Cell[][] =
         let arr = Array.init 5 (fun i ->
@@ -220,7 +214,7 @@ let ``cross-row gate accumulates content-hash recurrence as spinner moves betwee
         arr
     // Frame 0 is the seed (LastRowHashes = None initially;
     // every row is "changed" relative to nothing).
-    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame 0 0)
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) (buildFrame 0 0)
     // 5 more frames moving BAR through rows 1..4 and back to
     // row 0, each with unique padding so the frame hash differs.
     // Each frame's BAR row produces the SAME content hash
@@ -229,7 +223,7 @@ let ``cross-row gate accumulates content-hash recurrence as spinner moves betwee
     let bars =  [|   1;   2;   3;   4;   0;   1 |]
     for i in 0 .. times.Length - 1 do
         let frame = buildFrame (i + 1) bars.[i]
-        let _ = Coalescer.processRowsChanged state (at times.[i]) frame
+        let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at times.[i]) frame
         ()
     // BAR's content hash should have accumulated 7 entries (the
     // seed frame + 6 loop frames, all within the 1s spinnerWindow).
@@ -277,18 +271,18 @@ let ``static rows do not trip per-key gate at fast typing cadence (PR-M, Issue #
     // LastRowHashes = None initially treats every row as
     // changed); subsequent frames must NOT grow the static-row
     // counts past 1.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let cols = 5
     let buildFrame (typed: string) : Cell[][] =
         let arr = Array.init 30 (fun _ -> blankRow cols)
         arr.[0] <- rowOf cols typed
         arr
-    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame "a")
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) (buildFrame "a")
     // Pump 6 more frames at 50ms intervals; only row 0 changes
     // each frame.
     let typeSeq = [ "ab"; "abc"; "abcd"; "abcde"; "abcdef"; "abcdefg" ]
     for i in 0 .. typeSeq.Length - 1 do
-        let _ = Coalescer.processRowsChanged state (at ((i + 1) * 50)) (buildFrame typeSeq.[i])
+        let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at ((i + 1) * 50)) (buildFrame typeSeq.[i])
         ()
     // Static-row history counts should remain at 1 (only the
     // seed frame contributed; no subsequent frame changed those
@@ -319,15 +313,15 @@ let ``cross-row HashHistory ignores static blank rows (PR-M, Issue #117)`` () =
     // would accumulate 29 entries per frame (one per static
     // blank row) and trip the gate within 1 frame. With change
     // detection, blank-rows-that-stay-blank contribute nothing.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let cols = 5
     let buildFrame (typed: string) : Cell[][] =
         let arr = Array.init 30 (fun _ -> blankRow cols)
         arr.[0] <- rowOf cols typed
         arr
-    let _ = Coalescer.processRowsChanged state (at 0) (buildFrame "a")
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) (buildFrame "a")
     for i in 0 .. 5 do
-        let _ = Coalescer.processRowsChanged state (at ((i + 1) * 50)) (buildFrame (sprintf "x%d" i))
+        let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at ((i + 1) * 50)) (buildFrame (sprintf "x%d" i))
         ()
     // The blank-content hash should have at most 1 entry (the
     // initial seed frame, where every row was "changed"
@@ -348,14 +342,14 @@ let ``ModeChanged resets LastRowHashes and HashHistory (PR-M, Issue #117)`` () =
     // gate could carry forward stale recurrence counts from the
     // previous buffer, and the change-detection's "changed?"
     // check could falsely return false against pre-mode hashes.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap = snapshotOf 1 5 [ "hello" ]
-    let _ = Coalescer.processRowsChanged state (at 0) snap
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap
     Assert.True(state.LastRowHashes.IsSome,
         "LastRowHashes should be populated after first frame")
     Assert.True(state.HashHistory.Count > 0,
         "HashHistory should be populated after first frame")
-    let _ = Coalescer.onModeChanged state (at 100) AltScreen true
+    let _ = StreamProfile.onModeChanged StreamProfile.defaultParameters state (at 100) AltScreen true
     Assert.True(state.LastRowHashes.IsNone,
         "LastRowHashes should be reset to None after mode change")
     Assert.Equal(0, state.HashHistory.Count)
@@ -366,19 +360,19 @@ let ``spinner per-key history is GC'd after spinnerWindow elapses`` () =
     // Once spinnerWindow of quiet has passed, the per-key
     // history is trimmed by gcHistory and a new frame can
     // re-engage the leading-edge emit path.
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let frameA = snapshotOf 1 1 [ "A" ]
     let frameB = snapshotOf 1 1 [ "B" ]
     // Pump enough alternations to engage spinner suppression.
-    let _ = Coalescer.processRowsChanged state (at 0) frameA
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) frameA
     for i in 1 .. 14 do
         let frame = if i % 2 = 1 then frameB else frameA
-        let _ = Coalescer.processRowsChanged state (at (i * 60)) frame
+        let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at (i * 60)) frame
         ()
     // After 1.5s of quiet (well past spinnerWindow=1000ms),
     // a fresh content should emit again.
     let frameC = snapshotOf 1 1 [ "C" ]
-    let result = Coalescer.processRowsChanged state (at 5000) frameC
+    let result = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 5000) frameC
     Assert.True(result.Length >= 1,
         "Expected emit to recover after spinnerWindow of quiet")
 
@@ -388,16 +382,16 @@ let ``spinner per-key history is GC'd after spinnerWindow elapses`` () =
 
 [<Fact>]
 let ``ModeChanged AltScreen flushes pending accumulator first`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap1 = snapshotOf 1 5 [ "hello" ]
     let snap2 = snapshotOf 1 5 [ "world" ]
     // Leading-edge emit at t=0.
-    let _ = Coalescer.processRowsChanged state (at 0) snap1
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap1
     // Within debounce — accumulates.
-    let r2 = Coalescer.processRowsChanged state (at 50) snap2
+    let r2 = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 50) snap2
     Assert.Equal(0, r2.Length)
     // Mode change should flush the pending then pass through.
-    let result = Coalescer.onModeChanged state (at 100) AltScreen true
+    let result = StreamProfile.onModeChanged StreamProfile.defaultParameters state (at 100) AltScreen true
     Assert.Equal(2, result.Length)
     match result.[0] with
     | Coalescer.OutputBatch text -> Assert.Contains("world", text)
@@ -410,8 +404,8 @@ let ``ModeChanged AltScreen flushes pending accumulator first`` () =
 
 [<Fact>]
 let ``ModeChanged with no pending still passes the barrier through`` () =
-    let state = Coalescer.createState ()
-    let result = Coalescer.onModeChanged state (at 0) AltScreen false
+    let state = StreamProfile.createState ()
+    let result = StreamProfile.onModeChanged StreamProfile.defaultParameters state (at 0) AltScreen false
     Assert.Equal(1, result.Length)
     match result.[0] with
     | Coalescer.ModeBarrier (flag, value) ->
@@ -421,16 +415,16 @@ let ``ModeChanged with no pending still passes the barrier through`` () =
 
 [<Fact>]
 let ``ModeChanged resets frame-dedup state`` () =
-    let state = Coalescer.createState ()
+    let state = StreamProfile.createState ()
     let snap = snapshotOf 1 5 [ "hello" ]
-    let _ = Coalescer.processRowsChanged state (at 0) snap
+    let _ = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 0) snap
     // Frame dedup would normally suppress this repeat...
-    let dup = Coalescer.processRowsChanged state (at 500) snap
+    let dup = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 500) snap
     Assert.Equal(0, dup.Length)
     // ...but a mode barrier resets the dedup state, so the
     // same content emits again afterward.
-    let _ = Coalescer.onModeChanged state (at 600) AltScreen true
-    let after = Coalescer.processRowsChanged state (at 1000) snap
+    let _ = StreamProfile.onModeChanged StreamProfile.defaultParameters state (at 600) AltScreen true
+    let after = StreamProfile.processRowsChanged StreamProfile.defaultParameters state (at 1000) snap
     Assert.Equal(1, after.Length)
 
 // ---------------------------------------------------------------------
@@ -439,7 +433,7 @@ let ``ModeChanged resets frame-dedup state`` () =
 
 [<Fact>]
 let ``ParserError passes through immediately as ErrorPassthrough`` () =
-    let result = Coalescer.onParserError "boom"
+    let result = StreamProfile.onParserError "boom"
     Assert.Equal(1, result.Length)
     match result.[0] with
     | Coalescer.ErrorPassthrough s -> Assert.Equal("boom", s)
@@ -448,7 +442,7 @@ let ``ParserError passes through immediately as ErrorPassthrough`` () =
 [<Fact>]
 let ``ParserError strips control chars via sanitiser`` () =
     // BEL (\x07) must be stripped before NVDA sees it.
-    let result = Coalescer.onParserError "boom\x07!"
+    let result = StreamProfile.onParserError "boom\x07!"
     match result.[0] with
     | Coalescer.ErrorPassthrough s ->
         Assert.False(s.Contains('\x07'),
@@ -515,129 +509,13 @@ let ``mode-barrier activityId is pty-speak.mode`` () =
     Assert.Equal("pty-speak.mode", ActivityIds.mode)
 
 // ---------------------------------------------------------------------
-// runLoop end-to-end with FakeTimeProvider
+// Stage 8b note: the Stage-7 `runLoop` orchestrator has been removed.
+// Its three integration tests (cancellation, end-to-end emit, and the
+// PeriodicTimer-concurrent-call regression) covered the orchestration
+// shell, which now lives in `src/Terminal.App/Program.fs` as the
+// TranslatorPump + TickPump pair. Composition-root orchestration is
+// not unit-tested in this codebase; the algorithm-level pins above
+// + the Stage-5 NVDA-validation matrix in
+// `docs/ACCESSIBILITY-TESTING.md` cover what those three tests
+// covered before.
 // ---------------------------------------------------------------------
-
-let private buildChannels () =
-    let inOpts =
-        BoundedChannelOptions(256,
-            FullMode = BoundedChannelFullMode.DropOldest)
-    let outOpts =
-        BoundedChannelOptions(16,
-            FullMode = BoundedChannelFullMode.Wait)
-    let inCh = Channel.CreateBounded<ScreenNotification>(inOpts)
-    let outCh = Channel.CreateBounded<Coalescer.CoalescedNotification>(outOpts)
-    inCh, outCh
-
-[<Fact>]
-let ``runLoop cancels cleanly when token is cancelled`` () =
-    let inCh, outCh = buildChannels ()
-    let screen = Screen(rows = 3, cols = 5)
-    let cts = new CancellationTokenSource()
-    let timeProvider = FakeTimeProvider(epoch)
-    let task =
-        Coalescer.runLoop
-            inCh.Reader
-            outCh.Writer
-            screen
-            (timeProvider :> TimeProvider)
-            cts.Token
-    cts.Cancel()
-    // Loop should terminate without throwing OCE outwards.
-    let completed = task.Wait(TimeSpan.FromSeconds 2.0)
-    Assert.True(completed, "Coalescer task should exit within 2s of cancellation")
-
-[<Fact>]
-let ``runLoop emits OutputBatch end-to-end via real Screen + FakeTimeProvider`` () =
-    let inCh, outCh = buildChannels ()
-    let screen = Screen(rows = 3, cols = 10)
-    // Apply some content so SnapshotRows has something to hash.
-    let parser = Terminal.Parser.Parser.create ()
-    let bytes = Encoding.ASCII.GetBytes "hi"
-    let events = Terminal.Parser.Parser.feedArray parser bytes
-    for e in events do screen.Apply(e)
-    let cts = new CancellationTokenSource()
-    let timeProvider = FakeTimeProvider(epoch)
-    let task =
-        Coalescer.runLoop
-            inCh.Reader
-            outCh.Writer
-            screen
-            (timeProvider :> TimeProvider)
-            cts.Token
-    // Push a RowsChanged through the input channel.
-    Assert.True(inCh.Writer.TryWrite(RowsChanged []))
-    // Read one CoalescedNotification with a timeout.
-    let readTask = outCh.Reader.ReadAsync(cts.Token).AsTask()
-    let completed = readTask.Wait(TimeSpan.FromSeconds 2.0)
-    Assert.True(completed, "Expected one CoalescedNotification within 2s")
-    match readTask.Result with
-    | Coalescer.OutputBatch text -> Assert.Contains("hi", text)
-    | other -> Assert.Fail(sprintf "Expected OutputBatch; got %A" other)
-    cts.Cancel()
-    task.Wait(TimeSpan.FromSeconds 2.0) |> ignore
-
-[<Fact>]
-let ``runLoop survives multiple consecutive reader-wins without crashing the PeriodicTimer`` () =
-    // Regression test for "Coalescer crashed: Operation is not
-    // valid due to the state of the object" surfaced during
-    // post-Stage-6 manual NVDA verification.
-    //
-    // Cause: PeriodicTimer.WaitForNextTickAsync throws
-    // InvalidOperationException ("Operation is not valid due to
-    // the state of the object") when called concurrently — i.e.
-    // a second call before the previous one has completed. The
-    // pre-fix runLoop called WaitForNextTickAsync at the top of
-    // every loop iteration; when the reader won Task.WhenAny,
-    // the timer's pending wait was abandoned but not cancelled,
-    // and the next iteration's WaitForNextTickAsync crashed.
-    //
-    // Repro: pump events through the reader channel faster than
-    // the 200ms timer would fire. Every iteration, the reader
-    // wins. The pre-fix code crashed on the second iteration.
-    let inCh, outCh = buildChannels ()
-    let screen = Screen(rows = 3, cols = 10)
-    // Apply enough content so each push produces a unique frame
-    // hash (avoiding the dedup short-circuit).
-    let parser = Terminal.Parser.Parser.create ()
-    let mutable applyCount = 0
-    let pushUniqueChunk () =
-        applyCount <- applyCount + 1
-        let chunk =
-            Encoding.ASCII.GetBytes(sprintf "x%d " applyCount)
-        let events = Terminal.Parser.Parser.feedArray parser chunk
-        for e in events do screen.Apply(e)
-    pushUniqueChunk ()
-    let cts = new CancellationTokenSource()
-    let timeProvider = FakeTimeProvider(epoch)
-    let task =
-        Coalescer.runLoop
-            inCh.Reader
-            outCh.Writer
-            screen
-            (timeProvider :> TimeProvider)
-            cts.Token
-    // Push 20 events as fast as we can; under the pre-fix code
-    // the loop crashes on iteration 2 with InvalidOperationException
-    // and the task transitions to Faulted.
-    for _ in 1 .. 20 do
-        pushUniqueChunk ()
-        Assert.True(inCh.Writer.TryWrite(RowsChanged []))
-    // Drain a few notifications to ensure the loop is making
-    // progress, NOT crashing.
-    let mutable got = 0
-    let drainCts = new CancellationTokenSource(TimeSpan.FromSeconds 3.0)
-    try
-        while got < 3 && not drainCts.IsCancellationRequested do
-            let readTask = outCh.Reader.ReadAsync(drainCts.Token).AsTask()
-            if readTask.Wait(500) then
-                got <- got + 1
-    with
-    | _ -> ()
-    Assert.True(
-        got >= 1,
-        sprintf "Expected runLoop to deliver at least one notification under reader-bursts; got %d. Task state: %A"
-            got task.Status)
-    Assert.NotEqual(TaskStatus.Faulted, task.Status)
-    cts.Cancel()
-    task.Wait(TimeSpan.FromSeconds 2.0) |> ignore

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -26,7 +26,7 @@
     <Compile Include="UpdateMessagesTests.fs" />
     <Compile Include="WordBoundaryTests.fs" />
     <Compile Include="AnnounceSanitiserTests.fs" />
-    <Compile Include="CoalescerTests.fs" />
+    <Compile Include="StreamProfileTests.fs" />
     <Compile Include="OutputEventTests.fs" />
     <Compile Include="NvdaChannelTests.fs" />
     <Compile Include="OutputDispatcherTests.fs" />


### PR DESCRIPTION
## Summary

Stage 8b of the Output framework cycle. The Stage-7 Coalescer's `runLoop` orchestrator + module-level constants move into the Stream profile, completing the PR-N substrate-cleanup contract previously docstring'd at `Coalescer.fs:82-99`. Algorithms unchanged; the pipeline thread model collapses the two-channel + drain triplet to a one-channel + TranslatorPump + concurrent TickPump pair.

Behaviour identical to the post-[8a (#152)](https://github.com/KyleKeane/pty-speak/pull/152) release build the maintainer cut and confirmed working: same debounce / spinner-suppress / mode-barrier / parser-error / 500-char-cap defaults, same NVDA reading. The 8b refactor moves constants to per-instance `StreamProfile.Parameters` fields without changing their values; the **next sub-stage 8b.2** will add a TOML loader that overrides them per the `[profile.stream]` section.

## Substrate API extensions (called out for spec follow-up)

The spec ([`spec/event-and-output-framework.md`](spec/event-and-output-framework.md) Part B.3) is silent on time-driven flush. 8b adds these as substrate extensions; a focused doc-only PR will update the spec after maintainer approval.

- **`Profile.Tick: DateTimeOffset → (OutputEvent * ChannelDecision[])[]`** — new field for time-driven flush. Most profiles supply `Tick = fun _ -> [||]` — zero-cost no-op. The Stream profile uses Tick to release pending content when the debounce window elapses with no new event arriving (the Stage-7 trailing-edge flush).
- **`Profile.Apply` return type changes** from `ChannelDecision[]` to `(OutputEvent * ChannelDecision[])[]` — multi-pair shape. Each pair is `(effectiveEvent, decisionsForThatEvent)`: the effectiveEvent is what the channel's `Send` receives. Most profiles return a single pair carrying the input event. The Stream profile may return two pairs when an incoming mode-change forces a flush — one for the flushed pending stream content (Semantic = StreamChunk → ActivityIds.output), one for the mode barrier itself (Semantic = AltScreenEntered or ModeBarrier → ActivityIds.mode).
- **`OutputDispatcher.dispatchTick(now)`** — new dispatcher entry point. The composition root's TickPump task runs a `PeriodicTimer(50ms)` and calls dispatchTick on each tick.

## Files modified

**`src/Terminal.Core/`:**
- `OutputEventTypes.fs` — Profile gains Tick; Apply returns pairs
- `StreamProfile.fs` — full rewrite; Parameters + State + algorithms + Apply/Tick/Reset closures; `create` takes `(Parameters, Screen)`
- `Coalescer.fs` — gutted to ~140 lines; keeps `CoalescedNotification` DU + the five pure helpers (`hashRowContent`, `hashRow`, `hashAttrs`, `hashFrame`, `renderRows`); PR-N contract re-anchored
- `OutputDispatcher.fs` — `dispatchTick` added; `dispatch` updated for pair shape
- `OutputEventBuilder.fs` — rewritten as `fromScreenNotification` (pre-coalesce); `fromCoalescedNotification` removed

**`src/Terminal.App/Program.fs`:**
- `coalescedChannel` removed; `Coalescer.runLoop` call removed
- Stage-8a drain task replaced by **TranslatorPump** (reads ScreenNotification → builds OutputEvent → dispatches) and **TickPump** (50ms PeriodicTimer → dispatchTick)
- Diagnostic health-check (`Ctrl+Shift+H`) + heartbeat updated to omit the coalesced-queue depth (channel no longer exists)
- Diagnostic safety-net + cancellation-token plumbing preserved

## Tests

- `tests/Tests.Unit/CoalescerTests.fs` → **`StreamProfileTests.fs`**. Module rename + mechanical `Coalescer.X state` → `StreamProfile.X StreamProfile.defaultParameters state` for the four algorithm functions. **The 30 algorithm tests (including the 4 PR-M (#145) cross-row spinner gate pins on lines `:198`, `:264`, `:316`, `:345`) preserve assertions verbatim** — algorithm logic is unchanged. Three `Coalescer.runLoop` end-to-end tests removed (orchestrator now in Program.fs composition root; composition-root logic isn't unit-tested).
- `OutputEventTests.fs` — builder tests updated for `fromScreenNotification` shape (ScreenNotification inputs replace CoalescedNotification inputs).
- `OutputDispatcherTests.fs` — synthetic `passthroughProfile` + `tickEmittingProfile` helpers replace `StreamProfile.create()` calls (which now require Parameters + Screen). New tests for `dispatchTick` + the multi-pair Apply path.
- `Tests.Unit.fsproj` — `<Compile Include>` entry renamed.

## Behaviour preservation gate

- 30 algorithm tests in `StreamProfileTests.fs` (incl. 4 PR-M #145 pins) — assertions verbatim
- 10 `AnnounceSanitiserTests.fs` — untouched
- 12 `ScreenTests.fs` (incl. ModeChanged-no-deadlock pin) — untouched
- 4 `UpdateMessagesTests.fs` — untouched

## Open question carried forward from 8a

Spec D.2 maps `ParserError → Background`, where Background is "suppressed at profile layer" per spec B.5.2. The 8b Stream profile does NOT suppress Background events — it dispatches a ChannelDecision that announces via NVDA. So 8b's behaviour matches Stage 7 (parser errors reach NVDA via `pty-speak.error`). Reconciliation deferred to a future sub-stage.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest. All 30 migrated algorithm tests + 12 dispatcher tests + 10 builder tests + remaining pre-existing tests pass
- [ ] CI Markdown link check + workflow lint pass
- [ ] Manual NVDA validation per `docs/ACCESSIBILITY-TESTING.md`:
  - [ ] Type fast in cmd; reading cadence is identical to the post-8a release build
  - [ ] Trigger an alt-screen toggle (`vim` or `less <largefile>`); mode-barrier announces; pending stream content flushes correctly before the barrier
  - [ ] Trigger streaming output (`dir`, `ls -la`); 500-char cap still fires
  - [ ] `Ctrl+Shift+H` health check still announces correctly (note: the announcement now omits "Coalesced queue X of 16" — the channel no longer exists)
  - [ ] `Ctrl+Shift+;` log capture still works; logs include `TranslatorPump` + `TickPump` entries

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_