### PR TITLE
Phase A.1 — hot-switch baseline-seed (NVDA regression on Ctrl+Shift+1/2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,62 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Phase A.1 — hot-switch baseline-seed)
+
+The maintainer's NVDA validation pass on Phase A surfaced a
+regression on shell hot-switch (`Ctrl+Shift+1/2/3`): after
+switching from Claude Code to cmd, NVDA kept reading the
+previous shell's screen content for the first emit of the new
+shell, instead of just the new shell's first paint.
+
+Cause: `activePathway.Reset ()` clears the pathway's
+`LastEmittedRowHashes` baseline to `[||]`, which makes the
+next `Consume` call treat every row as "new" and emit the
+entire screen verbatim. The screen buffer itself isn't cleared
+on shell-switch (existing framework-cycle deferral; see the
+`switchToShell` comment block at `Program.fs`), so the entire
+screen at the moment of the first emit still contains the
+previous shell's content overlaid by however much the new
+shell has painted so far.
+
+Pre-Phase-A this didn't bite because every emit shipped the
+full screen anyway (verbose-readback). Post-Phase-A the diff-
+only contract makes the shell-switch first-emit conspicuous.
+
+Fix: add `SetBaseline: Canonical -> unit` to `DisplayPathway.T`.
+`switchToShell` calls it immediately after the new pathway is
+constructed and BEFORE `wirePostSpawn` starts the new reader
+loop, seeding the baseline with the screen's snapshot at the
+moment of switch. The next `Consume` then emits only the rows
+the new shell actually painted (typically just the new
+prompt), not the residual content from the previous shell.
+
+`StreamPathway.SetBaseline` writes
+`canonical.RowHashes` into both `LastEmittedRowHashes` (the
+diff baseline) and `LastRowHashes` (the spinner-suppress
+"previous frame hashes" — without seeding this too, the first
+post-switch Consume would mark every row as "changed" against
+`ValueNone` and over-count spinner-history entries for the
+seeded frame's content).
+
+`TuiPathway.SetBaseline` is a no-op — TuiPathway is stateless
+and never tracks baselines.
+
+Files:
+- `src/Terminal.Core/DisplayPathway.fs` — `T` record gains
+  `SetBaseline: Canonical -> unit`.
+- `src/Terminal.Core/StreamPathway.fs` — internal `seedBaseline`
+  helper + wires through `create` + `createWithExposedState`.
+- `src/Terminal.Core/TuiPathway.fs` — no-op `SetBaseline`.
+- `src/Terminal.App/Program.fs` — `switchToShell` snapshots the
+  screen, builds `Canonical`, calls
+  `activePathway.SetBaseline canonical` before
+  `wirePostSpawn newHost`.
+- `tests/Tests.Unit/StreamPathwayTests.fs` — 4 new tests
+  pinning the baseline-seed behaviour.
+- `tests/Tests.Unit/TuiPathwayTests.fs` — 1 new test pinning
+  the no-op contract.
+
 ### Changed (Phase A — display-pathway substrate)
 
 Resolves the verbose-readback regression

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1725,6 +1725,35 @@ module Program =
                                         try activePathway.Reset () with _ -> ()
                                         activePathway <-
                                             selectPathwayForShell shell.Id
+                                        // Phase A.1 — seed the new
+                                        // pathway's diff baseline
+                                        // with the screen's current
+                                        // snapshot so the next
+                                        // Consume emits only the
+                                        // new shell's paint, not the
+                                        // residual content the old
+                                        // shell left on the screen.
+                                        // The screen buffer is NOT
+                                        // cleared on shell-switch
+                                        // (separate framework-cycle
+                                        // concern, see the comment
+                                        // block above), so without
+                                        // this seed the user hears
+                                        // the previous shell's
+                                        // content re-announced when
+                                        // the new shell's first
+                                        // RowsChanged arrives. Must
+                                        // happen BEFORE wirePostSpawn
+                                        // starts the reader loop so
+                                        // there's no race with the
+                                        // new shell's first paint.
+                                        try
+                                            let seq, snapshot =
+                                                screen.SnapshotRows(0, screen.Rows)
+                                            let canonical =
+                                                CanonicalState.create snapshot seq
+                                            activePathway.SetBaseline canonical
+                                        with _ -> ()
                                         wirePostSpawn newHost
                                         window.TerminalSurface.Announce(
                                             sprintf "Switched to %s." shell.DisplayName,

--- a/src/Terminal.Core/DisplayPathway.fs
+++ b/src/Terminal.Core/DisplayPathway.fs
@@ -71,4 +71,23 @@ module DisplayPathway =
           /// resets its internal state so the new shell's
           /// session starts with a clean baseline (no leaked
           /// row hashes, no pending debounce, etc.).
-          Reset: unit -> unit }
+          Reset: unit -> unit
+          /// Called immediately after `Reset` on a shell-switch
+          /// — seeds the pathway's diff baseline with the
+          /// supplied canonical state. Without this seed, the
+          /// next `Consume` after a `Reset` treats every row as
+          /// "new" and emits the entire screen verbatim — which
+          /// surfaces as NVDA reading the previous shell's
+          /// stale screen content after `Ctrl+Shift+1/2/3`
+          /// hot-switch (the screen buffer isn't cleared on
+          /// switch; only the new shell's paint progressively
+          /// overwrites the old content). Seeding the baseline
+          /// against the screen's snapshot at the moment of
+          /// switch makes subsequent `Consume` emits diff-only
+          /// against the post-switch frame.
+          ///
+          /// **No emission.** `SetBaseline` MUST NOT emit
+          /// OutputEvents — it only updates internal hash state.
+          /// Pathways without baseline state (TuiPathway) treat
+          /// it as a no-op.
+          SetBaseline: CanonicalState.Canonical -> unit }

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -345,6 +345,23 @@ module StreamPathway =
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()
 
+    /// Internal — seed the pathway's diff baseline + spinner-
+    /// gate "previous hashes" with the supplied canonical
+    /// state's hashes. Used by `SetBaseline` (hot-switch). No
+    /// emission; this is purely state-setting. The next
+    /// `Consume` will compute its diff against this seeded
+    /// baseline rather than against `[||]`.
+    let internal seedBaseline (state: State) (canonical: CanonicalState.Canonical) : unit =
+        state.LastEmittedRowHashes <- canonical.RowHashes
+        // Also prime LastRowHashes so the spinner-suppress
+        // "this row changed?" check on the next Consume sees
+        // the seeded frame as "no rows changed yet". Without
+        // this, the first Consume after Reset+SetBaseline
+        // would still mark every row as "changed" against
+        // ValueNone and accumulate spinner-history entries
+        // for the seeded frame's content.
+        state.LastRowHashes <- ValueSome canonical.RowHashes
+
     /// Construct a StreamPathway. The pathway captures
     /// `parameters` in its closure; v1 ships a single
     /// pathway-instance per shell session, recycled via
@@ -363,7 +380,9 @@ module StreamPathway =
             fun now ->
                 onModeBarrier state now
           Reset =
-            fun () -> resetState state }
+            fun () -> resetState state
+          SetBaseline =
+            fun canonical -> seedBaseline state canonical }
 
     /// Test-only — expose the state for direct manipulation in
     /// the test harness. Production code never calls this.
@@ -394,5 +413,7 @@ module StreamPathway =
                 fun now ->
                     onModeBarrier state now
               Reset =
-                fun () -> resetState state }
+                fun () -> resetState state
+              SetBaseline =
+                fun canonical -> seedBaseline state canonical }
         pathway, state

--- a/src/Terminal.Core/TuiPathway.fs
+++ b/src/Terminal.Core/TuiPathway.fs
@@ -87,4 +87,10 @@ module TuiPathway =
           Reset =
             fun () ->
                 // No state to reset.
+                ()
+          SetBaseline =
+            fun _canonical ->
+                // No baseline to seed — TuiPathway is stateless
+                // and its `Consume` always returns `[||]`
+                // regardless of the canonical state.
                 () }

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -416,6 +416,82 @@ let ``pathway Id is "stream"`` () =
     let pathway = StreamPathway.create StreamPathway.defaultParameters
     Assert.Equal("stream", pathway.Id)
 
+// ---- SetBaseline (hot-switch baseline-seed) ------------------------
+
+[<Fact>]
+let ``SetBaseline seeds LastEmittedRowHashes from the supplied canonical state`` () =
+    // Use createWithExposedState so the test can inspect the
+    // mutable State directly — SetBaseline writes through the
+    // closure, not through any observable return value.
+    let pathway, state = StreamPathway.createWithExposedState StreamPathway.defaultParameters
+    let snap = snapshotOf 3 10 [ "claude prompt"; "row two"; "row three" ]
+    let canonical = CanonicalState.create snap 0L
+    pathway.SetBaseline canonical
+    Assert.Equal<uint64[]>(canonical.RowHashes, state.LastEmittedRowHashes)
+    Assert.True(state.LastRowHashes.IsSome)
+    Assert.Equal<uint64[]>(canonical.RowHashes, state.LastRowHashes.Value)
+
+[<Fact>]
+let ``SetBaseline emits no events`` () =
+    // SetBaseline updates internal state ONLY — no OutputEvents.
+    // The signature returns `unit`; this test pins that the
+    // state mutation doesn't piggy-back on Consume's emission
+    // path.
+    let pathway = StreamPathway.create StreamPathway.defaultParameters
+    let snap = snapshotOf 2 10 [ "stale claude content" ]
+    let canonical = CanonicalState.create snap 0L
+    pathway.SetBaseline canonical  // returns unit; no events to inspect
+    // A subsequent Consume of the SAME snapshot should now
+    // return zero events because the baseline matches.
+    let result = pathway.Consume canonical
+    Assert.Equal(0, result.Length)
+
+[<Fact>]
+let ``SetBaseline + Consume of changed frame emits diff-only`` () =
+    // The headline hot-switch fix: after SetBaseline against
+    // the pre-switch screen, the next Consume emits only the
+    // rows the new shell painted, not the entire stale screen.
+    let pathway = StreamPathway.create StreamPathway.defaultParameters
+    // Pre-switch screen — claude content.
+    let preSwitch =
+        snapshotOf 5 20
+            [ "claude code chat"
+              "context: working on..."
+              "blah blah blah"
+              ""
+              "" ]
+    pathway.SetBaseline (CanonicalState.create preSwitch 100L)
+    // New cmd shell paints its prompt at row 4 (assume cmd
+    // overwrites only that row); rows 0-3 still hold claude
+    // content because the screen buffer isn't cleared.
+    let postSwitch =
+        snapshotOf 5 20
+            [ "claude code chat"
+              "context: working on..."
+              "blah blah blah"
+              ""
+              "C:\\>" ]
+    let result = pathway.Consume (CanonicalState.create postSwitch 101L)
+    Assert.Equal(1, result.Length)
+    // The user should hear "C:\>" — NOT the claude content.
+    Assert.Contains("C:\\>", result.[0].Payload)
+    Assert.DoesNotContain("claude", result.[0].Payload)
+    Assert.DoesNotContain("blah", result.[0].Payload)
+
+[<Fact>]
+let ``SetBaseline overrides a prior baseline`` () =
+    // If the user hot-switches twice in quick succession,
+    // SetBaseline must always take the latest canonical's
+    // hashes (not mix with prior state).
+    let pathway, state = StreamPathway.createWithExposedState StreamPathway.defaultParameters
+    let snap1 = snapshotOf 1 5 [ "first" ]
+    let snap2 = snapshotOf 1 5 [ "second" ]
+    let canonical1 = CanonicalState.create snap1 0L
+    let canonical2 = CanonicalState.create snap2 1L
+    pathway.SetBaseline canonical1
+    pathway.SetBaseline canonical2
+    Assert.Equal<uint64[]>(canonical2.RowHashes, state.LastEmittedRowHashes)
+
 // ---- ActivityIds vocabulary pinning (preserved from StreamProfileTests) -----
 
 [<Fact>]

--- a/tests/Tests.Unit/TuiPathwayTests.fs
+++ b/tests/Tests.Unit/TuiPathwayTests.fs
@@ -86,6 +86,19 @@ let ``pathway Id is "tui"`` () =
     Assert.Equal("tui", pathway.Id)
 
 [<Fact>]
+let ``SetBaseline is a no-op (no exception, no state change)`` () =
+    // TuiPathway has no baseline to seed — it's stateless and
+    // never tracks row hashes. SetBaseline must be a safe
+    // no-op so the hot-switch path can call it uniformly
+    // across pathway types.
+    let pathway = TuiPathway.create ()
+    let canonical = CanonicalState.create (snapshotOf 3 10 [ "vim"; "buffer" ]) 0L
+    pathway.SetBaseline canonical
+    // Subsequent Consume still emits nothing.
+    let result = pathway.Consume (CanonicalState.create (snapshotOf 3 10 [ "vim"; "different" ]) 1L)
+    Assert.Equal(0, result.Length)
+
+[<Fact>]
 let ``OnModeBarrier returns Polite priority`` () =
     // The TuiPathway can't reliably distinguish AltScreen
     // toggles from other mode flips through the v1 pathway


### PR DESCRIPTION
## Summary

NVDA validation of Phase A (PR #159) surfaced a regression on shell hot-switch (`Ctrl+Shift+1/2/3`): after switching from Claude Code to cmd, NVDA kept reading the previous shell's screen content for the first emit of the new shell, instead of just the new shell's first paint.

**Cause.** `activePathway.Reset ()` clears the pathway's `LastEmittedRowHashes` baseline to `[||]`, which makes the next `Consume` call treat every row as "new" and emit the entire screen verbatim. The screen buffer itself isn't cleared on shell-switch (existing framework-cycle deferral; see the `switchToShell` comment block), so the entire screen at the moment of the first emit still contains the previous shell's content overlaid by however much the new shell has painted so far. Pre-Phase-A this didn't bite because every emit shipped the full screen anyway (verbose-readback); post-Phase-A the diff-only contract makes the first post-switch emit conspicuous.

**Fix.** Add `SetBaseline: Canonical -> unit` to `DisplayPathway.T`. `switchToShell` calls it immediately after the new pathway is constructed and BEFORE `wirePostSpawn` starts the new reader loop, seeding the baseline with the screen's snapshot at the moment of switch. The next `Consume` then emits only the rows the new shell actually painted (typically just the new prompt), not the residual content from the previous shell.

`StreamPathway.SetBaseline` writes `canonical.RowHashes` into both `LastEmittedRowHashes` (the diff baseline) and `LastRowHashes` (the spinner-suppress "previous frame hashes"). Seeding the latter avoids over-counting spinner-history entries for the seeded frame's content on the first post-switch Consume. `TuiPathway.SetBaseline` is a no-op (stateless pathway).

**Out of scope.** Clearing the Screen buffer itself on shell-switch (so the new shell paints onto a blank canvas) remains framework-territory per the existing `switchToShell` comment block — the same deferral applies for parser-state reset and UIA peer invalidation. The Phase A.1 baseline-seed fix is a strict improvement that resolves the audible regression without touching Screen state semantics.

## Test plan

Unit tests:
- [ ] `StreamPathway`: `SetBaseline` writes through to `LastEmittedRowHashes` + `LastRowHashes`
- [ ] `StreamPathway`: `SetBaseline` emits no events; subsequent `Consume` of the same canonical state returns `[||]`
- [ ] `StreamPathway`: post-`SetBaseline` `Consume` of a changed frame emits only the changed rows (the headline hot-switch test)
- [ ] `StreamPathway`: `SetBaseline` overrides a prior baseline (rapid double-switch case)
- [ ] `TuiPathway`: `SetBaseline` is a no-op

Manual NVDA validation row (deferred to maintainer):
- [ ] Boot pty-speak in Claude Code, type a few prompts so the screen has content
- [ ] Press `Ctrl+Shift+1` to switch to cmd
- [ ] Verify NVDA announces "Switching to..." then "Switched to..." and reads ONLY the new cmd prompt, NOT the previous Claude content
- [ ] Switch back to Claude (`Ctrl+Shift+3`); verify same behaviour the other direction
- [ ] Rapid double-switch: `Ctrl+Shift+1` then `Ctrl+Shift+2` within a second; verify no stale content leaks

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_