### PR TITLE
fix(terminal-audio): EarconPlayer — fresh WasapiOut per play (fixes AUDCLNT_E_ALREADY_INITIALIZED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (EarconPlayer — fresh WasapiOut per play)
+
+The post-PR-#157 release-build logs showed the second + third
+earcons in the Ctrl+Shift+D diagnostic failing with
+`AUDCLNT_E_ALREADY_INITIALIZED` (HRESULT `0x88890002`):
+
+```
+[INF] WasapiOut initialised. Device=Speakers (Realtek(R) Audio)
+[DBG] Earcon play started. EarconId=bell-ping ...
+[INF] Earcon play failed; suppressing. EarconId=error-tone Reason=0x88890002
+      System.Runtime.InteropServices.COMException (0x88890002):
+        at NAudio.CoreAudioApi.AudioClient.Initialize(...)
+        at NAudio.Wave.WasapiOut.Init(...)
+[INF] Earcon play failed; suppressing. EarconId=warning-tone Reason=0x88890002
+```
+
+Root cause: NAudio's `WasapiOut.Init` cannot be called twice
+on the same `WasapiOut` instance — the underlying
+`AudioClient.Initialize` throws `AUDCLNT_E_ALREADY_INITIALIZED`
+on second call. The 8d.1 release shipped with a lazy-singleton
+`WasapiOut` that played the first earcon successfully then
+failed silently on every subsequent play. The bug went
+unnoticed because the original 8d.1 NVDA-validation row
+exercised only the bell-ping path (single play); PR #157's
+new diagnostic plays three earcons in sequence and exposed
+the regression.
+
+Fix: drop the singleton; construct a fresh `WasapiOut` per
+play. `MMDeviceEnumerator` is still cached (cheap to share).
+Each play registers a `PlaybackStopped` handler that disposes
+the `WasapiOut` when the bounded sample provider exhausts;
+init/play exceptions trigger explicit disposal too. The
+construct-per-play overhead is acceptable for our use case
+(BEL + diagnostic + future colour detection trigger plays well
+under once-per-150ms).
+
+`src/Terminal.Audio/EarconPlayer.fs` — re-architected:
+- Removed `wasapiOut: WasapiOut option` cached field
+- Added `MMDeviceEnumerator`-only caching via `ensureEnumerator`
+- `play` now creates `new WasapiOut(...)` each call
+- `PlaybackStopped` event handler disposes the instance
+- Inner try/with disposes on init/play failure + rethrows
+
 ### Reverted (Stage 8d.2 — colour detection + ErrorLine/WarningLine earcons)
 
 The maintainer cut a release build with PR #156 (Stage 8d.2)

--- a/src/Terminal.Audio/EarconPlayer.fs
+++ b/src/Terminal.Audio/EarconPlayer.fs
@@ -8,95 +8,82 @@ open Microsoft.Extensions.Logging
 open Terminal.Core
 
 /// Stage 8d.1 — WASAPI playback glue for earcons.
+/// Re-architected 2026-05-05 after the post-8d.1 release-build
+/// logs surfaced `AUDCLNT_E_ALREADY_INITIALIZED` (0x88890002)
+/// errors on the second + third calls to `WasapiOut.Init`.
 ///
-/// Holds a singleton `WasapiOut` instance, initialised lazily on
-/// first call to `play`. NAudio's `WasapiOut` runs its own audio
-/// thread internally — `Play()` returns immediately once the
-/// engine is primed and the audio thread feeds samples on its
-/// own schedule. So `play` is non-blocking from the dispatcher's
-/// perspective, satisfying the channel "do not block the
-/// dispatcher" contract (spec B.5.3).
+/// **Per-play WasapiOut.** Each call to `play` constructs a
+/// fresh `WasapiOut` instance, calls `Init`, calls `Play`, and
+/// registers a `PlaybackStopped` handler that disposes the
+/// instance once the bounded sample provider exhausts. NAudio's
+/// underlying `AudioClient.Initialize` cannot be called twice
+/// on the same `WasapiOut` — it throws
+/// `AUDCLNT_E_ALREADY_INITIALIZED` — so the lazy-singleton
+/// pattern we shipped initially in 8d.1 was wrong: only the
+/// first earcon ever played; the second + third silently
+/// failed (and the original 8d.1 release wasn't end-to-end-
+/// validated for the multi-earcon path because we shipped
+/// before the diagnostic that exercises it).
 ///
-/// **Lazy init.** The WasapiOut + MMDeviceEnumerator are
-/// constructed on first use rather than at app startup. This
-/// avoids paying the audio-subsystem initialisation cost for
-/// users who never trigger an earcon (e.g., shell sessions
-/// that never emit BEL). The lazy init is gated by a `lock` so
-/// concurrent first-plays don't double-construct.
+/// `MMDeviceEnumerator` is still cached because it's a thin
+/// COM wrapper around device enumeration that's safe to share
+/// across `WasapiOut` instances and not free to construct.
 ///
-/// **Single-stream model.** WasapiOut plays ONE sample provider
-/// at a time. If a second `play` arrives while the previous is
-/// still rendering, the first is stopped and the second begins.
-/// In practice earcons are short (100ms) and rare (BEL triggers
-/// only when a shell emits 0x07); collisions are unlikely. A
-/// future PR can add a mixer (`MixingSampleProvider`) if
-/// overlapping earcons become a real use case.
+/// **Concurrency.** A single `lock initLock` brackets the
+/// device-acquire + WasapiOut-create + Init + Play sequence
+/// so two concurrent `play` calls don't race during
+/// initialisation. The audio playback itself runs on NAudio's
+/// internal audio thread; multiple in-flight `WasapiOut`
+/// instances can coexist and play in parallel (each owns its
+/// own `AudioClient`). For our use case (BEL + diagnostic +
+/// future colour-detection), play rates are well below
+/// once-per-150ms, so overlap is rare.
 ///
 /// **Error swallowing.** Audio failures must NEVER crash the
-/// app or block the dispatcher. Every `play` call is wrapped in
-/// `try/with`; exceptions are logged at Information level and
-/// silently dropped. Common failure modes: no audio device, WASAPI
-/// init failure (e.g., headless CI), driver permission errors.
-/// All of these become "no sound" for the user — the rest of the
-/// app continues running.
+/// app or block the dispatcher. Every `play` call is wrapped
+/// in `try/with`; exceptions are logged at Information level
+/// and silently dropped. Common failure modes: no audio
+/// device, WASAPI init failure, driver permission errors,
+/// the AUDCLNT_E_ALREADY_INITIALIZED bug above (now fixed).
+/// All of these become "no sound" for the user — the rest of
+/// the app continues running.
 module EarconPlayer =
 
     /// Helper: fetch the current logger. Called per-log-site
     /// rather than cached at module-init because
     /// `Terminal.Core.Logger` returns a NullLogger sentinel
-    /// before `Logger.configure` runs (composition root,
-    /// `Program.fs` line ~788) and the real factory-backed
-    /// logger after. Module-init for Terminal.Audio happens
-    /// when `compose` touches the EarconPlayer (after
-    /// configure), but we use the per-call lookup pattern that
-    /// the rest of the codebase uses (see e.g.
-    /// `Coalescer.processRowsChanged`).
+    /// before `Logger.configure` runs.
     let private getLogger () : ILogger =
         Logger.get "Terminal.Audio.EarconPlayer"
 
     let private initLock : obj = obj ()
-    let mutable private wasapiOut : WasapiOut option = None
     let mutable private deviceEnumerator : MMDeviceEnumerator option = None
 
-    /// Initialise the WASAPI output device on first use. Caller
-    /// MUST hold `initLock`. Returns the cached instance on
-    /// subsequent calls. Returns `None` if the audio subsystem
-    /// is unavailable (no device, permission denied, headless
-    /// runner, etc.).
-    let private ensureWasapiOut () : WasapiOut option =
-        match wasapiOut with
+    /// Lazily acquire the device enumerator on first play.
+    /// Caller MUST hold `initLock`. Returns `None` if the audio
+    /// subsystem is unavailable.
+    let private ensureEnumerator () : MMDeviceEnumerator option =
+        match deviceEnumerator with
         | Some _ as cached -> cached
         | None ->
             try
                 let enumerator = new MMDeviceEnumerator()
-                let device =
-                    enumerator.GetDefaultAudioEndpoint(
-                        DataFlow.Render,
-                        Role.Console)
-                let wo =
-                    new WasapiOut(
-                        device,
-                        AudioClientShareMode.Shared,
-                        true,
-                        100)
                 deviceEnumerator <- Some enumerator
-                wasapiOut <- Some wo
                 (getLogger ()).LogInformation(
-                    "WasapiOut initialised. Device={Device}",
-                    device.FriendlyName)
-                Some wo
+                    "MMDeviceEnumerator initialised.")
+                Some enumerator
             with ex ->
                 (getLogger ()).LogInformation(
                     ex,
-                    "WasapiOut initialisation failed; earcons will be silent. Reason: {Reason}",
+                    "MMDeviceEnumerator initialisation failed; earcons will be silent. Reason: {Reason}",
                     ex.Message)
                 None
 
     /// Play the earcon identified by `earconId` using the
     /// supplied palette. Non-blocking: returns immediately
-    /// after starting the playback. Errors are logged and
-    /// silently swallowed — earcon failures don't crash the
-    /// dispatcher.
+    /// after `WasapiOut.Play` (the audio thread feeds samples
+    /// asynchronously). Errors are logged and silently
+    /// swallowed.
     let play
             (palette: Map<EarconPalette.EarconId, EarconWaveform.Parameters>)
             (earconId: EarconPalette.EarconId)
@@ -110,34 +97,54 @@ module EarconPlayer =
         | Some parameters ->
             try
                 lock initLock (fun () ->
-                    match ensureWasapiOut () with
+                    match ensureEnumerator () with
                     | None -> ()
-                    | Some wo ->
-                        // Stop the in-flight earcon (if any)
-                        // before initialising the next. WasapiOut
-                        // doesn't queue; calling Init twice
-                        // without Stop produces undefined
-                        // behaviour.
-                        if wo.PlaybackState = PlaybackState.Playing then
-                            wo.Stop()
+                    | Some enumerator ->
+                        let device =
+                            enumerator.GetDefaultAudioEndpoint(
+                                DataFlow.Render,
+                                Role.Console)
+                        // Fresh WasapiOut per play. NAudio's
+                        // AudioClient.Initialize throws
+                        // AUDCLNT_E_ALREADY_INITIALIZED if Init
+                        // is called twice on the same WasapiOut.
+                        // Each play is short (≤150ms tone); the
+                        // construct/dispose overhead is acceptable.
+                        let wo =
+                            new WasapiOut(
+                                device,
+                                AudioClientShareMode.Shared,
+                                true,
+                                100)
+                        // Dispose-on-stop chain: when the bounded
+                        // sample provider exhausts, NAudio fires
+                        // PlaybackStopped on its audio thread; we
+                        // dispose the WasapiOut to release the
+                        // AudioClient handle. Wrapped in try/with
+                        // because Dispose can race with the GC
+                        // finalizer and multiple Dispose calls
+                        // can throw; we treat the cleanup as
+                        // best-effort.
+                        wo.PlaybackStopped.Add(fun _ ->
+                            try wo.Dispose() with _ -> ())
                         let waveform =
                             EarconWaveform.synthSineEnvelope parameters
-                        // WasapiOut.Init takes IWaveProvider;
-                        // wrap the ISampleProvider chain in a
-                        // 16-bit PCM converter (NAudio's
-                        // standard adapter). 16-bit is the
-                        // universally-supported lowest-CPU
-                        // option for short tones; spatial
-                        // future-stages may upgrade to 32-bit
-                        // float for better dynamic range.
                         let waveProvider = SampleToWaveProvider16(waveform)
-                        wo.Init(waveProvider :> IWaveProvider)
-                        wo.Play()
-                        (getLogger ()).LogDebug(
-                            "Earcon play started. EarconId={EarconId} FreqHz={FreqHz} DurationMs={DurationMs}",
-                            earconId,
-                            parameters.FrequencyHz,
-                            parameters.DurationMs))
+                        try
+                            wo.Init(waveProvider :> IWaveProvider)
+                            wo.Play()
+                            (getLogger ()).LogDebug(
+                                "Earcon play started. EarconId={EarconId} FreqHz={FreqHz} DurationMs={DurationMs}",
+                                earconId,
+                                parameters.FrequencyHz,
+                                parameters.DurationMs)
+                        with ex ->
+                            // Init or Play failed before
+                            // PlaybackStopped could fire to clean
+                            // up; dispose explicitly here, then
+                            // rethrow to the outer handler.
+                            try wo.Dispose() with _ -> ()
+                            reraise ())
             with ex ->
                 (getLogger ()).LogInformation(
                     ex,


### PR DESCRIPTION
## Summary

Fixes the earcon-repeat regression surfaced by [PR #157](https://github.com/KyleKeane/pty-speak/pull/157)'s Ctrl+Shift+D diagnostic. The post-#157 release-build logs showed:

```
[INF] WasapiOut initialised. Device=Speakers (Realtek(R) Audio)
[DBG] Earcon play started. EarconId=bell-ping FreqHz=800 DurationMs=100
   ↑ bell-ping plays successfully
[INF] Earcon play failed; suppressing. EarconId=error-tone Reason=0x88890002
[INF] Earcon play failed; suppressing. EarconId=warning-tone Reason=0x88890002
   ↑ error-tone + warning-tone fail silently
```

`0x88890002` = `AUDCLNT_E_ALREADY_INITIALIZED`. NAudio's `WasapiOut.Init` cannot be called twice on the same `WasapiOut` instance — the underlying `AudioClient.Initialize` throws on the second call. The 8d.1 release shipped a **lazy-singleton** `WasapiOut` that played the first earcon then silently failed on every subsequent play. The bug was masked because 8d.1's NVDA-validation row only exercised the BEL → bell-ping single-play path; PR #157's diagnostic plays three earcons in sequence and exposed it.

## Fix

Drop the singleton. Each `play` constructs a fresh `WasapiOut`, registers a `PlaybackStopped → Dispose` handler, and falls through. The `MMDeviceEnumerator` is still cached (cheap to share). Init/play exceptions trigger explicit disposal + rethrow to the outer log-and-suppress handler.

Construct-per-play overhead is acceptable for our use case (BEL + Ctrl+Shift+D diagnostic + future colour detection trigger plays well under once-per-150ms).

## Files

- `src/Terminal.Audio/EarconPlayer.fs` — re-architected. Removed `wasapiOut: WasapiOut option` cached field; added `PlaybackStopped` disposal chain; inner try/with disposes on init/play failure + `reraise()`. Module docstring updated to call out the singleton mistake + the 0x88890002 root cause.
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry.

## Behaviour preservation

No changes to channel / profile / dispatcher substrate. Only the audio playback module changes. All ~202 pre-existing tests remain unchanged.

## NVDA validation row (manual; maintainer)

After this lands:
1. Cut a release build, install, launch
2. Press Ctrl+Shift+D
3. Verify hearing all three earcons in sequence:
   - "Bell ping." → 800Hz tone
   - "Error tone." → 400Hz tone (lower-pitched, longer)
   - "Warning tone." → 600Hz tone (mid)
4. Verify the announces between each earcon land via NVDA

## Test plan

- [ ] CI runs `dotnet test` on Windows-latest. ~202 tests pass
- [ ] CI Markdown link check + workflow lint pass
- [ ] Manual NVDA validation per the row above

## Carried forward to next planning

The verbose-readback issue (NVDA reads the entire screen on every event, GitHub issue #115/#139). The maintainer's PR #157 logs confirmed it's still the dominant accessibility friction in the Stream profile. The proper fix (suffix-diff: track last-emitted text + emit only the changed suffix) is a substantial StreamProfile refactor; deserves its own sub-stage with planning. Will queue after this earcon fix lands.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_