### PR TITLE
Phase A.2 hotfix — scope colour detection to diff's changed rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,59 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Phase A.2 hotfix — colour detection scoped to diff)
+
+The maintainer's release-build validation of Phase A.2 (PR
+#163) surfaced two coupled symptoms:
+
+1. After running `Write-Host -ForegroundColor Red "Build
+   failed"` (which plays `error-tone` correctly), the next
+   command `Write-Host -ForegroundColor Yellow "..."` plays
+   `error-tone` AGAIN — same tone, never `warning-tone`.
+2. The error-tone fires on every keystroke while typing the
+   new command, even though only the prompt row is changing.
+
+Root cause: Phase A.2's `snapshotDominantColor` walked the
+ENTIRE `canonical.Snapshot` rather than just the rows in
+`diff.ChangedRows`. After the red command, "Build failed"
+remains rendered red on its row in the screen buffer. Every
+subsequent frame sees that red row (even though it's
+unchanged), `snapshotDominantColor` returns `Some "red"`,
+red wins precedence over yellow, ErrorLine fires, and the
+warning-tone path is starved.
+
+Behaviour intent: the colour earcon should supplement *new*
+content, not "any colour anywhere on the screen". A red error
+that scrolls off shouldn't keep beeping; a yellow warning
+typed into a buffer that still contains earlier red text
+should fire warning-tone, not error-tone.
+
+Fix: new `changedRowsDominantColor` helper that walks only the
+rows in `diff.ChangedRows` (or the pending diff's changed rows
+at trailing-edge flush time). The leading-edge emit branch and
+the debounce-accumulate branch both call this scoped variant
+instead of the whole-snapshot version. The original
+`snapshotDominantColor` is retained for the helper-level unit
+tests and for any future caller that legitimately wants the
+whole-snapshot scan.
+
+Files:
+- `src/Terminal.Core/StreamPathway.fs` — new
+  `changedRowsDominantColor`; `processCanonicalState` calls it
+  from a `computeColor (changedRows: int[])` local closure
+  that's invoked inside the leading-edge and accumulate
+  branches against the diff's ChangedRows.
+- `tests/Tests.Unit/StreamPathwayTests.fs` — 2 new tests:
+  `changedRowsDominantColor` walks only the supplied indices;
+  the integration regression — red row outside diff scope
+  produces no ErrorLine emit.
+
+The fix is small (~80 LOC + 2 tests) and the existing 14
+Phase A.2 colour-detection tests all stay green because their
+red/yellow snapshots have the coloured rows IN the diff (the
+tests construct fresh state and emit on first call, where
+every row is "changed").
+
 ### Added (Phase A.2 — colour-detection earcons re-introduced)
 
 Re-introduces the SGR colour-detection feature originally

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -264,6 +264,34 @@ module StreamPathway =
         elif hasYellow then Some "yellow"
         else None
 
+    /// Phase A.2 hotfix — same precedence logic as
+    /// `snapshotDominantColor` but scoped to the rows that
+    /// CHANGED in the most recent diff (`diff.ChangedRows`)
+    /// rather than every row of the snapshot. Without this
+    /// scoping the earcon path treated "any red anywhere on
+    /// screen" as a trigger — so a red error message rendered
+    /// once would fire `error-tone` on every subsequent
+    /// keystroke (the new prompt row was the only changed row,
+    /// but the snapshot still contained the leftover red row).
+    /// The intent of the colour earcon is to supplement *new*
+    /// content; only changed rows count.
+    let internal changedRowsDominantColor
+            (snapshot: Cell[][])
+            (changedRows: int[])
+            : string option
+            =
+        let mutable hasRed = false
+        let mutable hasYellow = false
+        for rowIdx in changedRows do
+            if rowIdx >= 0 && rowIdx < snapshot.Length then
+                match rowDominantColor snapshot.[rowIdx] with
+                | Some "red" -> hasRed <- true
+                | Some "yellow" -> hasYellow <- true
+                | _ -> ()
+        if hasRed then Some "red"
+        elif hasYellow then Some "yellow"
+        else None
+
     /// Build the StreamChunk OutputEvent for a flushed diff.
     /// Producer-stamp is "stream" (the StreamPathway origin).
     let private streamOutputEvent (text: string) : OutputEvent =
@@ -320,13 +348,16 @@ module StreamPathway =
             let mutable h = 0UL
             for rh in rowHashes do h <- h ^^^ rh
             h
-        // Phase A.2 — compute the dominant colour eagerly
-        // (only if config-enabled). Used both at leading-edge
-        // (emits supplementary event) and at debounce-accumulate
-        // (stashed in state.PendingColor for trailing-edge flush).
-        let dominantColor =
+        // Phase A.2 hotfix — colour detection moved INSIDE the
+        // emit branches so it runs against the diff's
+        // `ChangedRows` rather than the whole snapshot. See
+        // `changedRowsDominantColor` for the rationale; the
+        // earlier "scan all rows" version made stale red text
+        // re-trigger error-tone on every keystroke at a new
+        // prompt.
+        let computeColor (changedRows: int[]) : string option =
             if parameters.ColorDetection then
-                snapshotDominantColor canonical.Snapshot
+                changedRowsDominantColor canonical.Snapshot changedRows
             else
                 None
         match state.LastFrameHash with
@@ -371,6 +402,7 @@ module StreamPathway =
                             "Suppressed (empty-diff). FrameHash=0x{Hash:X16}", frameHash)
                         [||]
                     else
+                        let dominantColor = computeColor diff.ChangedRows
                         state.LastFrameHash <- ValueSome frameHash
                         state.LastFlushAt <- ValueSome now
                         state.PendingDiff <- ValueNone
@@ -384,9 +416,10 @@ module StreamPathway =
                             (match dominantColor with Some c -> c | None -> "none"))
                         // Phase A.2 — emit a supplementary
                         // ErrorLine/WarningLine event when the
-                        // frame is colour-dominant. EarconProfile
-                        // claims it semantically; NvdaChannel skips
-                        // the empty payload so no double-announce.
+                        // diff's changed rows are colour-dominant.
+                        // EarconProfile claims it semantically;
+                        // NvdaChannel skips the empty payload so no
+                        // double-announce.
                         match dominantColor |> Option.bind colorOutputEvent with
                         | Some colorEvt -> [| streamOutputEvent capped; colorEvt |]
                         | None -> [| streamOutputEvent capped |]
@@ -397,7 +430,9 @@ module StreamPathway =
                     // emits both events together. Overwrite any
                     // previous PendingColor — latest pending frame
                     // wins, matching PendingDiff semantics.
-                    state.PendingDiff <- ValueSome (canonical.computeDiff state.LastEmittedRowHashes)
+                    let pendingDiff = canonical.computeDiff state.LastEmittedRowHashes
+                    let dominantColor = computeColor pendingDiff.ChangedRows
+                    state.PendingDiff <- ValueSome pendingDiff
                     state.PendingFrameHash <- ValueSome frameHash
                     state.PendingColor <-
                         match dominantColor with

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -741,3 +741,58 @@ let ``onModeBarrier with PendingColor clears it without emitting colour event`` 
     Assert.Equal(1, result.Length)
     Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
     Assert.Equal(ValueNone, state.PendingColor)
+
+// ---- Phase A.2 hotfix — colour detection scoped to diff -----------
+
+[<Fact>]
+let ``changedRowsDominantColor — only walks rows in the changedRows index`` () =
+    // Two rows: row 0 red, row 1 plain. The "all rows" scan
+    // (snapshotDominantColor) returns Some "red"; the
+    // "changed rows only" scan with changedRows = [|1|] must
+    // return None because only the plain row is in scope.
+    let row0 = rowOfFg 10 (Indexed 1uy) "Error"
+    let row1 = rowOf 10 "okay"
+    let snap = [| row0; row1 |]
+    Assert.Equal(Some "red", StreamPathway.snapshotDominantColor snap)
+    Assert.Equal(None, StreamPathway.changedRowsDominantColor snap [| 1 |])
+    Assert.Equal(Some "red", StreamPathway.changedRowsDominantColor snap [| 0 |])
+    Assert.Equal(Some "red", StreamPathway.changedRowsDominantColor snap [| 0; 1 |])
+
+[<Fact>]
+let ``red row outside diff scope produces no ErrorLine emit`` () =
+    // The Phase A.2 hotfix regression. Sequence:
+    //   1. snap1 has row 0 = red "Error", row 1 = plain "okay".
+    //      Leading-edge emit: 2 events (StreamChunk + ErrorLine).
+    //   2. snap2 has row 0 unchanged red "Error", row 1 = plain
+    //      "later". Only row 1 changed.
+    //   3. Second leading-edge (at debounce + 1ms): 1 event
+    //      (StreamChunk only — no ErrorLine). The red row is
+    //      OUTSIDE the diff's ChangedRows so the supplementary
+    //      colour event must NOT fire.
+    //
+    // Pre-hotfix: snapshotDominantColor walks all rows, sees red
+    //   row 0, returns Some "red", emits ErrorLine on every
+    //   keystroke at the new prompt. This is the bug the hotfix
+    //   addresses.
+    let state = StreamPathway.createState ()
+    let row0 = rowOfFg 10 (Indexed 1uy) "Error"
+    let row1Original = rowOf 10 "okay"
+    let row1Changed = rowOf 10 "later"
+    let snap1 = [| row0; row1Original |]
+    let snap2 = [| row0; row1Changed |]
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(2, r1.Length)
+    Assert.Equal(SemanticCategory.ErrorLine, r1.[1].Semantic)
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 500)
+            (canonicalAt snap2 1L)
+    Assert.Equal(1, r2.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, r2.[0].Semantic)
+    // The diff's changed text contains only the row that
+    // actually changed (row 1).
+    Assert.Contains("later", r2.[0].Payload)
+    Assert.DoesNotContain("Error", r2.[0].Payload)


### PR DESCRIPTION
## Summary

Maintainer's release-build validation of Phase A.2 (PR #163) surfaced two coupled symptoms:

1. **Yellow plays the error-tone (red's tone), never `warning-tone`.** `Write-Host -ForegroundColor Red "Build failed"` correctly plays the 400Hz error-tone. Then `Write-Host -ForegroundColor Yellow "..."` plays error-tone again — same tone, never the 600Hz warning-tone.
2. **The tone fires on every keystroke** while typing the new command, even though only the prompt row is changing.

## Root cause

Phase A.2's `snapshotDominantColor` walked the **entire** `canonical.Snapshot` rather than just the rows in `diff.ChangedRows`. After the red command, "Build failed" remains rendered red on its row in the screen buffer. Every subsequent frame:
- The whole-snapshot scan finds the red row (still on screen, unchanged)
- Returns `Some "red"`
- Red wins precedence over yellow → ErrorLine fires
- EarconProfile emits error-tone

The warning-tone path is starved because red wins precedence even when the red row hasn't changed since the last emit. The per-keystroke firing happens because every keystroke at the new prompt produces a 1-row diff (the prompt row), but the colour scan ignores the diff and re-evaluates the whole screen each time.

## Behaviour intent

The colour earcon should supplement **new content**, not "any colour anywhere on the screen". A red error that scrolls off the visible buffer shouldn't keep beeping. A yellow warning typed into a buffer that still contains earlier red text should fire warning-tone, not error-tone.

## Fix

New `changedRowsDominantColor` helper that walks only the rows in the supplied `changedRows` index:

```fsharp
let internal changedRowsDominantColor
        (snapshot: Cell[][])
        (changedRows: int[])
        : string option =
    let mutable hasRed = false
    let mutable hasYellow = false
    for rowIdx in changedRows do
        if rowIdx >= 0 && rowIdx < snapshot.Length then
            match rowDominantColor snapshot.[rowIdx] with
            | Some "red" -> hasRed <- true
            | Some "yellow" -> hasYellow <- true
            | _ -> ()
    if hasRed then Some "red"
    elif hasYellow then Some "yellow"
    else None
```

`processCanonicalState` calls this from a `computeColor (changedRows: int[])` local closure. The closure is invoked inside the leading-edge emit branch (against `diff.ChangedRows`) and inside the debounce-accumulate branch (against the pending diff's changed rows). The empty-diff branch doesn't call it (no rows changed → no colour to detect).

`snapshotDominantColor` is retained for the helper-level unit tests and for any future caller that legitimately wants the whole-snapshot scan.

## Test plan

Unit tests (2 new):

- [ ] `changedRowsDominantColor` walks only the supplied indices — table test: red row 0 + plain row 1 snapshot; full scan returns red, scoped scan with `[|1|]` returns None, scoped scan with `[|0|]` returns red, scoped scan with `[|0; 1|]` returns red.
- [ ] **Integration regression**: red row outside diff scope produces no ErrorLine emit. Sequence: leading-edge emit on snap1 (red row 0 + plain row 1) → 2 events including ErrorLine. Then leading-edge emit on snap2 (red row 0 unchanged, plain row 1 changed) → only 1 event (StreamChunk), no ErrorLine, even though the screen still contains the red row.

Existing Phase A.2 tests (14) stay green because their test snapshots have the coloured rows IN the diff (fresh state + first emit treats every row as changed).

Manual NVDA validation matrix (deferred to maintainer):

- [ ] Cut a fresh release with this hotfix
- [ ] `Write-Host -ForegroundColor Red "Build failed"` → 400Hz error-tone (unchanged)
- [ ] `Write-Host -ForegroundColor Yellow "Warning"` immediately after → 600Hz warning-tone (was previously 400Hz)
- [ ] Type a third command at the prompt → no tone fires while typing (was previously firing on every keystroke)
- [ ] Plain `Write-Host "Hello"` → no tone (regression guard, unchanged)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_