### PR TITLE
Phase B subset — alt-screen → TuiPathway auto-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,77 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Phase B subset — alt-screen → TuiPathway auto-detect)
+
+`TuiPathway` shipped in Phase A as a wired-but-never-selected
+option (only the hardcoded `selectPathwayForShell` mapping
+chose pathways, and v1 mapped cmd / powershell / claude all to
+StreamPathway). The Phase A plan deferred auto-detection of
+pathway from screen state to "Phase B paired with TOML config"
+because mid-session pathway swap had unsettled state semantics.
+
+Phase A.1's `DisplayPathway.T.SetBaseline` primitive resolved
+the state-semantics concern (no leaked baseline, no stale-diff
+regression on swap), so alt-screen auto-detect is now
+independently shippable without the TOML config.
+
+**Behaviour.** When the active shell enters an alt-screen TUI
+(`vim`, `less`, `top`, full-screen `fzf`), the screen fires
+`ModeChanged(AltScreen, true)`; the `PathwayPump` swaps the
+active pathway to `TuiPathway` (no streaming output — review-
+cursor / browse-mode is the navigation primary). When the user
+quits the TUI, `ModeChanged(AltScreen, false)` swaps the
+pathway back to whatever the active shell's default is
+(`StreamPathway` for cmd / powershell / claude in v1).
+
+Without this change, the user's NVDA experience inside vim was
+constant streaming announcements as the editor repainted —
+unusable. The vim experience now matches the implicit Stage 5
+alt-screen suppression that pre-Stage-8 pty-speak shipped, but
+with the pathway substrate's state-management discipline
+(flush via `OnModeBarrier`, `Reset` outgoing, seed `SetBaseline`
+on incoming) so no diff state leaks across the swap.
+
+**Implementation.** A new pure decision module
+`PathwaySelector` returns one of `Keep` / `SwapToTui` /
+`SwapToShellDefault` from `(currentPathwayId, ScreenNotification)`
+without depending on `Terminal.Pty`'s `ShellRegistry`. The
+`PathwayPump`'s `handleModeChanged` calls it after the existing
+`OnModeBarrier` flush + before the existing barrier-OutputEvent
+dispatch; on a non-`Keep` decision, it runs the same
+flush/Reset/reassign/SetBaseline sequence used by the
+`switchToShell` hot-switch path so the swap-state semantics are
+identical.
+
+The PathwayPump tracks a new `currentShellId` mutable
+(initialised to `Cmd`, updated on startup-shell resolve and on
+`switchToShell`'s `Ok newHost` branch) so a `SwapToShellDefault`
+on alt-screen exit resolves to the active shell's default
+pathway, not always to cmd's.
+
+Files:
+- `src/Terminal.Core/PathwaySelector.fs` — new pure decision
+  module.
+- `src/Terminal.Core/Terminal.Core.fsproj` — `<Compile Include>`
+  for the new module.
+- `src/Terminal.App/Program.fs` — `currentShellId` mutable +
+  `swapPathwayForAltScreen` helper + updated `handleModeChanged`
+  + sync at startup-resolve and `switchToShell`.
+- `tests/Tests.Unit/PathwaySelectorTests.fs` — 11 tests
+  exhausting the swap matrix (alt-screen entry/exit × current
+  pathway × non-alt-screen flag toggles + non-ModeChanged
+  notification defensives).
+- `tests/Tests.Unit/Tests.Unit.fsproj` — `<Compile Include>`
+  for the new test file.
+- `CHANGELOG.md` — this entry.
+
+**Out of scope.** The TOML-driven per-shell pathway selection
+that was originally bundled with this change in the Phase B
+sequencing — landing separately so the user-facing alt-screen
+experience improves without waiting on a config-file design
+cycle. Auto-detection of OSC 133 → ReplPathway is also
+deferred (no ReplPathway exists yet; Phase 2 territory).
+
 ### Fixed (Phase A.1 — hot-switch baseline-seed)
 
 The maintainer's NVDA validation pass on Phase A surfaced a

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1048,6 +1048,26 @@ module Program =
         let mutable activePathway : DisplayPathway.T =
             StreamPathway.create StreamPathway.defaultParameters
 
+        // Phase B (subset) — alt-screen → TuiPathway auto-detect
+        // bookkeeping. The PathwayPump's `handleModeChanged`
+        // consults `PathwaySelector.decideAltScreenAction` on
+        // every `ModeChanged`; when an alt-screen toggle requires
+        // a pathway swap, the pump needs to know which shell to
+        // resolve the "default" back to (i.e., on alt-screen
+        // exit, swap back to the active shell's default
+        // streaming pathway, not always to cmd's). Tracked as a
+        // `ShellId` rather than the full `Shell` record because
+        // `selectPathwayForShell` only needs the id; this avoids
+        // a forward reference to `chosenShell` (which is resolved
+        // later in `compose`). Defaults to `Cmd` so a swap that
+        // somehow fires before `chosenShell` resolves still
+        // produces a valid pathway. Updated in two places:
+        //   - startup-shell alignment (after `chosenShell`
+        //     resolves)
+        //   - `switchToShell`'s `Ok newHost` branch
+        let mutable currentShellId : ShellRegistry.ShellId =
+            ShellRegistry.Cmd
+
         // PathwayPump — Phase A replacement for TranslatorPump.
         // Reads raw ScreenNotifications and routes by case:
         //   - RowsChanged: snapshot the screen → build a
@@ -1088,14 +1108,61 @@ module Program =
                 activePathway.Id,
                 emitted.Length)
             dispatchPathwayEvents emitted
+        // Phase B (subset) — alt-screen swap helper. Mirrors
+        // `switchToShell`'s pathway-swap sequence (flush via
+        // `OnModeBarrier`, `Reset` outgoing, reassign, seed
+        // `SetBaseline` against the current screen) so the
+        // mid-session pathway-swap state semantics match the
+        // hot-switch path. Idempotent under no-op decisions
+        // (`PathwaySelector.Keep` short-circuits to the existing
+        // mode-barrier flush).
+        let swapPathwayForAltScreen (next: DisplayPathway.T) : unit =
+            try activePathway.Reset () with _ -> ()
+            activePathway <- next
+            try
+                let seq, snapshot =
+                    screen.SnapshotRows(0, screen.Rows)
+                let canonical =
+                    CanonicalState.create snapshot seq
+                activePathway.SetBaseline canonical
+            with _ -> ()
+            pumpLog.LogInformation(
+                "PathwayPump auto-swapped pathway. NewPathway={Pathway}",
+                activePathway.Id)
+
         let handleModeChanged (notification: ScreenNotification) : unit =
             let now = DateTimeOffset.UtcNow
+            // Step 1 — flush the OUTGOING pathway's pending
+            // state via OnModeBarrier so any pre-mode-change
+            // diff lands at NVDA before the pathway swap.
             let flushed = activePathway.OnModeBarrier now
             pumpLog.LogDebug(
                 "PathwayPump ModeChanged → {Pathway}.OnModeBarrier → {Count} flushed events.",
                 activePathway.Id,
                 flushed.Length)
             dispatchPathwayEvents flushed
+            // Step 2 — consult PathwaySelector to decide whether
+            // an alt-screen toggle warrants a pathway swap. Most
+            // ModeChanged events return Keep (no swap) and the
+            // existing barrier-OutputEvent dispatch finishes
+            // the flow. Alt-screen toggles between the user's
+            // streaming shell and a TUI app (vim / less / top)
+            // swap pathways here so the user gets streaming
+            // diffs in cmd / powershell / claude and review-
+            // cursor-only navigation in vim / less.
+            match PathwaySelector.decideAltScreenAction
+                    activePathway.Id notification with
+            | PathwaySelector.Keep ->
+                ()
+            | PathwaySelector.SwapToTui ->
+                swapPathwayForAltScreen (TuiPathway.create ())
+            | PathwaySelector.SwapToShellDefault ->
+                swapPathwayForAltScreen (selectPathwayForShell currentShellId)
+            // Step 3 — dispatch the barrier OutputEvent so the
+            // FileLogger captures the mode transition in the
+            // audit trail and NvdaChannel routes via
+            // ActivityIds.mode (empty Payload skips the actual
+            // announce per NvdaChannel's contract).
             let barrier =
                 OutputEventBuilder.fromScreenNotification notification
             OutputDispatcher.dispatch barrier
@@ -1278,6 +1345,12 @@ module Program =
         // PathwayPump processes the first ScreenNotification.
         try activePathway.Reset () with _ -> ()
         activePathway <- selectPathwayForShell chosenShell.Id
+        // Phase B (subset) — sync the alt-screen-detect
+        // bookkeeping with the resolved startup shell so the
+        // PathwayPump's `SwapToShellDefault` (alt-screen exit)
+        // resolves to the correct pathway for the running
+        // shell.
+        currentShellId <- chosenShell.Id
 
         // Stage 7-followup PR-I — `chosenShell` is the value chosen
         // at startup and never changes. Hot-switching shells
@@ -1704,6 +1777,18 @@ module Program =
                                         // (cosmetic but confusing for
                                         // log analysis).
                                         currentShell <- shell
+                                        // Phase B (subset) —
+                                        // keep alt-screen-
+                                        // detect bookkeeping
+                                        // aligned with the
+                                        // hot-switched shell so
+                                        // a subsequent alt-
+                                        // screen-exit swap
+                                        // resolves to the new
+                                        // shell's default
+                                        // pathway, not the
+                                        // pre-switch shell's.
+                                        currentShellId <- shell.Id
                                         // Phase A — swap the active
                                         // pathway for the new shell.
                                         // `Reset` clears any pending

--- a/src/Terminal.Core/PathwaySelector.fs
+++ b/src/Terminal.Core/PathwaySelector.fs
@@ -1,0 +1,99 @@
+namespace Terminal.Core
+
+/// Phase B (subset) — Layer 3 pathway auto-selection.
+///
+/// Phase A's plan deferred auto-detection of pathway from
+/// screen state to "Phase B paired with TOML config". Phase A.1
+/// shipped the `DisplayPathway.T.SetBaseline` primitive that
+/// makes mid-session pathway swap a solved problem (no leaked
+/// state, no stale-diff regression). With that primitive in
+/// hand, alt-screen auto-detect can ship independently of the
+/// TOML config — TuiPathway becomes useful for vim / less /
+/// top / full-screen fzf without the user having to set
+/// `PTYSPEAK_SHELL` to a TUI-default shell.
+///
+/// **Decision contract.** This module is a pure decision
+/// helper consulted from `Program.fs`'s `PathwayPump` when a
+/// `ScreenNotification.ModeChanged` arrives. It looks at:
+/// - the current pathway's `Id` (`"stream"` or `"tui"` today)
+/// - the notification's `(flag, value)` pair
+///
+/// and returns one of three actions:
+/// - `Keep` — no swap; the current pathway handles the mode
+///   barrier and continues operating
+/// - `SwapToTui` — alt-screen entered while not already on
+///   TuiPathway
+/// - `SwapToShellDefault` — alt-screen exited while currently
+///   on TuiPathway; swap back to whatever the active shell's
+///   default pathway is (`StreamPathway` for cmd / powershell /
+///   claude in v1)
+///
+/// The caller resolves `SwapToShellDefault` by calling its
+/// own `selectPathwayForShell currentShellId` — `PathwaySelector`
+/// stays free of the `ShellRegistry` dependency from
+/// `Terminal.Pty`.
+///
+/// **Why a separate module instead of inline match.** The
+/// decision is small but the test surface benefits from
+/// isolation: `Program.fs`'s `compose ()` body is hard to unit-
+/// test without a full WPF + ConPty harness, but a pure
+/// `(string, ScreenNotification) -> Action` function can be
+/// pinned exhaustively without any of that.
+///
+/// **Spec reference.** The architectural-spec draft at the top
+/// of `/root/.claude/plans/hello-i-lost-my-velvet-deer.md`
+/// (Phase B — auto-detection of pathway from screen state).
+module PathwaySelector =
+
+    /// What to do with the active pathway in response to a
+    /// `ScreenNotification.ModeChanged`. The caller is
+    /// responsible for the actual swap (`OnModeBarrier` flush
+    /// + `Reset` + reassign + `SetBaseline`); this module just
+    /// decides which direction.
+    type AltScreenAction =
+        /// Keep the current pathway. The vast majority of
+        /// `ModeChanged` events take this branch (bracketed-
+        /// paste toggles, focus-reporting toggles, alt-screen
+        /// toggles when the pathway is already aligned).
+        | Keep
+        /// Alt-screen entered AND the current pathway is not
+        /// TuiPathway. Caller swaps to a fresh TuiPathway.
+        | SwapToTui
+        /// Alt-screen exited AND the current pathway IS
+        /// TuiPathway. Caller swaps back to whatever the active
+        /// shell's default pathway is (looks up via the
+        /// caller's `selectPathwayForShell` helper).
+        | SwapToShellDefault
+
+    /// Decide what to do with the active pathway when a
+    /// `ScreenNotification.ModeChanged` arrives. Pure function
+    /// of `(currentPathwayId, notification)`; no side effects.
+    ///
+    /// **Behaviour.**
+    /// - `ModeChanged(AltScreen, true)` + current pathway is
+    ///   not TuiPathway → `SwapToTui`. The user just ran
+    ///   `vim` / `less` / similar; switch to alt-screen-aware
+    ///   suppression.
+    /// - `ModeChanged(AltScreen, false)` + current pathway IS
+    ///   TuiPathway → `SwapToShellDefault`. The user just
+    ///   quit the alt-screen TUI; swap back to streaming.
+    /// - All other `ModeChanged` events (bracketed-paste,
+    ///   focus-reporting, alt-screen-toggle when pathway is
+    ///   already aligned) → `Keep`.
+    /// - Non-`ModeChanged` notifications → `Keep` (defensive;
+    ///   callers shouldn't pass these but the function stays
+    ///   total).
+    let decideAltScreenAction
+            (currentPathwayId: string)
+            (notification: ScreenNotification)
+            : AltScreenAction
+            =
+        match notification with
+        | ModeChanged (TerminalModeFlag.AltScreen, true)
+            when currentPathwayId <> TuiPathway.id ->
+            SwapToTui
+        | ModeChanged (TerminalModeFlag.AltScreen, false)
+            when currentPathwayId = TuiPathway.id ->
+            SwapToShellDefault
+        | _ ->
+            Keep

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="DisplayPathway.fs" />
     <Compile Include="StreamPathway.fs" />
     <Compile Include="TuiPathway.fs" />
+    <Compile Include="PathwaySelector.fs" />
     <Compile Include="EarconChannel.fs" />
     <Compile Include="EarconProfile.fs" />
     <Compile Include="PassThroughProfile.fs" />

--- a/tests/Tests.Unit/PathwaySelectorTests.fs
+++ b/tests/Tests.Unit/PathwaySelectorTests.fs
@@ -1,0 +1,126 @@
+module PtySpeak.Tests.Unit.PathwaySelectorTests
+
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Phase B (subset) — PathwaySelector behavioural pinning
+// ---------------------------------------------------------------------
+//
+// PathwaySelector.decideAltScreenAction is a pure function over
+// (currentPathwayId, ScreenNotification) → AltScreenAction. The
+// PathwayPump consults it on every ModeChanged event to decide
+// whether to swap pathways. These tests pin the swap matrix +
+// the no-swap defaults.
+
+[<Fact>]
+let ``alt-screen entry from stream pathway returns SwapToTui`` () =
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (ModeChanged (TerminalModeFlag.AltScreen, true))
+    Assert.Equal(PathwaySelector.SwapToTui, action)
+
+[<Fact>]
+let ``alt-screen entry from tui pathway returns Keep`` () =
+    // Already on TuiPathway — no swap needed.
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "tui"
+            (ModeChanged (TerminalModeFlag.AltScreen, true))
+    Assert.Equal(PathwaySelector.Keep, action)
+
+[<Fact>]
+let ``alt-screen exit from tui pathway returns SwapToShellDefault`` () =
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "tui"
+            (ModeChanged (TerminalModeFlag.AltScreen, false))
+    Assert.Equal(PathwaySelector.SwapToShellDefault, action)
+
+[<Fact>]
+let ``alt-screen exit from stream pathway returns Keep`` () =
+    // Already on StreamPathway — no swap needed.
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (ModeChanged (TerminalModeFlag.AltScreen, false))
+    Assert.Equal(PathwaySelector.Keep, action)
+
+[<Fact>]
+let ``bracketed-paste toggle returns Keep regardless of pathway`` () =
+    // Non-alt-screen mode flips don't trigger pathway swaps.
+    let action1 =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (ModeChanged (TerminalModeFlag.BracketedPaste, true))
+    Assert.Equal(PathwaySelector.Keep, action1)
+    let action2 =
+        PathwaySelector.decideAltScreenAction
+            "tui"
+            (ModeChanged (TerminalModeFlag.BracketedPaste, false))
+    Assert.Equal(PathwaySelector.Keep, action2)
+
+[<Fact>]
+let ``focus-reporting toggle returns Keep regardless of pathway`` () =
+    let action1 =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (ModeChanged (TerminalModeFlag.FocusReporting, true))
+    Assert.Equal(PathwaySelector.Keep, action1)
+    let action2 =
+        PathwaySelector.decideAltScreenAction
+            "tui"
+            (ModeChanged (TerminalModeFlag.FocusReporting, false))
+    Assert.Equal(PathwaySelector.Keep, action2)
+
+[<Fact>]
+let ``RowsChanged notification returns Keep`` () =
+    // Defensive: PathwayPump only calls decideAltScreenAction
+    // for ModeChanged, but the function stays total.
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (RowsChanged [])
+    Assert.Equal(PathwaySelector.Keep, action)
+
+[<Fact>]
+let ``Bell notification returns Keep`` () =
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            ScreenNotification.Bell
+    Assert.Equal(PathwaySelector.Keep, action)
+
+[<Fact>]
+let ``ParserError notification returns Keep`` () =
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "stream"
+            (ParserError "boom")
+    Assert.Equal(PathwaySelector.Keep, action)
+
+[<Fact>]
+let ``unknown pathway id treats alt-screen entry as SwapToTui`` () =
+    // Any pathway other than "tui" gets swapped on alt-screen
+    // entry. A future ClaudeCodePathway with id = "claude-code"
+    // would currently swap to TuiPathway when entering alt-
+    // screen — until ClaudeCodePathway gains its own alt-
+    // screen-aware behaviour. Pinning this contract so the
+    // future change is visible at PR-review time.
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "claude-code"
+            (ModeChanged (TerminalModeFlag.AltScreen, true))
+    Assert.Equal(PathwaySelector.SwapToTui, action)
+
+[<Fact>]
+let ``unknown pathway id treats alt-screen exit as Keep`` () =
+    // Inverse of the above: a pathway not currently on TuiPathway
+    // doesn't need to swap "back" on alt-screen exit. (The user
+    // never went to TuiPathway in the first place.)
+    let action =
+        PathwaySelector.decideAltScreenAction
+            "claude-code"
+            (ModeChanged (TerminalModeFlag.AltScreen, false))
+    Assert.Equal(PathwaySelector.Keep, action)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="CanonicalStateTests.fs" />
     <Compile Include="StreamPathwayTests.fs" />
     <Compile Include="TuiPathwayTests.fs" />
+    <Compile Include="PathwaySelectorTests.fs" />
     <Compile Include="OutputEventTests.fs" />
     <Compile Include="NvdaChannelTests.fs" />
     <Compile Include="FileLoggerChannelTests.fs" />


### PR DESCRIPTION
## Summary

`TuiPathway` shipped in Phase A (#159) as wired-but-never-selected. The Phase A plan deferred auto-detection of pathway from screen state to "Phase B paired with TOML config" because mid-session pathway swap had unsettled state semantics. Phase A.1 (#160)'s `SetBaseline` primitive resolved the state-semantics concern, so alt-screen auto-detect is now independently shippable without waiting on the TOML config-file design.

**Behaviour.** When the active shell enters an alt-screen TUI (`vim`, `less`, `top`, full-screen `fzf`), the screen fires `ModeChanged(AltScreen, true)`; the `PathwayPump` swaps the active pathway to `TuiPathway` — no streaming output, review-cursor / browse-mode is the navigation primary. When the user quits the TUI, `ModeChanged(AltScreen, false)` swaps the pathway back to whatever the active shell's default is (`StreamPathway` for cmd / powershell / claude in v1).

Without this change the user's NVDA experience inside vim was constant streaming announcements as the editor repainted — unusable.

## Design decisions pinned

| Question | Decision |
|---|---|
| Where does the swap decision live? | New `Terminal.Core.PathwaySelector` pure decision module — `Keep` / `SwapToTui` / `SwapToShellDefault` from `(currentPathwayId, ScreenNotification)`. Stays free of `Terminal.Pty`'s `ShellRegistry` so the test surface doesn't pull the Pty assembly. |
| When does the swap fire? | Inside `PathwayPump.handleModeChanged`, AFTER the existing `OnModeBarrier` flush (so any pre-mode-change diff lands at NVDA before the swap) and BEFORE the existing barrier-OutputEvent dispatch (so the FileLogger captures the mode transition). |
| What happens to outgoing pathway state? | Same sequence as `switchToShell` hot-switch: `OnModeBarrier` flush → `Reset` → reassign → `SetBaseline` against the screen's current snapshot. The Phase A.1 primitive keeps the state-semantics identical between hot-switch and alt-screen-swap. |
| Where does the "default for this shell" come from? | New `currentShellId` mutable (initialised to `Cmd`, updated on startup-resolve + `switchToShell`'s `Ok newHost` branch). `SwapToShellDefault` resolves through `selectPathwayForShell currentShellId` so the alt-screen-exit lands on the active shell's default, not always on cmd's. |
| What about non-AltScreen mode toggles? | `Keep` — bracketed-paste / focus-reporting / cursor-visible toggles don't swap pathways. |
| Thread safety? | `currentShellId` is written from the UI thread (`switchToShell` via `Dispatcher.InvokeAsync`) and the PathwayPump worker thread (in `handleModeChanged`). `ShellId` is a small DU; F# mutable-DU writes on x64 are atomic via single-pointer rewrite. The race window is "swap decision sees stale shellId one frame after hot-switch" — outcome is "swap to old shell's default for one frame", recovered on next ModeChanged. Acceptable for v1; a future Phase B sub-stage may upgrade to `Volatile` reads. |

## Test plan

Unit tests (PathwaySelectorTests, 11 pins):
- [ ] Alt-screen entry from stream pathway → `SwapToTui`
- [ ] Alt-screen entry from tui pathway → `Keep` (already aligned)
- [ ] Alt-screen exit from tui pathway → `SwapToShellDefault`
- [ ] Alt-screen exit from stream pathway → `Keep` (already aligned)
- [ ] Bracketed-paste toggle → `Keep` (regardless of pathway)
- [ ] Focus-reporting toggle → `Keep` (regardless of pathway)
- [ ] RowsChanged / Bell / ParserError → `Keep` (defensive — function stays total)
- [ ] Future pathway id (`"claude-code"`) on alt-screen entry → `SwapToTui` (pin contract for review)
- [ ] Future pathway id on alt-screen exit → `Keep`

Manual NVDA validation row (deferred to maintainer; the PR doesn't gate on this):
- [ ] Boot pty-speak in cmd, run `vim test.txt` (or `less test.txt` if vim isn't installed). Verify NVDA stops streaming announcements as soon as vim takes over the screen — review-cursor navigation is the primary
- [ ] Quit vim. Verify NVDA resumes streaming output for cmd's prompt
- [ ] Switch to PowerShell (`Ctrl+Shift+2`), run an alt-screen TUI; verify same behaviour
- [ ] Hot-switch to a different shell while still inside vim (`Ctrl+Shift+1` from inside vim). Edge case — verify no diff state leaks; the post-quit experience should still match

**Out of scope (carried forward).** TOML-driven per-shell pathway selection (separate Phase B follow-up — substrate is ready, just needs a config-file design cycle); OSC 133 → ReplPathway auto-detect (no ReplPathway exists yet; Phase 2).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_