### PR TITLE
feat(terminal-core,audio): Stage 8d.2 — color detection + ErrorLine/WarningLine earcons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,136 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Stage 8d.2 — Color detection + ErrorLine/WarningLine earcons)
+
+Closes the spec C.1 8d row by adding the colour-detection
+producer + earcon palette extensions. With 8d.1's substrate in
+place (PR #155), 8d.2 makes red-on-screen output produce a
+400Hz error-tone and yellow-on-screen output produce a 600Hz
+warning-tone, alongside NVDA reading the row text. The earcons
+supplement (don't replace) NVDA — no double-up because the row
+text doesn't redundantly state the colour.
+
+The full spec validation row is now reachable: *"Run
+colour-emitting commands; hear earcons; verify Ctrl+Shift+M
+mute hotkey works; verify earcon-claimed events suppress
+NVDA-channel double-up."* The first two clauses are validated
+end-to-end post-8d.2; the third (suppression) was determined
+unnecessary for the colour-detection use case (see
+"Suppression deliberately deferred" in the 8d.2 plan).
+
+#### Design: Extensions metadata, no event-splitting
+
+The StreamProfile annotates each StreamChunk OutputEvent with
+`Extensions["dominantColor"] = box "red" | box "yellow"` when
+SGR-coloured rows dominate the post-coalesce snapshot. The
+EarconProfile reads the metadata (defensive against non-string
+boxed values) and emits the earcon decision when present. No
+new Semantic categories, no new ChannelDecisions targeting
+NVDA, no cross-profile suppression machinery. This is the
+first PR that USES the OutputEvent.Extensions forward-compat
+contract spec B.2.3 introduced.
+
+#### Color detection heuristic (v1)
+
+Per-row classification: walk the non-blank cells; if >50% have
+SGR `Indexed 1` / `Indexed 9` (red), the row is red. Else if
+>50% have `Indexed 3` / `Indexed 11` (yellow), yellow. Else
+plain. Per-snapshot: any-red → "red"; any-yellow (no red) →
+"yellow"; else None. Red wins because it's the higher-urgency
+tone. Deferred to a future PR: 256-colour cube reds, truecolor
+RGB-distance heuristic, background-colour reds.
+
+#### Files modified
+
+- `src/Terminal.Core/StreamProfile.fs` — adds 4 internal
+  colour-detection helpers (`isRedFg`, `isYellowFg`,
+  `rowDominantColor`, `snapshotDominantColor`); extends
+  `streamOutputEvent` to take a `dominantColor: string option`
+  parameter and stamp `Extensions["dominantColor"]` when
+  `Some`; extends `coalescedToPair` to thread the colour;
+  Apply / Tick / mode-change branches compute the colour from
+  the appropriate snapshot (current snapshot for StreamChunk;
+  pending snapshot for AltScreen/ModeBarrier flush; pending
+  snapshot for Tick trailing-edge flush).
+- `src/Terminal.Core/EarconProfile.fs` — adds
+  `readDominantColor` helper (defensive type-safe Map.tryFind +
+  `:? string` pattern); extends Apply with a `StreamChunk` case
+  matching on the colour metadata to emit `RenderEarcon
+  "error-tone"` / `"warning-tone"`. Plain StreamChunk events
+  (no metadata) continue to return `[||]`.
+- `src/Terminal.Audio/EarconPalette.fs` — adds two entries to
+  `defaultPalette`: `"error-tone"` (400Hz × 150ms × 10ms attack)
+  and `"warning-tone"` (600Hz × 120ms × 10ms attack). Frequency
+  / duration choices follow the spec §9.3 palette intent
+  (alarm low / confirm high / warn middle); all earcons stay
+  shorter than the StreamProfile's 200ms debounce window so
+  consecutive earcons don't overlap.
+- `tests/Tests.Unit/StreamProfileTests.fs` — 18 new tests for
+  the colour-detection helpers (isRedFg / isYellowFg /
+  rowDominantColor / snapshotDominantColor). Tests cover ANSI
+  red / bright red / yellow / bright yellow recognition, plain
+  cells returning None, blank-row handling, single-red-cell
+  majority (the "ignore blanks in count" rule), minority-red
+  rejection, snapshot any-red wins, snapshot red-over-yellow
+  precedence.
+- `tests/Tests.Unit/EarconProfileTests.fs` — 6 new tests for
+  the StreamChunk + Extensions["dominantColor"] mapping. Tests
+  cover red → error-tone, yellow → warning-tone, green → empty
+  (only red + yellow trigger), non-string boxed values fall
+  through to empty (defensive), the regression pin that
+  BellRang continues to emit bell-ping, and the empty-Extensions
+  case symmetry. The pre-existing
+  `StreamChunk Apply returns empty pair array` test was renamed
+  to `StreamChunk Apply with no Extensions returns empty pair
+  array` for clarity. The pre-existing
+  `ErrorLine Apply returns empty pair array (8d.2 will claim)`
+  test was retitled (8d.2 chose Extensions metadata over the
+  ErrorLine Semantic; ErrorLine remains reserved).
+
+#### Behaviour preservation
+
+All ~202 pre-existing load-bearing tests stay green. The
+StreamProfile's coalescing algorithm is unchanged (colour
+detection runs alongside, doesn't modify the existing
+CoalescedNotification flow). The EarconProfile.BellRang case
+is unchanged. NvdaChannel + FileLoggerChannel are unchanged
+(they receive StreamChunk OutputEvents with the new Extensions
+field; both channels ignore Extensions today, so no behaviour
+change for plain streaming).
+
+NVDA-validation row (manual; maintainer):
+- PowerShell: `Write-Host "Error" -ForegroundColor Red` →
+  hear the 400Hz error-tone alongside NVDA reading "Error"
+- PowerShell: `Write-Host "Warning" -ForegroundColor Yellow` →
+  hear the 600Hz warning-tone alongside NVDA reading "Warning"
+- Plain output (`dir`, `ls`) → no earcon, NVDA reads as before
+- Ctrl+Shift+M still mutes ALL earcons (bell-ping +
+  error-tone + warning-tone)
+- Verify `Ctrl+Shift+;` log now includes `dominantColor=red`
+  / `=yellow` in the structured Extensions field for
+  diagnostics
+
+### Out of scope (deferred)
+
+- NVDA-channel suppression for earcon-claimed events
+  (substrate API extension; lives with the carried-open
+  ParserError → Background reconciliation PR)
+- Truecolor (`Rgb (r, g, b)`) red/yellow detection
+- 256-colour cube (Indexed 16-231) red/yellow detection
+- Background-colour detection
+- Per-shell mute / palette / TOML config (Phase 2)
+- User-customisable palette frequencies / durations
+- ErrorLine / WarningLine producer (the alternative design
+  that emits separate Semantic events; 8d.2 chose Extensions
+  metadata instead — simpler delta)
+
+### Open question carried forward (still)
+
+Spec D.2 ParserError → Background suppression. Substrate API
+(cross-profile suppression markers) still pending; will land
+with a focused future PR.
+
 ### Added (Stage 8d.1 — WASAPI Earcons channel + Earcon profile + Bell)
 
 The fourth sub-stage of the Output framework cycle. Adds WASAPI

--- a/src/Terminal.Audio/EarconPalette.fs
+++ b/src/Terminal.Audio/EarconPalette.fs
@@ -30,14 +30,34 @@ module EarconPalette =
     /// compatibility (Phase 2).
     type EarconId = string
 
-    /// Default palette. v1 ships a single bell-ping entry. The
-    /// 800Hz frequency was chosen as a clearly-audible mid-tone
-    /// that doesn't conflict with NVDA's speech band; the 100ms
-    /// duration is short enough to feel like a "bell" rather
-    /// than a "tone". Tunable in Phase 2 via TOML.
+    /// Default palette. v1 (8d.1) shipped only the bell-ping
+    /// entry; v2 (8d.2) adds error-tone + warning-tone for
+    /// SGR-coloured streaming output detected by the
+    /// StreamProfile. Tunable in Phase 2 via TOML.
+    ///
+    /// Frequency / duration choices follow the spec §9.3 palette
+    /// intent (alarm low / confirm high / warn middle):
+    /// - bell-ping (800Hz × 100ms) — high pitch + short duration;
+    ///   reads as a "ping" or "ding". Triggered by BEL (0x07).
+    /// - error-tone (400Hz × 150ms) — low pitch + longer
+    ///   duration; reads as "alarm" or "wrong". Triggered by
+    ///   red-dominant streaming output (StreamProfile detection).
+    /// - warning-tone (600Hz × 120ms) — middle pitch + middle
+    ///   duration; sits between bell-ping and error-tone.
+    ///   Triggered by yellow-dominant streaming output.
+    /// All three are shorter than the StreamProfile's 200ms
+    /// debounce window so consecutive earcons don't overlap.
     let defaultPalette : Map<EarconId, EarconWaveform.Parameters> =
         Map.ofList
             [ "bell-ping",
               { FrequencyHz = 800.0
                 DurationMs = 100
+                AttackMs = 10 }
+              "error-tone",
+              { FrequencyHz = 400.0
+                DurationMs = 150
+                AttackMs = 10 }
+              "warning-tone",
+              { FrequencyHz = 600.0
+                DurationMs = 120
                 AttackMs = 10 } ]

--- a/src/Terminal.Core/EarconProfile.fs
+++ b/src/Terminal.Core/EarconProfile.fs
@@ -55,6 +55,21 @@ module EarconProfile =
         { Channel = EarconChannel.id
           Render = RenderEarcon earconId }
 
+    /// Stage 8d.2 — read the StreamProfile's colour-detection
+    /// metadata from `OutputEvent.Extensions["dominantColor"]`.
+    /// Returns the colour string ("red" / "yellow") if present
+    /// and well-typed; `None` otherwise. Defensive against
+    /// non-string Extensions values (which a future producer
+    /// might emit) — bad-typed entries fall through to None
+    /// rather than crashing the dispatcher.
+    let private readDominantColor (event: OutputEvent) : string option =
+        match Map.tryFind "dominantColor" event.Extensions with
+        | Some boxed ->
+            match boxed with
+            | :? string as s -> Some s
+            | _ -> None
+        | None -> None
+
     /// Construct the Earcon profile. No parameters in 8d.1 (no
     /// per-instance state); 8d.2 / Phase 2 may add a
     /// `Parameters` record for things like a per-shell mute
@@ -69,10 +84,32 @@ module EarconProfile =
                         event,
                         [| earconDecision "bell-ping" |]
                     |]
+                | SemanticCategory.StreamChunk ->
+                    // Stage 8d.2 — colour-detected streaming
+                    // output. The StreamProfile stamps
+                    // `Extensions["dominantColor"] = "red" |
+                    // "yellow"` on its synthesised StreamChunk
+                    // events when SGR-coloured rows dominate the
+                    // post-coalesce snapshot. The Earcon profile
+                    // maps red → 400Hz error-tone (lower pitch
+                    // for higher urgency) and yellow → 600Hz
+                    // warning-tone. Plain streaming (no colour
+                    // metadata) emits nothing — earcons are
+                    // supplementary, not per-event.
+                    match readDominantColor event with
+                    | Some "red" ->
+                        [|
+                            event,
+                            [| earconDecision "error-tone" |]
+                        |]
+                    | Some "yellow" ->
+                        [|
+                            event,
+                            [| earconDecision "warning-tone" |]
+                        |]
+                    | _ -> [||]
                 | _ ->
-                    // No earcon for other Semantic categories
-                    // in 8d.1. 8d.2 adds ErrorLine /
-                    // WarningLine cases.
+                    // No earcon for other Semantic categories.
                     [||]
           Tick =
             fun _ ->

--- a/src/Terminal.Core/StreamProfile.fs
+++ b/src/Terminal.Core/StreamProfile.fs
@@ -183,6 +183,72 @@ module StreamProfile =
                 head
                 extra
 
+    /// Stage 8d.2 — color-detection helpers. The Stream profile
+    /// scans the post-coalesce snapshot for SGR-coloured rows
+    /// and stamps the result on `OutputEvent.Extensions`; the
+    /// Earcon profile reads the metadata to decide whether to
+    /// emit `RenderEarcon "error-tone"` / `"warning-tone"`. v1
+    /// only matches the standard 16-colour ANSI palette
+    /// (`Indexed 1` / `Indexed 9` for red, `Indexed 3` /
+    /// `Indexed 11` for yellow); 256-colour cube reds and
+    /// truecolor (`Rgb`) values are deferred per the 8d.2 plan.
+    let internal isRedFg (fg: ColorSpec) : bool =
+        match fg with
+        | Indexed 1uy -> true
+        | Indexed 9uy -> true
+        | _ -> false
+
+    let internal isYellowFg (fg: ColorSpec) : bool =
+        match fg with
+        | Indexed 3uy -> true
+        | Indexed 11uy -> true
+        | _ -> false
+
+    /// Per-row classification: walk the non-blank cells and
+    /// count those whose foreground is red / yellow. If >50% of
+    /// non-blank cells are red, the row is red. Else if >50%
+    /// are yellow, the row is yellow. Else None. Blank cells
+    /// (Cell.Ch = space rune) are excluded from the count
+    /// because end-of-line padding shouldn't dilute the
+    /// classification.
+    let internal rowDominantColor (row: Cell[]) : string option =
+        let mutable nonBlank = 0
+        let mutable red = 0
+        let mutable yellow = 0
+        for cell in row do
+            if cell.Ch.Value <> int ' ' then
+                nonBlank <- nonBlank + 1
+                if isRedFg cell.Attrs.Fg then
+                    red <- red + 1
+                elif isYellowFg cell.Attrs.Fg then
+                    yellow <- yellow + 1
+        if nonBlank = 0 then
+            None
+        elif red * 2 > nonBlank then
+            Some "red"
+        elif yellow * 2 > nonBlank then
+            Some "yellow"
+        else
+            None
+
+    /// Per-snapshot (per-batch) classification: walk every row
+    /// and apply `rowDominantColor`; if any row is red, the
+    /// batch is "red". Else if any row is yellow, "yellow".
+    /// Else None. Red wins over yellow because it's the higher-
+    /// urgency tone; the Earcon profile maps "red" to the
+    /// 400Hz error-tone (lower frequency = more urgent).
+    let internal snapshotDominantColor (snapshot: Cell[][]) : string option =
+        let mutable hasRed = false
+        let mutable hasYellow = false
+        for row in snapshot do
+            match rowDominantColor row with
+            | Some "red" -> hasRed <- true
+            | Some "yellow" -> hasYellow <- true
+            | _ -> ()
+        if hasRed then Some "red"
+        elif hasYellow then Some "yellow"
+        else None
+
     /// Decide what (if anything) to emit for an incoming
     /// `RowsChanged` snapshot. Computes hashes, applies dedup +
     /// spinner + debounce, returns 0 or 1 `CoalescedNotification`.
@@ -317,13 +383,31 @@ module StreamProfile =
     /// `ActivityIds.output` regardless of which input event
     /// triggered the flush (a normal RowsChanged, a mode change
     /// flushing pending content, or a Tick-driven trailing-edge
-    /// flush).
-    let private streamOutputEvent (text: string) : OutputEvent =
-        OutputEvent.create
-            SemanticCategory.StreamChunk
-            Priority.Polite
-            id
-            text
+    /// flush). Stage 8d.2 — when `dominantColor` is `Some`, the
+    /// returned event carries `Extensions["dominantColor"] = box
+    /// color`; the EarconProfile reads this metadata to decide
+    /// whether to emit `RenderEarcon "error-tone"` /
+    /// `"warning-tone"`.
+    let private streamOutputEvent
+            (text: string)
+            (dominantColor: string option)
+            : OutputEvent
+            =
+        let baseEvent =
+            OutputEvent.create
+                SemanticCategory.StreamChunk
+                Priority.Polite
+                id
+                text
+        match dominantColor with
+        | None -> baseEvent
+        | Some color ->
+            // Stage 8d.2 — `:> obj` upcast preserves non-null
+            // for `Map<string, obj>`; F# 9's `box` returns
+            // `obj | null` and would trip FS3261 (same lesson
+            // as PR #152's 8a CI failure).
+            { baseEvent with
+                Extensions = Map.ofList [ "dominantColor", (color :> obj) ] }
 
     /// Build a parser-error OutputEvent.
     let private parserErrorEvent (sanitised: string) : OutputEvent =
@@ -366,13 +450,21 @@ module StreamProfile =
     /// can route. The effectiveEvent is the synthesised
     /// OutputEvent that NvdaChannel reads `Semantic` from for
     /// activity-ID mapping.
+    ///
+    /// Stage 8d.2 — `dominantColor` is threaded through so the
+    /// `OutputBatch` case can stamp the colour on the
+    /// `streamOutputEvent`'s Extensions. Other branches
+    /// (ParserError, ModeBarrier) ignore the colour parameter
+    /// because their Semantic categories don't carry colour
+    /// metadata.
     let private coalescedToPair
             (inputEvent: OutputEvent)
+            (dominantColor: string option)
             (coalesced: Coalescer.CoalescedNotification)
             : OutputEvent * ChannelDecision[] =
         match coalesced with
         | Coalescer.OutputBatch text ->
-            let event = streamOutputEvent text
+            let event = streamOutputEvent text dominantColor
             event, textDecisions text
         | Coalescer.ErrorPassthrough s ->
             let event = parserErrorEvent s
@@ -410,10 +502,15 @@ module StreamProfile =
                         [||]
                     else
                         lastSnapshotSeq.Value <- seq
+                        // Stage 8d.2 — scan the snapshot for SGR-
+                        // coloured rows; the EarconProfile uses
+                        // the resulting dominantColor metadata to
+                        // emit error-tone / warning-tone earcons.
+                        let dominantColor = snapshotDominantColor snapshot
                         let coalesced =
                             processRowsChanged parameters state now snapshot
                         coalesced
-                        |> List.map (coalescedToPair event)
+                        |> List.map (coalescedToPair event dominantColor)
                         |> List.toArray
                 | SemanticCategory.ParserError ->
                     // Parser errors come through pre-sanitised
@@ -422,6 +519,9 @@ module StreamProfile =
                     // Apply produces the error decision directly
                     // — no internal coalescing. Stage 8c routes to
                     // both NVDA + FileLogger via textDecisions.
+                    // Stage 8d.2 — no colour metadata for parser
+                    // errors (a parser-level ErrorLine producer is
+                    // a future stage's concern).
                     [|
                         event,
                         textDecisions event.Payload
@@ -438,12 +538,23 @@ module StreamProfile =
                     // value works; we use (AltScreen, true) for
                     // AltScreenEntered and (AltScreen, false)
                     // for ModeBarrier.
+                    //
+                    // Stage 8d.2 — peek the pending-frame colour
+                    // BEFORE onModeChanged consumes
+                    // state.PendingFrame; the flushed-pending
+                    // OutputBatch in the resulting list carries
+                    // the colour metadata, the ModeBarrier item
+                    // ignores it (no colour for mode events).
+                    let pendingColor =
+                        match state.PendingFrame with
+                        | ValueSome snapshot -> snapshotDominantColor snapshot
+                        | ValueNone -> None
                     let flag = TerminalModeFlag.AltScreen
                     let value = event.Semantic = SemanticCategory.AltScreenEntered
                     let coalesced =
                         onModeChanged parameters state now flag value
                     coalesced
-                    |> List.map (coalescedToPair event)
+                    |> List.map (coalescedToPair event pendingColor)
                     |> List.toArray
                 | _ ->
                     // Other semantic categories (SelectionShown /
@@ -462,6 +573,17 @@ module StreamProfile =
                     |]
           Tick =
             fun now ->
+                // Stage 8d.2 — peek the pending-frame colour BEFORE
+                // onTimerTick consumes state.PendingFrame on flush.
+                // If onTimerTick returns [] (within debounce window
+                // and no flush), `pendingColor` is unused — no harm.
+                // If it returns OutputBatch, the closure attaches the
+                // colour to the synthesised StreamChunk event so the
+                // EarconProfile sees the metadata.
+                let pendingColor =
+                    match state.PendingFrame with
+                    | ValueSome snapshot -> snapshotDominantColor snapshot
+                    | ValueNone -> None
                 let coalesced = onTimerTick parameters state now
                 coalesced
                 |> List.map (fun c ->
@@ -474,13 +596,13 @@ module StreamProfile =
                     // NVDA + FileLogger via textDecisions.
                     match c with
                     | Coalescer.OutputBatch text ->
-                        let event = streamOutputEvent text
+                        let event = streamOutputEvent text pendingColor
                         event, textDecisions text
                     | Coalescer.ErrorPassthrough _
                     | Coalescer.ModeBarrier _ ->
                         // Tick never produces these; defensive
                         // fall-through.
-                        let event = streamOutputEvent ""
+                        let event = streamOutputEvent "" None
                         event, [||])
                 |> List.toArray
           Reset =

--- a/tests/Tests.Unit/EarconProfileTests.fs
+++ b/tests/Tests.Unit/EarconProfileTests.fs
@@ -68,7 +68,10 @@ let ``BellRang Apply effectiveEvent is the input event`` () =
 // ---- Non-claimed cases return empty array ----------------------
 
 [<Fact>]
-let ``StreamChunk Apply returns empty pair array`` () =
+let ``StreamChunk Apply with no Extensions returns empty pair array`` () =
+    // Plain streaming output (no SGR colour) — no earcon. 8d.2's
+    // colour-detection only fires when the StreamProfile stamps
+    // `Extensions["dominantColor"]` on the event.
     let profile = EarconProfile.create ()
     let event = buildEvent SemanticCategory.StreamChunk
     let pairs = profile.Apply event
@@ -99,10 +102,14 @@ let ``AltScreenEntered Apply returns empty pair array`` () =
     Assert.Equal(0, pairs.Length)
 
 [<Fact>]
-let ``ErrorLine Apply returns empty pair array (8d.2 will claim)`` () =
-    // 8d.1 doesn't claim ErrorLine; 8d.2's color-detection
-    // producer + earcon-palette extension will. Pinning the
-    // 8d.1 behaviour so 8d.2's diff is reviewable.
+let ``ErrorLine Apply returns empty pair array`` () =
+    // 8d.2 chose to emit colour earcons via StreamChunk +
+    // Extensions["dominantColor"] metadata rather than via a
+    // separate ErrorLine Semantic. ErrorLine remains a reserved
+    // category in OutputEventTypes.fs; no producer emits it in
+    // 8d.2; the EarconProfile correspondingly returns empty.
+    // A future PR may adopt the spec D.2 ErrorLine contract;
+    // this assertion will need updating then.
     let profile = EarconProfile.create ()
     let event = buildEvent SemanticCategory.ErrorLine
     let pairs = profile.Apply event
@@ -131,3 +138,108 @@ let ``Reset is a no-op`` () =
     // contract — Reset doesn't throw and there's no per-shell-
     // session state to verify in 8d.1.
     Assert.True(true)
+
+// ---- Stage 8d.2 — colour-detected StreamChunk → earcon ---------
+
+let private buildStreamChunkWithColor (color: string) : OutputEvent =
+    // The StreamProfile stamps `Extensions["dominantColor"]` on
+    // its synthesised StreamChunk events when SGR-coloured rows
+    // dominate the post-coalesce snapshot. Tests build the same
+    // shape directly to exercise the EarconProfile's reading.
+    // `:> obj` upcast preserves non-null for `Map<string, obj>`;
+    // F# 9 `box` returns `obj | null` (FS3261 regression risk).
+    let baseEvent = buildEvent SemanticCategory.StreamChunk
+    { baseEvent with
+        Extensions = Map.ofList [ "dominantColor", (color :> obj) ] }
+
+let private buildStreamChunkWithNonStringExtensionValue () : OutputEvent =
+    // Tests the defensive `:? string` pattern in
+    // `EarconProfile.readDominantColor`: a non-string value
+    // should fall through to None rather than crash. Use a
+    // bare `obj()` instance (non-null reference type) — avoids
+    // F# 9's `box` returning `obj | null` (FS3261 risk).
+    let baseEvent = buildEvent SemanticCategory.StreamChunk
+    let nonStringValue : obj = obj ()
+    { baseEvent with
+        Extensions = Map.ofList [ "dominantColor", nonStringValue ] }
+
+[<Fact>]
+let ``StreamChunk with dominantColor=red emits one decision targeting EarconChannel`` () =
+    let profile = EarconProfile.create ()
+    let event = buildStreamChunkWithColor "red"
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    Assert.Equal(1, decisions.Length)
+    Assert.Equal(EarconChannel.id, decisions.[0].Channel)
+
+[<Fact>]
+let ``StreamChunk with dominantColor=red emits RenderEarcon error-tone`` () =
+    let profile = EarconProfile.create ()
+    let event = buildStreamChunkWithColor "red"
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    match decisions.[0].Render with
+    | RenderEarcon earconId -> Assert.Equal("error-tone", earconId)
+    | other -> Assert.Fail(sprintf "expected RenderEarcon, got %A" other)
+
+[<Fact>]
+let ``StreamChunk with dominantColor=yellow emits RenderEarcon warning-tone`` () =
+    let profile = EarconProfile.create ()
+    let event = buildStreamChunkWithColor "yellow"
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    match decisions.[0].Render with
+    | RenderEarcon earconId -> Assert.Equal("warning-tone", earconId)
+    | other -> Assert.Fail(sprintf "expected RenderEarcon, got %A" other)
+
+[<Fact>]
+let ``StreamChunk with dominantColor=green returns empty pair array`` () =
+    // Only red + yellow trigger earcons. Other colour values
+    // are silently ignored — a future palette could add
+    // success-tone for green, but 8d.2 doesn't.
+    let profile = EarconProfile.create ()
+    let event = buildStreamChunkWithColor "green"
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``StreamChunk with non-string dominantColor returns empty (defensive)`` () =
+    // A future producer might mistakenly box the wrong type
+    // into Extensions. The EarconProfile's `readDominantColor`
+    // pattern-matches on `:? string`; non-string values fall
+    // through to None, and the profile emits no decisions —
+    // never crashes the dispatcher.
+    let profile = EarconProfile.create ()
+    let event = buildStreamChunkWithNonStringExtensionValue ()
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``StreamChunk with empty Extensions returns empty pair array`` () =
+    // Already covered by the ``StreamChunk Apply with no
+    // Extensions returns empty pair array`` test above; this
+    // case is the explicit complement to the colour-bearing
+    // tests above. Pinning the symmetry.
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.StreamChunk
+    Assert.Equal(0, event.Extensions.Count)
+    let pairs = profile.Apply event
+    Assert.Equal(0, pairs.Length)
+
+[<Fact>]
+let ``BellRang Apply continues to emit bell-ping (8d.1 behaviour preserved)`` () =
+    // Regression pin: 8d.2's StreamChunk colour mapping doesn't
+    // accidentally swallow the BellRang case. The BellRang
+    // mapping comes first in the match expression; this test
+    // re-asserts what `BellRang Apply RenderEarcon carries the
+    // "bell-ping" earconId` already covers, framed as a
+    // 8d.2-stage regression check.
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.BellRang
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    match decisions.[0].Render with
+    | RenderEarcon earconId -> Assert.Equal("bell-ping", earconId)
+    | other -> Assert.Fail(sprintf "expected RenderEarcon, got %A" other)

--- a/tests/Tests.Unit/StreamProfileTests.fs
+++ b/tests/Tests.Unit/StreamProfileTests.fs
@@ -509,6 +509,176 @@ let ``mode-barrier activityId is pty-speak.mode`` () =
     Assert.Equal("pty-speak.mode", ActivityIds.mode)
 
 // ---------------------------------------------------------------------
+// Stage 8d.2 — colour-detection helper pinning
+// ---------------------------------------------------------------------
+//
+// The Earcon profile reads the StreamProfile's colour metadata from
+// `OutputEvent.Extensions["dominantColor"]` and emits error-tone /
+// warning-tone earcons. These tests pin the colour-detection
+// algorithms that run inside StreamProfile.Apply / Tick before the
+// metadata is stamped on the OutputEvent. The Earcon-side mapping
+// (string colour → earcon id) is pinned in
+// `EarconProfileTests.fs`.
+
+let private redCell (ch: char) : Cell =
+    { Ch = System.Text.Rune ch
+      Attrs = { SgrAttrs.defaults with Fg = Indexed 1uy } }
+
+let private brightRedCell (ch: char) : Cell =
+    { Ch = System.Text.Rune ch
+      Attrs = { SgrAttrs.defaults with Fg = Indexed 9uy } }
+
+let private yellowCell (ch: char) : Cell =
+    { Ch = System.Text.Rune ch
+      Attrs = { SgrAttrs.defaults with Fg = Indexed 3uy } }
+
+let private brightYellowCell (ch: char) : Cell =
+    { Ch = System.Text.Rune ch
+      Attrs = { SgrAttrs.defaults with Fg = Indexed 11uy } }
+
+[<Fact>]
+let ``isRedFg returns true for Indexed 1`` () =
+    Assert.True(StreamProfile.isRedFg (Indexed 1uy))
+
+[<Fact>]
+let ``isRedFg returns true for Indexed 9 (bright red)`` () =
+    Assert.True(StreamProfile.isRedFg (Indexed 9uy))
+
+[<Fact>]
+let ``isRedFg returns false for Indexed 0`` () =
+    Assert.False(StreamProfile.isRedFg (Indexed 0uy))
+
+[<Fact>]
+let ``isRedFg returns false for Default`` () =
+    Assert.False(StreamProfile.isRedFg Default)
+
+[<Fact>]
+let ``isRedFg returns false for Indexed 3 (yellow)`` () =
+    Assert.False(StreamProfile.isRedFg (Indexed 3uy))
+
+[<Fact>]
+let ``isYellowFg returns true for Indexed 3`` () =
+    Assert.True(StreamProfile.isYellowFg (Indexed 3uy))
+
+[<Fact>]
+let ``isYellowFg returns true for Indexed 11 (bright yellow)`` () =
+    Assert.True(StreamProfile.isYellowFg (Indexed 11uy))
+
+[<Fact>]
+let ``isYellowFg returns false for Default`` () =
+    Assert.False(StreamProfile.isYellowFg Default)
+
+[<Fact>]
+let ``isYellowFg returns false for Indexed 1 (red)`` () =
+    Assert.False(StreamProfile.isYellowFg (Indexed 1uy))
+
+[<Fact>]
+let ``rowDominantColor returns red for majority-red row`` () =
+    // 4 red cells + 1 plain + trailing blanks.
+    let row = blankRow 10
+    row.[0] <- redCell 'e'
+    row.[1] <- redCell 'r'
+    row.[2] <- redCell 'r'
+    row.[3] <- redCell '!'
+    row.[4] <- cellOf 'a'
+    Assert.Equal(Some "red", StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor returns yellow for majority-yellow row`` () =
+    let row = blankRow 10
+    row.[0] <- yellowCell 'w'
+    row.[1] <- yellowCell 'a'
+    row.[2] <- yellowCell 'r'
+    row.[3] <- yellowCell 'n'
+    Assert.Equal(Some "yellow", StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor returns None for plain row`` () =
+    let row = rowOf 10 "hello"
+    Assert.Equal(None, StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor returns None for all-blank row`` () =
+    let row = blankRow 10
+    Assert.Equal(None, StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor ignores blank cells in the count`` () =
+    // 1 red cell + 9 blanks. >50% of non-blanks (1/1 = 100%)
+    // are red, so the row is red even though most cells are
+    // blank. Blank-cell padding shouldn't dilute the count.
+    let row = blankRow 10
+    row.[0] <- redCell 'X'
+    Assert.Equal(Some "red", StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor returns None for minority-red row`` () =
+    // 1 red + 4 plain = 5 non-blank cells, 1 red. Red count
+    // is not majority of non-blanks (1 * 2 = 2 ≯ 5).
+    let row = blankRow 10
+    row.[0] <- redCell '>'
+    row.[1] <- cellOf 'p'
+    row.[2] <- cellOf 'l'
+    row.[3] <- cellOf 'a'
+    row.[4] <- cellOf 'n'
+    Assert.Equal(None, StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor handles bright-red cells`` () =
+    let row = blankRow 5
+    row.[0] <- brightRedCell 'E'
+    row.[1] <- brightRedCell 'R'
+    row.[2] <- brightRedCell 'R'
+    Assert.Equal(Some "red", StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor handles bright-yellow cells`` () =
+    let row = blankRow 5
+    row.[0] <- brightYellowCell 'W'
+    row.[1] <- brightYellowCell 'A'
+    row.[2] <- brightYellowCell 'R'
+    Assert.Equal(Some "yellow", StreamProfile.rowDominantColor row)
+
+[<Fact>]
+let ``snapshotDominantColor returns red when any row is red`` () =
+    let snap = Array.init 3 (fun _ -> blankRow 5)
+    snap.[1].[0] <- redCell 'e'
+    snap.[1].[1] <- redCell 'r'
+    snap.[1].[2] <- redCell 'r'
+    Assert.Equal(Some "red", StreamProfile.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor returns yellow when only yellow rows present`` () =
+    let snap = Array.init 3 (fun _ -> blankRow 5)
+    snap.[0].[0] <- yellowCell 'w'
+    snap.[0].[1] <- yellowCell 'a'
+    Assert.Equal(Some "yellow", StreamProfile.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor prefers red over yellow when both present`` () =
+    let snap = Array.init 3 (fun _ -> blankRow 5)
+    // Yellow row first.
+    snap.[0].[0] <- yellowCell 'w'
+    snap.[0].[1] <- yellowCell 'a'
+    snap.[0].[2] <- yellowCell 'r'
+    snap.[0].[3] <- yellowCell 'n'
+    // Red row second.
+    snap.[2].[0] <- redCell 'e'
+    snap.[2].[1] <- redCell 'r'
+    snap.[2].[2] <- redCell 'r'
+    Assert.Equal(Some "red", StreamProfile.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor returns None for all-plain snapshot`` () =
+    let snap = snapshotOf 3 5 [ "hi"; "lo"; "ok" ]
+    Assert.Equal(None, StreamProfile.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor returns None for all-blank snapshot`` () =
+    let snap = Array.init 3 (fun _ -> blankRow 5)
+    Assert.Equal(None, StreamProfile.snapshotDominantColor snap)
+
+// ---------------------------------------------------------------------
 // Stage 8b note: the Stage-7 `runLoop` orchestrator has been removed.
 // Its three integration tests (cancellation, end-to-end emit, and the
 // PeriodicTimer-concurrent-call regression) covered the orchestration


### PR DESCRIPTION
## Summary

Stage 8d.2 of the Output framework cycle. Closes the spec C.1 8d row by adding the colour-detection producer + earcon palette extensions. With [8d.1's substrate (PR #155)](https://github.com/KyleKeane/pty-speak/pull/155) in place, 8d.2 makes red-on-screen output produce a 400Hz error-tone and yellow-on-screen output produce a 600Hz warning-tone, alongside NVDA reading the row text.

**Behaviour change vs. post-8d.1**: shells emitting SGR-coloured rows (e.g. `Write-Host "Error" -ForegroundColor Red`) now play a supplementary tone. The earcons supplement (don't replace) NVDA — no double-up because the row text doesn't redundantly state the colour.

## Design — Extensions metadata, no event-splitting

The StreamProfile annotates each `StreamChunk` OutputEvent with `Extensions["dominantColor"] = "red" | "yellow"` when SGR-coloured rows dominate the post-coalesce snapshot; the EarconProfile reads the metadata (defensive against non-string boxed values via `:? string` pattern) and emits the earcon decision when present. **First PR using the spec B.2.3 `OutputEvent.Extensions` forward-compat contract.**

Alternative approaches considered (event-splitting, separate ColorDetectorProfile) were rejected for being larger deltas. The Extensions-metadata path is purely additive on top of 8d.1.

## Color detection heuristic (v1)

- **Per-row**: walk non-blank cells; if >50% have SGR `Indexed 1` / `Indexed 9` (red), the row is red. Else if >50% `Indexed 3` / `Indexed 11` (yellow), yellow. Else plain.
- **Per-snapshot**: any-red wins; else any-yellow; else None. Red has higher urgency.
- **Deferred**: 256-colour cube reds (Indexed 16-231), truecolor RGB-distance, background-colour reds.

## What ships

**`src/Terminal.Core/StreamProfile.fs`:**
- 4 internal colour-detection helpers (`isRedFg`, `isYellowFg`, `rowDominantColor`, `snapshotDominantColor`)
- `streamOutputEvent` takes `dominantColor: string option`; stamps Extensions when Some
- `coalescedToPair` threads colour through to OutputBatch synthesis
- Apply branches compute colour from current snapshot (StreamChunk) or pending snapshot (AltScreen/ModeBarrier flush, Tick trailing-edge flush)
- Uses `(color :> obj)` upcast (not `box`) for the Extensions Map — avoids F# 9 FS3261 nullness regression from PR #152

**`src/Terminal.Core/EarconProfile.fs`:**
- `readDominantColor` helper: defensive `Map.tryFind` + `:? string` pattern (returns None for missing or non-string values)
- Apply gains `StreamChunk` case mapping red → `error-tone`, yellow → `warning-tone`; plain StreamChunk continues returning empty array

**`src/Terminal.Audio/EarconPalette.fs`:**
- `error-tone`: 400Hz × 150ms × 10ms attack
- `warning-tone`: 600Hz × 120ms × 10ms attack
- All earcons stay shorter than the StreamProfile's 200ms debounce window so consecutive earcons don't overlap

## Tests (24 new)

- **StreamProfileTests.fs** (+18): colour-detection helpers across standard 16-colour palette + plain + blank cases + minority/majority thresholds + multi-row precedence
- **EarconProfileTests.fs** (+6): StreamChunk + Extensions = red → error-tone; yellow → warning-tone; green → empty; non-string boxed value → empty (defensive); BellRang preserved (regression pin); empty-Extensions symmetry

Pre-existing test renamed for clarity: `StreamChunk Apply returns empty pair array` → `StreamChunk Apply with no Extensions returns empty pair array`.

## Behaviour preservation

All ~202 pre-existing load-bearing tests stay green. StreamProfile's coalescing algorithm unchanged (colour detection runs alongside). EarconProfile.BellRang case unchanged. NvdaChannel + FileLoggerChannel unchanged (both ignore Extensions today).

## NVDA validation row (manual; maintainer)

- PowerShell: `Write-Host "Error" -ForegroundColor Red` → hear 400Hz error-tone alongside NVDA reading "Error"
- PowerShell: `Write-Host "Warning" -ForegroundColor Yellow` → hear 600Hz warning-tone alongside NVDA reading "Warning"
- Plain output (`dir`, `ls`) → no earcon, NVDA reads as before
- Ctrl+Shift+M mutes all three earcons (bell-ping + error-tone + warning-tone)
- `Ctrl+Shift+;` log captures `Extensions={dominantColor=red}` etc. on coloured streaming events

## Out of scope

- NVDA-channel suppression for earcon-claimed events (substrate API extension; lives with the carried-open ParserError → Background reconciliation PR)
- Truecolor / 256-colour cube / background-colour detection
- Per-shell mute / palette / TOML config (Phase 2)
- Separate ErrorLine / WarningLine producers (8d.2 chose Extensions metadata; ErrorLine remains a reserved Semantic category)

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest. ~226 tests pass (24 new + ~202 pre-existing)
- [ ] CI Markdown link check + workflow lint pass
- [ ] Manual NVDA validation per the row above

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_