### PR TITLE
feat(terminal-core): Stage 8c — FileLogger as first-class channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,111 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Stage 8c — FileLogger as first-class channel)
+
+The third sub-stage of the Output framework cycle. Promotes
+`Terminal.Core.FileLogger` to a first-class `Channel` so the
+rolling log captures every `OutputEvent` the Stream profile
+emits, structurally. The `Ctrl+Shift+;` clipboard-copy flow
+(PR-F) now carries the full event trail for post-hoc diagnosis
+— each entry includes Semantic / Priority / Verbosity / Producer
+/ Shell / PayloadLen / Payload as structured-template fields.
+
+Behaviour-identical to the post-8b release build for the
+user-perceived NVDA reading: the Stream profile's emit decisions
+now route to BOTH NvdaChannel and the new FileLoggerChannel, but
+NVDA's behaviour (reading + activity-ID mapping + empty-payload
+skip) is unchanged. The new addition is purely diagnostic
+infrastructure.
+
+**`src/Terminal.Core/FileLoggerChannel.fs` (new file).** Module
+mirrors the NvdaChannel shape: `[<Literal>] id: ChannelId =
+"filelogger"` + `create (logger: ILogger) : Channel`. The
+channel's Send extracts a payload string from the
+RenderInstruction (`RenderText` → text; `RenderText2` → Precise
+register; `RenderEarcon` → `[earcon=<id>]` placeholder;
+`RenderRaw` → `[raw payload]` placeholder) and writes a
+structured `LogInformation` call with the OutputEvent's
+metadata. **Empty-payload contract — CONTRARY to NvdaChannel:**
+mode barriers + future Background-suppressed events land in the
+log even if NVDA didn't read them.
+
+**`src/Terminal.Core/StreamProfile.fs` updates.** Added a
+`fileLoggerTextDecision` helper alongside `nvdaTextDecision` and
+a `textDecisions` helper that returns
+`[| nvdaTextDecision text; fileLoggerTextDecision text |]`. The
+`coalescedToPair` helper + the inline Apply branches (ParserError,
+catch-all) + the Tick closure all now use `textDecisions` instead
+of single-decision `[| nvdaTextDecision ... |]` arrays. The
+multi-pair `(OutputEvent * ChannelDecision[])[]` shape is
+preserved; only the inner decision-array length changes from 1
+to 2.
+
+**`src/Terminal.App/Program.fs` composition root.** Three-line
+addition after the NvdaChannel registration: create + register
+the FileLoggerChannel passing
+`Logger.get "Terminal.Core.FileLoggerChannel"` (which routes
+through the configured factory at line 788 to the production
+`FileLoggerSink`).
+
+**`src/Terminal.Core/Terminal.Core.fsproj`** — new
+`<Compile Include>` entry for `FileLoggerChannel.fs`, ordered
+between `NvdaChannel.fs` and `StreamProfile.fs` (StreamProfile
+references both channel IDs).
+
+### Tests (Stage 8c)
+
+- **`tests/Tests.Unit/FileLoggerChannelTests.fs` (new).** 14
+  tests pinning the channel's structured-log behaviour. Uses a
+  `RecordingLogger` ILogger fake that captures every Log call's
+  formatted message string. Tests cover: identity (`id =
+  "filelogger"`); RenderText / RenderText2 / RenderEarcon /
+  RenderRaw payload extraction; the empty-payload-still-logged
+  contract; ParserError events log the wrapped error message
+  (anchor for the future Background-suppression PR);
+  structured-template field substitution (Semantic / Priority /
+  Verbosity / Producer / Shell); Source.Shell None vs Some "cmd"
+  rendering; LogLevel.Information.
+- **`tests/Tests.Unit/Tests.Unit.fsproj`** — new
+  `<Compile Include>` entry for `FileLoggerChannelTests.fs`,
+  ordered between `NvdaChannelTests.fs` and
+  `OutputDispatcherTests.fs`.
+
+### Behaviour preservation (the regression bar)
+
+All ~144 pre-existing load-bearing tests stay green:
+
+- 30 algorithm tests in `StreamProfileTests.fs` (incl. the 4
+  PR-M #145 cross-row spinner gate pins) — untouched
+- 14 tests in `NvdaChannelTests.fs` — untouched
+- 17 tests in `OutputDispatcherTests.fs` — untouched (the
+  synthetic `passthroughProfile` helper produces 1 decision per
+  event regardless of the StreamProfile's 8c shape change)
+- 17 tests in `OutputEventTests.fs` — untouched
+- 15 tests in `FileLoggerTests.fs` (existing FileLogger sink
+  tests) — untouched (the 8c channel uses the existing sink via
+  the standard ILogger pipeline; no contract changes)
+- 10 tests in `AnnounceSanitiserTests.fs` — untouched
+- 12 tests in `ScreenTests.fs` — untouched
+- 4 tests in `UpdateMessagesTests.fs` — untouched
+
+NVDA-validation row (manual; maintainer): "Reproduce a session;
+verify log captures match announcements." Type a few commands
+in cmd, trigger an alt-screen toggle, `Ctrl+Shift+;` to copy the
+log, verify the log contains `OutputEvent. Semantic=...` lines
+for every announcement NVDA spoke. Verify NVDA reading is
+unchanged from the post-8b release build.
+
+### Open question carried forward
+
+Spec D.2 maps `ParserError → Background`, where Background is
+"suppressed at profile layer" per spec B.5.2. After 8c the
+FileLogger channel receives every ParserError event regardless
+of whether NVDA reads it; this enables the future suppression
+PR's diagnostic story ("NVDA stayed silent; the parser error is
+in the log via `Ctrl+Shift+;`"). Reconciliation deferred to a
+focused follow-up PR.
+
 ### Changed (Stage 8b — Coalescer absorbs as the Stream profile)
 
 The Stage-7 `Coalescer.runLoop` orchestrator and its module-level

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -893,6 +893,15 @@ module Program =
                     window.TerminalSurface.Announce(msg, activityId)
                 window.Dispatcher.Invoke(Action(action)))
         OutputDispatcher.ChannelRegistry.register nvdaChannel
+        // Stage 8c — FileLogger as a first-class channel. Every
+        // event the Stream profile emits now lands in the rolling
+        // log structurally, alongside the live NVDA reading. The
+        // `Ctrl+Shift+;` clipboard-copy flow (PR-F) carries the
+        // full event trail for post-hoc diagnosis.
+        let fileLoggerChannel =
+            FileLoggerChannel.create
+                (Logger.get "Terminal.Core.FileLoggerChannel")
+        OutputDispatcher.ChannelRegistry.register fileLoggerChannel
         let streamProfile =
             StreamProfile.create StreamProfile.defaultParameters screen
         OutputDispatcher.ProfileRegistry.register streamProfile

--- a/src/Terminal.Core/FileLoggerChannel.fs
+++ b/src/Terminal.Core/FileLoggerChannel.fs
@@ -1,0 +1,91 @@
+namespace Terminal.Core
+
+open Microsoft.Extensions.Logging
+
+/// Stage 8c — FileLogger channel. Translates `OutputEvent` +
+/// `RenderInstruction` into a structured `ILogger.LogInformation`
+/// call so the rolling FileLogger sink (`Terminal.Core.FileLogger`,
+/// itself unchanged from Stage 7) records every event the Stream
+/// profile emits. The `Ctrl+Shift+;` clipboard-copy flow (PR-F)
+/// then carries the full event trail for post-hoc diagnosis.
+///
+/// The channel is constructed with an `ILogger` parameter for
+/// testability. Production composition
+/// (`src/Terminal.App/Program.fs`) passes
+/// `Logger.get "Terminal.Core.FileLoggerChannel"` (which routes
+/// through the configured factory to the production
+/// `FileLoggerSink`); tests pass a recording-logger fake to
+/// capture LogInformation calls and assert on the
+/// structured-template arguments.
+///
+/// **Empty-payload contract — CONTRARY to NvdaChannel.**
+/// NvdaChannel skips `Announce` for empty-payload events (mode
+/// barriers carry `""`); FileLoggerChannel does NOT skip. The
+/// capture-everything-for-diagnosis behaviour is the spec-intended
+/// contract — mode barriers, parser errors, every event lands in
+/// the log even if the user-visible NVDA reading was silent. This
+/// becomes load-bearing when the spec D.2 ParserError → Background
+/// suppression activates in a future PR: ParserError events stop
+/// reaching NVDA but continue to land in the FileLogger channel,
+/// so post-hoc diagnosis sees them.
+///
+/// **RenderInstruction handling.** The channel extracts a payload
+/// string from the `RenderInstruction` and writes it as the
+/// `Payload` field of the structured log entry:
+///
+/// - `RenderText text` → `text`
+/// - `RenderText2 (_, precise)` → `precise` (Precise register;
+///   same convention NvdaChannel uses)
+/// - `RenderEarcon earconId` → `"[earcon=<id>]"` placeholder so
+///   the log captures earcon emission events even though the
+///   actual playback goes through the 8d Earcon channel
+/// - `RenderRaw _` → `"[raw payload]"` placeholder for opaque
+///   per-channel data (e.g. UIA-listbox metadata from the 8e
+///   Selection profile)
+///
+/// **Spec reference.** `spec/event-and-output-framework.md`
+/// Part B.4.2 (FileLogger channel description) + Part C.1 (8c
+/// row).
+module FileLoggerChannel =
+
+    /// Stable channel identifier registered with the dispatcher's
+    /// `ChannelRegistry`. Profiles refer to this string in their
+    /// `ChannelDecision.Channel` field.
+    [<Literal>]
+    let id: ChannelId = "filelogger"
+
+    /// Extract a payload string from a `RenderInstruction` for the
+    /// structured log entry's `Payload` field. Mirrors
+    /// `NvdaChannel`'s render handling but does NOT skip on empty
+    /// payloads — see module docstring for the
+    /// capture-everything contract.
+    let internal formatPayload (render: RenderInstruction) : string =
+        match render with
+        | RenderText text -> text
+        | RenderText2 (_, precise) -> precise
+        | RenderEarcon earconId -> sprintf "[earcon=%s]" earconId
+        | RenderRaw _ -> "[raw payload]"
+
+    /// Construct a Channel that writes a structured log line per
+    /// event via the supplied `ILogger`. The structured template
+    /// fields (Semantic / Priority / Verbosity / Producer / Shell
+    /// / PayloadLen / Payload) feed the existing FileLogger sink's
+    /// MPSC bounded channel — non-blocking from the dispatcher's
+    /// perspective per spec B.5.3.
+    let create (logger: ILogger) : Channel =
+        { Id = id
+          Send =
+            fun event render ->
+                let payload = formatPayload render
+                let shell =
+                    event.Source.Shell
+                    |> Option.defaultValue ""
+                logger.LogInformation(
+                    "OutputEvent. Semantic={Semantic} Priority={Priority} Verbosity={Verbosity} Producer={Producer} Shell={Shell} PayloadLen={PayloadLen} Payload={Payload}",
+                    event.Semantic,
+                    event.Priority,
+                    event.Verbosity,
+                    event.Source.Producer,
+                    shell,
+                    payload.Length,
+                    payload) }

--- a/src/Terminal.Core/StreamProfile.fs
+++ b/src/Terminal.Core/StreamProfile.fs
@@ -338,6 +338,29 @@ module StreamProfile =
         { Channel = NvdaChannel.id
           Render = RenderText text }
 
+    /// Build a FileLogger-channel decision rendering the supplied
+    /// text. Stage 8c — every Stream-profile emission now produces
+    /// decisions for both NVDA and FileLogger so the rolling log
+    /// captures everything the user heard, structurally, alongside
+    /// the live NVDA reading. The dispatcher silently drops a
+    /// FileLogger decision if the channel isn't registered (e.g.,
+    /// in tests that only register NvdaChannel), preserving 8b
+    /// behaviour for those test paths.
+    let private fileLoggerTextDecision (text: string) : ChannelDecision =
+        { Channel = FileLoggerChannel.id
+          Render = RenderText text }
+
+    /// Build the channel-decision array for a text payload —
+    /// targets both NVDA and FileLogger. The empty-payload case
+    /// is handled per-channel: NvdaChannel skips empty payloads
+    /// (preserves Stage-7 behaviour); FileLoggerChannel logs
+    /// every event regardless (capture-everything contract).
+    let private textDecisions (text: string) : ChannelDecision[] =
+        [|
+            nvdaTextDecision text
+            fileLoggerTextDecision text
+        |]
+
     /// Translate a `CoalescedNotification` into an
     /// `(effectiveEvent, ChannelDecision[])` pair the dispatcher
     /// can route. The effectiveEvent is the synthesised
@@ -350,18 +373,19 @@ module StreamProfile =
         match coalesced with
         | Coalescer.OutputBatch text ->
             let event = streamOutputEvent text
-            event, [| nvdaTextDecision text |]
+            event, textDecisions text
         | Coalescer.ErrorPassthrough s ->
             let event = parserErrorEvent s
-            event, [| nvdaTextDecision event.Payload |]
+            event, textDecisions event.Payload
         | Coalescer.ModeBarrier _ ->
             // The mode barrier reuses the input event's Semantic
             // / Priority (AltScreenEntered / ModeBarrier with the
             // appropriate Priority) so NvdaChannel routes via
             // `ActivityIds.mode`. Stage 5's barrier announcement
             // is the empty string per `Types.fs:290-294`; the
-            // empty payload survives behaviour-identically.
-            inputEvent, [| nvdaTextDecision "" |]
+            // empty payload survives behaviour-identically for
+            // NVDA (skipped) and is captured by FileLogger.
+            inputEvent, textDecisions ""
 
     /// Construct a Stream profile instance. `screen` is captured
     /// in the closure so `Apply` can call `screen.SnapshotRows`
@@ -396,10 +420,11 @@ module StreamProfile =
                     // (the producer in Program.fs's TranslatorPump
                     // sanitises before building the OutputEvent).
                     // Apply produces the error decision directly
-                    // — no internal coalescing.
+                    // — no internal coalescing. Stage 8c routes to
+                    // both NVDA + FileLogger via textDecisions.
                     [|
                         event,
-                        [| nvdaTextDecision event.Payload |]
+                        textDecisions event.Payload
                     |]
                 | SemanticCategory.AltScreenEntered
                 | SemanticCategory.ModeBarrier ->
@@ -429,9 +454,11 @@ module StreamProfile =
                     // (8d Earcon, 8e Selection) will produce these
                     // and the Stream profile will return [||] for
                     // them (so they don't double-up on NVDA).
+                    // Stage 8c routes to both NVDA + FileLogger via
+                    // textDecisions.
                     [|
                         event,
-                        [| nvdaTextDecision event.Payload |]
+                        textDecisions event.Payload
                     |]
           Tick =
             fun now ->
@@ -443,11 +470,12 @@ module StreamProfile =
                     // pattern-match defensively. The synthesised
                     // event for OutputBatch carries Semantic =
                     // StreamChunk so NvdaChannel routes via
-                    // ActivityIds.output.
+                    // ActivityIds.output. Stage 8c routes to both
+                    // NVDA + FileLogger via textDecisions.
                     match c with
                     | Coalescer.OutputBatch text ->
                         let event = streamOutputEvent text
-                        event, [| nvdaTextDecision text |]
+                        event, textDecisions text
                     | Coalescer.ErrorPassthrough _
                     | Coalescer.ModeBarrier _ ->
                         // Tick never produces these; defensive

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="OutputEventTypes.fs" />
     <Compile Include="OutputEventBuilder.fs" />
     <Compile Include="NvdaChannel.fs" />
+    <Compile Include="FileLoggerChannel.fs" />
     <Compile Include="StreamProfile.fs" />
     <Compile Include="OutputDispatcher.fs" />
     <Compile Include="KeyEncoding.fs" />

--- a/tests/Tests.Unit/FileLoggerChannelTests.fs
+++ b/tests/Tests.Unit/FileLoggerChannelTests.fs
@@ -39,10 +39,16 @@ type private RecordingLogger() =
     let calls = ResizeArray<LogLevel * string>()
     member _.Calls = calls
     interface ILogger with
-        member _.BeginScope<'TState>(_state: 'TState) : System.IDisposable =
+        // F# 9 + .NET 9 require the `'TState : not null` constraint
+        // here to match the C# `where TState : notnull` on
+        // `ILogger.BeginScope<TState>` and
+        // `ILogger.Log<TState>`. Without the constraint the F#
+        // compiler emits `FS0193: A type parameter is missing a
+        // constraint 'when 'TState: not null'`.
+        member _.BeginScope<'TState when 'TState : not null>(_state: 'TState) : System.IDisposable =
             (new NoopScope()) :> System.IDisposable
         member _.IsEnabled(_: LogLevel) : bool = true
-        member _.Log<'TState>
+        member _.Log<'TState when 'TState : not null>
                 (level: LogLevel,
                  _eventId: EventId,
                  state: 'TState,

--- a/tests/Tests.Unit/FileLoggerChannelTests.fs
+++ b/tests/Tests.Unit/FileLoggerChannelTests.fs
@@ -39,21 +39,26 @@ type private RecordingLogger() =
     let calls = ResizeArray<LogLevel * string>()
     member _.Calls = calls
     interface ILogger with
-        // F# 9 + .NET 9 require the `'TState : not null` constraint
-        // here to match the C# `where TState : notnull` on
-        // `ILogger.BeginScope<TState>` and
-        // `ILogger.Log<TState>`. Without the constraint the F#
-        // compiler emits `FS0193: A type parameter is missing a
-        // constraint 'when 'TState: not null'`.
+        // F# 9 + .NET 9 nullness signatures (per the `FS0193` and
+        // `FS0017` errors during 8c CI):
+        //
+        //   - `BeginScope<TState>` has `where TState : notnull` in
+        //     the C# interface; F# requires `when 'TState : not null`.
+        //   - `Log<TState>` does NOT carry the constraint in F#'s
+        //     reading of the metadata; the compiler reports the
+        //     interface signature as `Log<'TState>` plain.
+        //   - The `exception` parameter is `Exception?` (nullable) in
+        //     the C# signature; F# 9 requires `exn | null` here AND
+        //     in the formatter `Func<'TState, exn | null, string>`.
         member _.BeginScope<'TState when 'TState : not null>(_state: 'TState) : System.IDisposable =
             (new NoopScope()) :> System.IDisposable
         member _.IsEnabled(_: LogLevel) : bool = true
-        member _.Log<'TState when 'TState : not null>
+        member _.Log<'TState>
                 (level: LogLevel,
                  _eventId: EventId,
                  state: 'TState,
-                 ex: exn,
-                 formatter: System.Func<'TState, exn, string>) : unit =
+                 ex: exn | null,
+                 formatter: System.Func<'TState, exn | null, string>) : unit =
             let message = formatter.Invoke(state, ex)
             calls.Add((level, message))
 

--- a/tests/Tests.Unit/FileLoggerChannelTests.fs
+++ b/tests/Tests.Unit/FileLoggerChannelTests.fs
@@ -1,0 +1,230 @@
+module PtySpeak.Tests.Unit.FileLoggerChannelTests
+
+open System
+open Microsoft.Extensions.Logging
+open Xunit
+open Terminal.Core
+
+/// Stage 8c — pins the FileLogger channel's structured-log
+/// behaviour. The channel consumes `OutputEvent` +
+/// `RenderInstruction` and writes a structured log line via the
+/// supplied `ILogger` so the rolling FileLogger sink captures
+/// every event the Stream profile emits.
+///
+/// The channel implementation lives at
+/// `src/Terminal.Core/FileLoggerChannel.fs`. Production
+/// composition (`src/Terminal.App/Program.fs`) passes
+/// `Logger.get "Terminal.Core.FileLoggerChannel"`; these tests
+/// pass a `RecordingLogger` fake that captures
+/// `Log<TState>(...)` calls (which is what `LogInformation`
+/// extension methods funnel through) and exposes the formatted
+/// message string for assertions.
+///
+/// **Empty-payload contract — CONTRARY to NvdaChannel.**
+/// NvdaChannel skips empty payloads; FileLoggerChannel logs
+/// them. Mode barriers + future Background-suppressed events
+/// must appear in the log even if NVDA didn't read them.
+
+/// Recording ILogger fake: captures every `Log<TState>` call's
+/// formatted message string. F# `interface ... with` syntax
+/// implements the full ILogger contract (BeginScope returns a
+/// no-op IDisposable to avoid the F# 9 nullness `FS3261` that
+/// fires when assigning `null` to a non-null reference type;
+/// IsEnabled returns true so every Log call lands).
+type private NoopScope() =
+    interface System.IDisposable with
+        member _.Dispose() = ()
+
+type private RecordingLogger() =
+    let calls = ResizeArray<LogLevel * string>()
+    member _.Calls = calls
+    interface ILogger with
+        member _.BeginScope<'TState>(_state: 'TState) : System.IDisposable =
+            (new NoopScope()) :> System.IDisposable
+        member _.IsEnabled(_: LogLevel) : bool = true
+        member _.Log<'TState>
+                (level: LogLevel,
+                 _eventId: EventId,
+                 state: 'TState,
+                 ex: exn,
+                 formatter: System.Func<'TState, exn, string>) : unit =
+            let message = formatter.Invoke(state, ex)
+            calls.Add((level, message))
+
+let private buildEvent
+        (semantic: SemanticCategory)
+        (priority: Priority)
+        (producer: string)
+        (shell: string option)
+        (payload: string)
+        : OutputEvent
+        =
+    let baseEvent = OutputEvent.create semantic priority producer payload
+    { baseEvent with Source = { baseEvent.Source with Shell = shell } }
+
+// ---- Channel identity ------------------------------------------
+
+[<Fact>]
+let ``FileLoggerChannel.id is filelogger`` () =
+    Assert.Equal("filelogger", FileLoggerChannel.id)
+
+[<Fact>]
+let ``create returns a Channel whose Id matches the module-level id`` () =
+    let channel = FileLoggerChannel.create (RecordingLogger() :> ILogger)
+    Assert.Equal(FileLoggerChannel.id, channel.Id)
+
+// ---- RenderInstruction handling --------------------------------
+
+[<Fact>]
+let ``RenderText payload reaches the logger as the Payload field`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "ls"
+    channel.Send event (RenderText event.Payload)
+    Assert.Equal(1, logger.Calls.Count)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Payload=ls", message)
+    Assert.Contains("PayloadLen=2", message)
+
+[<Fact>]
+let ``RenderText2 picks the Precise register for the logger`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "approx"
+    channel.Send event (RenderText2 ("approx-form", "precise-form"))
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Payload=precise-form", message)
+
+[<Fact>]
+let ``RenderEarcon logs an earcon-id placeholder`` () =
+    // Earcons go to the 8d Earcon channel for actual playback,
+    // but FileLogger captures the emission event so post-hoc
+    // diagnosis sees the earcon was triggered.
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.BellRang Priority.Assertive "test" None ""
+    channel.Send event (RenderEarcon "bell-ping")
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Payload=[earcon=bell-ping]", message)
+
+[<Fact>]
+let ``RenderRaw logs a raw-payload placeholder`` () =
+    // Raw payloads are channel-specific opaque data (e.g. UIA
+    // listbox metadata from the future Selection profile);
+    // FileLogger logs a placeholder so the event's existence
+    // is captured.
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.SelectionShown Priority.Polite "test" None ""
+    channel.Send event (RenderRaw ("opaque" :> obj))
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Payload=[raw payload]", message)
+
+// ---- Empty-payload (mode barrier + the spec D.2 contract) ------
+
+[<Fact>]
+let ``empty-payload events are still logged (mode barriers)`` () =
+    // Stage 8c capture-everything contract. NvdaChannel skips
+    // empty; FileLogger does not.
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.ModeBarrier Priority.Polite "translator" None ""
+    channel.Send event (RenderText "")
+    Assert.Equal(1, logger.Calls.Count)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("PayloadLen=0", message)
+    Assert.Contains("Semantic=ModeBarrier", message)
+
+[<Fact>]
+let ``ParserError events log the wrapped error message`` () =
+    // Anchor for the future spec D.2 ParserError → Background
+    // suppression: even if NvdaChannel stops reading parser
+    // errors, FileLogger continues to record them so
+    // Ctrl+Shift+; diagnosis works.
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event =
+        buildEvent
+            SemanticCategory.ParserError
+            Priority.Background
+            "translator"
+            None
+            "Terminal parser error: decoder failed"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Semantic=ParserError", message)
+    Assert.Contains("Priority=Background", message)
+    Assert.Contains("Payload=Terminal parser error: decoder failed", message)
+
+// ---- Structured-template field substitution --------------------
+
+[<Fact>]
+let ``OutputEvent.Semantic substitutes into the structured template`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Semantic=StreamChunk", message)
+
+[<Fact>]
+let ``OutputEvent.Priority substitutes into the structured template`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Assertive "test" None "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Priority=Assertive", message)
+
+[<Fact>]
+let ``OutputEvent.Verbosity substitutes into the structured template`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Verbosity=Precise", message)
+
+[<Fact>]
+let ``OutputEvent.Source.Producer substitutes into the structured template`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "translator" None "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Producer=translator", message)
+
+[<Fact>]
+let ``Source.Shell None renders as empty string`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    // Shell= followed by space (next field) means empty value.
+    Assert.Contains("Shell= ", message)
+
+[<Fact>]
+let ``Source.Shell Some "cmd" renders as "cmd"`` () =
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" (Some "cmd") "x"
+    channel.Send event (RenderText event.Payload)
+    let _, message = logger.Calls.[0]
+    Assert.Contains("Shell=cmd", message)
+
+// ---- Log level -------------------------------------------------
+
+[<Fact>]
+let ``channel writes at LogLevel.Information`` () =
+    // The level affects sink-side filtering (FileLoggerOptions.MinLevel).
+    // Information is the production default; Debug events would
+    // be filtered out unless the user toggled `Ctrl+Shift+G`. The
+    // channel always emits at Information so every OutputEvent
+    // lands at the default level.
+    let logger = RecordingLogger()
+    let channel = FileLoggerChannel.create (logger :> ILogger)
+    let event = buildEvent SemanticCategory.StreamChunk Priority.Polite "test" None "x"
+    channel.Send event (RenderText event.Payload)
+    let level, _ = logger.Calls.[0]
+    Assert.Equal(LogLevel.Information, level)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="StreamProfileTests.fs" />
     <Compile Include="OutputEventTests.fs" />
     <Compile Include="NvdaChannelTests.fs" />
+    <Compile Include="FileLoggerChannelTests.fs" />
     <Compile Include="OutputDispatcherTests.fs" />
     <Compile Include="KeyEncodingTests.fs" />
     <Compile Include="FileLoggerTests.fs" />


### PR DESCRIPTION
## Summary

Stage 8c of the Output framework cycle. Promotes `Terminal.Core.FileLogger` to a first-class `Channel` so the rolling log captures every `OutputEvent` the Stream profile emits, **structurally**. The `Ctrl+Shift+;` clipboard-copy flow (PR-F) now carries the full event trail for post-hoc diagnosis — each entry includes Semantic / Priority / Verbosity / Producer / Shell / PayloadLen / Payload as structured-template fields.

Behaviour-identical to the post-[8b (#153)](https://github.com/KyleKeane/pty-speak/pull/153) release build for the user-perceived NVDA reading: the Stream profile's emit decisions now route to BOTH NvdaChannel and the new FileLoggerChannel, but NVDA's behaviour (reading + activity-ID mapping + empty-payload skip) is unchanged. The new addition is purely diagnostic infrastructure.

## What ships

**New file: `src/Terminal.Core/FileLoggerChannel.fs`** (~95 lines)
- `[<Literal>] id: ChannelId = "filelogger"`
- `create (logger: ILogger) : Channel`
- `Send` writes a structured `LogInformation` line with the OutputEvent's metadata
- RenderInstruction handling: `RenderText → text`; `RenderText2 → Precise`; `RenderEarcon → "[earcon=<id>]"`; `RenderRaw → "[raw payload]"`
- **Empty-payload contract — CONTRARY to NvdaChannel**: logs every event including those with empty Payload. Mode barriers + future Background-suppressed events land in the log even if NVDA didn't read them.

**New file: `tests/Tests.Unit/FileLoggerChannelTests.fs`** (~205 lines, 14 tests)
- `RecordingLogger` ILogger fake (with `NoopScope` BeginScope to dodge F# 9 `FS3261` nullness on null IDisposable returns — same lesson as PR #152's box→`:>` fix)
- Identity + create round-trip
- All four RenderInstruction cases
- Empty-payload still logged (mode barriers + ParserError anchor for the future spec-D.2 Background-suppression PR)
- Structured-template field substitution (Semantic / Priority / Verbosity / Producer / Shell)
- Shell `None` vs `Some "cmd"` rendering
- `LogLevel.Information` confirmation

**Modified:**
- `src/Terminal.Core/StreamProfile.fs` — added private `fileLoggerTextDecision` + `textDecisions` helpers; updated `coalescedToPair` + the inline Apply branches (ParserError, catch-all) + the Tick closure to use `textDecisions` instead of single-decision arrays. Multi-pair Apply shape preserved.
- `src/Terminal.App/Program.fs` — 3-line addition in the composition root: create + register the FileLoggerChannel via `Logger.get "Terminal.Core.FileLoggerChannel"`.
- `Terminal.Core.fsproj` — `<Compile Include>` for FileLoggerChannel.fs, ordered between NvdaChannel.fs and StreamProfile.fs.
- `Tests.Unit.fsproj` — `<Compile Include>` for the new tests.
- `CHANGELOG.md` — `[Unreleased] ### Added (Stage 8c)` entry.

## Behaviour preservation gate

All ~144 pre-existing load-bearing tests stay green:

- 30 algorithm tests in `StreamProfileTests.fs` (incl. 4 PR-M #145 cross-row spinner gate pins) — untouched
- 14 `NvdaChannelTests.fs` — untouched
- 17 `OutputDispatcherTests.fs` — untouched (synthetic `passthroughProfile` produces 1 decision per event regardless of StreamProfile's 8c shape change)
- 17 `OutputEventTests.fs` — untouched
- 15 `FileLoggerTests.fs` (existing FileLogger sink) — untouched (channel uses sink via standard ILogger pipeline)
- 10 `AnnounceSanitiserTests.fs` — untouched
- 12 `ScreenTests.fs` — untouched
- 4 `UpdateMessagesTests.fs` — untouched

## NVDA validation row (manual; maintainer)

- Reproduce a session: type a few commands in cmd, trigger an alt-screen toggle (`vim` or `less`), `Ctrl+Shift+;` to copy the log
- Verify the log contains `OutputEvent. Semantic=...` lines for every announcement NVDA spoke
- Verify NVDA reading is unchanged from the post-8b release build

## Open question carried forward from 8a/8b

Spec D.2 maps `ParserError → Background`, where Background is "suppressed at profile layer" per spec B.5.2. After 8c the FileLogger channel receives every ParserError event regardless of whether NVDA reads it — this enables the future suppression PR's diagnostic story ("NVDA stayed silent; the parser error is in the log via `Ctrl+Shift+;`"). Reconciliation deferred to a focused follow-up.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest. ~158 tests pass (14 new + ~144 pre-existing)
- [ ] CI Markdown link check + workflow lint pass
- [ ] Manual NVDA validation per the row above

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_