### PR TITLE
Phase A.2 — re-introduce colour-detection earcons via event-splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,130 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Phase A.2 — colour-detection earcons re-introduced)
+
+Re-introduces the SGR colour-detection feature originally
+shipped in Stage 8d.2 (PR #156) and reverted in PR #157 due
+to an unknown release-build regression. The new design avoids
+the original's structural flaw + likely cause by using
+**event-splitting** on the Phase A pathway substrate rather
+than `Extensions["dominantColor"]` stamping on synthesized
+events.
+
+**User-visible behaviour.** When red-foreground text dominates
+the streaming output (>50% of non-blank cells in any row of
+the canonical snapshot), pty-speak plays a brief 400Hz tone
+(`error-tone` earcon, ~150ms) alongside NVDA reading the
+content. Yellow-foreground dominant text plays 600Hz
+(`warning-tone`, ~120ms). Both are supplementary to NVDA — no
+double-announce, no replacement of the spoken content. v1
+matches the standard 16-colour ANSI palette
+(`Indexed 1` / `Indexed 9` for red, `Indexed 3` / `Indexed 11`
+for yellow); 256-cube reds and Truecolor RGB-distance matching
+are deferred per the original 8d.2 plan.
+
+**Configurability.** Per the C2 principle ("transparent + user
+configurable + sensible defaults"), the feature is on by
+default but disable-able via TOML:
+
+```toml
+# %LOCALAPPDATA%\PtySpeak\config.toml
+[pathway.stream]
+color_detection = false
+```
+
+`true`/`false` recognised; non-bool values log a Warning and
+fall back to `true`. Schema documented in `docs/USER-SETTINGS.md`.
+
+**What changed structurally vs original 8d.2.** The original
+stamped `Extensions["dominantColor"]` on the StreamProfile-
+synthesized `StreamChunk` event; EarconProfile read
+`event.Extensions` to decide whether to emit an earcon. That
+design had a latent bug: the dispatcher fans the SAME raw
+input event to all profiles in parallel; EarconProfile only
+saw the RAW translator event (with empty Extensions), not the
+StreamProfile-synthesized event with the colour metadata. The
+unit tests passed because they fed EarconProfile pre-populated
+synthetic events with Extensions, bypassing the dispatcher. The
+release-build regression where NVDA stopped reading is also
+suspected (though never confirmed at runtime) to involve the
+non-empty Extensions interaction with the synthesized event
+flow.
+
+The new design splits the colour signal into a SECOND
+`OutputEvent` with a dedicated semantic category (`ErrorLine`
+for red, `WarningLine` for yellow) and an EMPTY payload.
+EarconProfile claims ErrorLine/WarningLine semantically (no
+Extensions snoop). NvdaChannel skips the empty payload
+(NvdaChannel.fs:87 `RenderText "" -> ()`) — no double-announce.
+FileLogger records both events for the audit trail. The
+dispatcher's existing per-profile fan-out works correctly: the
+ErrorLine event is the ACTUAL OutputEvent dispatched, and
+EarconProfile sees it directly.
+
+**State management for trailing-edge flush.** Within the
+StreamPathway's debounce window, the colour is captured
+alongside the pending diff in a new `State.PendingColor:
+string voption`. The trailing-edge `onTimerTick` flushes both
+events together. `OnModeBarrier` clears the pending colour
+WITHOUT emitting the supplementary event — mode barriers are
+themselves discontinuities (alt-screen toggle, vim exiting),
+and emitting an error-tone for the flushed pre-barrier diff
+would be misleading.
+
+**Library + palette.** No new packages or palette entries
+needed. `EarconPalette.defaultPalette` retained `error-tone`
+(400Hz × 150ms × 10ms) + `warning-tone` (600Hz × 120ms × 10ms)
+across the 8d.2 revert. NvdaChannel's `semanticToActivityId`
+already maps ErrorLine + WarningLine to `ActivityIds.error`.
+
+Files:
+- `src/Terminal.Core/StreamPathway.fs` — colour-detection
+  helpers (`isRedFg`, `isYellowFg`, `rowDominantColor`,
+  `snapshotDominantColor`); `colorOutputEvent` builder;
+  `Parameters.ColorDetection: bool`; `State.PendingColor`;
+  `processCanonicalState` + `onTimerTick` + `onModeBarrier`
+  + `resetState` updates.
+- `src/Terminal.Core/EarconProfile.fs` — `Apply` gains
+  `ErrorLine -> error-tone` and `WarningLine -> warning-tone`
+  cases.
+- `src/Terminal.Core/Config.fs` — `tryGetBool` helper;
+  `StreamParameterOverrides.ColorDetection: bool option`;
+  `parseStreamOverrides` + `resolveStreamParameters` +
+  `knownStreamKeys` updates.
+- `tests/Tests.Unit/StreamPathwayTests.fs` — 14 new tests:
+  helpers (red/yellow/threshold/blank), snapshot-level
+  precedence, double-emit (red, yellow, plain),
+  ColorDetection=false, trailing-edge flush, mode-barrier
+  pending-colour handling.
+- `tests/Tests.Unit/EarconProfileTests.fs` — replaces the
+  "8d.2 will claim" pin with two new tests:
+  `ErrorLine -> error-tone` and `WarningLine -> warning-tone`.
+- `tests/Tests.Unit/ConfigTests.fs` — 4 new tests:
+  default-true invariant, `color_detection = false` parses,
+  `color_detection = true` round-trip, non-bool warning.
+- `docs/USER-SETTINGS.md` — schema example + defaults table
+  row for `color_detection`.
+
+**Out of scope** (carried forward):
+
+- 256-colour cube reds (`Indexed 196` etc.)
+- Truecolor RGB-distance matching (`Rgb` ColorSpec)
+- Background-colour reds (`Bg` field)
+- `ParserError -> error-tone` routing — would need cross-
+  profile suppression substrate (NvdaChannel announces
+  ParserError on the error activityId; doubling up earcon +
+  announce would be noisy)
+- Per-shell colour-detection toggles
+  (`[shell.cmd] color_detection = false`) — uniform pathway-
+  level config is enough for v1
+- TuiPathway colour detection — TuiPathway emits no
+  StreamChunks; separate concern
+- Earcon palette frequency/duration overrides via TOML
+- Earcon dedup for sustained red errors (multiple emits across
+  rapid frames produce multiple earcons; matches original
+  8d.2 behaviour; refine if NVDA validation flags noisy)
+
 ### Added (Phase B subset — TOML config for pathway selection + parameters)
 
 Closes the Phase B "TOML config" item the Phase A plan deferred

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -408,6 +408,7 @@ can override the hardcoded mapping without rebuilding pty-speak.
   spinner_window_ms = 1000
   spinner_threshold = 5
   max_announce_chars = 500
+  color_detection = true
 
   [pathway.tui]
   # reserved; no parameters today
@@ -424,6 +425,7 @@ can override the hardcoded mapping without rebuilding pty-speak.
   | `[pathway.stream] spinner_window_ms` | `1000` | History window for spinner-suppress detection |
   | `[pathway.stream] spinner_threshold` | `5` | Row/content-hash change count to trigger suppression |
   | `[pathway.stream] max_announce_chars` | `500` | Text truncation cap for NVDA announcements |
+  | `[pathway.stream] color_detection` | `true` | Emit error-tone (red text) and warning-tone (yellow text) earcons alongside NVDA reading. `false` disables both earcons. |
 
 - Available pathway IDs: `"stream"`, `"tui"`. Future Phase 2
   IDs (`"claude-code"`, `"repl"`, `"form"`) will be added

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -86,7 +86,13 @@ module Config =
         { DebounceWindowMs: int option
           SpinnerWindowMs: int option
           SpinnerThreshold: int option
-          MaxAnnounceChars: int option }
+          MaxAnnounceChars: int option
+          /// Phase A.2 — toggle SGR colour-detection emission.
+          /// `None` falls back to the default (`true`); `Some
+          /// false` disables the supplementary
+          /// ErrorLine/WarningLine OutputEvents and the
+          /// associated error-tone/warning-tone earcons.
+          ColorDetection: bool option }
 
     /// The top-level config record. `ShellOverrides` is keyed
     /// by lowercase shell-id strings (`"cmd"`, `"claude"`,
@@ -112,7 +118,8 @@ module Config =
             { DebounceWindowMs = None
               SpinnerWindowMs = None
               SpinnerThreshold = None
-              MaxAnnounceChars = None } }
+              MaxAnnounceChars = None
+              ColorDetection = None } }
 
     /// The default config file path —
     /// `%LOCALAPPDATA%\PtySpeak\config.toml`. Mirrors the
@@ -159,6 +166,17 @@ module Config =
         | true, (:? TomlTable as t) -> Some t
         | _ -> None
 
+    /// Internal — try to read a `bool` value from a TomlTable
+    /// by key. Returns `None` if absent or non-bool. Tomlyn
+    /// boxes booleans as native `bool`. Same tuple-deconstruct
+    /// pattern as `tryGetInt` to avoid the F# 9 nullness
+    /// `byref<obj | null>` mismatch with Tomlyn's `out object`
+    /// signature.
+    let private tryGetBool (table: TomlTable) (key: string) : bool option =
+        match table.TryGetValue(key) with
+        | true, (:? bool as b) -> Some b
+        | _ -> None
+
     /// Internal — known parameter keys for `[pathway.stream]`.
     /// Used to detect typos and log Warnings for unknown keys.
     let private knownStreamKeys : Set<string> =
@@ -166,7 +184,8 @@ module Config =
             [ "debounce_window_ms"
               "spinner_window_ms"
               "spinner_threshold"
-              "max_announce_chars" ]
+              "max_announce_chars"
+              "color_detection" ]
 
     /// Internal — known shell-id keys for `[shell.<id>]`.
     /// Mirrors `ShellRegistry.parseEnvVar`'s lowercase
@@ -235,10 +254,22 @@ module Config =
                         key)
                 None
             | Some raw -> parsePositiveInt logger "[pathway.stream]" key raw
+        let readBool (key: string) : bool option =
+            match tryGetBool table key with
+            | None ->
+                // Same key-present-but-wrong-type Warning
+                // pattern as readField above.
+                if table.ContainsKey(key) then
+                    logger.LogWarning(
+                        "Config: [pathway.stream] {Key} is non-boolean; ignored.",
+                        key)
+                None
+            | Some b -> Some b
         { DebounceWindowMs = readField "debounce_window_ms"
           SpinnerWindowMs = readField "spinner_window_ms"
           SpinnerThreshold = readField "spinner_threshold"
-          MaxAnnounceChars = readField "max_announce_chars" }
+          MaxAnnounceChars = readField "max_announce_chars"
+          ColorDetection = readBool "color_detection" }
 
     /// Internal — parse the `[shell.X]` family into
     /// `Map<string, ShellPathwayConfig>`. Unknown shell keys
@@ -423,4 +454,6 @@ module Config =
           SpinnerThreshold =
             Option.defaultValue defaults.SpinnerThreshold ov.SpinnerThreshold
           MaxAnnounceChars =
-            Option.defaultValue defaults.MaxAnnounceChars ov.MaxAnnounceChars }
+            Option.defaultValue defaults.MaxAnnounceChars ov.MaxAnnounceChars
+          ColorDetection =
+            Option.defaultValue defaults.ColorDetection ov.ColorDetection }

--- a/src/Terminal.Core/EarconProfile.fs
+++ b/src/Terminal.Core/EarconProfile.fs
@@ -69,10 +69,30 @@ module EarconProfile =
                         event,
                         [| earconDecision "bell-ping" |]
                     |]
+                | SemanticCategory.ErrorLine ->
+                    // Phase A.2 — re-introduces 8d.2's red →
+                    // 400Hz error-tone earcon. StreamPathway
+                    // emits an empty-payload `ErrorLine`
+                    // OutputEvent alongside the StreamChunk
+                    // when the frame is red-dominant.
+                    // NvdaChannel skips the empty payload
+                    // (NvdaChannel.fs:87 RenderText "" → no
+                    // marshalAnnounce); EarconChannel plays the
+                    // tone via the palette's "error-tone"
+                    // entry. No double-announce.
+                    [|
+                        event,
+                        [| earconDecision "error-tone" |]
+                    |]
+                | SemanticCategory.WarningLine ->
+                    // Phase A.2 — yellow → 600Hz warning-tone.
+                    // Same event-splitting design as ErrorLine.
+                    [|
+                        event,
+                        [| earconDecision "warning-tone" |]
+                    |]
                 | _ ->
-                    // No earcon for other Semantic categories
-                    // in 8d.1. 8d.2 adds ErrorLine /
-                    // WarningLine cases.
+                    // No earcon for other Semantic categories.
                     [||]
           Tick =
             fun _ ->

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -60,13 +60,25 @@ module StreamPathway =
         { DebounceWindowMs: int
           SpinnerWindowMs: int
           SpinnerThreshold: int
-          MaxAnnounceChars: int }
+          MaxAnnounceChars: int
+          /// Phase A.2 — toggle SGR colour-detection emission.
+          /// When `true` (default), red-dominant frames emit a
+          /// supplementary `ErrorLine` OutputEvent (claimed by
+          /// EarconProfile → 400Hz error-tone) alongside the
+          /// normal `StreamChunk`; yellow-dominant frames emit
+          /// a `WarningLine` (600Hz warning-tone). When `false`,
+          /// the helpers don't run + only `StreamChunk` events
+          /// emit, identical to the post-revert behaviour. The
+          /// TOML config schema exposes this as
+          /// `[pathway.stream] color_detection`.
+          ColorDetection: bool }
 
     let defaultParameters: Parameters =
         { DebounceWindowMs = 200
           SpinnerWindowMs = 1000
           SpinnerThreshold = 5
-          MaxAnnounceChars = 500 }
+          MaxAnnounceChars = 500
+          ColorDetection = true }
 
     type private SpinnerKey = int * uint64
 
@@ -78,12 +90,20 @@ module StreamPathway =
     /// - The Stage 8b StreamProfile.State fields, preserved
     ///   verbatim so the existing dedup + spinner + debounce
     ///   algorithms work unchanged.
+    /// - `PendingColor`: Phase A.2 — captures the dominant
+    ///   colour computed at accumulate-time (within debounce
+    ///   window) so the trailing-edge `onTimerTick` flush can
+    ///   emit the supplementary `ErrorLine`/`WarningLine`
+    ///   OutputEvent alongside the flushed `StreamChunk`.
+    ///   Cleared in `resetState`, `onModeBarrier`, and on every
+    ///   leading-edge or trailing-edge emit.
     type State =
         { mutable LastEmittedRowHashes: uint64[]
           mutable LastFrameHash: uint64 voption
           mutable LastFlushAt: DateTimeOffset voption
           mutable PendingDiff: CanonicalState.CanonicalDiff voption
           mutable PendingFrameHash: uint64 voption
+          mutable PendingColor: string voption
           mutable LastRowHashes: uint64[] voption
           PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
           HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
@@ -94,6 +114,7 @@ module StreamPathway =
           LastFlushAt = ValueNone
           PendingDiff = ValueNone
           PendingFrameHash = ValueNone
+          PendingColor = ValueNone
           LastRowHashes = ValueNone
           PerRowHistory = Dictionary()
           HashHistory = Dictionary() }
@@ -172,6 +193,77 @@ module StreamPathway =
                 head
                 extra
 
+    /// Phase A.2 — SGR colour-detection helpers. Red-dominant
+    /// rows produce an `ErrorLine` supplementary OutputEvent
+    /// (EarconProfile claims → 400Hz error-tone); yellow ditto
+    /// `WarningLine` → 600Hz warning-tone. v1 only matches the
+    /// standard 16-colour ANSI palette (`Indexed 1`/`Indexed 9`
+    /// for red, `Indexed 3`/`Indexed 11` for yellow); 256-cube
+    /// reds (`Indexed 196` etc.) and Truecolor RGB-distance
+    /// matching are deferred per the original 8d.2 plan.
+    ///
+    /// **Re-introduction context.** PR #156 (8d.2) shipped this
+    /// via `Extensions["dominantColor"]` stamping on the
+    /// StreamProfile-synthesized event; the EarconProfile snoop
+    /// path was structurally broken (it only saw the RAW
+    /// translator event, not the synthesized one). The Phase A
+    /// substrate makes event-splitting trivial: emit two events
+    /// per coloured frame, EarconProfile claims via Semantic
+    /// rather than Extensions. NvdaChannel skips the empty
+    /// `ErrorLine`/`WarningLine` payload (NvdaChannel.fs:87) so
+    /// no double-announce.
+    let internal isRedFg (fg: ColorSpec) : bool =
+        match fg with
+        | Indexed 1uy -> true
+        | Indexed 9uy -> true
+        | _ -> false
+
+    let internal isYellowFg (fg: ColorSpec) : bool =
+        match fg with
+        | Indexed 3uy -> true
+        | Indexed 11uy -> true
+        | _ -> false
+
+    /// Per-row classification: walk non-blank cells and count
+    /// red/yellow foregrounds. >50% of non-blank cells red →
+    /// "red"; else >50% yellow → "yellow"; else None. Blank
+    /// cells (space rune) are excluded from the count so
+    /// end-of-line padding doesn't dilute the classification.
+    let internal rowDominantColor (row: Cell[]) : string option =
+        let mutable nonBlank = 0
+        let mutable red = 0
+        let mutable yellow = 0
+        for cell in row do
+            if cell.Ch.Value <> int ' ' then
+                nonBlank <- nonBlank + 1
+                if isRedFg cell.Attrs.Fg then
+                    red <- red + 1
+                elif isYellowFg cell.Attrs.Fg then
+                    yellow <- yellow + 1
+        if nonBlank = 0 then
+            None
+        elif red * 2 > nonBlank then
+            Some "red"
+        elif yellow * 2 > nonBlank then
+            Some "yellow"
+        else
+            None
+
+    /// Per-snapshot classification: any-red wins; else any-
+    /// yellow; else None. Red wins over yellow because it's
+    /// the higher-urgency tone (400Hz lower-pitched earcon).
+    let internal snapshotDominantColor (snapshot: Cell[][]) : string option =
+        let mutable hasRed = false
+        let mutable hasYellow = false
+        for row in snapshot do
+            match rowDominantColor row with
+            | Some "red" -> hasRed <- true
+            | Some "yellow" -> hasYellow <- true
+            | _ -> ()
+        if hasRed then Some "red"
+        elif hasYellow then Some "yellow"
+        else None
+
     /// Build the StreamChunk OutputEvent for a flushed diff.
     /// Producer-stamp is "stream" (the StreamPathway origin).
     let private streamOutputEvent (text: string) : OutputEvent =
@@ -180,6 +272,32 @@ module StreamPathway =
             Priority.Polite
             id
             text
+
+    /// Phase A.2 — build the supplementary colour-event for a
+    /// flushed diff. Returns `None` for plain frames (caller
+    /// emits only the StreamChunk); `Some ErrorLine` for red,
+    /// `Some WarningLine` for yellow. Empty payload — NVDA
+    /// skips its announce (NvdaChannel.fs:87 RenderText "" →
+    /// no marshalAnnounce); EarconProfile claims via Semantic
+    /// and emits the earcon decision; FileLogger records the
+    /// event for the audit trail. `Priority.Assertive` matches
+    /// the urgency intent (bell-class), mirroring `Bell`'s
+    /// priority in `OutputEventBuilder.fromScreenNotification`.
+    let private colorOutputEvent (color: string) : OutputEvent option =
+        match color with
+        | "red" ->
+            Some (OutputEvent.create
+                    SemanticCategory.ErrorLine
+                    Priority.Assertive
+                    id
+                    "")
+        | "yellow" ->
+            Some (OutputEvent.create
+                    SemanticCategory.WarningLine
+                    Priority.Assertive
+                    id
+                    "")
+        | _ -> None
 
     /// Decide what (if anything) to emit for an incoming
     /// canonical state. Mirrors the Stage 8b
@@ -202,6 +320,15 @@ module StreamPathway =
             let mutable h = 0UL
             for rh in rowHashes do h <- h ^^^ rh
             h
+        // Phase A.2 — compute the dominant colour eagerly
+        // (only if config-enabled). Used both at leading-edge
+        // (emits supplementary event) and at debounce-accumulate
+        // (stashed in state.PendingColor for trailing-edge flush).
+        let dominantColor =
+            if parameters.ColorDetection then
+                snapshotDominantColor canonical.Snapshot
+            else
+                None
         match state.LastFrameHash with
         | ValueSome prev when prev = frameHash ->
             logger.LogDebug(
@@ -239,6 +366,7 @@ module StreamPathway =
                         state.LastFlushAt <- ValueSome now
                         state.PendingDiff <- ValueNone
                         state.PendingFrameHash <- ValueNone
+                        state.PendingColor <- ValueNone
                         logger.LogDebug(
                             "Suppressed (empty-diff). FrameHash=0x{Hash:X16}", frameHash)
                         [||]
@@ -247,20 +375,38 @@ module StreamPathway =
                         state.LastFlushAt <- ValueSome now
                         state.PendingDiff <- ValueNone
                         state.PendingFrameHash <- ValueNone
+                        state.PendingColor <- ValueNone
                         state.LastEmittedRowHashes <- rowHashes
                         let capped = capAnnounce parameters diff.ChangedText
                         logger.LogInformation(
-                            "Emit StreamChunk (leading-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len}",
-                            frameHash, diff.ChangedRows.Length, capped.Length)
-                        [| streamOutputEvent capped |]
+                            "Emit StreamChunk (leading-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
+                            frameHash, diff.ChangedRows.Length, capped.Length,
+                            (match dominantColor with Some c -> c | None -> "none"))
+                        // Phase A.2 — emit a supplementary
+                        // ErrorLine/WarningLine event when the
+                        // frame is colour-dominant. EarconProfile
+                        // claims it semantically; NvdaChannel skips
+                        // the empty payload so no double-announce.
+                        match dominantColor |> Option.bind colorOutputEvent with
+                        | Some colorEvt -> [| streamOutputEvent capped; colorEvt |]
+                        | None -> [| streamOutputEvent capped |]
                 else
                     // Within debounce: accumulate the diff;
-                    // trailing edge will flush.
+                    // trailing edge will flush. Stash the dominant
+                    // colour alongside so the trailing-edge tick
+                    // emits both events together. Overwrite any
+                    // previous PendingColor — latest pending frame
+                    // wins, matching PendingDiff semantics.
                     state.PendingDiff <- ValueSome (canonical.computeDiff state.LastEmittedRowHashes)
                     state.PendingFrameHash <- ValueSome frameHash
+                    state.PendingColor <-
+                        match dominantColor with
+                        | Some c -> ValueSome c
+                        | None -> ValueNone
                     logger.LogDebug(
-                        "Accumulated (within debounce window). FrameHash=0x{Hash:X16}",
-                        frameHash)
+                        "Accumulated (within debounce window). FrameHash=0x{Hash:X16} Color={Color}",
+                        frameHash,
+                        (match dominantColor with Some c -> c | None -> "none"))
                     [||]
 
     /// Trailing-edge timer tick. If a debounced diff is pending
@@ -283,10 +429,15 @@ module StreamPathway =
                 | ValueNone -> debounceWindow
                 | ValueSome t -> now - t
             if elapsed >= debounceWindow then
+                // Phase A.2 — capture the pending colour BEFORE
+                // resetting state so it survives the same
+                // condition-block that promotes the diff.
+                let pendingColor = state.PendingColor
                 state.LastFrameHash <- ValueSome hash
                 state.LastFlushAt <- ValueSome now
                 state.PendingDiff <- ValueNone
                 state.PendingFrameHash <- ValueNone
+                state.PendingColor <- ValueNone
                 if diff.ChangedRows.Length = 0 then
                     [||]
                 else
@@ -298,10 +449,17 @@ module StreamPathway =
                     | ValueSome rh -> state.LastEmittedRowHashes <- rh
                     | ValueNone -> ()
                     let capped = capAnnounce parameters diff.ChangedText
+                    let colorEvt =
+                        match pendingColor with
+                        | ValueSome c -> colorOutputEvent c
+                        | ValueNone -> None
                     logger.LogInformation(
-                        "Emit StreamChunk (trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len}",
-                        hash, diff.ChangedRows.Length, capped.Length)
-                    [| streamOutputEvent capped |]
+                        "Emit StreamChunk (trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
+                        hash, diff.ChangedRows.Length, capped.Length,
+                        (match pendingColor with ValueSome c -> c | ValueNone -> "none"))
+                    match colorEvt with
+                    | Some evt -> [| streamOutputEvent capped; evt |]
+                    | None -> [| streamOutputEvent capped |]
             else
                 [||]
         | _ -> [||]
@@ -322,8 +480,17 @@ module StreamPathway =
             | ValueSome diff when diff.ChangedRows.Length > 0 ->
                 [| streamOutputEvent diff.ChangedText |]
             | _ -> [||]
+        // Phase A.2 — clear PendingColor WITHOUT emitting the
+        // supplementary ErrorLine/WarningLine. Mode barriers are
+        // themselves discontinuities (alt-screen toggle, vim
+        // exiting); emitting an error-tone for the flushed
+        // pre-barrier diff would be misleading because the user
+        // already heard the live coloured output. The barrier
+        // itself dispatches separately via OutputEventBuilder
+        // → PathwayPump.handleModeChanged.
         state.PendingDiff <- ValueNone
         state.PendingFrameHash <- ValueNone
+        state.PendingColor <- ValueNone
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueSome now
         state.LastRowHashes <- ValueNone
@@ -341,6 +508,7 @@ module StreamPathway =
         state.LastFlushAt <- ValueNone
         state.PendingDiff <- ValueNone
         state.PendingFrameHash <- ValueNone
+        state.PendingColor <- ValueNone
         state.LastRowHashes <- ValueNone
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -293,3 +293,43 @@ let ``TOML containing [[bindings]] (future input-binding spec section) parses cl
 let ``defaultConfigFilePath ends with PtySpeak\config.toml`` () =
     let path = Config.defaultConfigFilePath ()
     Assert.EndsWith(@"PtySpeak\config.toml", path)
+
+// ---- Phase A.2 — color_detection knob -----------------------------
+
+[<Fact>]
+let ``defaultConfig resolveStreamParameters has ColorDetection = true`` () =
+    // Sensible-defaults invariant: byte-equivalent to the
+    // hardcoded behaviour. Phase A.2 enables colour detection
+    // by default.
+    let resolved = Config.resolveStreamParameters Config.defaultConfig
+    Assert.True(resolved.ColorDetection)
+
+[<Fact>]
+let ``[pathway.stream] color_detection = false flows through resolveStreamParameters`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ncolor_detection = false\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.False(resolved.ColorDetection)
+    // Other fields fall back to defaults.
+    Assert.Equal(StreamPathway.defaultParameters.DebounceWindowMs, resolved.DebounceWindowMs)
+
+[<Fact>]
+let ``[pathway.stream] color_detection = true is parsed as override (still true)`` () =
+    // Even when matching the default, the override is recorded
+    // — semantically a no-op, but the user-set flag survives
+    // round-trip.
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ncolor_detection = true\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(Some true, config.StreamOverrides.ColorDetection)
+    Assert.True((Config.resolveStreamParameters config).ColorDetection)
+
+[<Fact>]
+let ``non-bool color_detection logs Warning and falls back to default`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\ncolor_detection = 42\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.True(resolved.ColorDetection)
+    Assert.True(logger.HasLevel(LogLevel.Warning))

--- a/tests/Tests.Unit/EarconProfileTests.fs
+++ b/tests/Tests.Unit/EarconProfileTests.fs
@@ -99,14 +99,35 @@ let ``AltScreenEntered Apply returns empty pair array`` () =
     Assert.Equal(0, pairs.Length)
 
 [<Fact>]
-let ``ErrorLine Apply returns empty pair array (8d.2 will claim)`` () =
-    // 8d.1 doesn't claim ErrorLine; 8d.2's color-detection
-    // producer + earcon-palette extension will. Pinning the
-    // 8d.1 behaviour so 8d.2's diff is reviewable.
+let ``ErrorLine Apply emits one pair with error-tone ChannelDecision`` () =
+    // Phase A.2 — re-introduces 8d.2's red → 400Hz error-tone.
+    // StreamPathway emits an empty-payload ErrorLine
+    // OutputEvent alongside the StreamChunk when the frame is
+    // red-dominant; EarconProfile claims it semantically.
     let profile = EarconProfile.create ()
     let event = buildEvent SemanticCategory.ErrorLine
     let pairs = profile.Apply event
-    Assert.Equal(0, pairs.Length)
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    Assert.Equal(1, decisions.Length)
+    Assert.Equal(EarconChannel.id, decisions.[0].Channel)
+    match decisions.[0].Render with
+    | RenderEarcon earconId ->
+        Assert.Equal("error-tone", earconId)
+    | other -> Assert.Fail(sprintf "Expected RenderEarcon; got %A" other)
+
+[<Fact>]
+let ``WarningLine Apply emits one pair with warning-tone ChannelDecision`` () =
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.WarningLine
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    Assert.Equal(1, decisions.Length)
+    match decisions.[0].Render with
+    | RenderEarcon earconId ->
+        Assert.Equal("warning-tone", earconId)
+    | other -> Assert.Fail(sprintf "Expected RenderEarcon; got %A" other)
 
 [<Fact>]
 let ``Custom Semantic Apply returns empty pair array`` () =

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -565,3 +565,179 @@ let ``renderRows trims trailing blank cells per row`` () =
     let snap = snapshotOf 1 10 [ "ab" ]
     let text = Coalescer.renderRows snap
     Assert.Equal("ab", text)
+
+// ---- Phase A.2 — colour detection ----------------------------------
+
+let private cellWithFg (ch: char) (fg: ColorSpec) : Cell =
+    { Ch = System.Text.Rune ch
+      Attrs = { SgrAttrs.defaults with Fg = fg } }
+
+let private rowOfFg (cols: int) (fg: ColorSpec) (s: string) : Cell[] =
+    let row = blankRow cols
+    for i in 0 .. min (s.Length - 1) (cols - 1) do
+        row.[i] <- cellWithFg s.[i] fg
+    row
+
+let private redSnapshotOf (rows: int) (cols: int) (lines: string list) : Cell[][] =
+    let arr = Array.init rows (fun _ -> blankRow cols)
+    lines
+    |> List.iteri (fun i line ->
+        if i < rows then arr.[i] <- rowOfFg cols (Indexed 1uy) line)
+    arr
+
+let private yellowSnapshotOf (rows: int) (cols: int) (lines: string list) : Cell[][] =
+    let arr = Array.init rows (fun _ -> blankRow cols)
+    lines
+    |> List.iteri (fun i line ->
+        if i < rows then arr.[i] <- rowOfFg cols (Indexed 3uy) line)
+    arr
+
+[<Fact>]
+let ``isRedFg true for Indexed 1 and 9, false otherwise`` () =
+    Assert.True(StreamPathway.isRedFg (Indexed 1uy))
+    Assert.True(StreamPathway.isRedFg (Indexed 9uy))
+    Assert.False(StreamPathway.isRedFg (Indexed 2uy))
+    Assert.False(StreamPathway.isRedFg Default)
+    Assert.False(StreamPathway.isRedFg (Rgb (255uy, 0uy, 0uy)))
+
+[<Fact>]
+let ``isYellowFg true for Indexed 3 and 11, false otherwise`` () =
+    Assert.True(StreamPathway.isYellowFg (Indexed 3uy))
+    Assert.True(StreamPathway.isYellowFg (Indexed 11uy))
+    Assert.False(StreamPathway.isYellowFg (Indexed 4uy))
+    Assert.False(StreamPathway.isYellowFg Default)
+
+[<Fact>]
+let ``rowDominantColor red majority returns red`` () =
+    // 5 non-blank red cells → 100% red → "red".
+    let row = rowOfFg 10 (Indexed 1uy) "Error"
+    Assert.Equal(Some "red", StreamPathway.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor below 50 percent threshold returns None`` () =
+    // 2 red cells out of 4 non-blank → exactly 50% — NOT > 50%.
+    let row = blankRow 10
+    row.[0] <- cellWithFg 'E' (Indexed 1uy)
+    row.[1] <- cellWithFg 'R' (Indexed 1uy)
+    row.[2] <- cellOf 'O'
+    row.[3] <- cellOf 'K'
+    Assert.Equal(None, StreamPathway.rowDominantColor row)
+
+[<Fact>]
+let ``rowDominantColor blank row returns None`` () =
+    let row = blankRow 10
+    Assert.Equal(None, StreamPathway.rowDominantColor row)
+
+[<Fact>]
+let ``snapshotDominantColor — red wins over yellow`` () =
+    let snap =
+        Array.init 3 (fun i ->
+            if i = 0 then rowOfFg 5 (Indexed 1uy) "red"
+            elif i = 1 then rowOfFg 5 (Indexed 3uy) "yel"
+            else blankRow 5)
+    Assert.Equal(Some "red", StreamPathway.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor — yellow wins when no red`` () =
+    let snap =
+        [| rowOfFg 5 (Indexed 3uy) "warn"; blankRow 5 |]
+    Assert.Equal(Some "yellow", StreamPathway.snapshotDominantColor snap)
+
+[<Fact>]
+let ``snapshotDominantColor — plain returns None`` () =
+    let snap = snapshotOf 2 5 [ "abc"; "def" ]
+    Assert.Equal(None, StreamPathway.snapshotDominantColor snap)
+
+[<Fact>]
+let ``red snapshot leading-edge emit returns 2 events with ErrorLine`` () =
+    let state = StreamPathway.createState ()
+    let snap = redSnapshotOf 1 10 [ "Error" ]
+    let result =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap 0L)
+    Assert.Equal(2, result.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
+    Assert.Contains("Error", result.[0].Payload)
+    Assert.Equal(SemanticCategory.ErrorLine, result.[1].Semantic)
+    Assert.Equal("", result.[1].Payload)
+    Assert.Equal(Priority.Assertive, result.[1].Priority)
+
+[<Fact>]
+let ``yellow snapshot leading-edge emit returns 2 events with WarningLine`` () =
+    let state = StreamPathway.createState ()
+    let snap = yellowSnapshotOf 1 10 [ "Warn" ]
+    let result =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap 0L)
+    Assert.Equal(2, result.Length)
+    Assert.Equal(SemanticCategory.WarningLine, result.[1].Semantic)
+    Assert.Equal("", result.[1].Payload)
+
+[<Fact>]
+let ``plain snapshot leading-edge emit returns 1 event (regression guard)`` () =
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 1 10 [ "hello" ]
+    let result =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap 0L)
+    Assert.Equal(1, result.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
+
+[<Fact>]
+let ``ColorDetection = false suppresses second event on red snapshot`` () =
+    let state = StreamPathway.createState ()
+    let snap = redSnapshotOf 1 10 [ "Error" ]
+    let parameters =
+        { StreamPathway.defaultParameters with ColorDetection = false }
+    let result =
+        StreamPathway.processCanonicalState
+            parameters state (at 0) (canonicalAt snap 0L)
+    Assert.Equal(1, result.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
+
+[<Fact>]
+let ``red snapshot accumulated within debounce → onTimerTick emits both events`` () =
+    let state = StreamPathway.createState ()
+    let snap1 = redSnapshotOf 1 10 [ "E" ]
+    let snap2 = redSnapshotOf 1 10 [ "Err" ]
+    // Leading-edge at t=0 — emits 2 events for snap1.
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
+    Assert.Equal(2, r1.Length)
+    // Within debounce — accumulates snap2, no immediate emit.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
+    Assert.Equal(0, r2.Length)
+    // Trailing-edge at t=300 — flushes pending diff + colour.
+    let tick =
+        StreamPathway.onTimerTick StreamPathway.defaultParameters state (at 300)
+    Assert.Equal(2, tick.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, tick.[0].Semantic)
+    Assert.Equal(SemanticCategory.ErrorLine, tick.[1].Semantic)
+    // PendingColor cleared after the flush.
+    Assert.Equal(ValueNone, state.PendingColor)
+
+[<Fact>]
+let ``onModeBarrier with PendingColor clears it without emitting colour event`` () =
+    let state = StreamPathway.createState ()
+    let snap1 = redSnapshotOf 1 10 [ "E" ]
+    let snap2 = redSnapshotOf 1 10 [ "Err" ]
+    // Leading-edge emit (resets PendingColor inside).
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
+    // Within debounce — accumulates with PendingColor = ValueSome "red".
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
+    Assert.Equal(ValueSome "red", state.PendingColor)
+    // Mode barrier flushes the pending diff but NOT the colour event.
+    let result = StreamPathway.onModeBarrier state (at 100)
+    Assert.Equal(1, result.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
+    Assert.Equal(ValueNone, state.PendingColor)


### PR DESCRIPTION
## Summary

Restores the SGR colour-detection feature from PR #156 (Stage 8d.2) that was reverted in #157 due to an unknown release-build regression. The new design uses **event-splitting** on the Phase A pathway substrate rather than `Extensions["dominantColor"]` stamping — fixing both the original's structural flaw and avoiding the likely runtime cause.

**User-visible behaviour.** Red-foreground dominant text plays a brief 400Hz tone (`error-tone`, ~150ms) alongside NVDA reading the content. Yellow-foreground dominant plays 600Hz (`warning-tone`, ~120ms). Both are supplementary to NVDA — no double-announce, no replacement of spoken content. v1 matches the standard 16-colour ANSI palette (`Indexed 1`/`Indexed 9` for red, `Indexed 3`/`Indexed 11` for yellow); 256-cube reds and Truecolor RGB-distance matching are deferred per the original 8d.2 plan.

**Configurability.** Per the C2 principle, the feature is on by default but disable-able via TOML:

```toml
# %LOCALAPPDATA%\PtySpeak\config.toml
[pathway.stream]
color_detection = false
```

`true`/`false` recognised; non-bool values log a Warning and fall back to default. Schema documented in `docs/USER-SETTINGS.md`.

## Why this design avoids the original regression

The original 8d.2 had **two structural problems**:

1. **Latent bug: EarconProfile never saw the colour metadata.** The dispatcher fans the SAME raw input event to all profiles in parallel. StreamProfile synthesized a NEW event with `Extensions["dominantColor"]`; that synthesized event flowed only to channels (NVDA + FileLogger via `routePair`), never back through profiles. EarconProfile only saw the raw translator event with empty Extensions. The earcon path could never have fired in production. The 8d.2 unit tests passed because they fed EarconProfile pre-populated synthetic events, bypassing the dispatcher.

2. **Unknown release-build NVDA regression.** Symptom: NVDA stopped reading streaming output entirely after install; bell + diagnostic still worked. Cause was never confirmed at runtime. Most-likely candidates per the B1 writeup were a TranslatorPump exception in `snapshotDominantColor`, an interaction between non-empty `Extensions` and the post-8c FileLogger / NvdaChannel dispatch, or a Velopack-packaged-build-only IL trimming issue.

The new design **abandons Extensions stamping entirely.** StreamPathway emits TWO `OutputEvent`s per coloured frame: the existing `StreamChunk` (text payload) AND a separate empty-payload `ErrorLine` (red) or `WarningLine` (yellow). EarconProfile claims the latter **semantically** (no Extensions snoop). NvdaChannel skips the empty payload (`NvdaChannel.fs:87 RenderText "" -> ()`) so no double-announce. FileLogger records both events for the audit trail. The dispatcher's per-profile fan-out works correctly because the ErrorLine event IS the actual OutputEvent dispatched, not a hidden synthesized side-channel.

If the unknown release-build regression was Extensions-related, this design avoids it entirely. If it was unrelated, the maintainer's manual NVDA validation will surface it; the cleaner architecture makes the bisect easier.

## Architecture

**Trace (red diff text).** StreamPathway emits `[| streamChunk("Error: foo"); errorLine("") |]`. The dispatcher fans each:

- **StreamChunk**: PassThroughProfile → NvdaChannel announces via `ActivityIds.output`; FileLogger records. EarconProfile's catch-all returns `[||]`.
- **ErrorLine**: PassThroughProfile → NvdaChannel sees `RenderText ""` and skips; FileLogger records the empty-payload event for the audit trail. EarconProfile claims → emits `RenderEarcon "error-tone"` → EarconChannel plays the 400Hz tone via the palette's `error-tone` entry.

Net: one announcement, one earcon, two log entries.

**State for trailing-edge flush.** `State.PendingColor: string voption` carries the colour computed at debounce-accumulate-time. The trailing-edge `onTimerTick` flushes `[| streamChunk; colourEvent |]` together. `OnModeBarrier` clears `PendingColor` WITHOUT emitting the supplementary event — mode barriers are themselves discontinuities and emitting an error-tone for the pre-barrier flush would be misleading.

## Test plan

Unit tests (~22 new across 3 files):

**StreamPathwayTests** (14):
- [ ] `isRedFg` / `isYellowFg` table tests
- [ ] `rowDominantColor` red/threshold/blank
- [ ] `snapshotDominantColor` red-wins / yellow-fallback / plain-None
- [ ] Red snapshot leading-edge → 2 events with `ErrorLine` second
- [ ] Yellow snapshot leading-edge → 2 events with `WarningLine` second
- [ ] Plain snapshot leading-edge → 1 event (regression guard)
- [ ] `ColorDetection = false` → 1 event even on red snapshot
- [ ] Red snapshot accumulated within debounce → trailing-edge tick emits both
- [ ] `OnModeBarrier` with `PendingColor` clears it without emitting

**EarconProfileTests** (2 new + 1 updated):
- [ ] `ErrorLine` event → `RenderEarcon "error-tone"` decision
- [ ] `WarningLine` event → `RenderEarcon "warning-tone"` decision
- [ ] (replaced) The "8d.2 will claim" pin updated to assert the actual claim

**ConfigTests** (4):
- [ ] `defaultConfig.resolveStreamParameters.ColorDetection = true`
- [ ] `[pathway.stream] color_detection = false` flows through
- [ ] `color_detection = true` round-trip
- [ ] Non-bool `color_detection = 42` logs Warning + falls back

Manual NVDA validation (deferred to maintainer):
- [ ] In PowerShell (`Ctrl+Shift+2`), run `Write-Host -ForegroundColor Red "Build failed"` — verify NVDA reads "Build failed" and a 400Hz tone plays alongside.
- [ ] `Write-Host -ForegroundColor Yellow "Warning"` — verify 600Hz tone alongside reading.
- [ ] `Write-Host "Hello"` — verify NO tone (plain text).
- [ ] Drop `[pathway.stream] color_detection = false` to `%LOCALAPPDATA%\PtySpeak\config.toml`, relaunch, repeat the red command — verify the tone is suppressed but reading still happens.
- [ ] Press `Ctrl+Shift+D` to ensure the diagnostic earcon test still plays all three tones (bell-ping + error-tone + warning-tone) — sanity check that the audio path itself works in the release build.

## Out of scope (carried forward)

- 256-colour cube reds (`Indexed 196` etc.)
- Truecolor RGB-distance matching (`Rgb` ColorSpec)
- Background-colour reds (`Bg` field)
- `ParserError → error-tone` routing — needs cross-profile suppression substrate (NvdaChannel announces ParserError on the error activityId; doubling up earcon + announce would be noisy)
- Per-shell `color_detection` overrides — uniform pathway-level config is enough for v1
- TuiPathway colour detection (TuiPathway emits no StreamChunks)
- Earcon palette frequency/duration overrides via TOML
- Earcon dedup for sustained red errors (multiple emits across rapid frames produce multiple earcons; matches original 8d.2 behaviour)

## Implementation notes

No new packages, no fsproj changes, no palette additions. `EarconPalette.defaultPalette` retained `error-tone` + `warning-tone` entries across the 8d.2 revert. `NvdaChannel.semanticToActivityId` already maps `ErrorLine` + `WarningLine` to `ActivityIds.error` (Stage 8a).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_