### PR TITLE
feat(terminal-audio,core): Stage 8d.1 — WASAPI Earcons + Bell + Ctrl+Shift+M mute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,159 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Stage 8d.1 — WASAPI Earcons channel + Earcon profile + Bell)
+
+The fourth sub-stage of the Output framework cycle. Adds WASAPI
+audio playback infrastructure + a first-class Earcon channel +
+an Earcon profile that maps `OutputEvent.Semantic` to earcon
+sounds. v1 (8d.1) ships the substrate + the BEL → "bell-ping"
+mapping; 8d.2 will add color-detection + ErrorLine /
+WarningLine earcons (the full spec C.1 NVDA-validation row
+mentions "Run colour-emitting commands; hear earcons"; that's
+8d.2's payload).
+
+**`Ctrl+Shift+M` mute hotkey** lands as part of 8d.1, claiming
+the long-standing reservation in `CLAUDE.md`'s "Reserved (not
+yet bound)" list. Each press flips the process-wide mute state
+and announces "Earcons muted." / "Earcons unmuted." via NVDA
+through `ActivityIds.logToggle` (same family as Ctrl+Shift+G's
+debug-log toggle).
+
+#### NAudio dependency
+
+- `Directory.Packages.props` already pinned `NAudio` 2.2.1 — the
+  umbrella package pulls NAudio.Wasapi (WasapiOut +
+  MMDeviceEnumerator) and NAudio.Core (SignalGenerator +
+  ISampleProvider) transitively. 8d.1 adds the
+  `<PackageReference Include="NAudio" />` to
+  `src/Terminal.Audio/Terminal.Audio.fsproj`.
+
+#### Audio infrastructure (`src/Terminal.Audio/`)
+
+The 8a placeholder shell is replaced with three new files:
+
+- **`EarconWaveform.fs`** — pure-F# sine + envelope synthesis.
+  `synthSineEnvelope` returns an `ISampleProvider` chain
+  (`SignalGenerator → OffsetSampleProvider →
+  FadeInOutSampleProvider`) that NAudio's `WasapiOut` consumes.
+  v1 applies fade-in only (NAudio's `BeginFadeOut` triggers
+  immediately rather than scheduled); a small click at the end
+  of a 100ms tone is acceptable for v1; a future PR can add a
+  custom per-sample-envelope `ISampleProvider` if needed.
+- **`EarconPalette.fs`** — `EarconId = string` +
+  `Map<EarconId, EarconWaveform.Parameters>`. Default palette
+  ships `"bell-ping"` only (800Hz × 100ms × 10ms attack). 8d.2
+  adds `"error-tone"` + `"warning-tone"`; Phase 2 makes the
+  palette user-customisable via TOML.
+- **`EarconPlayer.fs`** — WASAPI playback glue. Lazy-init
+  singleton `WasapiOut` + thread-safe init under a lock. The
+  `play` function is non-blocking: it stops any in-flight
+  earcon, builds a fresh sample-provider chain via
+  `EarconWaveform.synthSineEnvelope`, calls `WasapiOut.Init` +
+  `Play`, returns. NAudio's audio thread feeds samples on its
+  own schedule. **Errors are swallowed + logged at Information
+  level** — earcon failures (no audio device, headless CI,
+  driver permission errors) become "no sound" rather than
+  crashing the dispatcher.
+
+#### Channel + profile (`src/Terminal.Core/`)
+
+- **`EarconChannel.fs` (new file).** Mirrors NvdaChannel /
+  FileLoggerChannel: `[<Literal>] id: ChannelId = "earcon"` +
+  `create (play: string -> unit) : Channel`. Send pattern-
+  matches on RenderInstruction; only `RenderEarcon earconId`
+  invokes `play` — the other cases (RenderText / RenderText2 /
+  RenderRaw) are skipped because they target NVDA / FileLogger,
+  not earcons. Process-wide mute state via `toggle ()` /
+  `isMuted ()` / `clearForTests ()` (single-thread-init pattern
+  matching the registries).
+- **`EarconProfile.fs` (new file).** Mirrors StreamProfile:
+  `[<Literal>] id: ProfileId = "earcon"` + `create () : Profile`.
+  Apply maps `BellRang → RenderEarcon "bell-ping"`; all other
+  Semantic categories return `[||]` (the profile is an
+  additive observer, not a router for everything). Tick + Reset
+  are no-ops in 8d.1.
+
+#### BEL producer (`src/Terminal.Core/`)
+
+- **`Types.fs`** — extends `ScreenNotification` DU with `| Bell`
+  case (no payload — pure signal).
+- **`Screen.fs`** — adds `bellEvent: Event<unit>` +
+  `pendingBell: bool` mutable + `[<CLIEvent>] member _.Bell`
+  property. `executeC0 0x07uy` sets `pendingBell`; Apply
+  drains the flag after lock release and triggers `bellEvent`,
+  same buffered-then-fire pattern as ModeChanged.
+- **`OutputEventBuilder.fs`** — extends `fromScreenNotification`
+  to map `Bell → SemanticCategory.BellRang`, `Priority =
+  Assertive`, `Payload = ""`.
+- **`src/Terminal.App/Program.fs`** — bridges `screen.Bell.Add`
+  into the notification channel via
+  `notificationChannel.Writer.TryWrite(ScreenNotification.Bell)`,
+  same pattern as the existing `screen.ModeChanged.Add` bridge.
+
+#### Mute hotkey (Ctrl+Shift+M)
+
+- **`HotkeyRegistry.fs`** — extends `AppCommand` DU with
+  `| MuteEarcons` case + matching `nameOf`, `builtIns`, and
+  `allCommands` updates.
+- **`Program.fs`** — `runMuteEarcons` handler calls
+  `EarconChannel.toggle ()` and announces the new state via
+  `ActivityIds.logToggle`. `bindHotkey` wires it.
+- **`Views/TerminalView.cs`** — extends `AppReservedHotkeys`
+  table with the `(Key.M, Ctrl|Shift, "Mute earcons")` entry;
+  removes the matching commented-out reservation.
+
+#### Composition root (`Program.fs`)
+
+The active profile set grows from `[ streamProfile ]` (post-8c)
+to `[ streamProfile; earconProfile ]`. For BellRang events:
+StreamProfile's catch-all branch produces NVDA + FileLogger
+decisions for the empty payload (NvdaChannel skips empty;
+FileLogger logs the event). EarconProfile produces the earcon
+decision. Total: bell ping plays + log entry; NVDA stays silent
+(no double-up because empty payload).
+
+### Tests (Stage 8d.1)
+
+- **`tests/Tests.Unit/EarconChannelTests.fs` (new).** 13 tests:
+  identity (`id = "earcon"`); RenderEarcon dispatch + multiple
+  ids; RenderText / RenderText2 / RenderRaw skip; mute toggle
+  state machine (initial false → toggle → true → toggle →
+  false); RenderEarcon skipped when muted; play resumes after
+  un-mute; clearForTests resets state.
+- **`tests/Tests.Unit/EarconProfileTests.fs` (new).** 14 tests:
+  identity; BellRang Apply emits one pair / one decision /
+  targets EarconChannel / RenderEarcon "bell-ping" /
+  effectiveEvent is the input event; empty pair array for
+  StreamChunk / ParserError / ModeBarrier / AltScreenEntered /
+  ErrorLine (8d.2 anchor) / Custom; Tick + Reset.
+- **`tests/Tests.Unit/OutputEventTests.fs`** — 2 new tests for
+  the `Bell → BellRang + Assertive` mapping.
+- **`tests/Tests.Unit/HotkeyRegistryTests.fs`** — adds
+  `MuteEarcons` to the `expected` Set in
+  `allCommands contains exactly the documented commands`.
+
+### Behaviour preservation (the regression bar)
+
+All ~158 pre-existing load-bearing tests stay green. Earcon
+infrastructure is purely additive: StreamProfile is unchanged;
+NvdaChannel + FileLoggerChannel are unchanged; OutputDispatcher
+is unchanged. The only behavioural change is the new BEL
+audible cue (which Stage 7 silently swallowed; 8d.1 surfaces
+it).
+
+NVDA-validation row (manual; maintainer): "Trigger a bell
+(`printf '\\a'` in cmd, or `tput bel`); hear bell ping; press
+Ctrl+Shift+M; verify mute toggles + announces; verify ping
+doesn't play when muted."
+
+### Open question carried forward
+
+Same as 8a/8b/8c: spec D.2 ParserError → Background
+suppression. The Earcon profile + FileLogger channel substrate
+now in place is the prerequisite for the future suppression PR
+(parser errors go to FileLogger only, NVDA stays silent on them).
+
 ### Added (Stage 8c — FileLogger as first-class channel)
 
 The third sub-stage of the Output framework cycle. Promotes

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -10,6 +10,7 @@ open Microsoft.Extensions.Logging
 open Velopack
 open Velopack.Sources
 open Terminal.Core
+open Terminal.Audio
 open Terminal.Parser
 open Terminal.Pty
 open PtySpeak.Views
@@ -770,6 +771,23 @@ module Program =
                 | _ -> "Debug logging off."
             window.TerminalSurface.Announce(cue, ActivityIds.logToggle)
 
+    /// Stage 8d.1 — Ctrl+Shift+M handler. Toggles the
+    /// process-wide earcon mute state via `EarconChannel.toggle`
+    /// and announces the new state via NVDA. Reuses
+    /// `ActivityIds.logToggle` for the announcement (same
+    /// semantic family — toggling a diagnostic-config setting,
+    /// like Ctrl+Shift+G's debug-logging toggle).
+    let private runMuteEarcons (window: MainWindow) : unit =
+        let log = Logger.get "Terminal.App.Program.runMuteEarcons"
+        let nowMuted = EarconChannel.toggle ()
+        log.LogInformation(
+            "Ctrl+Shift+M pressed; earcons toggled. NowMuted={NowMuted}",
+            nowMuted)
+        let cue =
+            if nowMuted then "Earcons muted."
+            else "Earcons unmuted."
+        window.TerminalSurface.Announce(cue, ActivityIds.logToggle)
+
     /// Composition seam — Stage 4+ plugs Elmish.WPF and the UIA peer
     /// in here. For Stage 3b we just hold references to the long-lived
     /// pieces and ensure they're disposed on Application.Exit.
@@ -820,6 +838,7 @@ module Program =
         bindHotkey window HotkeyRegistry.OpenLogsFolder (fun () -> runOpenLogs window)
         bindHotkey window HotkeyRegistry.CopyLatestLog (fun () -> runCopyLatestLog window)
         bindHotkey window HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
+        bindHotkey window HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
 
         // Direct dispatch via TerminalView.OnPreviewKeyDown is
         // kept as a defence-in-depth path because Window-level
@@ -876,6 +895,11 @@ module Program =
         // a Channel here is non-blocking and deadlock-free.
         screen.ModeChanged.Add(fun (flag, value) ->
             notificationChannel.Writer.TryWrite(ModeChanged (flag, value)) |> ignore)
+        // Stage 8d.1 — bridge screen.Bell events into the
+        // notification channel so the TranslatorPump produces
+        // OutputEvent.BellRang for the Earcon profile.
+        screen.Bell.Add(fun () ->
+            notificationChannel.Writer.TryWrite(ScreenNotification.Bell) |> ignore)
 
         // Stage 8b — output framework substrate composition.
         //
@@ -902,10 +926,24 @@ module Program =
             FileLoggerChannel.create
                 (Logger.get "Terminal.Core.FileLoggerChannel")
         OutputDispatcher.ChannelRegistry.register fileLoggerChannel
+        // Stage 8d.1 — WASAPI Earcons channel. Plays a sine-tone
+        // ping when the Earcon profile claims a Semantic
+        // category (today: BellRang only). The marshal callback
+        // binds to `Terminal.Audio.EarconPlayer.play` which feeds
+        // NAudio's WasapiOut. The Ctrl+Shift+M hotkey toggles
+        // mute via `EarconChannel.toggle ()` (the channel's Send
+        // checks `isMuted` before invoking play).
+        let earconChannel =
+            EarconChannel.create
+                (EarconPlayer.play EarconPalette.defaultPalette)
+        OutputDispatcher.ChannelRegistry.register earconChannel
         let streamProfile =
             StreamProfile.create StreamProfile.defaultParameters screen
         OutputDispatcher.ProfileRegistry.register streamProfile
-        OutputDispatcher.ProfileRegistry.setActiveProfileSet [ streamProfile ]
+        let earconProfile = EarconProfile.create ()
+        OutputDispatcher.ProfileRegistry.register earconProfile
+        OutputDispatcher.ProfileRegistry.setActiveProfileSet
+            [ streamProfile; earconProfile ]
 
         // TranslatorPump — read raw ScreenNotifications, build
         // OutputEvents, dispatch through the active profile set.

--- a/src/Terminal.Audio/EarconPalette.fs
+++ b/src/Terminal.Audio/EarconPalette.fs
@@ -1,0 +1,43 @@
+namespace Terminal.Audio
+
+/// Stage 8d.1 — earcon-id vocabulary + default palette mapping
+/// each id to an `EarconWaveform.Parameters` record. The palette
+/// is a `Map<EarconId, EarconWaveform.Parameters>`; the
+/// `EarconPlayer` looks up by id, builds a fresh sample-provider
+/// chain via `EarconWaveform.synthSineEnvelope`, and feeds it to
+/// the WASAPI device.
+///
+/// **v1 palette (8d.1).** Only `"bell-ping"` is defined — an
+/// 800Hz × 100ms tone with a 10ms attack envelope. The Earcon
+/// profile in `Terminal.Core/EarconProfile.fs` maps
+/// `SemanticCategory.BellRang → "bell-ping"` so when a shell
+/// emits BEL (0x07), the user hears the ping.
+///
+/// **8d.2 palette additions.** Color detection lands in 8d.2,
+/// which extends the palette with `"error-tone"` (probably
+/// 400Hz × 150ms — lower pitch + longer duration to feel "big")
+/// and `"warning-tone"` (probably 600Hz × 120ms — middle ground).
+///
+/// **Phase 2.** The palette becomes user-customisable via TOML
+/// (`[earcons.bell-ping] frequencyHz = 800` etc.). The 9c TOML
+/// loader will overlay user values on top of `defaultPalette`.
+module EarconPalette =
+
+    /// Stable string identifier for an earcon. The Earcon
+    /// profile's `Apply` produces `RenderEarcon earconId`
+    /// instructions; the EarconChannel resolves the id by
+    /// looking up the palette entry. String-keyed for TOML
+    /// compatibility (Phase 2).
+    type EarconId = string
+
+    /// Default palette. v1 ships a single bell-ping entry. The
+    /// 800Hz frequency was chosen as a clearly-audible mid-tone
+    /// that doesn't conflict with NVDA's speech band; the 100ms
+    /// duration is short enough to feel like a "bell" rather
+    /// than a "tone". Tunable in Phase 2 via TOML.
+    let defaultPalette : Map<EarconId, EarconWaveform.Parameters> =
+        Map.ofList
+            [ "bell-ping",
+              { FrequencyHz = 800.0
+                DurationMs = 100
+                AttackMs = 10 } ]

--- a/src/Terminal.Audio/EarconPlayer.fs
+++ b/src/Terminal.Audio/EarconPlayer.fs
@@ -104,7 +104,7 @@ module EarconPlayer =
             =
         match Map.tryFind earconId palette with
         | None ->
-            logger.LogInformation(
+            (getLogger ()).LogInformation(
                 "No earcon registered for id; skipping. EarconId={EarconId}",
                 earconId)
         | Some parameters ->

--- a/src/Terminal.Audio/EarconPlayer.fs
+++ b/src/Terminal.Audio/EarconPlayer.fs
@@ -1,0 +1,146 @@
+namespace Terminal.Audio
+
+open System
+open NAudio.Wave
+open NAudio.Wave.SampleProviders
+open NAudio.CoreAudioApi
+open Microsoft.Extensions.Logging
+open Terminal.Core
+
+/// Stage 8d.1 — WASAPI playback glue for earcons.
+///
+/// Holds a singleton `WasapiOut` instance, initialised lazily on
+/// first call to `play`. NAudio's `WasapiOut` runs its own audio
+/// thread internally — `Play()` returns immediately once the
+/// engine is primed and the audio thread feeds samples on its
+/// own schedule. So `play` is non-blocking from the dispatcher's
+/// perspective, satisfying the channel "do not block the
+/// dispatcher" contract (spec B.5.3).
+///
+/// **Lazy init.** The WasapiOut + MMDeviceEnumerator are
+/// constructed on first use rather than at app startup. This
+/// avoids paying the audio-subsystem initialisation cost for
+/// users who never trigger an earcon (e.g., shell sessions
+/// that never emit BEL). The lazy init is gated by a `lock` so
+/// concurrent first-plays don't double-construct.
+///
+/// **Single-stream model.** WasapiOut plays ONE sample provider
+/// at a time. If a second `play` arrives while the previous is
+/// still rendering, the first is stopped and the second begins.
+/// In practice earcons are short (100ms) and rare (BEL triggers
+/// only when a shell emits 0x07); collisions are unlikely. A
+/// future PR can add a mixer (`MixingSampleProvider`) if
+/// overlapping earcons become a real use case.
+///
+/// **Error swallowing.** Audio failures must NEVER crash the
+/// app or block the dispatcher. Every `play` call is wrapped in
+/// `try/with`; exceptions are logged at Information level and
+/// silently dropped. Common failure modes: no audio device, WASAPI
+/// init failure (e.g., headless CI), driver permission errors.
+/// All of these become "no sound" for the user — the rest of the
+/// app continues running.
+module EarconPlayer =
+
+    /// Helper: fetch the current logger. Called per-log-site
+    /// rather than cached at module-init because
+    /// `Terminal.Core.Logger` returns a NullLogger sentinel
+    /// before `Logger.configure` runs (composition root,
+    /// `Program.fs` line ~788) and the real factory-backed
+    /// logger after. Module-init for Terminal.Audio happens
+    /// when `compose` touches the EarconPlayer (after
+    /// configure), but we use the per-call lookup pattern that
+    /// the rest of the codebase uses (see e.g.
+    /// `Coalescer.processRowsChanged`).
+    let private getLogger () : ILogger =
+        Logger.get "Terminal.Audio.EarconPlayer"
+
+    let private initLock : obj = obj ()
+    let mutable private wasapiOut : WasapiOut option = None
+    let mutable private deviceEnumerator : MMDeviceEnumerator option = None
+
+    /// Initialise the WASAPI output device on first use. Caller
+    /// MUST hold `initLock`. Returns the cached instance on
+    /// subsequent calls. Returns `None` if the audio subsystem
+    /// is unavailable (no device, permission denied, headless
+    /// runner, etc.).
+    let private ensureWasapiOut () : WasapiOut option =
+        match wasapiOut with
+        | Some _ as cached -> cached
+        | None ->
+            try
+                let enumerator = new MMDeviceEnumerator()
+                let device =
+                    enumerator.GetDefaultAudioEndpoint(
+                        DataFlow.Render,
+                        Role.Console)
+                let wo =
+                    new WasapiOut(
+                        device,
+                        AudioClientShareMode.Shared,
+                        true,
+                        100)
+                deviceEnumerator <- Some enumerator
+                wasapiOut <- Some wo
+                (getLogger ()).LogInformation(
+                    "WasapiOut initialised. Device={Device}",
+                    device.FriendlyName)
+                Some wo
+            with ex ->
+                (getLogger ()).LogInformation(
+                    ex,
+                    "WasapiOut initialisation failed; earcons will be silent. Reason: {Reason}",
+                    ex.Message)
+                None
+
+    /// Play the earcon identified by `earconId` using the
+    /// supplied palette. Non-blocking: returns immediately
+    /// after starting the playback. Errors are logged and
+    /// silently swallowed — earcon failures don't crash the
+    /// dispatcher.
+    let play
+            (palette: Map<EarconPalette.EarconId, EarconWaveform.Parameters>)
+            (earconId: EarconPalette.EarconId)
+            : unit
+            =
+        match Map.tryFind earconId palette with
+        | None ->
+            logger.LogInformation(
+                "No earcon registered for id; skipping. EarconId={EarconId}",
+                earconId)
+        | Some parameters ->
+            try
+                lock initLock (fun () ->
+                    match ensureWasapiOut () with
+                    | None -> ()
+                    | Some wo ->
+                        // Stop the in-flight earcon (if any)
+                        // before initialising the next. WasapiOut
+                        // doesn't queue; calling Init twice
+                        // without Stop produces undefined
+                        // behaviour.
+                        if wo.PlaybackState = PlaybackState.Playing then
+                            wo.Stop()
+                        let waveform =
+                            EarconWaveform.synthSineEnvelope parameters
+                        // WasapiOut.Init takes IWaveProvider;
+                        // wrap the ISampleProvider chain in a
+                        // 16-bit PCM converter (NAudio's
+                        // standard adapter). 16-bit is the
+                        // universally-supported lowest-CPU
+                        // option for short tones; spatial
+                        // future-stages may upgrade to 32-bit
+                        // float for better dynamic range.
+                        let waveProvider = SampleToWaveProvider16(waveform)
+                        wo.Init(waveProvider :> IWaveProvider)
+                        wo.Play()
+                        (getLogger ()).LogDebug(
+                            "Earcon play started. EarconId={EarconId} FreqHz={FreqHz} DurationMs={DurationMs}",
+                            earconId,
+                            parameters.FrequencyHz,
+                            parameters.DurationMs))
+            with ex ->
+                (getLogger ()).LogInformation(
+                    ex,
+                    "Earcon play failed; suppressing. EarconId={EarconId} Reason={Reason}",
+                    earconId,
+                    ex.Message)

--- a/src/Terminal.Audio/EarconWaveform.fs
+++ b/src/Terminal.Audio/EarconWaveform.fs
@@ -1,0 +1,63 @@
+namespace Terminal.Audio
+
+open NAudio.Wave
+open NAudio.Wave.SampleProviders
+
+/// Stage 8d.1 — pure-F# earcon waveform synthesis. Produces an
+/// `ISampleProvider` representing a sine tone of the requested
+/// frequency + duration with a linear attack envelope to avoid
+/// the speaker-clicking artefact at start.
+///
+/// **8d.1 envelope simplification.** NAudio's
+/// `FadeInOutSampleProvider.BeginFadeOut` triggers immediately
+/// on call; there's no ahead-of-time "fade out at sample N"
+/// scheduling without a timer (which risks GC issues on the
+/// short-lived provider chain). 8d.1 ships fade-in only; the
+/// abrupt cut at the end of a 100ms tone produces a faint
+/// click that's acceptable for v1. A follow-up PR can swap in
+/// a custom `ISampleProvider` that applies the release ramp
+/// per-sample if the click proves audible in practice.
+///
+/// **Architecture.** Synthesis is parametric: each call to
+/// `synthSineEnvelope` returns a fresh
+/// `(SignalGenerator → OffsetSampleProvider →
+/// FadeInOutSampleProvider)` chain that NAudio's `WasapiOut`
+/// consumes. The provider chain is short-lived per playback;
+/// nothing is cached across calls (NAudio's sample providers
+/// are stateful and not safe to share across concurrent plays).
+module EarconWaveform =
+
+    /// Parameters for sine-tone synthesis. `FrequencyHz` is the
+    /// fundamental tone (typical earcon range 200-2000Hz);
+    /// `DurationMs` bounds the total envelope length;
+    /// `AttackMs` is the fade-in portion (subtracted from the
+    /// steady-state plateau).
+    type Parameters =
+        { FrequencyHz: float
+          DurationMs: int
+          AttackMs: int }
+
+    /// Sample format the synthesis chain produces. WASAPI
+    /// shared-mode mixing accepts any common format and
+    /// resamples internally; 44.1kHz mono float32 is a good
+    /// default — minimises CPU, matches NAudio's default
+    /// `SignalGenerator` output.
+    let internal sampleRate = 44_100
+    let internal channels = 1
+
+    /// Build a fresh `ISampleProvider` chain that plays one
+    /// envelope of a sine tone matching the supplied parameters.
+    /// Caller passes the result to `WasapiOut.Init` + `Play`.
+    let synthSineEnvelope (parameters: Parameters) : ISampleProvider =
+        let generator =
+            SignalGenerator(sampleRate, channels,
+                Type = SignalGeneratorType.Sin,
+                Frequency = parameters.FrequencyHz,
+                Gain = 0.5)
+        let bounded =
+            OffsetSampleProvider(generator,
+                TakeSamples =
+                    sampleRate * channels * parameters.DurationMs / 1000)
+        let fader = FadeInOutSampleProvider(bounded, true)
+        fader.BeginFadeIn(float parameters.AttackMs)
+        fader :> ISampleProvider

--- a/src/Terminal.Audio/Placeholder.fs
+++ b/src/Terminal.Audio/Placeholder.fs
@@ -1,5 +1,0 @@
-namespace Terminal.Audio
-
-/// Stage 7 fills in the NAudio earcon mixer.
-module internal Placeholder =
-    let private _reserved = ()

--- a/src/Terminal.Audio/Terminal.Audio.fsproj
+++ b/src/Terminal.Audio/Terminal.Audio.fsproj
@@ -7,11 +7,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Placeholder.fs" />
+    <Compile Include="EarconWaveform.fs" />
+    <Compile Include="EarconPalette.fs" />
+    <Compile Include="EarconPlayer.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <!--
+      Stage 8d.1 — NAudio for the WASAPI Earcons channel.
+      Replaces tech-plan §9's earcon stage. The `NAudio` umbrella
+      package pulls NAudio.Wasapi (WasapiOut + MMDeviceEnumerator)
+      and NAudio.Core (SignalGenerator + ISampleProvider) — all
+      that's needed for sine-tone earcon synthesis + WASAPI
+      playback. Pinned centrally to 2.2.1 in
+      `Directory.Packages.props`.
+    -->
+    <PackageReference Include="NAudio" />
     <ProjectReference Include="..\Terminal.Core\Terminal.Core.fsproj" />
   </ItemGroup>
 

--- a/src/Terminal.Core/EarconChannel.fs
+++ b/src/Terminal.Core/EarconChannel.fs
@@ -1,0 +1,80 @@
+namespace Terminal.Core
+
+/// Stage 8d.1 — WASAPI Earcons channel. Translates
+/// `RenderEarcon earconId` instructions into a `play` callback
+/// invocation; the composition root in Program.fs binds the
+/// callback to `Terminal.Audio.EarconPlayer.play
+/// EarconPalette.defaultPalette` (which feeds NAudio's
+/// WasapiOut). Other RenderInstruction cases (RenderText /
+/// RenderText2 / RenderRaw) are skipped — those go to the NVDA
+/// or FileLogger channels, not earcons.
+///
+/// The marshal-callback pattern keeps `Terminal.Core` free of
+/// NAudio dependency (same as NvdaChannel keeps Terminal.Core
+/// free of WPF, and FileLoggerChannel takes an injected ILogger
+/// instead of constructing one). The composition root threads
+/// the platform binding through.
+///
+/// **Mute state.** Module-level mutable bool. The Ctrl+Shift+M
+/// hotkey handler in Program.fs calls `toggle ()` to flip
+/// state; the channel's Send checks `isMuted ()` before
+/// invoking `play`. Process-wide because the user expects the
+/// mute toggle to affect all subsequent earcons regardless of
+/// shell or session. Single-thread-init pattern matches the
+/// other registries; cross-thread access on a `bool` is safe
+/// under the standard .NET memory model.
+///
+/// **Spec reference.** `spec/event-and-output-framework.md`
+/// Part B.4.2 (WASAPI Earcons channel) + Part C.1 (8d row).
+/// Per-shell mute state via TOML
+/// (`[shell.X] muteEarcons = true`) is a 9c TOML loader concern,
+/// out of scope for 8d.1.
+module EarconChannel =
+
+    /// Stable channel identifier registered with the
+    /// dispatcher's `ChannelRegistry`. Profiles refer to this
+    /// string in their `ChannelDecision.Channel` field.
+    [<Literal>]
+    let id: ChannelId = "earcon"
+
+    let private muteLock : obj = obj ()
+    let mutable private muted : bool = false
+
+    /// Flip the mute state. Returns the new state. Called by
+    /// the Ctrl+Shift+M hotkey handler in Program.fs.
+    let toggle () : bool =
+        lock muteLock (fun () ->
+            muted <- not muted
+            muted)
+
+    /// Read the current mute state. The channel's Send checks
+    /// this before invoking `play` so the play callback isn't
+    /// called when muted.
+    let isMuted () : bool =
+        muted
+
+    /// Test-only — reset mute to false. Tests use this in
+    /// their setup so test runs don't leak mute state across
+    /// each other. Production composition root never calls
+    /// this.
+    let internal clearForTests () : unit =
+        lock muteLock (fun () -> muted <- false)
+
+    /// Construct a Channel that plays earcons via the supplied
+    /// callback. The callback receives the earcon-id string
+    /// and is responsible for the actual audio output (in
+    /// production: `Terminal.Audio.EarconPlayer.play
+    /// defaultPalette`; in tests: a recording function that
+    /// captures invocations).
+    let create (play: string -> unit) : Channel =
+        { Id = id
+          Send =
+            fun _event render ->
+                if isMuted () then
+                    ()
+                else
+                    match render with
+                    | RenderEarcon earconId -> play earconId
+                    | RenderText _ -> ()
+                    | RenderText2 (_, _) -> ()
+                    | RenderRaw _ -> () }

--- a/src/Terminal.Core/EarconProfile.fs
+++ b/src/Terminal.Core/EarconProfile.fs
@@ -1,0 +1,83 @@
+namespace Terminal.Core
+
+/// Stage 8d.1 — Earcon profile. Maps `OutputEvent.Semantic` to
+/// `RenderEarcon earconId` ChannelDecisions targeting the
+/// `EarconChannel`. Other Semantic categories return `[||]` —
+/// the profile is a purely additive observer for events it
+/// claims, not a router for everything.
+///
+/// **8d.1 mapping (Bell only):**
+/// - `BellRang` → `RenderEarcon "bell-ping"`
+///
+/// **8d.2 will add:**
+/// - `ErrorLine` → `RenderEarcon "error-tone"`
+/// - `WarningLine` → `RenderEarcon "warning-tone"`
+///
+/// 8d.2 also requires a producer that emits ErrorLine /
+/// WarningLine OutputEvents based on row colors detected in
+/// the screen snapshot — that's the "color detection" piece
+/// the spec validation row references.
+///
+/// **Co-existence with StreamProfile.** When the dispatcher
+/// fans out to the active profile set, both StreamProfile and
+/// EarconProfile receive each event. For `BellRang` events:
+/// StreamProfile's catch-all branch produces NVDA + FileLogger
+/// decisions for the empty payload (NvdaChannel skips empty;
+/// FileLogger logs the event). EarconProfile produces the
+/// earcon decision. Total: bell ping plays + log entry; NVDA
+/// stays silent (no double-up because empty payload).
+///
+/// **NVDA-channel suppression deferred.** Spec B.3.2 mentions
+/// the Earcon profile "emits NVDA-channel suppression for
+/// events the earcon channel claims". 8d.1 doesn't need this
+/// because BellRang events have empty Payload and NvdaChannel
+/// already skips empty. 8d.2's color-detection (which would
+/// emit Payload with the colored row text) needs explicit
+/// suppression to avoid the user hearing both the earcon AND
+/// NVDA reading the colored row — that's a substrate API
+/// extension (cross-profile suppression markers) that lands
+/// with 8d.2.
+///
+/// **Spec reference.** `spec/event-and-output-framework.md`
+/// Part B.3.2 (Earcon profile row).
+module EarconProfile =
+
+    /// Stable profile identifier registered with the dispatcher's
+    /// `ProfileRegistry`. The 9c TOML config keys
+    /// `[profile.earcon]` on this string.
+    [<Literal>]
+    let id: ProfileId = "earcon"
+
+    /// Build a NVDA-irrelevant earcon decision for the supplied
+    /// earcon id. Mirrors NvdaChannel / FileLoggerChannel's
+    /// per-channel decision-builder helpers.
+    let private earconDecision (earconId: string) : ChannelDecision =
+        { Channel = EarconChannel.id
+          Render = RenderEarcon earconId }
+
+    /// Construct the Earcon profile. No parameters in 8d.1 (no
+    /// per-instance state); 8d.2 / Phase 2 may add a
+    /// `Parameters` record for things like a per-shell mute
+    /// state or a custom palette override.
+    let create () : Profile =
+        { Id = id
+          Apply =
+            fun event ->
+                match event.Semantic with
+                | SemanticCategory.BellRang ->
+                    [|
+                        event,
+                        [| earconDecision "bell-ping" |]
+                    |]
+                | _ ->
+                    // No earcon for other Semantic categories
+                    // in 8d.1. 8d.2 adds ErrorLine /
+                    // WarningLine cases.
+                    [||]
+          Tick =
+            fun _ ->
+                // No time-driven flush — earcons are
+                // event-driven only.
+                [||]
+          Reset =
+            fun () -> () }

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -90,6 +90,8 @@ module HotkeyRegistry =
         | SwitchToPowerShell
         // Stage 7 PR-C / PR-J — switch spawned shell to claude.
         | SwitchToClaude
+        // Stage 8d.1 — toggle WASAPI Earcons mute on/off.
+        | MuteEarcons
 
     /// Stable string name for a command, used as the
     /// `RoutedCommand` name passed to WPF and as a TOML key
@@ -109,6 +111,7 @@ module HotkeyRegistry =
         | SwitchToCmd -> "SwitchToCmd"
         | SwitchToPowerShell -> "SwitchToPowerShell"
         | SwitchToClaude -> "SwitchToClaude"
+        | MuteEarcons -> "MuteEarcons"
 
     /// Default key binding for a command. Mirrors the
     /// `AppReservedHotkeys` table in
@@ -174,7 +177,11 @@ module HotkeyRegistry =
           { Command = SwitchToClaude
             Key = Digit 3
             Modifiers = ctrlShift
-            Description = "Switch to Claude shell" } ]
+            Description = "Switch to Claude shell" }
+          { Command = MuteEarcons
+            Key = Letter 'M'
+            Modifiers = ctrlShift
+            Description = "Mute / unmute WASAPI earcons (Stage 8d.1)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —
@@ -217,4 +224,5 @@ module HotkeyRegistry =
           IncidentMarker
           SwitchToCmd
           SwitchToPowerShell
-          SwitchToClaude ]
+          SwitchToClaude
+          MuteEarcons ]

--- a/src/Terminal.Core/OutputEventBuilder.fs
+++ b/src/Terminal.Core/OutputEventBuilder.fs
@@ -77,3 +77,16 @@ module OutputEventBuilder =
                 | _ ->
                     SemanticCategory.ModeBarrier, Priority.Polite
             OutputEvent.create semantic priority producerId ""
+        | Bell ->
+            // Stage 8d.1 — BEL (0x07) → BellRang. Empty Payload
+            // (BEL is a pure signal). Priority = Assertive
+            // because BEL is a purposeful user-attention event
+            // that the shell deliberately emitted; the Earcon
+            // profile maps to a bell-ping; the NvdaChannel
+            // sees the empty payload and skips its announce
+            // (so no double-up between earcon and NVDA).
+            OutputEvent.create
+                SemanticCategory.BellRang
+                Priority.Assertive
+                producerId
+                ""

--- a/src/Terminal.Core/Screen.fs
+++ b/src/Terminal.Core/Screen.fs
@@ -116,6 +116,16 @@ type Screen(rows: int, cols: int) =
     let modeChangedEvent = Event<TerminalModeFlag * bool>()
     let pendingModeChanges = ResizeArray<TerminalModeFlag * bool>()
 
+    // Stage 8d.1 — bell event, same buffered-then-fire pattern
+    // as ModeChanged. `executeC0` sets `pendingBell` when it
+    // sees `0x07uy`; Apply drains the flag after lock release
+    // and fires `bellEvent`. Subscribers (e.g., Program.fs's
+    // bridge into the notification channel) push a
+    // `ScreenNotification.Bell` for the framework dispatcher
+    // to route to the Earcon profile.
+    let bellEvent = Event<unit>()
+    let mutable pendingBell : bool = false
+
     // Mutation gate. Apply takes this lock; SnapshotRows takes it to
     // capture (sequence, rows) atomically. Stage 3b feeds Apply on the
     // WPF dispatcher; Stage 4's UIA peer reads snapshots from the UIA
@@ -154,6 +164,12 @@ type Screen(rows: int, cols: int) =
 
     let executeC0 (b: byte) =
         match b with
+        | 0x07uy ->
+            // BEL — bell. Stage 8d.1 surfaces this as a
+            // `ScreenNotification.Bell` for the Earcon profile.
+            // No Cell-buffer mutation; just queue the signal.
+            // The flag is drained in Apply after lock release.
+            pendingBell <- true
         | 0x08uy ->
             // BS — backspace
             cursor.Col <- max 0 (cursor.Col - 1)
@@ -523,6 +539,16 @@ type Screen(rows: int, cols: int) =
     [<CLIEvent>]
     member _.ModeChanged = modeChangedEvent.Publish
 
+    /// Stage 8d.1 — fires when `executeC0` sees a BEL byte
+    /// (0x07) inside Apply. Same buffered-then-fire pattern as
+    /// `ModeChanged`: the flag is set under the gate; the event
+    /// fires after the gate releases. Subscribers (e.g.,
+    /// Program.fs's bridge into the notification channel) push
+    /// a `ScreenNotification.Bell` for the framework dispatcher
+    /// to route to the Earcon profile.
+    [<CLIEvent>]
+    member _.Bell = bellEvent.Publish
+
     /// Apply a single VT event to the buffer. Stage 3a covers the
     /// minimum needed to render cmd.exe-style output; unsupported
     /// sequences are silently no-ops so the parser can continue
@@ -533,7 +559,9 @@ type Screen(rows: int, cols: int) =
         // so subscribers (e.g. Stage 5's coalescer pushing to
         // a Channel) can't deadlock with concurrent SnapshotRows
         // calls or extend the gate's hold.
+        // Stage 8d.1: same pattern for the Bell signal.
         let toEmit = ResizeArray<TerminalModeFlag * bool>()
+        let mutable bellFired = false
         lock gate (fun () ->
             sequenceNumber <- sequenceNumber + 1L
             match event with
@@ -590,7 +618,11 @@ type Screen(rows: int, cols: int) =
             // the buffer for the next Apply.
             if pendingModeChanges.Count > 0 then
                 toEmit.AddRange(pendingModeChanges)
-                pendingModeChanges.Clear())
+                pendingModeChanges.Clear()
+            // Stage 8d.1: drain the bell flag the same way.
+            if pendingBell then
+                bellFired <- true
+                pendingBell <- false)
         // Post-lock: fire each event. Subscribers run on the
         // calling thread; if a subscriber throws, the exception
         // propagates back to the parser-loop's `with | ex -> ...`
@@ -598,3 +630,5 @@ type Screen(rows: int, cols: int) =
         // audit-cycle SR-2.
         for pair in toEmit do
             modeChangedEvent.Trigger(pair)
+        if bellFired then
+            bellEvent.Trigger(())

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -18,6 +18,8 @@
     <Compile Include="NvdaChannel.fs" />
     <Compile Include="FileLoggerChannel.fs" />
     <Compile Include="StreamProfile.fs" />
+    <Compile Include="EarconChannel.fs" />
+    <Compile Include="EarconProfile.fs" />
     <Compile Include="OutputDispatcher.fs" />
     <Compile Include="KeyEncoding.fs" />
     <Compile Include="HotkeyRegistry.fs" />

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -233,6 +233,20 @@ type ScreenNotification =
     /// `Screen.enterAltScreen` / `exitAltScreen` so the channel
     /// publish doesn't extend the gate's hold.
     | ModeChanged of flag: TerminalModeFlag * value: bool
+    /// Stage 8d.1 — BEL (0x07) byte received. The shell emitted
+    /// the bell character; the terminal frontend is expected to
+    /// produce an audible cue. Pure signal — no Cell-buffer
+    /// mutation. The Stage 8d Earcon profile (in
+    /// `src/Terminal.Core/EarconProfile.fs`) maps the resulting
+    /// `OutputEvent.BellRang` (built by
+    /// `OutputEventBuilder.fromScreenNotification`) to a
+    /// `RenderEarcon "bell-ping"` ChannelDecision; the Earcon
+    /// channel (in `src/Terminal.Core/EarconChannel.fs` +
+    /// `src/Terminal.Audio/EarconPlayer.fs`) plays the WASAPI
+    /// sine tone. Emitted **after** the Screen.Apply lock
+    /// release, same pattern as ModeChanged, so the channel
+    /// publish doesn't extend the gate's hold.
+    | Bell
 
 /// Discriminator for which `TerminalModes` bit just flipped.
 /// Mirrors the field names on the `TerminalModes` record so the

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -479,10 +479,16 @@ public class TerminalView : FrameworkElement
             (Key.H, ModifierKeys.Control | ModifierKeys.Shift, "Health check"),
             (Key.B, ModifierKeys.Control | ModifierKeys.Shift, "Incident marker"),
 
+            // Stage 8d.1 — toggle WASAPI earcons mute on/off.
+            // Each press flips the process-wide mute state and
+            // announces "Earcons muted." / "Earcons unmuted."
+            // via NVDA. The reservation has been on this slot
+            // since Stage 6 (per CLAUDE.md "Reserved (not yet
+            // bound)" list); 8d.1 is the first claim.
+            (Key.M, ModifierKeys.Control | ModifierKeys.Shift, "Mute earcons"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
-            //   (Key.M, ModifierKeys.Control | ModifierKeys.Shift,
-            //    "Stage 9 earcon mute"),
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,
             //    "Stage 10 review-mode toggle"),
             //   Higher Ctrl+Shift+digit slots (4, 5, 6, ...) reserved

--- a/tests/Tests.Unit/EarconChannelTests.fs
+++ b/tests/Tests.Unit/EarconChannelTests.fs
@@ -1,0 +1,141 @@
+module PtySpeak.Tests.Unit.EarconChannelTests
+
+open Xunit
+open Terminal.Core
+
+/// Stage 8d.1 — pins the EarconChannel's RenderEarcon dispatch
+/// behaviour, mute state, and the contract that non-Earcon
+/// RenderInstruction cases (RenderText / RenderText2 /
+/// RenderRaw) are skipped.
+///
+/// The channel implementation lives at
+/// `src/Terminal.Core/EarconChannel.fs`. The play callback
+/// signature `string -> unit` is what the composition root in
+/// `src/Terminal.App/Program.fs` binds to
+/// `Terminal.Audio.EarconPlayer.play
+/// EarconPalette.defaultPalette`; tests pass a recording
+/// callback and assert on the recorded earcon-id strings.
+
+let private makeRecorder () : ResizeArray<string> * (string -> unit) =
+    let calls = ResizeArray<string>()
+    let recorder (earconId: string) = calls.Add(earconId)
+    calls, recorder
+
+let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEvent =
+    OutputEvent.create semantic Priority.Polite "test" payload
+
+// ---- Channel identity ------------------------------------------
+
+[<Fact>]
+let ``EarconChannel.id is "earcon"`` () =
+    Assert.Equal("earcon", EarconChannel.id)
+
+[<Fact>]
+let ``create returns a Channel whose Id matches the module-level id`` () =
+    let _, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    Assert.Equal(EarconChannel.id, channel.Id)
+
+// ---- RenderEarcon dispatch -------------------------------------
+
+[<Fact>]
+let ``RenderEarcon invokes the play callback with the earcon ID`` () =
+    EarconChannel.clearForTests ()
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.BellRang ""
+    channel.Send event (RenderEarcon "bell-ping")
+    Assert.Equal(1, calls.Count)
+    Assert.Equal("bell-ping", calls.[0])
+
+[<Fact>]
+let ``RenderEarcon multiple distinct ids each invoke play once`` () =
+    EarconChannel.clearForTests ()
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.BellRang ""
+    channel.Send event (RenderEarcon "bell-ping")
+    channel.Send event (RenderEarcon "error-tone")
+    Assert.Equal(2, calls.Count)
+    Assert.Equal("bell-ping", calls.[0])
+    Assert.Equal("error-tone", calls.[1])
+
+// ---- Non-Earcon Render skip ------------------------------------
+
+[<Fact>]
+let ``RenderText does NOT invoke the play callback`` () =
+    EarconChannel.clearForTests ()
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.StreamChunk "hello"
+    channel.Send event (RenderText "hello")
+    Assert.Equal(0, calls.Count)
+
+[<Fact>]
+let ``RenderText2 does NOT invoke the play callback`` () =
+    EarconChannel.clearForTests ()
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.StreamChunk "hello"
+    channel.Send event (RenderText2 ("approx", "precise"))
+    Assert.Equal(0, calls.Count)
+
+[<Fact>]
+let ``RenderRaw does NOT invoke the play callback`` () =
+    EarconChannel.clearForTests ()
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.SelectionShown ""
+    channel.Send event (RenderRaw ("opaque" :> obj))
+    Assert.Equal(0, calls.Count)
+
+// ---- Mute state ------------------------------------------------
+
+[<Fact>]
+let ``initial mute state is false`` () =
+    EarconChannel.clearForTests ()
+    Assert.False(EarconChannel.isMuted ())
+
+[<Fact>]
+let ``toggle flips state from false to true`` () =
+    EarconChannel.clearForTests ()
+    let result = EarconChannel.toggle ()
+    Assert.True(result)
+    Assert.True(EarconChannel.isMuted ())
+
+[<Fact>]
+let ``toggle from true returns to false`` () =
+    EarconChannel.clearForTests ()
+    let _ = EarconChannel.toggle () // → true
+    let result = EarconChannel.toggle () // → false
+    Assert.False(result)
+    Assert.False(EarconChannel.isMuted ())
+
+[<Fact>]
+let ``RenderEarcon does NOT invoke play when muted`` () =
+    EarconChannel.clearForTests ()
+    let _ = EarconChannel.toggle () // mute
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.BellRang ""
+    channel.Send event (RenderEarcon "bell-ping")
+    Assert.Equal(0, calls.Count)
+    EarconChannel.clearForTests ()
+
+[<Fact>]
+let ``RenderEarcon resumes invoking play after un-mute`` () =
+    EarconChannel.clearForTests ()
+    let _ = EarconChannel.toggle () // mute
+    let _ = EarconChannel.toggle () // un-mute
+    let calls, recorder = makeRecorder ()
+    let channel = EarconChannel.create recorder
+    let event = buildEvent SemanticCategory.BellRang ""
+    channel.Send event (RenderEarcon "bell-ping")
+    Assert.Equal(1, calls.Count)
+
+[<Fact>]
+let ``clearForTests resets mute to false`` () =
+    EarconChannel.clearForTests ()
+    let _ = EarconChannel.toggle () // mute
+    EarconChannel.clearForTests ()
+    Assert.False(EarconChannel.isMuted ())

--- a/tests/Tests.Unit/EarconProfileTests.fs
+++ b/tests/Tests.Unit/EarconProfileTests.fs
@@ -1,0 +1,133 @@
+module PtySpeak.Tests.Unit.EarconProfileTests
+
+open System
+open Xunit
+open Terminal.Core
+
+/// Stage 8d.1 — pins the EarconProfile's Semantic → RenderEarcon
+/// mapping for BellRang events and the contract that other
+/// Semantic categories return an empty pair array (8d.2 will
+/// extend the mapping with ErrorLine / WarningLine entries).
+///
+/// The profile implementation lives at
+/// `src/Terminal.Core/EarconProfile.fs`. The pair-shape contract
+/// is `(OutputEvent * ChannelDecision[])[]` per the post-8b
+/// substrate; 8d's profile returns at most one pair.
+
+let private buildEvent (semantic: SemanticCategory) : OutputEvent =
+    OutputEvent.create semantic Priority.Polite "test" ""
+
+// ---- Profile identity ------------------------------------------
+
+[<Fact>]
+let ``EarconProfile.id is "earcon"`` () =
+    Assert.Equal("earcon", EarconProfile.id)
+
+[<Fact>]
+let ``create returns a Profile whose Id matches the module-level id`` () =
+    let profile = EarconProfile.create ()
+    Assert.Equal(EarconProfile.id, profile.Id)
+
+// ---- BellRang mapping ------------------------------------------
+
+[<Fact>]
+let ``BellRang Apply emits one pair with one ChannelDecision`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.BellRang
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    Assert.Equal(1, decisions.Length)
+
+[<Fact>]
+let ``BellRang Apply pair targets the EarconChannel`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.BellRang
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    Assert.Equal(EarconChannel.id, decisions.[0].Channel)
+
+[<Fact>]
+let ``BellRang Apply RenderEarcon carries the "bell-ping" earconId`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.BellRang
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    match decisions.[0].Render with
+    | RenderEarcon earconId -> Assert.Equal("bell-ping", earconId)
+    | other -> Assert.Fail(sprintf "expected RenderEarcon, got %A" other)
+
+[<Fact>]
+let ``BellRang Apply effectiveEvent is the input event`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.BellRang
+    let pairs = profile.Apply event
+    let effectiveEvent, _ = pairs.[0]
+    Assert.Equal(SemanticCategory.BellRang, effectiveEvent.Semantic)
+
+// ---- Non-claimed cases return empty array ----------------------
+
+[<Fact>]
+let ``StreamChunk Apply returns empty pair array`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.StreamChunk
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``ParserError Apply returns empty pair array`` () =
+    // 8d.1 doesn't claim ParserError. The future spec D.2
+    // suppression PR may add an earcon for parser errors; for
+    // now Apply skips them.
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.ParserError
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``ModeBarrier Apply returns empty pair array`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.ModeBarrier
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``AltScreenEntered Apply returns empty pair array`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.AltScreenEntered
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``ErrorLine Apply returns empty pair array (8d.2 will claim)`` () =
+    // 8d.1 doesn't claim ErrorLine; 8d.2's color-detection
+    // producer + earcon-palette extension will. Pinning the
+    // 8d.1 behaviour so 8d.2's diff is reviewable.
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.ErrorLine
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``Custom Semantic Apply returns empty pair array`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent (SemanticCategory.Custom "user-event")
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+// ---- Tick + Reset ----------------------------------------------
+
+[<Fact>]
+let ``Tick returns empty pair array (no time-driven flush)`` () =
+    let profile = EarconProfile.create ()
+    let pairs = profile.Tick DateTimeOffset.UtcNow
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``Reset is a no-op`` () =
+    let profile = EarconProfile.create ()
+    profile.Reset ()
+    // Reaching this assertion without an exception is the
+    // contract — Reset doesn't throw and there's no per-shell-
+    // session state to verify in 8d.1.
+    Assert.True(true)

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -67,7 +67,9 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               HotkeyRegistry.IncidentMarker
               HotkeyRegistry.SwitchToCmd
               HotkeyRegistry.SwitchToPowerShell
-              HotkeyRegistry.SwitchToClaude ]
+              HotkeyRegistry.SwitchToClaude
+              // Stage 8d.1 — earcon mute toggle.
+              HotkeyRegistry.MuteEarcons ]
     let actual = Set.ofList HotkeyRegistry.allCommands
     Assert.Equal<Set<HotkeyRegistry.AppCommand>>(expected, actual)
 

--- a/tests/Tests.Unit/OutputEventTests.fs
+++ b/tests/Tests.Unit/OutputEventTests.fs
@@ -209,6 +209,24 @@ let ``fromScreenNotification ModeChanged carries empty Payload`` () =
     Assert.Equal("", event.Payload)
 
 [<Fact>]
+let ``fromScreenNotification maps Bell to BellRang + Assertive`` () =
+    // Stage 8d.1 — BEL (0x07) → BellRang. The Earcon profile
+    // claims BellRang and emits a RenderEarcon "bell-ping"
+    // ChannelDecision; the NvdaChannel sees the empty Payload
+    // and skips its announce (so no double-up between earcon
+    // + NVDA).
+    let event = OutputEventBuilder.fromScreenNotification ScreenNotification.Bell
+    Assert.Equal(SemanticCategory.BellRang, event.Semantic)
+    Assert.Equal(Priority.Assertive, event.Priority)
+
+[<Fact>]
+let ``fromScreenNotification Bell carries empty Payload`` () =
+    // BEL is a pure signal — no text to announce. The Earcon
+    // profile produces the user-perceived sound.
+    let event = OutputEventBuilder.fromScreenNotification ScreenNotification.Bell
+    Assert.Equal("", event.Payload)
+
+[<Fact>]
 let ``fromScreenNotification stamps translator as the producer`` () =
     // Stage 8a producer was "drain" (the post-coalesce drain task);
     // Stage 8b producer is "translator" (pre-coalesce

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -30,6 +30,8 @@
     <Compile Include="OutputEventTests.fs" />
     <Compile Include="NvdaChannelTests.fs" />
     <Compile Include="FileLoggerChannelTests.fs" />
+    <Compile Include="EarconChannelTests.fs" />
+    <Compile Include="EarconProfileTests.fs" />
     <Compile Include="OutputDispatcherTests.fs" />
     <Compile Include="KeyEncodingTests.fs" />
     <Compile Include="FileLoggerTests.fs" />


### PR DESCRIPTION
## Summary

Stage 8d.1 of the Output framework cycle. Adds WASAPI audio playback infrastructure + a first-class Earcon channel + an Earcon profile that maps `OutputEvent.Semantic` to earcon sounds. v1 (8d.1) ships the substrate + the BEL → "bell-ping" mapping; **8d.2 will add color-detection + ErrorLine / WarningLine earcons** (the full spec C.1 NVDA-validation row mentions "Run colour-emitting commands; hear earcons" — that's 8d.2's payload).

**Behaviour change vs. post-[8c (#154)](https://github.com/KyleKeane/pty-speak/pull/154)**: the BEL byte (0x07) — which Stage 7 silently swallowed — now produces an audible 800Hz × 100ms sine ping via WASAPI. **Ctrl+Shift+M** toggles mute and announces the new state via NVDA.

## What ships

**Audio infrastructure (`src/Terminal.Audio/`):**
- `EarconWaveform.fs` — sine + envelope synthesis via NAudio's `SignalGenerator` + `OffsetSampleProvider` + `FadeInOutSampleProvider`. Fade-in only (NAudio's `BeginFadeOut` triggers immediately rather than scheduled; the trailing click on a 100ms tone is acceptable for v1; a follow-up PR can add a per-sample envelope `ISampleProvider` if needed)
- `EarconPalette.fs` — `Map<EarconId, EarconWaveform.Parameters>` with default `"bell-ping"` entry (800Hz × 100ms × 10ms attack)
- `EarconPlayer.fs` — `WasapiOut` singleton with lazy init under lock; `SampleToWaveProvider16` conversion for the `IWaveProvider` contract; non-blocking `play`; errors swallowed + logged at Information level (audio failures become "no sound", not crashes)

**Channel + profile (`src/Terminal.Core/`):**
- `EarconChannel.fs` — `[<Literal>] id: ChannelId = "earcon"` + `create (play: string -> unit) : Channel`. Send pattern-matches RenderInstruction; only `RenderEarcon` invokes play. Process-wide mute state via `toggle` / `isMuted` / `clearForTests` (single-thread-init pattern)
- `EarconProfile.fs` — `[<Literal>] id: ProfileId = "earcon"` + `create () : Profile`. Apply maps `BellRang → RenderEarcon "bell-ping"`; other Semantic categories return `[||]` (purely additive observer)

**BEL producer:**
- `Types.fs` — adds `ScreenNotification.Bell` case (no payload)
- `Screen.fs` — `bellEvent` + `pendingBell` flag; `executeC0 0x07uy` sets the flag; `Apply` drains after lock release and triggers the event; public `[<CLIEvent>] Bell` property
- `OutputEventBuilder.fs` — `fromScreenNotification` maps `Bell → BellRang` Semantic + Assertive priority + empty Payload
- `Program.fs` — bridges `screen.Bell.Add` into the notification channel mirroring the existing `screen.ModeChanged.Add`

**Mute hotkey (Ctrl+Shift+M):**
- `HotkeyRegistry.fs` — adds `MuteEarcons` AppCommand + `nameOf` + `builtIns` + `allCommands` entries
- `Program.fs` — `runMuteEarcons` handler calls `EarconChannel.toggle` and announces "Earcons muted." / "Earcons unmuted." via `ActivityIds.logToggle`; `bindHotkey` wires it
- `Views/TerminalView.cs` — adds `(Key.M, Ctrl|Shift, "Mute earcons")` to `AppReservedHotkeys`; removes the matching commented-out reservation that has been on this slot since Stage 6

**Composition root (`Program.fs`):**

The active profile set grows from `[ streamProfile ]` to `[ streamProfile; earconProfile ]`. For BellRang: StreamProfile's catch-all branch produces NVDA + FileLogger decisions for the empty payload (NvdaChannel skips empty; FileLogger logs the event). EarconProfile produces the earcon decision. **No NVDA double-up** because the empty payload causes NvdaChannel to skip naturally.

## Tests (27 new + 1 update)

- `EarconChannelTests.fs` (13): identity + RenderEarcon dispatch + non-Earcon Render skip (RenderText / RenderText2 / RenderRaw) + mute state machine + clearForTests
- `EarconProfileTests.fs` (14): identity + BellRang Apply (one pair, one decision, EarconChannel target, "bell-ping" earconId, effectiveEvent identity) + empty pair array for non-claimed categories (StreamChunk / ParserError / ModeBarrier / AltScreenEntered / ErrorLine — 8d.2 anchor — / Custom) + Tick + Reset
- `OutputEventTests.fs` (+2): Bell → BellRang + Assertive mapping; empty Payload
- `HotkeyRegistryTests.fs` (+1 expected): `MuteEarcons` in the documented-commands Set

## Behaviour preservation

All ~158 pre-existing load-bearing tests stay green. Earcon infrastructure is purely additive: StreamProfile is unchanged; NvdaChannel + FileLoggerChannel are unchanged; OutputDispatcher is unchanged.

## Out of scope for 8d.1 (deferred to 8d.2)

- Color detection (red/yellow text → ErrorLine/WarningLine OutputEvents)
- `error-tone` + `warning-tone` palette entries
- NVDA-channel suppression for color-detected events (substrate API extension)
- TOML config for palette / per-shell mute state

## Open question carried forward from 8a/8b/8c

Spec D.2 ParserError → Background suppression. The Earcon profile + FileLogger channel substrate now in place is the prerequisite. The future suppression PR can route parser errors to FileLogger only while NVDA stays silent.

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest. ~185 tests pass (27 new + ~158 pre-existing). The NAudio.Wasapi NuGet should resolve cleanly on the Windows-latest agent
- [ ] CI Markdown link check + workflow lint pass
- [ ] Manual NVDA validation:
  - [ ] Trigger a bell from cmd: `printf '\a'` or `tput bel`. Hear the bell ping
  - [ ] Press Ctrl+Shift+M. NVDA announces "Earcons muted."
  - [ ] Trigger another bell. No sound
  - [ ] Press Ctrl+Shift+M again. NVDA announces "Earcons unmuted."
  - [ ] Trigger another bell. Bell ping plays
  - [ ] Verify NVDA reading of streaming output is unchanged from the post-8c release build

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_