### PR TITLE
Phase B subset — TOML config for pathway selection + parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,140 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Phase B subset — TOML config for pathway selection + parameters)
+
+Closes the Phase B "TOML config" item the Phase A plan deferred
+(`/root/.claude/plans/hello-i-lost-my-velvet-deer.md` decision
+#5: "Per-shell pathway selection in v1 — Hardcoded mapping in
+Program.fs"). With C2 landed, users can override pathway
+selection and pathway parameters via a TOML file at
+`%LOCALAPPDATA%\PtySpeak\config.toml` without rebuilding
+pty-speak.
+
+Closes the loop on the maintainer's guiding principle for
+display configurability:
+
+> The interpreter pathway should be transparent and user
+> configurable and customizable with sensible defaults.
+
+C2 ships the *substrate* that realises this principle for
+pathway selection + pathway parameters. Future stages build on
+the substrate: per-content-type triggers (regex / colour /
+semantic-parser / LLM) are Phase 2/3 territory and need actual
+pathways that consume the triggers; runtime "adjust on the fly,
+save as template" workflows are Phase 2/3 UI work that this
+substrate enables.
+
+**Schema (v1).** `schema_version = 1` is required. Two table
+families:
+
+```toml
+schema_version = 1
+
+[shell.cmd]
+pathway = "stream"
+
+[shell.powershell]
+pathway = "stream"
+
+[shell.claude]
+pathway = "stream"
+
+[pathway.stream]
+debounce_window_ms = 200
+spinner_window_ms = 1000
+spinner_threshold = 5
+max_announce_chars = 500
+
+[pathway.tui]
+# reserved; no parameters today
+```
+
+`[shell.<id>]` keys mirror the lowercase IDs `parseEnvVar`
+recognises (`cmd`, `claude`, `powershell`). `pathway` values
+are pathway IDs (`"stream"`, `"tui"`; future Phase 2 IDs added
+without schema migration). `[pathway.<id>]` tables hold
+per-pathway parameter overrides; v1 ships `[pathway.stream]`
+with the four StreamPathway tunables.
+
+**Forward-compat with input-bindings.** Spec
+`event-and-output-framework.md` A.5 sketches a future schema
+for hotkey overrides (`[[bindings]]` / `[[handlers]]` arrays
+at top level). C2's loader silently ignores those sections —
+the same `config.toml` will accumulate sections cumulatively
+across Phase B sub-stages without conflict.
+
+**Defaults preserved exactly.** `Config.defaultConfig` matches
+`StreamPathway.defaultParameters` field-for-field; absence of
+the file (or any key within it) is byte-equivalent to pre-C2
+behaviour. Tests pin this equivalence.
+
+**Error handling — never crashes, never opens a dialog.**
+The maintainer is a screen-reader user; every error path logs
+via `ILogger` (routed to FileLogger, readable via
+`Ctrl+Shift+;`) and falls back to defaults:
+
+- Missing file → Information log; defaults
+- Malformed TOML → Error log (with parse detail); defaults
+- Schema version newer than supported → Error log; defaults
+- Unknown pathway name (e.g. `"stram"`) → Warning; that shell
+  falls to default
+- Unknown parameter key → Warning ("ignored"); drop value
+- Negative or zero parameter → Warning ("clamped to default");
+  use default for that field
+
+A single `Information` line on startup summarises the resolved
+config (e.g. `Config loaded: cmd→stream, claude→stream,
+powershell→stream; stream debounce=200ms`).
+
+**TOML library.** Tomlyn 0.18.0 (xoofx, BSD 2-Clause). Spec
+already named it (`tech-plan.md:997`,
+`event-and-output-framework.md:501`); this is its first
+appearance.
+
+Files:
+- `Directory.Packages.props` — Tomlyn 0.18.0 PackageVersion
+  added.
+- `src/Terminal.Core/Terminal.Core.fsproj` — Tomlyn
+  PackageReference + `Config.fs` Compile entry.
+- `src/Terminal.Core/Config.fs` — new module with `Config`
+  record, `defaultConfig`, `tryLoad`, `resolveShellPathway`,
+  `resolveStreamParameters`, `defaultConfigFilePath`.
+- `src/Terminal.App/Program.fs` — `Config.tryLoad` invoked at
+  composition root; `selectPathwayForShell` rewritten as a
+  closure capturing the loaded config (collapses three
+  identical hardcoded match arms into one config-consulting
+  body).
+- `tests/Tests.Unit/ConfigTests.fs` — new file pinning the
+  loader behaviour (15 tests covering parse OK / malformed /
+  defaults / overrides / unknown keys / schema versioning /
+  coexistence with future `[[bindings]]` sections).
+- `tests/Tests.Unit/Tests.Unit.fsproj` — `ConfigTests.fs`
+  Compile entry.
+- `docs/USER-SETTINGS.md` — intro updated to note C2 ships
+  the TOML substrate; new "Pathway selection" section with
+  schema, defaults table, error semantics, out-of-scope
+  list. "Process for adding a new setting" updated to tick
+  off "substrate is shipped".
+
+**Out of scope** (explicit, for reviewer + future-self
+clarity):
+
+- Hot-reload — changes require a restart.
+- Runtime config write-back from a hotkey or palette ("save
+  current settings as my config" workflow). Phase 2/3.
+- Kill-switch substrate (`Ctrl+Shift+K` + `extensibility.killSwitch`
+  per spec A.6). Phase B input-bindings owns this.
+- Per-content-type triggers (regex / colour / semantic-parser
+  / LLM dispatchers). Phase 2/3 — needs actual semantic /
+  AI-interpretation pathways that consume the triggers.
+- ClaudeCodePathway / ReplPathway / FormPathway selection —
+  those pathways don't exist yet (Phase 2).
+- Schema additions for input-binding overrides
+  (`[[bindings]]`). Separate Phase B sub-stage; coexists
+  cleanly with the current schema.
+- Config validator binary or CLI.
+
 ### Added (Phase B subset — alt-screen → TuiPathway auto-detect)
 
 `TuiPathway` shipped in Phase A as a wired-but-never-selected

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,14 @@
       assume present on any user machine running pty-speak.
     -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <!--
+      Phase B — TOML config substrate. Tomlyn (xoofx, BSD 2-Clause)
+      parses `%LOCALAPPDATA%\PtySpeak\config.toml` for per-shell
+      pathway selection + per-pathway parameter overrides. Spec
+      A.5 (event-and-output-framework.md:501) names Tomlyn as
+      the chosen library; this is its first appearance.
+    -->
+    <PackageVersion Include="Tomlyn" Version="0.18.0" />
 
     <!-- Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -16,21 +16,39 @@ section so the catalog stays current as the project grows.
 
 ## Current state of configuration
 
-`pty-speak` does **not yet have** a configuration surface
-beyond compile-time constants. The infrastructure for
-user-configurable settings is reserved as a Phase 2 stage in
-[`spec/tech-plan.md`](../spec/tech-plan.md) (TOML config via
-[Tomlyn](https://github.com/xoofx/Tomlyn) — referenced at the
-end of the plan's reference code map). Until that lands, every
-setting in this document is a "candidate" — known and tracked,
-not yet exposed.
+`pty-speak` ships a **minimal TOML config substrate** introduced
+in the Phase B "C2" sub-stage. The config file lives at
+`%LOCALAPPDATA%\PtySpeak\config.toml` (alongside the rolling
+log directory) and is parsed via
+[Tomlyn](https://github.com/xoofx/Tomlyn). v1 of the schema
+exposes:
 
-Why no config yet: the project ships through Stage 4 + 11 with
-flat hardcoded defaults. Adding a config substrate before we
-know which settings users actually want to change would build a
-half-finished setting system around the wrong choices. Tracking
-the candidates here lets the choices accumulate without paying
-the substrate cost prematurely.
+- **Per-shell pathway override** — which display pathway runs
+  for `cmd` / `claude` / `powershell` (see "Pathway selection"
+  below).
+- **Per-pathway parameter override** — debounce window,
+  spinner-window, spinner threshold, and max-announce-chars for
+  `StreamPathway`.
+
+Everything else in this catalog remains a "candidate" — known
+and tracked, not yet exposed. The Phase B sub-stages will keep
+adding to the schema (`[[bindings]]` / `[[handlers]]` for
+input-binding overrides per `spec/event-and-output-framework.md`
+A.5; per-content-type triggers for Phase 2/3 semantic +
+AI-interpretation pathways).
+
+Sensible-defaults principle: the absence of `config.toml` (or
+any TOML key within it) is **byte-equivalent** to the
+hardcoded behaviour. A user can delete the file at any time
+to revert to defaults; this catalog continues to document the
+defaults so deviations are intentional.
+
+Why incremental: adding the full configuration surface for
+every candidate setting before validating which ones users
+actually want to change would build a half-finished system
+around the wrong choices. C2 ships only the substrate the
+display-pathway architecture needs today; later sub-stages
+extend the schema as user-facing demand accumulates.
 
 ## How this document is organised
 
@@ -357,6 +375,106 @@ Three plausible levels of configurability, increasing in cost:
 - Persistence: `PTYSPEAK_SHELL` is per-process; the user sets it in
   their shell environment or via a launcher wrapper. Future TOML
   config persists across launches.
+
+## Pathway selection (shipped — Phase B subset, C2)
+
+The display-pathway substrate (Phase A, PR #159) introduced the
+abstraction "for each shell, which pathway translates canonical
+screen state into NVDA-bound events". The substrate ships
+`StreamPathway` (per-frame diff) and `TuiPathway` (alt-screen-
+aware suppression). C2 makes the choice config-driven so users
+can override the hardcoded mapping without rebuilding pty-speak.
+
+### Current state
+
+- Config file: `%LOCALAPPDATA%\PtySpeak\config.toml` (optional;
+  absent → hardcoded defaults).
+- Schema:
+
+  ```toml
+  schema_version = 1
+
+  [shell.cmd]
+  pathway = "stream"
+
+  [shell.powershell]
+  pathway = "stream"
+
+  [shell.claude]
+  pathway = "stream"
+
+  [pathway.stream]
+  debounce_window_ms = 200
+  spinner_window_ms = 1000
+  spinner_threshold = 5
+  max_announce_chars = 500
+
+  [pathway.tui]
+  # reserved; no parameters today
+  ```
+
+- Defaults table:
+
+  | Setting | Default | What it controls |
+  |---|---|---|
+  | `[shell.cmd] pathway` | `"stream"` | Pathway used by `cmd.exe` |
+  | `[shell.powershell] pathway` | `"stream"` | Pathway used by `powershell.exe` (and `pwsh.exe` alias) |
+  | `[shell.claude] pathway` | `"stream"` | Pathway used by `claude.exe` |
+  | `[pathway.stream] debounce_window_ms` | `200` | Trailing-edge flush window for diff accumulation |
+  | `[pathway.stream] spinner_window_ms` | `1000` | History window for spinner-suppress detection |
+  | `[pathway.stream] spinner_threshold` | `5` | Row/content-hash change count to trigger suppression |
+  | `[pathway.stream] max_announce_chars` | `500` | Text truncation cap for NVDA announcements |
+
+- Available pathway IDs: `"stream"`, `"tui"`. Future Phase 2
+  IDs (`"claude-code"`, `"repl"`, `"form"`) will be added
+  without schema migration.
+- Loader: `src/Terminal.Core/Config.fs` parses + resolves;
+  `src/Terminal.App/Program.fs`'s `selectPathwayForShell`
+  consults the loaded `Config` for both pathway selection and
+  parameter overrides on startup, hot-switch
+  (`Ctrl+Shift+1/2/3`), and alt-screen exit.
+
+### Error semantics
+
+The loader **never** crashes pty-speak. Every failure mode logs
+via `ILogger` (which routes to FileLogger; readable via
+`Ctrl+Shift+;`) and falls back to defaults. The maintainer is a
+screen-reader user; GUI dialogs are explicitly out of scope.
+
+| Condition | Log level | Effect |
+|---|---|---|
+| File does not exist | Information | Use all defaults |
+| Malformed TOML | Error (with parse detail) | Use all defaults |
+| `schema_version` missing | Warning | Treat as 1 |
+| `schema_version` newer than supported | Error | Use all defaults |
+| `schema_version` older | Warning | Best-effort parse |
+| Unknown `[shell.<key>]` | Warning | Skip that section |
+| Unknown pathway name (e.g. `"stram"`) | Warning | That shell falls to default |
+| Unknown parameter key | Warning | Drop the value |
+| Negative or zero parameter value | Warning ("clamped to default") | Use default for that field |
+
+A single `Information` line on startup summarises the resolved
+config (e.g. `"Config loaded: cmd→stream, claude→stream,
+powershell→stream; stream debounce=200ms"`) so post-hoc
+diagnosis via log capture is trivial.
+
+### Out of scope (deferred to later sub-stages)
+
+- Hot-reload — changes require a restart.
+- Runtime config write-back from a hotkey or palette
+  ("save current settings as my config"). Phase 2/3.
+- Kill-switch substrate (per spec A.6). Phase B input-bindings
+  owns this.
+- Per-content-type triggers (regex / colour / semantic-parser /
+  LLM dispatchers). Phase 2/3 territory; needs actual pathways
+  that consume the triggers.
+- ClaudeCodePathway / ReplPathway / FormPathway selection —
+  those pathways don't exist yet (Phase 2).
+- Schema additions for input-binding overrides
+  (`[[bindings]]`). Separate Phase B sub-stage; coexists
+  cleanly with the current schema (the loader silently
+  ignores those sections).
+- Config validator binary or CLI.
 
 ## Keybindings
 
@@ -722,9 +840,12 @@ When the project moves from "hardcoded" to "user-configurable"
 for a given setting, the following pattern keeps the change
 focused:
 
-1. **Land the substrate first.** Phase 2 introduces TOML
-   config via Tomlyn. Don't add a one-off settings file
-   ahead of that — it'll need to be migrated.
+1. **Substrate is shipped (Phase B C2).** TOML config via
+   Tomlyn lives at `%LOCALAPPDATA%\PtySpeak\config.toml` with
+   a versioned schema (`schema_version = 1`). New settings
+   extend the schema in a backwards-compat way; settings that
+   need a new section (e.g. `[[bindings]]` for input-binding
+   overrides) inherit the same loader.
 2. **Per-setting PR.** Each setting becomes its own PR rather
    than a "add 12 settings" mega-PR. Easier to review,
    easier to revert if the chosen default doesn't survive
@@ -732,10 +853,16 @@ focused:
 3. **Default = current behaviour.** The first version of any
    setting MUST default to whatever the code does today. No
    silent behaviour change for users who don't set the
-   value.
-4. **Validate the input.** Bad config files should produce a
-   clear error announcement at startup, not a silent revert
-   to defaults — silent reverts hide misspelled keys.
+   value. The C2 `Config.defaultConfig` is the authoritative
+   source of truth; new fields default to `None` and the
+   resolver merges with the existing hardcoded baseline.
+4. **Validate the input.** Bad config files should log clearly
+   via `ILogger` (which routes to FileLogger; readable via
+   `Ctrl+Shift+;`) and fall back to defaults — never crash.
+   The maintainer is a screen-reader user; GUI dialogs are
+   off limits. Mis-typed keys log a Warning and continue;
+   structurally-broken TOML logs an Error and uses defaults
+   wholesale.
 5. **Document in this file.** The candidate section here gets
    moved to a "Shipped settings" section (or a separate
    `docs/SETTINGS-REFERENCE.md` once the catalog grows large

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1013,40 +1013,61 @@ module Program =
         OutputDispatcher.ProfileRegistry.setActiveProfileSet
             [ passThroughProfile; earconProfile ]
 
-        // Phase A — per-shell pathway selection. v1 hardcoded
-        // mapping; Phase B replaces with TOML config. The
-        // pathway is recreated on every shell switch so its
-        // internal state is fresh — even StreamPathway → cmd
-        // → StreamPathway → PowerShell discards the cmd-session
-        // baseline so PowerShell's first paint emits in full.
+        // Phase B (subset, "C2") — load the user's TOML config
+        // once at startup. `Config.tryLoad` never throws; on
+        // any failure mode (file absent, malformed TOML, schema
+        // mismatch, unknown keys) it logs via `log` and falls
+        // back to defaults, so absence-of-config is byte-
+        // equivalent to pre-C2 behaviour. The loaded `config`
+        // is captured by `selectPathwayForShell`'s closure +
+        // consulted on every pathway construction (startup,
+        // Ctrl+Shift+1/2/3 hot-switch, alt-screen swap).
+        let config =
+            Config.tryLoad log (Config.defaultConfigFilePath ())
+
+        // Phase B (subset, "C2") — per-shell pathway selection.
+        // Reads the loaded `config` for both pathway choice and
+        // pathway parameters. Three v1 built-in shells (cmd /
+        // powershell / claude) all default to "stream"; users
+        // override per-shell via `[shell.<id>] pathway = "..."`
+        // and per-pathway parameters via `[pathway.stream]`.
+        // Unknown pathway names log a Warning and fall back to
+        // StreamPathway with resolved parameters (so the user
+        // still gets per-pathway parameter benefits even when
+        // the name is misspelled).
+        let shellIdToConfigKey (shellId: ShellRegistry.ShellId) : string =
+            match shellId with
+            | ShellRegistry.Cmd -> "cmd"
+            | ShellRegistry.PowerShell -> "powershell"
+            | ShellRegistry.Claude -> "claude"
         let selectPathwayForShell
                 (shellId: ShellRegistry.ShellId)
                 : DisplayPathway.T =
-            match shellId with
-            | ShellRegistry.Cmd ->
-                StreamPathway.create StreamPathway.defaultParameters
-            | ShellRegistry.PowerShell ->
-                StreamPathway.create StreamPathway.defaultParameters
-            | ShellRegistry.Claude ->
-                // Phase 2 will swap Claude to a ClaudeCodePathway
-                // that interprets the alt-screen UI. Phase A
-                // ships the streaming pathway so the verbose-
-                // readback regression is fixed for all three
-                // built-in shells.
-                StreamPathway.create StreamPathway.defaultParameters
+            let shellKey = shellIdToConfigKey shellId
+            let pathwayId = Config.resolveShellPathway config shellKey
+            let streamParams = Config.resolveStreamParameters config
+            match pathwayId with
+            | "stream" -> StreamPathway.create streamParams
+            | "tui" -> TuiPathway.create ()
+            | unknown ->
+                log.LogWarning(
+                    "Config: unknown pathway '{Pathway}' for shell {Shell}; falling back to stream.",
+                    unknown, shellKey)
+                StreamPathway.create streamParams
 
-        // Initial pathway — StreamPathway covers all three v1
-        // built-in shells (cmd / powershell / claude). The
-        // mutable is reassigned by `switchToShell` below when
-        // the user hot-switches; for the startup shell, the
-        // initial value matches whatever shell `chosenShell`
-        // resolves to (all three map to StreamPathway today).
-        // When a future Phase 2 maps a shell to a different
-        // pathway (e.g. ClaudeCodePathway), the startup-resolve
-        // path will need to reselect after `chosenShell` is
-        // determined.
+        // Initial pathway — StreamPathway with the resolved
+        // parameters from `config` (or defaults if no config
+        // is present). The mutable is reassigned by
+        // `switchToShell` below when the user hot-switches
+        // and by the startup-shell alignment block once
+        // `chosenShell` resolves; for the brief window
+        // between this initialisation and the alignment
+        // swap, no ScreenNotifications can arrive (the
+        // ConPty isn't spawned yet) so the StreamPathway
+        // placeholder is safe regardless of `config`'s
+        // shell-pathway override.
         let mutable activePathway : DisplayPathway.T =
-            StreamPathway.create StreamPathway.defaultParameters
+            StreamPathway.create (Config.resolveStreamParameters config)
 
         // Phase B (subset) — alt-screen → TuiPathway auto-detect
         // bookkeeping. The PathwayPump's `handleModeChanged`

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -132,43 +132,32 @@ module Config =
     /// Internal — try to read an `int64` value from a
     /// TomlTable by key. Returns `None` if absent or
     /// non-integer. Tomlyn boxes integers as `int64` (TOML's
-    /// only integer width), so we cast to `int64` and
+    /// only integer width), so we match `:? int64` and
     /// downcast to `int` at the consumer site (parameter
-    /// values fit comfortably in 32 bits).
+    /// values fit comfortably in 32 bits). Uses F#'s
+    /// tuple-deconstruction syntax for `out` parameters so
+    /// the F# 9 nullness checker doesn't fire on a
+    /// `byref<obj | null>` mismatch with Tomlyn's
+    /// `out object` parameter signature.
     let private tryGetInt (table: TomlTable) (key: string) : int64 option =
-        let mutable value : obj | null = null
-        if table.TryGetValue(key, &value) then
-            match value with
-            | null -> None
-            | :? int64 as i -> Some i
-            | _ -> None
-        else
-            None
+        match table.TryGetValue(key) with
+        | true, (:? int64 as i) -> Some i
+        | _ -> None
 
     /// Internal — try to read a `string` value from a
     /// TomlTable by key. Returns `None` if absent or
     /// non-string.
     let private tryGetString (table: TomlTable) (key: string) : string option =
-        let mutable value : obj | null = null
-        if table.TryGetValue(key, &value) then
-            match value with
-            | null -> None
-            | :? string as s -> Some s
-            | _ -> None
-        else
-            None
+        match table.TryGetValue(key) with
+        | true, (:? string as s) -> Some s
+        | _ -> None
 
     /// Internal — try to read a sub-table by key. Returns
     /// `None` if absent or non-table.
     let private tryGetTable (table: TomlTable) (key: string) : TomlTable option =
-        let mutable value : obj | null = null
-        if table.TryGetValue(key, &value) then
-            match value with
-            | null -> None
-            | :? TomlTable as t -> Some t
-            | _ -> None
-        else
-            None
+        match table.TryGetValue(key) with
+        | true, (:? TomlTable as t) -> Some t
+        | _ -> None
 
     /// Internal — known parameter keys for `[pathway.stream]`.
     /// Used to detect typos and log Warnings for unknown keys.
@@ -235,8 +224,12 @@ module Config =
         let readField (key: string) : int option =
             match tryGetInt table key with
             | None ->
-                let mutable value : obj | null = null
-                if table.TryGetValue(key, &value) then
+                // `tryGetInt` returns None both for "key absent"
+                // and "key present but non-int". Distinguish via
+                // `ContainsKey` so the user gets a typo Warning
+                // for the latter (a silently-dropped non-int
+                // value would hide schema mistakes).
+                if table.ContainsKey(key) then
                     logger.LogWarning(
                         "Config: [pathway.stream] {Key} is non-integer; ignored.",
                         key)
@@ -298,8 +291,7 @@ module Config =
         | None ->
             // Distinguish "key absent" from "key present but
             // non-integer" so the user can spot type errors.
-            let mutable value : obj | null = null
-            if root.TryGetValue("schema_version", &value) then
+            if root.ContainsKey("schema_version") then
                 logger.LogWarning(
                     "Config: schema_version is non-integer; treating as {Default}.",
                     CurrentSchemaVersion)

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -1,0 +1,434 @@
+namespace Terminal.Core
+
+open System
+open System.IO
+open Microsoft.Extensions.Logging
+open Tomlyn
+open Tomlyn.Model
+
+/// Phase B (subset, "C2") — minimal TOML config substrate for
+/// pathway selection + per-pathway parameter overrides.
+///
+/// **What this module owns.** Loading, parsing, and resolving
+/// the user's `%LOCALAPPDATA%\PtySpeak\config.toml` file. The
+/// loader is loud-via-log but never crashes: every error mode
+/// (missing file, malformed TOML, unknown keys, schema-version
+/// mismatch, out-of-range values) falls back to the hardcoded
+/// defaults that match `StreamPathway.defaultParameters`
+/// field-for-field. Absence of a config file is byte-equivalent
+/// to pre-C2 behaviour. The maintainer is a screen-reader user;
+/// every error path goes through `ILogger`, never through a GUI
+/// dialog.
+///
+/// **What this module does NOT own.** The pathway-name →
+/// constructor map (lives in `Program.fs`'s composition root —
+/// it's where `StreamPathway` and `TuiPathway` get wired with
+/// the resolved parameters). Hot-reload (changes require a
+/// restart). Runtime config write-back (Phase 2/3 UI work).
+/// The kill-switch substrate (Phase B input-bindings owns
+/// that). Per-content-type triggers (Phase 2/3 — needs actual
+/// pathways that consume them).
+///
+/// **Schema (v1).** See `docs/USER-SETTINGS.md` "Pathway
+/// selection" for the user-facing reference. Two table
+/// families:
+/// - `[shell.<id>]` — per-shell pathway override (`pathway`
+///   key is a pathway ID string).
+/// - `[pathway.<id>]` — per-pathway parameter overrides
+///   (`debounce_window_ms`, `spinner_window_ms`,
+///   `spinner_threshold`, `max_announce_chars` for `stream`
+///   today; reserved-but-empty for `tui`).
+///
+/// **Forward-compat.** Spec
+/// `event-and-output-framework.md` A.5 sketches a future schema
+/// for input-binding overrides (`[[bindings]]` /
+/// `[[handlers]]` arrays at top level). The C2 loader silently
+/// ignores those sections so a single `config.toml` can grow
+/// cumulatively across Phase B sub-stages without
+/// modification.
+///
+/// **Library.** Tomlyn 0.18 (xoofx, BSD 2-Clause). Uses the
+/// non-throwing `Toml.Parse` entry point (returns a
+/// `DocumentSyntax` carrying errors as data) rather than
+/// `Toml.ToModel(string)` (throws `TomlException` on parse
+/// failure). The two-step `Parse → check HasErrors → ToModel`
+/// keeps the loader exception-free for the "file is malformed"
+/// path.
+module Config =
+
+    /// The schema version this build supports. A `config.toml`
+    /// with `schema_version = N` for `N > CurrentSchemaVersion`
+    /// is rejected with an Error log + fallback to defaults
+    /// (per spec A.5: "the TOML schema includes an explicit
+    /// version field so older pty-speak versions can refuse to
+    /// parse a TOML written for a future schema"). A missing
+    /// `schema_version` key is treated as 1 with a Warning;
+    /// older values are best-effort-parsed with a Warning.
+    [<Literal>]
+    let CurrentSchemaVersion: int = 1
+
+    /// Per-shell pathway override. Captures the pathway ID
+    /// string (`"stream"`, `"tui"`, future `"claude-code"`,
+    /// etc.) the user wants for a given shell key. The
+    /// pathway-name → constructor map lives in
+    /// `Program.fs`'s composition root, not here — Config
+    /// stays free of `StreamPathway` / `TuiPathway` direct
+    /// references on the SHELL side so adding a new pathway in
+    /// Phase 2 doesn't require a Config-module change.
+    type ShellPathwayConfig = { PathwayId: string }
+
+    /// Optional overrides for `StreamPathway.Parameters`. Each
+    /// field is `int option` so the resolver can merge with
+    /// `StreamPathway.defaultParameters` field-by-field — a
+    /// user who overrides only `debounce_window_ms` keeps the
+    /// other three at their hardcoded defaults.
+    type StreamParameterOverrides =
+        { DebounceWindowMs: int option
+          SpinnerWindowMs: int option
+          SpinnerThreshold: int option
+          MaxAnnounceChars: int option }
+
+    /// The top-level config record. `ShellOverrides` is keyed
+    /// by lowercase shell-id strings (`"cmd"`, `"claude"`,
+    /// `"powershell"` — mirrors `ShellRegistry.parseEnvVar`'s
+    /// lowercase recognition). Using `string` rather than
+    /// `ShellRegistry.ShellId` keeps Terminal.Core free of a
+    /// `Terminal.Pty` dependency.
+    type Config =
+        { SchemaVersion: int
+          ShellOverrides: Map<string, ShellPathwayConfig>
+          StreamOverrides: StreamParameterOverrides }
+
+    /// The all-defaults Config — equivalent to "no config file
+    /// present". `defaultConfig` is the authoritative source
+    /// of truth for the byte-equivalence test in
+    /// `ConfigTests.fs`; if `StreamPathway.defaultParameters`
+    /// changes, this module's resolver picks up the new
+    /// defaults automatically (no constants are duplicated).
+    let defaultConfig: Config =
+        { SchemaVersion = CurrentSchemaVersion
+          ShellOverrides = Map.empty
+          StreamOverrides =
+            { DebounceWindowMs = None
+              SpinnerWindowMs = None
+              SpinnerThreshold = None
+              MaxAnnounceChars = None } }
+
+    /// The default config file path —
+    /// `%LOCALAPPDATA%\PtySpeak\config.toml`. Mirrors the
+    /// FileLogger convention (`%LOCALAPPDATA%\PtySpeak\logs\`).
+    /// Falls back to `Path.GetTempPath()` if `LOCALAPPDATA` is
+    /// unset — same defensive pattern FileLogger uses.
+    let defaultConfigFilePath () : string =
+        let envValue =
+            Environment.GetEnvironmentVariable("LOCALAPPDATA")
+        let baseDir =
+            match envValue with
+            | null -> Path.GetTempPath()
+            | "" -> Path.GetTempPath()
+            | v -> v
+        Path.Combine(baseDir, "PtySpeak", "config.toml")
+
+    /// Internal — try to read an `int64` value from a
+    /// TomlTable by key. Returns `None` if absent or
+    /// non-integer. Tomlyn boxes integers as `int64` (TOML's
+    /// only integer width), so we cast to `int64` and
+    /// downcast to `int` at the consumer site (parameter
+    /// values fit comfortably in 32 bits).
+    let private tryGetInt (table: TomlTable) (key: string) : int64 option =
+        let mutable value : obj | null = null
+        if table.TryGetValue(key, &value) then
+            match value with
+            | null -> None
+            | :? int64 as i -> Some i
+            | _ -> None
+        else
+            None
+
+    /// Internal — try to read a `string` value from a
+    /// TomlTable by key. Returns `None` if absent or
+    /// non-string.
+    let private tryGetString (table: TomlTable) (key: string) : string option =
+        let mutable value : obj | null = null
+        if table.TryGetValue(key, &value) then
+            match value with
+            | null -> None
+            | :? string as s -> Some s
+            | _ -> None
+        else
+            None
+
+    /// Internal — try to read a sub-table by key. Returns
+    /// `None` if absent or non-table.
+    let private tryGetTable (table: TomlTable) (key: string) : TomlTable option =
+        let mutable value : obj | null = null
+        if table.TryGetValue(key, &value) then
+            match value with
+            | null -> None
+            | :? TomlTable as t -> Some t
+            | _ -> None
+        else
+            None
+
+    /// Internal — known parameter keys for `[pathway.stream]`.
+    /// Used to detect typos and log Warnings for unknown keys.
+    let private knownStreamKeys : Set<string> =
+        Set.ofList
+            [ "debounce_window_ms"
+              "spinner_window_ms"
+              "spinner_threshold"
+              "max_announce_chars" ]
+
+    /// Internal — known shell-id keys for `[shell.<id>]`.
+    /// Mirrors `ShellRegistry.parseEnvVar`'s lowercase
+    /// recognition; unknown shells log a Warning and are
+    /// ignored (don't crash on a future Wsl/Bash addition that
+    /// hasn't shipped yet).
+    let private knownShellKeys : Set<string> =
+        Set.ofList [ "cmd"; "claude"; "powershell" ]
+
+    /// Internal — parse a positive int parameter override.
+    /// Returns `None` (with Warning log) for negative or zero
+    /// values; the resolver then falls back to the default for
+    /// that field. Negative debounce makes no sense; the user
+    /// is more likely to have a typo than an intentional
+    /// override, and a clamped fallback is safer than letting
+    /// `TimeSpan.FromMilliseconds(-50.0)` propagate into the
+    /// pathway's debounce arithmetic.
+    let private parsePositiveInt
+            (logger: ILogger)
+            (section: string)
+            (key: string)
+            (raw: int64)
+            : int option
+            =
+        if raw <= 0L then
+            logger.LogWarning(
+                "Config: {Section}.{Key} = {Value} is non-positive; clamping to default.",
+                section, key, raw)
+            None
+        elif raw > int64 Int32.MaxValue then
+            logger.LogWarning(
+                "Config: {Section}.{Key} = {Value} exceeds Int32.MaxValue; clamping to default.",
+                section, key, raw)
+            None
+        else
+            Some (int raw)
+
+    /// Internal — parse the `[pathway.stream]` table into
+    /// `StreamParameterOverrides`. Unknown keys produce a
+    /// Warning + are dropped; non-int values produce a
+    /// Warning + fall back to default for that field. Returns
+    /// the override record (each field `Some` if user-set
+    /// + valid, `None` otherwise).
+    let private parseStreamOverrides
+            (logger: ILogger)
+            (table: TomlTable)
+            : StreamParameterOverrides
+            =
+        // Walk the user-supplied keys to surface typos.
+        for key in table.Keys do
+            if not (knownStreamKeys.Contains(key)) then
+                logger.LogWarning(
+                    "Config: [pathway.stream] unknown key '{Key}'; ignored.",
+                    key)
+        let readField (key: string) : int option =
+            match tryGetInt table key with
+            | None ->
+                let mutable value : obj | null = null
+                if table.TryGetValue(key, &value) then
+                    logger.LogWarning(
+                        "Config: [pathway.stream] {Key} is non-integer; ignored.",
+                        key)
+                None
+            | Some raw -> parsePositiveInt logger "[pathway.stream]" key raw
+        { DebounceWindowMs = readField "debounce_window_ms"
+          SpinnerWindowMs = readField "spinner_window_ms"
+          SpinnerThreshold = readField "spinner_threshold"
+          MaxAnnounceChars = readField "max_announce_chars" }
+
+    /// Internal — parse the `[shell.X]` family into
+    /// `Map<string, ShellPathwayConfig>`. Unknown shell keys
+    /// produce a Warning + are dropped. Each shell table must
+    /// contain a `pathway` string key; shells without one are
+    /// skipped (no override).
+    let private parseShellOverrides
+            (logger: ILogger)
+            (root: TomlTable)
+            : Map<string, ShellPathwayConfig>
+            =
+        match tryGetTable root "shell" with
+        | None -> Map.empty
+        | Some shellRoot ->
+            let mutable result = Map.empty
+            for key in shellRoot.Keys do
+                if not (knownShellKeys.Contains(key)) then
+                    logger.LogWarning(
+                        "Config: [shell.{Key}] unknown shell id; ignored.",
+                        key)
+                else
+                    match tryGetTable shellRoot key with
+                    | None ->
+                        logger.LogWarning(
+                            "Config: [shell.{Key}] is not a table; ignored.",
+                            key)
+                    | Some shellTable ->
+                        match tryGetString shellTable "pathway" with
+                        | None -> ()
+                        | Some pathwayId ->
+                            result <-
+                                result
+                                |> Map.add key { PathwayId = pathwayId }
+            result
+
+    /// Internal — parse the schema_version field. Missing → 1
+    /// with Warning. Newer than CurrentSchemaVersion → Error +
+    /// raises so the caller can fall back to defaults. Older
+    /// → best-effort with Warning.
+    ///
+    /// Returns the parsed version. The caller (`tryLoad`)
+    /// handles the "newer than supported" case by checking
+    /// the returned version and short-circuiting to defaults.
+    let private parseSchemaVersion
+            (logger: ILogger)
+            (root: TomlTable)
+            : int
+            =
+        match tryGetInt root "schema_version" with
+        | None ->
+            // Distinguish "key absent" from "key present but
+            // non-integer" so the user can spot type errors.
+            let mutable value : obj | null = null
+            if root.TryGetValue("schema_version", &value) then
+                logger.LogWarning(
+                    "Config: schema_version is non-integer; treating as {Default}.",
+                    CurrentSchemaVersion)
+            else
+                logger.LogWarning(
+                    "Config: schema_version missing; treating as {Default}.",
+                    CurrentSchemaVersion)
+            CurrentSchemaVersion
+        | Some raw ->
+            let v = int raw
+            if v > CurrentSchemaVersion then
+                // Caller short-circuits to defaults on this branch.
+                v
+            elif v < CurrentSchemaVersion then
+                logger.LogWarning(
+                    "Config: schema_version {Version} is older than supported {Current}; best-effort parse.",
+                    v, CurrentSchemaVersion)
+                v
+            else
+                v
+
+    /// Try to load + parse the config file at `filePath`.
+    /// Always returns a `Config`; never throws. All error modes
+    /// log via `logger` and fall back to defaults:
+    ///
+    /// | Condition | Log level | Outcome |
+    /// |---|---|---|
+    /// | File does not exist | Information | `defaultConfig` |
+    /// | Malformed TOML | Error (with parse detail) | `defaultConfig` |
+    /// | `schema_version` newer than supported | Error | `defaultConfig` |
+    /// | `schema_version` older | Warning | best-effort parse |
+    /// | Unknown `[shell.<key>]` | Warning | skip section |
+    /// | Unknown pathway name | Warning (resolver-side) | shell falls to default |
+    /// | Unknown parameter key | Warning | drop value |
+    /// | Negative/zero parameter | Warning ("clamped") | use default for field |
+    let tryLoad (logger: ILogger) (filePath: string) : Config =
+        if not (File.Exists(filePath)) then
+            logger.LogInformation(
+                "Config: no file at {Path}; using defaults.",
+                filePath)
+            defaultConfig
+        else
+            let text =
+                try Some (File.ReadAllText(filePath))
+                with ex ->
+                    logger.LogError(
+                        ex,
+                        "Config: read failed for {Path}; using defaults.",
+                        filePath)
+                    None
+            match text with
+            | None -> defaultConfig
+            | Some content ->
+                let doc = Toml.Parse(content)
+                if doc.HasErrors then
+                    let detail =
+                        doc.Diagnostics
+                        |> Seq.map (fun d -> d.ToString())
+                        |> String.concat "; "
+                    logger.LogError(
+                        "Config: parse error in {Path}; using defaults. Detail={Detail}",
+                        filePath, detail)
+                    defaultConfig
+                else
+                    let model = doc.ToModel()
+                    let version = parseSchemaVersion logger model
+                    if version > CurrentSchemaVersion then
+                        logger.LogError(
+                            "Config: schema_version {Version} newer than supported {Current}; using defaults.",
+                            version, CurrentSchemaVersion)
+                        defaultConfig
+                    else
+                        let shellOverrides =
+                            parseShellOverrides logger model
+                        let streamOverrides =
+                            match tryGetTable model "pathway" with
+                            | None -> defaultConfig.StreamOverrides
+                            | Some pathwayRoot ->
+                                match tryGetTable pathwayRoot "stream" with
+                                | None -> defaultConfig.StreamOverrides
+                                | Some streamTable ->
+                                    parseStreamOverrides logger streamTable
+                        let result =
+                            { SchemaVersion = version
+                              ShellOverrides = shellOverrides
+                              StreamOverrides = streamOverrides }
+                        // One Information line summarising the
+                        // resolved config so post-hoc diagnosis
+                        // via Ctrl+Shift+; is trivial. The
+                        // shell-pathway summary lists overrides
+                        // only (defaults are silent).
+                        let overrideSummary =
+                            if Map.isEmpty result.ShellOverrides then
+                                "no shell overrides"
+                            else
+                                result.ShellOverrides
+                                |> Map.toSeq
+                                |> Seq.map (fun (k, v) -> sprintf "%s→%s" k v.PathwayId)
+                                |> String.concat ", "
+                        logger.LogInformation(
+                            "Config loaded from {Path}: {Overrides}.",
+                            filePath, overrideSummary)
+                        result
+
+    /// Resolve the pathway ID for a given shell key (lowercase:
+    /// `"cmd"`, `"claude"`, `"powershell"`). Returns the
+    /// configured pathway name if present, else `"stream"` as
+    /// the substrate-wide default. Caller (`Program.fs`'s
+    /// `selectPathwayForShell`) maps the returned string to a
+    /// `DisplayPathway.T` instance.
+    let resolveShellPathway (config: Config) (shellKey: string) : string =
+        match Map.tryFind shellKey config.ShellOverrides with
+        | Some entry -> entry.PathwayId
+        | None -> "stream"
+
+    /// Resolve the StreamPathway parameters from a Config.
+    /// Each field that's `None` in `StreamOverrides` falls
+    /// back to `StreamPathway.defaultParameters`'s value.
+    let resolveStreamParameters
+            (config: Config)
+            : StreamPathway.Parameters
+            =
+        let defaults = StreamPathway.defaultParameters
+        let ov = config.StreamOverrides
+        { DebounceWindowMs =
+            Option.defaultValue defaults.DebounceWindowMs ov.DebounceWindowMs
+          SpinnerWindowMs =
+            Option.defaultValue defaults.SpinnerWindowMs ov.SpinnerWindowMs
+          SpinnerThreshold =
+            Option.defaultValue defaults.SpinnerThreshold ov.SpinnerThreshold
+          MaxAnnounceChars =
+            Option.defaultValue defaults.MaxAnnounceChars ov.MaxAnnounceChars }

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="StreamPathway.fs" />
     <Compile Include="TuiPathway.fs" />
     <Compile Include="PathwaySelector.fs" />
+    <Compile Include="Config.fs" />
     <Compile Include="EarconChannel.fs" />
     <Compile Include="EarconProfile.fs" />
     <Compile Include="PassThroughProfile.fs" />
@@ -33,6 +34,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Tomlyn" />
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -1,0 +1,295 @@
+module PtySpeak.Tests.Unit.ConfigTests
+
+open System
+open System.IO
+open Xunit
+open Microsoft.Extensions.Logging
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Phase B (subset, "C2") — Config behavioural pinning
+// ---------------------------------------------------------------------
+//
+// Config.tryLoad never throws — every error path logs via the
+// supplied ILogger and falls back to defaultConfig. These tests
+// exercise the loader's parse + validate + resolve contract
+// against synthetic TOML strings written to a temp file.
+
+/// Minimal ILogger that records (level, message) pairs.
+/// Mirrors the pattern in FileLoggerChannelTests; F# 9 nullness
+/// constraints handled per the comments there.
+type private NoopScope() =
+    interface IDisposable with
+        member _.Dispose() = ()
+
+type private RecordingLogger() =
+    let calls = ResizeArray<LogLevel * string>()
+    member _.Calls = calls
+    member _.HasLevel (level: LogLevel) : bool =
+        calls |> Seq.exists (fun (l, _) -> l = level)
+    member _.MessagesAtLevel (level: LogLevel) : string seq =
+        calls
+        |> Seq.choose (fun (l, m) -> if l = level then Some m else None)
+    interface ILogger with
+        member _.BeginScope<'TState when 'TState : not null>
+                (_state: 'TState) : IDisposable =
+            (new NoopScope()) :> IDisposable
+        member _.IsEnabled(_: LogLevel) : bool = true
+        member _.Log<'TState>
+                (level: LogLevel,
+                 _eventId: EventId,
+                 state: 'TState,
+                 ex: exn | null,
+                 formatter: Func<'TState, exn | null, string>) : unit =
+            let message = formatter.Invoke(state, ex)
+            calls.Add((level, message))
+
+/// Write the supplied TOML text to a fresh temp file, run
+/// `Config.tryLoad`, and return the (config, logger). The temp
+/// file is deleted on the way out.
+let private loadFromText (toml: string) : Config.Config * RecordingLogger =
+    let logger = RecordingLogger()
+    let path =
+        Path.Combine(
+            Path.GetTempPath(),
+            sprintf "pty-speak-config-test-%s.toml" (Guid.NewGuid().ToString("N")))
+    try
+        File.WriteAllText(path, toml)
+        let config = Config.tryLoad (logger :> ILogger) path
+        config, logger
+    finally
+        try File.Delete(path) with _ -> ()
+
+// ---- defaultConfig + resolver byte-equivalence ---------------------
+
+[<Fact>]
+let ``defaultConfig resolveStreamParameters matches StreamPathway.defaultParameters exactly`` () =
+    // The substrate-wide invariant: "no config = pre-C2 behaviour".
+    // If StreamPathway.defaultParameters changes, the resolver
+    // picks up the new defaults automatically (no constant
+    // duplication in Config).
+    let resolved = Config.resolveStreamParameters Config.defaultConfig
+    Assert.Equal(StreamPathway.defaultParameters, resolved)
+
+[<Fact>]
+let ``defaultConfig resolveShellPathway returns "stream" for any shell key`` () =
+    Assert.Equal("stream", Config.resolveShellPathway Config.defaultConfig "cmd")
+    Assert.Equal("stream", Config.resolveShellPathway Config.defaultConfig "claude")
+    Assert.Equal("stream", Config.resolveShellPathway Config.defaultConfig "powershell")
+
+// ---- tryLoad: missing file ------------------------------------------
+
+[<Fact>]
+let ``tryLoad on missing file returns defaultConfig and logs Information`` () =
+    let logger = RecordingLogger()
+    let path =
+        Path.Combine(
+            Path.GetTempPath(),
+            sprintf "pty-speak-missing-%s.toml" (Guid.NewGuid().ToString("N")))
+    let config = Config.tryLoad (logger :> ILogger) path
+    Assert.Equal(Config.defaultConfig, config)
+    Assert.True(logger.HasLevel(LogLevel.Information))
+
+// ---- tryLoad: malformed TOML ---------------------------------------
+
+[<Fact>]
+let ``tryLoad on malformed TOML returns defaultConfig and logs Error`` () =
+    let toml = "this is not = valid toml ["
+    let config, logger = loadFromText toml
+    Assert.Equal(Config.defaultConfig, config)
+    Assert.True(logger.HasLevel(LogLevel.Error))
+
+// ---- tryLoad: minimal valid TOML -----------------------------------
+
+[<Fact>]
+let ``tryLoad on minimal valid TOML returns default-shape Config`` () =
+    let toml = "schema_version = 1\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(1, config.SchemaVersion)
+    Assert.Equal(Map.empty, config.ShellOverrides)
+    Assert.Equal(StreamPathway.defaultParameters, Config.resolveStreamParameters config)
+
+// ---- Per-shell pathway override ------------------------------------
+
+[<Fact>]
+let ``[shell.cmd] pathway = "stream" parses correctly`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\npathway = \"stream\"\n"
+    let config, _ = loadFromText toml
+    Assert.Equal("stream", Config.resolveShellPathway config "cmd")
+
+[<Fact>]
+let ``[shell.claude] pathway = "tui" parses correctly`` () =
+    let toml =
+        "schema_version = 1\n[shell.claude]\npathway = \"tui\"\n"
+    let config, _ = loadFromText toml
+    Assert.Equal("tui", Config.resolveShellPathway config "claude")
+    // Other shells fall back to default
+    Assert.Equal("stream", Config.resolveShellPathway config "cmd")
+
+// ---- Per-pathway parameter override --------------------------------
+
+[<Fact>]
+let ``[pathway.stream] debounce_window_ms = 50 flows through resolveStreamParameters`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ndebounce_window_ms = 50\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(50, resolved.DebounceWindowMs)
+    // Other fields fall back to defaults
+    Assert.Equal(StreamPathway.defaultParameters.SpinnerWindowMs, resolved.SpinnerWindowMs)
+    Assert.Equal(StreamPathway.defaultParameters.SpinnerThreshold, resolved.SpinnerThreshold)
+    Assert.Equal(StreamPathway.defaultParameters.MaxAnnounceChars, resolved.MaxAnnounceChars)
+
+[<Fact>]
+let ``partial [pathway.stream] override merges with defaults field-by-field`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nspinner_threshold = 10\nmax_announce_chars = 1000\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.defaultParameters.DebounceWindowMs, resolved.DebounceWindowMs)
+    Assert.Equal(StreamPathway.defaultParameters.SpinnerWindowMs, resolved.SpinnerWindowMs)
+    Assert.Equal(10, resolved.SpinnerThreshold)
+    Assert.Equal(1000, resolved.MaxAnnounceChars)
+
+// ---- Unknown keys / invalid values ----------------------------------
+
+[<Fact>]
+let ``unknown parameter key in [pathway.stream] logs Warning and is dropped`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ndebounce_window_ms = 50\ncebounce = 99\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(50, resolved.DebounceWindowMs)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+    let warnings =
+        logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList
+    Assert.Contains(warnings, fun m -> m.Contains("cebounce"))
+
+[<Fact>]
+let ``unknown shell section [shell.bash] logs Warning and is ignored`` () =
+    let toml =
+        "schema_version = 1\n[shell.bash]\npathway = \"stream\"\n"
+    let config, logger = loadFromText toml
+    Assert.False(Map.containsKey "bash" config.ShellOverrides)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+    let warnings =
+        logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList
+    Assert.Contains(warnings, fun m -> m.Contains("bash"))
+
+[<Fact>]
+let ``negative parameter value logs Warning and falls back to default`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ndebounce_window_ms = -50\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.defaultParameters.DebounceWindowMs, resolved.DebounceWindowMs)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+[<Fact>]
+let ``zero parameter value logs Warning and falls back to default`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ndebounce_window_ms = 0\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.defaultParameters.DebounceWindowMs, resolved.DebounceWindowMs)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+// ---- Schema versioning --------------------------------------------
+
+[<Fact>]
+let ``schema_version too new logs Error and returns defaultConfig`` () =
+    let toml =
+        sprintf "schema_version = %d\n[shell.cmd]\npathway = \"tui\"\n" 999
+    let config, logger = loadFromText toml
+    Assert.Equal(Config.defaultConfig, config)
+    Assert.True(logger.HasLevel(LogLevel.Error))
+
+[<Fact>]
+let ``schema_version too old logs Warning and best-effort parses`` () =
+    // schema_version = 0 is older than CurrentSchemaVersion (1).
+    // The loader proceeds to parse the rest of the TOML.
+    let toml =
+        "schema_version = 0\n[shell.cmd]\npathway = \"tui\"\n"
+    let config, logger = loadFromText toml
+    Assert.Equal("tui", Config.resolveShellPathway config "cmd")
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+[<Fact>]
+let ``missing schema_version logs Warning and treats as 1`` () =
+    let toml = "[shell.cmd]\npathway = \"tui\"\n"
+    let config, logger = loadFromText toml
+    Assert.Equal(Config.CurrentSchemaVersion, config.SchemaVersion)
+    Assert.Equal("tui", Config.resolveShellPathway config "cmd")
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+// ---- Round-trip --------------------------------------------------
+
+[<Fact>]
+let ``round-trip: comprehensive TOML parses to expected resolved values`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              ""
+              "[shell.cmd]"
+              "pathway = \"stream\""
+              ""
+              "[shell.claude]"
+              "pathway = \"tui\""
+              ""
+              "[shell.powershell]"
+              "pathway = \"stream\""
+              ""
+              "[pathway.stream]"
+              "debounce_window_ms = 100"
+              "spinner_window_ms = 2000"
+              "spinner_threshold = 8"
+              "max_announce_chars = 750"
+              "" ]
+    let config, _ = loadFromText toml
+    Assert.Equal("stream", Config.resolveShellPathway config "cmd")
+    Assert.Equal("tui", Config.resolveShellPathway config "claude")
+    Assert.Equal("stream", Config.resolveShellPathway config "powershell")
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(100, resolved.DebounceWindowMs)
+    Assert.Equal(2000, resolved.SpinnerWindowMs)
+    Assert.Equal(8, resolved.SpinnerThreshold)
+    Assert.Equal(750, resolved.MaxAnnounceChars)
+
+// ---- Forward-compat: ignore unknown sections ----------------------
+
+[<Fact>]
+let ``TOML containing [[bindings]] (future input-binding spec section) parses cleanly`` () =
+    // Spec event-and-output-framework.md A.5 sketches a future
+    // input-binding schema with [[bindings]] arrays at top level.
+    // C2's loader silently ignores those sections so a single
+    // config.toml can grow cumulatively across Phase B sub-stages.
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              ""
+              "[shell.cmd]"
+              "pathway = \"stream\""
+              ""
+              "[[bindings]]"
+              "intent = \"SwitchToCmd\""
+              "gesture = \"Ctrl+Alt+1\""
+              ""
+              "[[bindings]]"
+              "intent = \"SwitchToClaude\""
+              "gesture = \"Ctrl+Alt+3\""
+              "" ]
+    let config, logger = loadFromText toml
+    // The shell override still applies.
+    Assert.Equal("stream", Config.resolveShellPathway config "cmd")
+    // No Warnings or Errors fired for the [[bindings]] sections.
+    Assert.False(logger.HasLevel(LogLevel.Error))
+    let warnings = logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList
+    Assert.DoesNotContain(warnings, fun m -> m.Contains("bindings"))
+
+// ---- defaultConfigFilePath -----------------------------------------
+
+[<Fact>]
+let ``defaultConfigFilePath ends with PtySpeak\config.toml`` () =
+    let path = Config.defaultConfigFilePath ()
+    Assert.EndsWith(@"PtySpeak\config.toml", path)

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -106,7 +106,7 @@ let ``tryLoad on minimal valid TOML returns default-shape Config`` () =
     let toml = "schema_version = 1\n"
     let config, _ = loadFromText toml
     Assert.Equal(1, config.SchemaVersion)
-    Assert.Equal(Map.empty, config.ShellOverrides)
+    Assert.Equal<Map<string, Config.ShellPathwayConfig>>(Map.empty, config.ShellOverrides)
     Assert.Equal(StreamPathway.defaultParameters, Config.resolveStreamParameters config)
 
 // ---- Per-shell pathway override ------------------------------------

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="StreamPathwayTests.fs" />
     <Compile Include="TuiPathwayTests.fs" />
     <Compile Include="PathwaySelectorTests.fs" />
+    <Compile Include="ConfigTests.fs" />
     <Compile Include="OutputEventTests.fs" />
     <Compile Include="NvdaChannelTests.fs" />
     <Compile Include="FileLoggerChannelTests.fs" />


### PR DESCRIPTION
## Summary

Closes the Phase B "TOML config" item the Phase A plan deferred. Users can now drop a `%LOCALAPPDATA%\PtySpeak\config.toml` and override pathway selection and per-pathway parameters without rebuilding pty-speak. Realises the maintainer's guiding principle for display configurability — *"the interpreter pathway should be transparent and user configurable and customizable with sensible defaults"* — at the substrate level. Future stages (per-content-type triggers, runtime adjust-on-the-fly + save-as-template, semantic / AI-interpretation pathways) all build on this substrate but are explicitly out of scope for C2.

## Schema (v1)

```toml
schema_version = 1

[shell.cmd]
pathway = "stream"

[shell.powershell]
pathway = "stream"

[shell.claude]
pathway = "stream"

[pathway.stream]
debounce_window_ms = 200
spinner_window_ms = 1000
spinner_threshold = 5
max_announce_chars = 500

[pathway.tui]
# reserved; no parameters today
```

`[shell.<id>]` keys mirror the lowercase IDs `parseEnvVar` recognises (`cmd`, `claude`, `powershell`). `pathway` values are pathway IDs (`"stream"`, `"tui"`; future Phase 2 IDs added without schema migration). `[pathway.<id>]` tables hold per-pathway parameter overrides.

**Forward-compat with future input-bindings.** Spec `event-and-output-framework.md` A.5 sketches `[[bindings]]` / `[[handlers]]` arrays at top level for hotkey overrides. C2's loader silently ignores those sections — a single `config.toml` will accumulate cumulatively across Phase B sub-stages.

**Defaults preserved exactly.** `Config.defaultConfig` matches `StreamPathway.defaultParameters` field-for-field; absence of the file (or any key within it) is **byte-equivalent** to pre-C2 behaviour. Pinned by a `defaultConfig resolveStreamParameters matches StreamPathway.defaultParameters exactly` test.

## Error handling — never crashes, never opens a dialog

The maintainer is a screen-reader user. Every failure mode logs via `ILogger` (routed to FileLogger; readable via `Ctrl+Shift+;`) and falls back to defaults:

| Condition | Log level | Effect |
|---|---|---|
| Missing file | Information | Use all defaults |
| Malformed TOML | Error (with parse detail) | Use all defaults |
| `schema_version` newer than supported | Error | Use all defaults |
| `schema_version` older | Warning | Best-effort parse |
| Unknown `[shell.<key>]` (e.g. `bash`) | Warning | Skip section |
| Unknown pathway name (e.g. `"stram"`) | Warning | Falls back to stream |
| Unknown parameter key | Warning | Drop value |
| Negative or zero parameter | Warning ("clamped to default") | Use default for that field |

A single `Information` line on startup summarises the resolved config so post-hoc diagnosis is trivial.

## TOML library — Tomlyn 0.18.0

- BSD 2-Clause; targets net8.0/net9.0 (works under `net9.0-windows`).
- xoofx maintainer (high trust).
- Already named in spec (`tech-plan.md:997`, `event-and-output-framework.md:501`).
- Uses `Toml.Parse(text)` (non-throwing) → check `HasErrors` → `ToModel()`. Avoids `Toml.ToModel(string)` which throws `TomlException` on parse error.

## Test plan

Unit tests (`ConfigTests.fs`, 18 cases):

- [ ] `defaultConfig` resolved parameters match `StreamPathway.defaultParameters` field-for-field
- [ ] `defaultConfig.resolveShellPathway` returns `"stream"` for any shell key
- [ ] Missing file → `defaultConfig` + Information log
- [ ] Malformed TOML → `defaultConfig` + Error log
- [ ] Minimal valid TOML (only `schema_version = 1`) → default shape
- [ ] `[shell.cmd] pathway = "stream"` parses correctly
- [ ] `[shell.claude] pathway = "tui"` parses correctly + other shells fall back
- [ ] `[pathway.stream] debounce_window_ms = 50` flows through the resolver
- [ ] Partial override merges with defaults field-by-field
- [ ] Unknown parameter key → Warning + dropped
- [ ] Unknown shell section → Warning + ignored
- [ ] Negative parameter → Warning + default
- [ ] Zero parameter → Warning + default
- [ ] `schema_version = 999` → Error + defaults
- [ ] `schema_version = 0` → Warning + best-effort
- [ ] `schema_version` missing → Warning + treat as 1
- [ ] Round-trip: comprehensive TOML → expected resolved values
- [ ] Coexistence: `[[bindings]]` sections parse cleanly with no warnings
- [ ] `defaultConfigFilePath` ends with `PtySpeak\config.toml`

Manual NVDA validation row (deferred to maintainer; the PR doesn't gate on this):

- [ ] Without a `config.toml` present, behaviour is byte-equivalent to pre-C2 (the headline guarantee)
- [ ] Drop `[shell.cmd] pathway = "tui"`, launch — cmd uses TuiPathway (no streaming output)
- [ ] Drop `[pathway.stream] debounce_window_ms = 50`, launch — typing in cmd feels snappier (50ms debounce instead of 200ms)
- [ ] Drop a malformed `config.toml` — pty-speak still launches; log via `Ctrl+Shift+;` shows the parse Error line; behaviour matches default

## Out of scope (carried forward)

- **Hot-reload** — changes require a restart
- **Runtime config write-back** from a hotkey or palette ("save current settings as my config") — Phase 2/3 UI work
- **Kill-switch substrate** (`Ctrl+Shift+K` + `extensibility.killSwitch` per spec A.6) — Phase B input-bindings owns this
- **Per-content-type triggers** (regex / colour / semantic-parser / LLM dispatchers) — Phase 2/3; needs actual pathways that consume the triggers
- **ClaudeCodePathway / ReplPathway / FormPathway selection** — those pathways don't exist yet (Phase 2)
- **Schema additions for input-binding overrides** (`[[bindings]]`) — separate Phase B sub-stage
- **Config validator binary or CLI**

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_