### PR TITLE
Extend Ctrl+Shift+D into a self-test battery + write-through diagnostic log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,107 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Ctrl+Shift+D extended diagnostic battery)
+
+Ctrl+Shift+D now runs a self-test battery against the active
+shell rather than just snapshotting + replaying earcons. Goal:
+collapse the manual NVDA validation loop ("open shell → run
+command → listen → describe what NVDA said") into a single
+"press hotkey, paste log" round-trip. The maintainer's framing
+2026-05-06: every future colour-detection or pathway behaviour
+change should be validatable without minutes of describe-what-
+you-heard.
+
+What runs on press:
+
+1. Process snapshot via `enumerateShellProcesses` (kept from the
+   previous behaviour) — counts of `cmd.exe`,
+   `powershell.exe`, `pwsh.exe`, `claude.exe`, and
+   `Terminal.App.exe`.
+2. Earcon replay (kept) — plays bell-ping, error-tone,
+   warning-tone with NVDA labels between each, so the audio
+   path is verifiable independent of the test battery.
+3. Per-shell command battery, exercising the canonical pipeline
+   end-to-end. For each test case: write command bytes via
+   `ConPtyHost.WriteBytes`, capture the resulting `OutputEvent`s
+   via a temporary tap on `OutputDispatcher`, compare against
+   expected, log PASS / FAIL with full event detail.
+4. Summary line + clipboard copy of the full diagnostic log,
+   announced via NVDA. Maintainer pastes the log into chat
+   directly — no `Ctrl+Shift+;` step needed.
+
+PowerShell test set (5 cases, each ~1.5s settle window):
+
+* **T1.Plain** — `Write-Host` plain text emits `StreamChunk`
+  only, no colour event.
+* **T2.Red** — `Write-Host -ForegroundColor Red` emits
+  `StreamChunk + ErrorLine`.
+* **T3.Yellow** — `Write-Host -ForegroundColor Yellow` emits
+  `StreamChunk + WarningLine`.
+* **T4.PlainAfterRed** — red command, then plain. Asserts the
+  second emit has NO `ErrorLine` (PR #164 hotfix regression
+  guard — catches "stale red row in snapshot fires error-tone
+  on every keystroke").
+* **T5.YellowAfterRed** — red command, then yellow. Asserts
+  the second emit has `WarningLine`, not `ErrorLine` (catches
+  "red precedence shadows yellow when red is outside the diff
+  scope").
+
+Cmd test set (1 case): plain `echo`. Cmd has minimal colour
+support; ANSI-escape colour testing is a separate follow-up.
+
+Claude shell: command battery skipped (non-deterministic
+interactive AI). Snapshot + earcon replay still run.
+
+Diagnostic log file:
+`%LOCALAPPDATA%\PtySpeak\logs\YYYY-MM-DD\diagnostic-YYYY-MM-DD-HH-mm-ss-fff.log`.
+Same parent folder as regular `pty-speak-*.log` so
+`Ctrl+Shift+L` opens the right area; `diagnostic-` prefix is
+the distinguisher. Crash-safety mirrors `FileLogger`:
+`StreamWriter.AutoFlush = true` + `FileShare.ReadWrite` +
+`FileMode.Create`. Every line is on disk before the next is
+queued, so a crash mid-battery still leaves a tail file with
+everything up to the crash.
+
+New infrastructure under the hood:
+
+* `OutputDispatcher.installEventTap` — registers an
+  `OutputEvent -> unit` observer that fires before profile
+  fan-out. Returns `IDisposable` for cleanup. Tap exceptions
+  are swallowed so a misbehaving tap can't break production
+  routing. 6 new unit tests in
+  `tests/Tests.Unit/OutputDispatcherTests.fs` cover register-
+  fires, dispose-stops, multi-tap fan-out, single-dispose-
+  doesn't-affect-others, throwing-tap-doesn't-break-dispatch,
+  and tap-fires-with-no-profiles.
+* `Terminal.App.Diagnostics` (new module) — owns the writer,
+  the tap wrapper, the test definitions, the per-test loop,
+  and the entry point `runFullBattery`. ~510 lines; lives
+  under `src/Terminal.App/Diagnostics.fs`.
+
+Files:
+
+* `src/Terminal.App/Diagnostics.fs` — new module.
+* `src/Terminal.App/Terminal.App.fsproj` — `Diagnostics.fs`
+  ordered before `Program.fs`.
+* `src/Terminal.Core/OutputDispatcher.fs` — `installEventTap` +
+  `fireTaps` + tap-firing in `dispatch` and `dispatchTick`.
+* `src/Terminal.App/Program.fs` — old `runDiagnostic` body +
+  `enumerateShellProcesses` helper deleted (~140 lines, plus
+  the dead commented-out PowerShell-script launch). The
+  Ctrl+Shift+D bind moves to the closure-bind group near the
+  health-check + incident-marker binds because the new
+  closure captures `hostHandle` / `currentShell` /
+  `screen.SequenceNumber`.
+* `tests/Tests.Unit/OutputDispatcherTests.fs` — 6 new tests
+  for the tap surface.
+
+The `scripts/test-process-cleanup.ps1` script remains in the
+repo and can still be invoked manually for close-and-recheck
+testing — it just no longer launches from Ctrl+Shift+D (the
+launch was already commented out as of 2026-05-04; this PR
+removes the dead code and the surrounding stale comments).
+
 ### Fixed (Phase A.2 hotfix — colour detection scoped to diff)
 
 The maintainer's release-build validation of Phase A.2 (PR

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -566,92 +566,92 @@ module Diagnostics =
                     log.LogInformation(
                         "Diagnostic battery starting. Shell={Shell} LogPath={LogPath}",
                         shell.DisplayName, logPath)
-                let announce (msg: string) : Task =
-                    task {
-                        let act () =
-                            window.TerminalSurface.Announce(msg, ActivityIds.diagnostic)
-                        do! window.Dispatcher.InvokeAsync(Action(act)).Task
-                    }
-                do! announce
-                    (sprintf
-                        "Starting diagnostic on %s. About 10 seconds; commands will run in your shell."
-                        shell.DisplayName)
-                // T0 — process snapshot.
-                let snapshot = enumerateShellProcesses ()
-                writer.WriteLine LogLevel.Information "Diagnostic.T0.Snapshot" snapshot
-                log.LogInformation(
-                    "Diagnostic snapshot. ProcessCounts={Snapshot}", snapshot)
-                // T_Earcons — replay the three earcons.
-                do! runEarconReplay window writer
-                // Per-shell command battery.
-                let writeBytes (bytes: byte[]) : Task =
-                    task {
-                        let act () =
-                            match resolveHost () with
-                            | Some h -> h.WriteBytes(bytes)
-                            | None -> ()
-                        do! window.Dispatcher.InvokeAsync(Action(act)).Task
-                    }
-                let tests = selectTestsForShell shell.Id
-                let mutable pass = 0
-                let mutable fail = 0
-                if Array.isEmpty tests then
-                    writer.WriteLine LogLevel.Information "Diagnostic.Battery"
-                        (sprintf
-                            "Skipped command battery: no test set for shell %A."
-                            shell.Id)
-                else
-                    for test in tests do
-                        let! ok = runOneTest writer writeBytes resolveSeq test
-                        if ok then pass <- pass + 1 else fail <- fail + 1
-                let total = pass + fail
-                writer.WriteLine LogLevel.Information "Diagnostic.Summary"
-                    (sprintf "PASS=%d FAIL=%d TOTAL=%d Shell=%A"
-                         pass fail total shell.Id)
-                log.LogInformation(
-                    "Diagnostic battery complete. Pass={Pass} Fail={Fail} Total={Total}",
-                    pass, fail, total)
-                // Close the writer BEFORE reading the file for clipboard.
-                (writer :> IDisposable).Dispose()
-                // Read the diagnostic log content for clipboard. Same
-                // FileShare.ReadWrite open mode as Ctrl+Shift+; uses.
-                let content =
-                    try
-                        use stream =
-                            new FileStream(
-                                logPath, FileMode.Open, FileAccess.Read,
-                                FileShare.ReadWrite)
-                        use reader = new StreamReader(stream, Encoding.UTF8)
-                        reader.ReadToEnd()
-                    with ex ->
-                        log.LogWarning(
-                            ex,
-                            "Failed to read diagnostic log for clipboard: {Message}",
-                            ex.Message)
-                        ""
-                let summaryLine =
-                    if total = 0 then
-                        sprintf
-                            "Diagnostic complete. Snapshot and earcons logged. Shell %s skipped command battery."
-                            shell.DisplayName
-                    else
-                        sprintf
-                            "Diagnostic complete. %d of %d passed."
-                            pass total
-                if String.IsNullOrEmpty content then
+                    let announce (msg: string) : Task =
+                        task {
+                            let act () =
+                                window.TerminalSurface.Announce(msg, ActivityIds.diagnostic)
+                            do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                        }
                     do! announce
-                        (sprintf "%s Could not read diagnostic log." summaryLine)
-                else
-                    let! copied = copyToClipboardSta log content
-                    if copied then
-                        do! announce
-                            (sprintf "%s Diagnostic log copied to clipboard." summaryLine)
-                    else
-                        do! announce
+                        (sprintf
+                            "Starting diagnostic on %s. About 10 seconds; commands will run in your shell."
+                            shell.DisplayName)
+                    // T0 — process snapshot.
+                    let snapshot = enumerateShellProcesses ()
+                    writer.WriteLine LogLevel.Information "Diagnostic.T0.Snapshot" snapshot
+                    log.LogInformation(
+                        "Diagnostic snapshot. ProcessCounts={Snapshot}", snapshot)
+                    // T_Earcons — replay the three earcons.
+                    do! runEarconReplay window writer
+                    // Per-shell command battery.
+                    let writeBytes (bytes: byte[]) : Task =
+                        task {
+                            let act () =
+                                match resolveHost () with
+                                | Some h -> h.WriteBytes(bytes)
+                                | None -> ()
+                            do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                        }
+                    let tests = selectTestsForShell shell.Id
+                    let mutable pass = 0
+                    let mutable fail = 0
+                    if Array.isEmpty tests then
+                        writer.WriteLine LogLevel.Information "Diagnostic.Battery"
                             (sprintf
-                                "%s Clipboard copy failed; diagnostic log at %s."
-                                summaryLine
-                                logPath)
+                                "Skipped command battery: no test set for shell %A."
+                                shell.Id)
+                    else
+                        for test in tests do
+                            let! ok = runOneTest writer writeBytes resolveSeq test
+                            if ok then pass <- pass + 1 else fail <- fail + 1
+                    let total = pass + fail
+                    writer.WriteLine LogLevel.Information "Diagnostic.Summary"
+                        (sprintf "PASS=%d FAIL=%d TOTAL=%d Shell=%A"
+                             pass fail total shell.Id)
+                    log.LogInformation(
+                        "Diagnostic battery complete. Pass={Pass} Fail={Fail} Total={Total}",
+                        pass, fail, total)
+                    // Close the writer BEFORE reading the file for clipboard.
+                    (writer :> IDisposable).Dispose()
+                    // Read the diagnostic log content for clipboard. Same
+                    // FileShare.ReadWrite open mode as Ctrl+Shift+; uses.
+                    let content =
+                        try
+                            use stream =
+                                new FileStream(
+                                    logPath, FileMode.Open, FileAccess.Read,
+                                    FileShare.ReadWrite)
+                            use reader = new StreamReader(stream, Encoding.UTF8)
+                            reader.ReadToEnd()
+                        with ex ->
+                            log.LogWarning(
+                                ex,
+                                "Failed to read diagnostic log for clipboard: {Message}",
+                                ex.Message)
+                            ""
+                    let summaryLine =
+                        if total = 0 then
+                            sprintf
+                                "Diagnostic complete. Snapshot and earcons logged. Shell %s skipped command battery."
+                                shell.DisplayName
+                        else
+                            sprintf
+                                "Diagnostic complete. %d of %d passed."
+                                pass total
+                    if String.IsNullOrEmpty content then
+                        do! announce
+                            (sprintf "%s Could not read diagnostic log." summaryLine)
+                    else
+                        let! copied = copyToClipboardSta log content
+                        if copied then
+                            do! announce
+                                (sprintf "%s Diagnostic log copied to clipboard." summaryLine)
+                        else
+                            do! announce
+                                (sprintf
+                                    "%s Clipboard copy failed; diagnostic log at %s."
+                                    summaryLine
+                                    logPath)
                 with ex ->
                     log.LogError(
                         ex,

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -572,10 +572,11 @@ module Diagnostics =
                                 window.TerminalSurface.Announce(msg, ActivityIds.diagnostic)
                             do! window.Dispatcher.InvokeAsync(Action(act)).Task
                         }
-                    do! announce
-                        (sprintf
+                    let startMsg =
+                        sprintf
                             "Starting diagnostic on %s. About 10 seconds; commands will run in your shell."
-                            shell.DisplayName)
+                            shell.DisplayName
+                    do! announce startMsg
                     // T0 — process snapshot.
                     let snapshot = enumerateShellProcesses ()
                     writer.WriteLine LogLevel.Information "Diagnostic.T0.Snapshot" snapshot
@@ -639,19 +640,20 @@ module Diagnostics =
                                 "Diagnostic complete. %d of %d passed."
                                 pass total
                     if String.IsNullOrEmpty content then
-                        do! announce
-                            (sprintf "%s Could not read diagnostic log." summaryLine)
+                        let msg = sprintf "%s Could not read diagnostic log." summaryLine
+                        do! announce msg
                     else
                         let! copied = copyToClipboardSta log content
                         if copied then
-                            do! announce
-                                (sprintf "%s Diagnostic log copied to clipboard." summaryLine)
+                            let msg = sprintf "%s Diagnostic log copied to clipboard." summaryLine
+                            do! announce msg
                         else
-                            do! announce
-                                (sprintf
+                            let msg =
+                                sprintf
                                     "%s Clipboard copy failed; diagnostic log at %s."
                                     summaryLine
-                                    logPath)
+                                    logPath
+                            do! announce msg
                 with ex ->
                     log.LogError(
                         ex,

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -1,0 +1,668 @@
+namespace PtySpeak.App
+
+open System
+open System.Collections.Concurrent
+open System.IO
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+open Microsoft.Extensions.Logging
+open PtySpeak.Views
+open Terminal.Audio
+open Terminal.Core
+open Terminal.Pty
+
+/// Ctrl+Shift+D diagnostic battery.
+///
+/// **What this is.** A self-test harness that runs on demand
+/// from the Ctrl+Shift+D hotkey. Captures the current process
+/// snapshot, replays the three earcons, then runs a per-shell
+/// command battery that exercises the canonical pipeline end-
+/// to-end (write bytes via `ConPtyHost.WriteBytes`, observe the
+/// `OutputEvent`s the active pathway emits, compare against
+/// expected). Writes a structured artefact log file with PASS /
+/// FAIL per test + a summary, then copies the log to the
+/// clipboard so the maintainer can paste it into chat without
+/// any extra steps.
+///
+/// **Why.** Phase A.2 + the changed-rows hotfix shipped on the
+/// back of one round of manual NVDA validation per behaviour.
+/// Each round costs the maintainer minutes of "open shell, run
+/// command, listen, describe what NVDA said". As pathway
+/// behaviour grows (suffix-diff, ReplPathway, content-type
+/// triggers), the validation cost grows linearly. This battery
+/// reduces the loop to "press one hotkey, paste log".
+///
+/// **Architecture.** Three pieces:
+///
+///   * `DiagnosticLogWriter` — short-lived per-run file writer.
+///     `AutoFlush = true` + `FileShare.ReadWrite` mirror the
+///     FileLogger crash-safety paradigm: every line is on disk
+///     before the next is queued, so a crash mid-battery still
+///     leaves a tail file with everything up to the crash.
+///   * `DiagnosticEventTap` — wraps `OutputDispatcher.installEventTap`
+///     to capture `OutputEvent`s during a known time window.
+///     Drained synchronously after each test; cross-thread-safe
+///     via `ConcurrentQueue<T>`.
+///   * `runFullBattery` — orchestrator. Opens the writer, runs
+///     universal + per-shell tests, closes the writer, copies
+///     to clipboard, announces the summary.
+///
+/// **Threading.** The hotkey handler runs on the WPF dispatcher
+/// thread. `runFullBattery` posts a `Task.Run` body so the
+/// dispatcher isn't blocked for the ~10s battery duration; each
+/// `WriteBytes` and `Announce` marshals back to the dispatcher
+/// via `window.Dispatcher.InvokeAsync` (matching the existing
+/// keystroke-write contract per `ConPtyHost.fs:49-56`).
+[<RequireQualifiedAccess>]
+module Diagnostics =
+
+    // ---------------------------------------------------------------
+    // Format helpers
+    // ---------------------------------------------------------------
+
+    /// Map `LogLevel` to the three-letter label that FileLogger
+    /// uses (`INF`, `DBG`, `ERR`, ...). Inlined here rather than
+    /// extracted from FileLogger because `FileLogger.formatEntry`
+    /// is class-private and exposing it would require a wider
+    /// refactor — eight lines of duplication isn't worth that.
+    let private levelLabel (level: LogLevel) : string =
+        match level with
+        | LogLevel.Trace -> "TRC"
+        | LogLevel.Debug -> "DBG"
+        | LogLevel.Information -> "INF"
+        | LogLevel.Warning -> "WRN"
+        | LogLevel.Error -> "ERR"
+        | LogLevel.Critical -> "CRT"
+        | _ -> "???"
+
+    // ---------------------------------------------------------------
+    // DiagnosticLogWriter — short-lived per-run file writer.
+    // ---------------------------------------------------------------
+
+    /// A line-oriented log writer whose crash-safety story matches
+    /// `FileLogger`: every WriteLine is flushed to disk before
+    /// returning, the FileStream is opened with
+    /// `FileShare.ReadWrite` so external readers (NVDA, Notepad)
+    /// can open the file mid-write, and `Dispose` flushes one
+    /// final time before closing. One instance per diagnostic run.
+    type DiagnosticLogWriter (path: string) =
+        do
+            // Make sure the parent directory exists. The day-folder
+            // may be fresh on the first diagnostic of the day.
+            // `Path.GetDirectoryName` is nullable per F# 9 nullness
+            // rules (see CONTRIBUTING.md "F# 9 nullness annotations"
+            // — same list as `Environment.GetEnvironmentVariable`,
+            // `Path.GetFileName`, etc.); narrow before passing to
+            // `Directory.CreateDirectory`.
+            match Path.GetDirectoryName(path) with
+            | null -> ()
+            | dir when String.IsNullOrEmpty dir -> ()
+            | dir ->
+                Directory.CreateDirectory(dir) |> ignore
+        let stream =
+            new FileStream(
+                path, FileMode.Create, FileAccess.Write,
+                FileShare.ReadWrite, bufferSize = 4096,
+                options = FileOptions.None)
+        let writer = new StreamWriter(stream, Encoding.UTF8)
+        do writer.AutoFlush <- true
+
+        /// Resolved file path. Useful for the announce or for
+        /// later `File.ReadAllText` to load the log content for
+        /// the clipboard copy.
+        member _.Path = path
+
+        /// Append one log line. Format mirrors FileLogger:
+        /// `yyyy-MM-ddTHH:mm:ss.fffZ [LEVEL] [Category] message`.
+        /// Multi-line `message` is preserved as-is; downstream
+        /// tooling that expects one-entry-per-line should split
+        /// on the timestamp prefix.
+        member _.WriteLine (level: LogLevel) (category: string) (message: string) : unit =
+            let ts =
+                DateTimeOffset.UtcNow.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            let line = sprintf "%s [%s] [%s] %s" ts (levelLabel level) category message
+            writer.WriteLine(line)
+
+        /// Flush + close. Idempotent — `Dispose` may be called
+        /// twice with no ill effect (StreamWriter handles that).
+        interface IDisposable with
+            member _.Dispose () =
+                try writer.Flush() with _ -> ()
+                try writer.Close() with _ -> ()
+
+    // ---------------------------------------------------------------
+    // DiagnosticEventTap — observes events flowing through the
+    // dispatcher during a known time window.
+    // ---------------------------------------------------------------
+
+    /// Captures every `OutputEvent` dispatched between `Enable`
+    /// and the matching `DisableAndDrain`. Backed by a
+    /// `ConcurrentQueue<T>` because `OutputDispatcher.dispatch`
+    /// runs on the PathwayPump worker thread while the diagnostic
+    /// orchestrator drains from the test-loop thread.
+    type DiagnosticEventTap () =
+        let queue = ConcurrentQueue<OutputEvent>()
+        let mutable subscription : IDisposable option = None
+
+        /// Begin capturing. Must be paired with `DisableAndDrain`
+        /// before the next test (otherwise events leak across the
+        /// boundary). Idempotent — re-enabling without disabling
+        /// disposes the previous subscription first.
+        member this.Enable () : unit =
+            this.DisableAndDrain () |> ignore
+            subscription <-
+                Some (OutputDispatcher.installEventTap (fun ev -> queue.Enqueue(ev)))
+
+        /// Stop capturing and return everything captured since
+        /// `Enable`. Calling this without an active subscription
+        /// returns an empty array.
+        member _.DisableAndDrain () : OutputEvent[] =
+            (match subscription with
+             | Some s ->
+                 try s.Dispose() with _ -> ()
+                 subscription <- None
+             | None -> ())
+            let buf = ResizeArray<OutputEvent>()
+            let mutable item = Unchecked.defaultof<OutputEvent>
+            while queue.TryDequeue(&item) do buf.Add(item)
+            buf.ToArray()
+
+    // ---------------------------------------------------------------
+    // Process snapshot — moved from Program.fs so it lives next
+    // to its only caller (the diagnostic).
+    // ---------------------------------------------------------------
+
+    /// Count `cmd.exe`, `powershell.exe`, `pwsh.exe`, `claude.exe`,
+    /// and `Terminal.App.exe` in the live process list. Returns
+    /// a screen-reader-friendly comma-separated string. Mirrors
+    /// the in-app live counts the maintainer might cross-check
+    /// against `tasklist | findstr` if they suspect a leak.
+    let enumerateShellProcesses () : string =
+        let names = [| "cmd"; "powershell"; "pwsh"; "claude"; "Terminal.App" |]
+        let counts =
+            names
+            |> Array.map (fun n ->
+                let count =
+                    try
+                        let procs = System.Diagnostics.Process.GetProcessesByName(n)
+                        for p in procs do
+                            try p.Dispose() with _ -> ()
+                        procs.Length
+                    with _ -> -1
+                n, count)
+        let parts =
+            counts
+            |> Array.map (fun (n, c) ->
+                if c < 0 then sprintf "%s ?" n
+                else sprintf "%d %s" c n)
+        String.concat ", " parts
+
+    // ---------------------------------------------------------------
+    // Test definitions
+    // ---------------------------------------------------------------
+
+    /// One battery test case. `SetupCommand` runs first if Some
+    /// (no assertions; tap drained between setup and main); then
+    /// `Command` runs and the captured events are checked against
+    /// `MustInclude` / `MustNotInclude`. The setup field is what
+    /// makes the "plain after red" regression-guard test
+    /// expressible — the red command is setup, then the plain
+    /// command is the assertion target.
+    type DiagnosticTest =
+        { Name: string
+          Description: string
+          SetupCommand: string option
+          Command: string
+          MustInclude: SemanticCategory[]
+          MustNotInclude: SemanticCategory[] }
+
+    /// Convert a UTF-8 command string + trailing CR into bytes
+    /// suitable for `ConPtyHost.WriteBytes`. CR (`\r`, 0x0D) is
+    /// the byte the WPF keyboard handler sends for the Enter key
+    /// per `KeyEncoding.fs:204-208` — shells respond to it
+    /// identically to a real Enter press.
+    let private commandBytes (cmd: string) : byte[] =
+        let bs = Encoding.UTF8.GetBytes(cmd)
+        Array.append bs [| 0x0Duy |]
+
+    /// PowerShell test set. Exercises plain output + the colour-
+    /// detection paths added by Phase A.2 (PR #163) and refined
+    /// by the changed-rows hotfix (PR #164).
+    let private powerShellTests : DiagnosticTest[] =
+        [|
+            { Name = "T1.Plain"
+              Description = "Plain Write-Host emits StreamChunk only."
+              SetupCommand = None
+              Command = "Write-Host PtySpeakDiagPlain"
+              MustInclude = [| SemanticCategory.StreamChunk |]
+              MustNotInclude = [| SemanticCategory.ErrorLine; SemanticCategory.WarningLine |] }
+            { Name = "T2.Red"
+              Description = "Red Write-Host emits StreamChunk + ErrorLine."
+              SetupCommand = None
+              Command = "Write-Host -ForegroundColor Red PtySpeakDiagRed"
+              MustInclude = [| SemanticCategory.StreamChunk; SemanticCategory.ErrorLine |]
+              MustNotInclude = [| SemanticCategory.WarningLine |] }
+            { Name = "T3.Yellow"
+              Description = "Yellow Write-Host emits StreamChunk + WarningLine."
+              SetupCommand = None
+              Command = "Write-Host -ForegroundColor Yellow PtySpeakDiagYellow"
+              MustInclude = [| SemanticCategory.StreamChunk; SemanticCategory.WarningLine |]
+              MustNotInclude = [| SemanticCategory.ErrorLine |] }
+            { Name = "T4.PlainAfterRed"
+              Description = "Plain after red emits StreamChunk only (PR #164 regression guard)."
+              SetupCommand = Some "Write-Host -ForegroundColor Red PtySpeakDiagSetup"
+              Command = "Write-Host PtySpeakDiagPlainAfter"
+              MustInclude = [| SemanticCategory.StreamChunk |]
+              MustNotInclude = [| SemanticCategory.ErrorLine; SemanticCategory.WarningLine |] }
+            { Name = "T5.YellowAfterRed"
+              Description = "Yellow after red emits WarningLine, not ErrorLine (PR #164 regression guard)."
+              SetupCommand = Some "Write-Host -ForegroundColor Red PtySpeakDiagSetup2"
+              Command = "Write-Host -ForegroundColor Yellow PtySpeakDiagYellowAfter"
+              MustInclude = [| SemanticCategory.StreamChunk; SemanticCategory.WarningLine |]
+              MustNotInclude = [| SemanticCategory.ErrorLine |] }
+        |]
+
+    /// Cmd test set — limited to plain echo. Cmd has minimal
+    /// colour support; ANSI-escape colour testing is a separate
+    /// follow-up.
+    let private cmdTests : DiagnosticTest[] =
+        [|
+            { Name = "T1.Plain"
+              Description = "Plain echo emits StreamChunk only."
+              SetupCommand = None
+              Command = "echo PtySpeakDiagPlain"
+              MustInclude = [| SemanticCategory.StreamChunk |]
+              MustNotInclude = [| SemanticCategory.ErrorLine; SemanticCategory.WarningLine |] }
+        |]
+
+    /// Pick the test set matching the active shell. Claude
+    /// returns an empty array — non-deterministic interactive AI
+    /// can't be exercised with fixed expectations.
+    let private selectTestsForShell (shellId: ShellRegistry.ShellId) : DiagnosticTest[] =
+        match shellId with
+        | ShellRegistry.PowerShell -> powerShellTests
+        | ShellRegistry.Cmd -> cmdTests
+        | ShellRegistry.Claude -> [||]
+
+    // ---------------------------------------------------------------
+    // Quiescence detection
+    // ---------------------------------------------------------------
+
+    /// Wait until the screen sequence number stops advancing for
+    /// `quiescenceMs` consecutive milliseconds, or until
+    /// `timeoutMs` total milliseconds have elapsed (whichever
+    /// comes first). Returns `(settled, elapsedMs)` —
+    /// `settled = true` if quiescence was detected within the
+    /// budget, `false` if the timeout fired.
+    let private waitForQuiescence
+            (resolveSeq: unit -> int64)
+            (quiescenceMs: int)
+            (timeoutMs: int)
+            : Task<bool * int> =
+        task {
+            let pollMs = 50
+            let started = DateTimeOffset.UtcNow
+            let mutable lastSeq = resolveSeq ()
+            let mutable lastChangeAt = started
+            let mutable settled = false
+            let mutable timedOut = false
+            while not settled && not timedOut do
+                do! Task.Delay(pollMs)
+                let now = DateTimeOffset.UtcNow
+                let curSeq = resolveSeq ()
+                if curSeq <> lastSeq then
+                    lastSeq <- curSeq
+                    lastChangeAt <- now
+                let sinceChange = (now - lastChangeAt).TotalMilliseconds
+                let sinceStart = (now - started).TotalMilliseconds
+                if sinceChange >= float quiescenceMs then
+                    settled <- true
+                elif sinceStart >= float timeoutMs then
+                    timedOut <- true
+            let elapsed =
+                int (DateTimeOffset.UtcNow - started).TotalMilliseconds
+            return settled, elapsed
+        }
+
+    // ---------------------------------------------------------------
+    // Per-test runner
+    // ---------------------------------------------------------------
+
+    /// Hex dump of a byte array — `[57 72 69 74 65 ... 0D] (16 bytes)`.
+    let private hexDump (bytes: byte[]) : string =
+        let sb = StringBuilder()
+        sb.Append('[') |> ignore
+        let n = min 32 bytes.Length
+        for i in 0 .. n - 1 do
+            if i > 0 then sb.Append(' ') |> ignore
+            sb.AppendFormat("{0:X2}", bytes.[i]) |> ignore
+        if bytes.Length > n then sb.Append(" ...") |> ignore
+        sb.AppendFormat("] ({0} bytes)", bytes.Length) |> ignore
+        sb.ToString()
+
+    /// Format an OutputEvent for the diagnostic log — keeps it to
+    /// one line, payload truncated at 120 chars so a long stack
+    /// trace doesn't blow up the log.
+    let private formatEvent (ev: OutputEvent) : string =
+        let payload = ev.Payload
+        let truncated =
+            if payload.Length <= 120 then payload
+            else payload.Substring(0, 117) + "..."
+        let safe = truncated.Replace('\n', ' ').Replace('\r', ' ')
+        sprintf "%A(payload=\"%s\")" ev.Semantic safe
+
+    /// Run one test. Issues setup (if any), drains tap, runs
+    /// main command, waits for quiescence, drains tap, evaluates
+    /// MustInclude / MustNotInclude, logs PASS / FAIL with full
+    /// detail. Returns `true` for PASS.
+    let private runOneTest
+            (writer: DiagnosticLogWriter)
+            (writeBytes: byte[] -> Task)
+            (resolveSeq: unit -> int64)
+            (test: DiagnosticTest)
+            : Task<bool> =
+        task {
+            let cat = sprintf "Diagnostic.%s" test.Name
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "BEGIN %s" test.Description)
+            // Setup phase: write setup bytes, wait, drain tap
+            // without checking. Fresh tap for the main phase.
+            let tap = DiagnosticEventTap()
+            match test.SetupCommand with
+            | Some setupCmd ->
+                let setupBytes = commandBytes setupCmd
+                writer.WriteLine LogLevel.Information cat
+                    (sprintf "SETUP %s" (hexDump setupBytes))
+                tap.Enable()
+                do! writeBytes setupBytes
+                let! settled, elapsed =
+                    waitForQuiescence resolveSeq 200 1500
+                let setupEvents = tap.DisableAndDrain()
+                writer.WriteLine LogLevel.Information cat
+                    (sprintf "SETUP_RESULT settled=%b elapsedMs=%d events=%d"
+                         settled elapsed setupEvents.Length)
+            | None -> ()
+            // Main phase
+            let mainBytes = commandBytes test.Command
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "WRITE %s" (hexDump mainBytes))
+            tap.Enable()
+            do! writeBytes mainBytes
+            let! settled, elapsed =
+                waitForQuiescence resolveSeq 200 1500
+            let events = tap.DisableAndDrain()
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "WAIT settled=%b elapsedMs=%d" settled elapsed)
+            let semantics =
+                events |> Array.map (fun ev -> ev.Semantic)
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "EVENTS (%d): %s"
+                     events.Length
+                     (events
+                      |> Array.map formatEvent
+                      |> String.concat " | "))
+            // Check inclusions
+            let missing =
+                test.MustInclude
+                |> Array.filter (fun s -> not (Array.contains s semantics))
+            // Check exclusions
+            let unexpected =
+                test.MustNotInclude
+                |> Array.filter (fun s -> Array.contains s semantics)
+            let pass =
+                Array.isEmpty missing
+                && Array.isEmpty unexpected
+                && settled
+            let resultMsg =
+                if pass then "PASS"
+                elif not settled then
+                    sprintf
+                        "FAIL — no quiescence within %dms (events captured: %d)"
+                        1500 events.Length
+                else
+                    let parts = ResizeArray<string>()
+                    if not (Array.isEmpty missing) then
+                        parts.Add(
+                            sprintf "missing=%s"
+                                (missing
+                                 |> Array.map (sprintf "%A")
+                                 |> String.concat ","))
+                    if not (Array.isEmpty unexpected) then
+                        parts.Add(
+                            sprintf "unexpected=%s"
+                                (unexpected
+                                 |> Array.map (sprintf "%A")
+                                 |> String.concat ","))
+                    sprintf "FAIL — %s" (String.concat "; " parts)
+            writer.WriteLine
+                (if pass then LogLevel.Information else LogLevel.Warning)
+                cat resultMsg
+            return pass
+        }
+
+    // ---------------------------------------------------------------
+    // Earcon replay — extracted from the previous runDiagnostic
+    // body so it's part of the battery rather than parallel to it.
+    // ---------------------------------------------------------------
+
+    /// Replay the three earcons (bell-ping, error-tone,
+    /// warning-tone) with NVDA labels between each, so the
+    /// maintainer can verify the audio path independently of the
+    /// test-battery's `EarconChannel` route.
+    let private runEarconReplay
+            (window: MainWindow)
+            (writer: DiagnosticLogWriter)
+            : Task =
+        task {
+            let cat = "Diagnostic.Earcons"
+            let announceAndPlay (label: string) (earconId: string) : Task =
+                task {
+                    let act () =
+                        window.TerminalSurface.Announce(label, ActivityIds.diagnostic)
+                    do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                    do! Task.Delay(400)
+                    EarconPlayer.play EarconPalette.defaultPalette earconId
+                    writer.WriteLine LogLevel.Information cat
+                        (sprintf "PLAYED %s" earconId)
+                    do! Task.Delay(500)
+                }
+            // Brief settle so the earlier announce reaches the
+            // NVDA queue before this one queues behind it.
+            do! Task.Delay(800)
+            do! announceAndPlay "Bell ping." "bell-ping"
+            do! announceAndPlay "Error tone." "error-tone"
+            do! announceAndPlay "Warning tone." "warning-tone"
+            ()
+        }
+
+    // ---------------------------------------------------------------
+    // Clipboard helper — mirror Ctrl+Shift+; (Program.fs:674-754)
+    // pattern: STA thread + 3s timeout.
+    // ---------------------------------------------------------------
+
+    /// Copy `content` to the Windows clipboard via a dedicated
+    /// STA thread with a 3s timeout. Returns `true` on success.
+    /// Never throws — clipboard contention or hook misbehaviour
+    /// is logged but not propagated.
+    let private copyToClipboardSta
+            (log: ILogger)
+            (content: string)
+            : Task<bool> =
+        task {
+            let setOk = TaskCompletionSource<bool>()
+            let staBody = ThreadStart(fun () ->
+                try
+                    System.Windows.Clipboard.SetText(content)
+                    setOk.TrySetResult(true) |> ignore
+                with ex ->
+                    log.LogWarning(
+                        ex,
+                        "Diagnostic clipboard SetText threw: {Message}",
+                        ex.Message)
+                    setOk.TrySetResult(false) |> ignore)
+            let staThread = new Thread(staBody)
+            staThread.SetApartmentState(ApartmentState.STA)
+            staThread.IsBackground <- true
+            staThread.Start()
+            let! winner =
+                Task.WhenAny(setOk.Task :> Task, Task.Delay(3000))
+            return
+                obj.ReferenceEquals(winner, setOk.Task)
+                && setOk.Task.Result
+        }
+
+    // ---------------------------------------------------------------
+    // Path resolution
+    // ---------------------------------------------------------------
+
+    /// Resolve the diagnostic-log path for a fresh run.
+    /// `%LOCALAPPDATA%\PtySpeak\logs\YYYY-MM-DD\diagnostic-YYYY-MM-DD-HH-mm-ss-fff.log`.
+    /// Same parent folder as regular `pty-speak-*.log` files so
+    /// `Ctrl+Shift+L` opens the right area; the
+    /// `diagnostic-` prefix is what distinguishes them.
+    let private resolveDiagnosticLogPath () : string =
+        let now = DateTimeOffset.UtcNow.UtcDateTime
+        let root =
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        let dayFolder = now.ToString("yyyy-MM-dd")
+        let stamp = now.ToString("yyyy-MM-dd-HH-mm-ss-fff")
+        let dir = Path.Combine(root, "PtySpeak", "logs", dayFolder)
+        Path.Combine(dir, sprintf "diagnostic-%s.log" stamp)
+
+    // ---------------------------------------------------------------
+    // Main entry — runFullBattery
+    // ---------------------------------------------------------------
+
+    /// Run the complete diagnostic battery. Called from the
+    /// Ctrl+Shift+D hotkey handler; returns immediately while
+    /// the battery runs on a background task.
+    ///
+    /// Parameters are resolvers (rather than direct values) so
+    /// the diagnostic always reads the LIVE state — e.g. the
+    /// active shell may have changed via `Ctrl+Shift+1/2/3`
+    /// between the hotkey binding and the press.
+    let runFullBattery
+            (window: MainWindow)
+            (resolveHost: unit -> ConPtyHost option)
+            (resolveShell: unit -> ShellRegistry.Shell)
+            (resolveSeq: unit -> int64)
+            : unit =
+        let log = Logger.get "Terminal.App.Diagnostics.runFullBattery"
+        let _ =
+            task {
+                try
+                    let logPath = resolveDiagnosticLogPath ()
+                    use writer = new DiagnosticLogWriter(logPath)
+                    let cat = "Diagnostic.Init"
+                    let shell = resolveShell ()
+                    let pid =
+                        match resolveHost () with
+                        | Some h -> int h.ProcessId
+                        | None -> 0
+                    writer.WriteLine LogLevel.Information cat
+                        (sprintf "Battery starting. Shell=%s ShellId=%A PID=%d LogPath=%s"
+                             shell.DisplayName shell.Id pid logPath)
+                    log.LogInformation(
+                        "Diagnostic battery starting. Shell={Shell} LogPath={LogPath}",
+                        shell.DisplayName, logPath)
+                let announce (msg: string) : Task =
+                    task {
+                        let act () =
+                            window.TerminalSurface.Announce(msg, ActivityIds.diagnostic)
+                        do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                    }
+                do! announce
+                    (sprintf
+                        "Starting diagnostic on %s. About 10 seconds; commands will run in your shell."
+                        shell.DisplayName)
+                // T0 — process snapshot.
+                let snapshot = enumerateShellProcesses ()
+                writer.WriteLine LogLevel.Information "Diagnostic.T0.Snapshot" snapshot
+                log.LogInformation(
+                    "Diagnostic snapshot. ProcessCounts={Snapshot}", snapshot)
+                // T_Earcons — replay the three earcons.
+                do! runEarconReplay window writer
+                // Per-shell command battery.
+                let writeBytes (bytes: byte[]) : Task =
+                    task {
+                        let act () =
+                            match resolveHost () with
+                            | Some h -> h.WriteBytes(bytes)
+                            | None -> ()
+                        do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                    }
+                let tests = selectTestsForShell shell.Id
+                let mutable pass = 0
+                let mutable fail = 0
+                if Array.isEmpty tests then
+                    writer.WriteLine LogLevel.Information "Diagnostic.Battery"
+                        (sprintf
+                            "Skipped command battery: no test set for shell %A."
+                            shell.Id)
+                else
+                    for test in tests do
+                        let! ok = runOneTest writer writeBytes resolveSeq test
+                        if ok then pass <- pass + 1 else fail <- fail + 1
+                let total = pass + fail
+                writer.WriteLine LogLevel.Information "Diagnostic.Summary"
+                    (sprintf "PASS=%d FAIL=%d TOTAL=%d Shell=%A"
+                         pass fail total shell.Id)
+                log.LogInformation(
+                    "Diagnostic battery complete. Pass={Pass} Fail={Fail} Total={Total}",
+                    pass, fail, total)
+                // Close the writer BEFORE reading the file for clipboard.
+                (writer :> IDisposable).Dispose()
+                // Read the diagnostic log content for clipboard. Same
+                // FileShare.ReadWrite open mode as Ctrl+Shift+; uses.
+                let content =
+                    try
+                        use stream =
+                            new FileStream(
+                                logPath, FileMode.Open, FileAccess.Read,
+                                FileShare.ReadWrite)
+                        use reader = new StreamReader(stream, Encoding.UTF8)
+                        reader.ReadToEnd()
+                    with ex ->
+                        log.LogWarning(
+                            ex,
+                            "Failed to read diagnostic log for clipboard: {Message}",
+                            ex.Message)
+                        ""
+                let summaryLine =
+                    if total = 0 then
+                        sprintf
+                            "Diagnostic complete. Snapshot and earcons logged. Shell %s skipped command battery."
+                            shell.DisplayName
+                    else
+                        sprintf
+                            "Diagnostic complete. %d of %d passed."
+                            pass total
+                if String.IsNullOrEmpty content then
+                    do! announce
+                        (sprintf "%s Could not read diagnostic log." summaryLine)
+                else
+                    let! copied = copyToClipboardSta log content
+                    if copied then
+                        do! announce
+                            (sprintf "%s Diagnostic log copied to clipboard." summaryLine)
+                    else
+                        do! announce
+                            (sprintf
+                                "%s Clipboard copy failed; diagnostic log at %s."
+                                summaryLine
+                                logPath)
+                with ex ->
+                    log.LogError(
+                        ex,
+                        "Diagnostic battery raised an unhandled exception: {Message}",
+                        ex.Message)
+                    try
+                        let act () =
+                            window.TerminalSurface.Announce(
+                                sprintf "Diagnostic failed: %s" ex.Message,
+                                ActivityIds.error)
+                        do! window.Dispatcher.InvokeAsync(Action(act)).Task
+                    with _ -> ()
+            }
+        ()

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -320,175 +320,14 @@ module Program =
                 ExecutedRoutedEventHandler(fun _ _ -> handler ())))
         |> ignore
 
-    /// Launch the bundled process-cleanup diagnostic script in a
-    /// separate PowerShell window. Triggered by `Ctrl+Shift+D` —
-    /// added because Task Manager's Processes-tab chevron-expand
-    /// affordance is not screen-reader-accessible, so a maintainer
-    /// running the deferred Stage 4 process-cleanup test on
-    /// NVDA cannot navigate the Task Manager UI to verify the
-    /// process tree by hand. The diagnostic script lives next to
-    /// `Terminal.App.exe` (bundled via `Terminal.App.fsproj`'s
-    /// `Content` include) and emits one-fact-per-line stdout that
-    /// NVDA reads aloud naturally.
-    ///
-    /// The PowerShell process is launched with `-NoExit` so the
-    /// spawned window stays open after the test completes; the
-    /// user reads the result, then closes that window manually.
-    /// This is intentional — auto-closing would lose the output.
-    ///
-    /// Future: more diagnostics (UIA peer health, ConPTY child
-    /// status, version dump) can be added as additional scripts
-    /// next to this one and routed through the same hotkey via
-    /// a sub-menu, OR added as their own hotkeys following the
-    /// app-reserved-hotkey contract in `spec/tech-plan.md` §6.
-    /// PR-J — enumerate the live shell-related processes and
-    /// return both a per-name count list and a one-line announce-
-    /// safe summary. Used by the Ctrl+Shift+D handler to report
-    /// state inline BEFORE launching the cleanup script — gives
-    /// the user (or a Claude session triaging on their behalf)
-    /// an immediate "what's currently running" snapshot without
-    /// the close-and-recheck round trip.
-    ///
-    /// Names checked: `cmd`, `powershell`, `pwsh`, `claude`,
-    /// `Terminal.App`. `Process.GetProcessesByName` is the supported
-    /// .NET API — case-insensitive, no `.exe` suffix in the name
-    /// argument. The returned `Process` objects are disposed
-    /// immediately; we only need the count.
-    ///
-    /// Logged at Information level too so post-hoc log analysis
-    /// captures the snapshot even if the user pressed Ctrl+Shift+D
-    /// without writing down what NVDA said.
-    let private enumerateShellProcesses () : string =
-        let names = [| "cmd"; "powershell"; "pwsh"; "claude"; "Terminal.App" |]
-        let counts =
-            names
-            |> Array.map (fun n ->
-                let count =
-                    try
-                        let procs = System.Diagnostics.Process.GetProcessesByName(n)
-                        for p in procs do
-                            try p.Dispose() with _ -> ()
-                        procs.Length
-                    with _ -> -1
-                n, count)
-        let parts =
-            counts
-            |> Array.map (fun (n, c) ->
-                if c < 0 then sprintf "%s ?" n
-                else sprintf "%d %s" c n)
-        String.concat ", " parts
-
-    let private runDiagnostic (window: MainWindow) : unit =
-        let snapshot = enumerateShellProcesses ()
-        let log = Logger.get "Terminal.App.Program.runDiagnostic"
-        log.LogInformation(
-            "Diagnostic snapshot. ProcessCounts={Snapshot}",
-            snapshot)
-        // Stage 8d-followup (2026-05-04) — earcon audio diagnostic.
-        //
-        // The original Ctrl+Shift+D ritual launched a PowerShell
-        // script (`test-process-cleanup.ps1`) in a separate window
-        // that ran a process-tree close-and-recheck. The script
-        // had been consistently passing in NVDA validation, but
-        // required closing pty-speak to complete — adding friction
-        // to the diagnostic ritual. The PS1 launch is commented
-        // out below per maintainer 2026-05-04. Restore by
-        // uncommenting if orphan-detection diagnosis ever needs
-        // it again; the PS1 file still ships in the installer.
-        //
-        // The new ritual plays each earcon in sequence with an
-        // announce between, so the maintainer can verify the
-        // earcon audio path by pressing Ctrl+Shift+D — no need to
-        // trigger BEL or coloured shell output. Earcons play via
-        // a direct `EarconPlayer.play` call (bypassing the
-        // EarconChannel mute state); this lets the test verify
-        // the audio output path even when earcons are muted via
-        // Ctrl+Shift+M for normal use.
-        window.TerminalSurface.Announce(
-            sprintf
-                "Diagnostic snapshot: %s. Testing earcons."
-                snapshot,
-            ActivityIds.diagnostic)
-        // Helper: announce a label, wait for NVDA to read it,
-        // play the earcon, wait for the tone to finish. Defined
-        // outside the outer `task { ... }` block to keep the
-        // outer state machine statically compilable (the F# 9
-        // task CE flags `for tuple in list do { do! ... }`
-        // patterns as `FS3511`; an explicit unroll with three
-        // `do!` calls compiles cleanly).
-        let announceAndPlay (label: string) (earconId: string) : Task =
-            task {
-                let action () =
-                    window.TerminalSurface.Announce(
-                        label,
-                        ActivityIds.diagnostic)
-                do! window.Dispatcher.InvokeAsync(Action(action)).Task
-                // Wait for NVDA to finish reading the label
-                // before the tone plays — otherwise the tone
-                // overlaps the speech.
-                do! Task.Delay(400)
-                EarconPlayer.play
-                    EarconPalette.defaultPalette
-                    earconId
-                // Wait for the tone to finish (max 150ms) so
-                // the next label announce doesn't fire while
-                // the tone is still audible.
-                do! Task.Delay(500)
-            }
-        let _ =
-            task {
-                // Brief settle so the snapshot announce reaches
-                // NVDA's speech queue before the first per-earcon
-                // announce queues up behind it.
-                do! Task.Delay(800)
-                do! announceAndPlay "Bell ping." "bell-ping"
-                do! announceAndPlay "Error tone." "error-tone"
-                do! announceAndPlay "Warning tone." "warning-tone"
-                let final () =
-                    window.TerminalSurface.Announce(
-                        "Earcon test complete.",
-                        ActivityIds.diagnostic)
-                do! window.Dispatcher.InvokeAsync(Action(final)).Task
-                ()
-            }
-        // PowerShell script launch — commented out per maintainer
-        // 2026-05-04. Original code preserved below for future
-        // reactivation if needed.
-        //
-        // let scriptPath =
-        //     System.IO.Path.Combine(
-        //         System.AppContext.BaseDirectory,
-        //         "test-process-cleanup.ps1")
-        // if not (System.IO.File.Exists scriptPath) then
-        //     window.TerminalSurface.Announce(
-        //         sprintf
-        //             "Cleanup script not found at %s."
-        //             scriptPath,
-        //         ActivityIds.diagnostic)
-        // else
-        //     let _ =
-        //         task {
-        //             do! Task.Delay(700)
-        //             let action () =
-        //                 try
-        //                     let psi = System.Diagnostics.ProcessStartInfo()
-        //                     psi.FileName <- "powershell.exe"
-        //                     psi.Arguments <-
-        //                         sprintf
-        //                             "-ExecutionPolicy Bypass -NoExit -File \"%s\""
-        //                             scriptPath
-        //                     psi.UseShellExecute <- true
-        //                     System.Diagnostics.Process.Start(psi) |> ignore
-        //                 with ex ->
-        //                     let safe = AnnounceSanitiser.sanitise ex.Message
-        //                     window.TerminalSurface.Announce(
-        //                         sprintf "Could not launch diagnostic: %s" safe,
-        //                         ActivityIds.error)
-        //             do! window.Dispatcher.InvokeAsync(Action(action)).Task
-        //             ()
-        //         }
-        //     ()
-        ()
+    // Ctrl+Shift+D's body lives in
+    // `Terminal.App.Diagnostics.runFullBattery` (PR #165 —
+    // extended diagnostic battery). The closure that wires the
+    // hotkey to the new module is defined next to
+    // `runHealthCheck` further down because it captures compose-
+    // local state (`hostHandle`, `currentShell`,
+    // `screen.SequenceNumber`); the bind itself sits in the
+    // closure-bind group near line 1537.
 
     /// Open the GitHub "draft a new release" form for this
     /// repository in the user's default web browser. Triggered
@@ -517,8 +356,8 @@ module Program =
     /// inherits whatever the user configures.
     let private runOpenNewRelease (window: MainWindow) : unit =
         let url = UpdateRepoUrl + "/releases/new"
-        // Same announce-before-focus-grab pattern as `runDiagnostic`
-        // above (the launched browser will steal focus and NVDA's
+        // Announce-before-focus-grab pattern: the launched browser
+        // will steal focus and NVDA's
         // interrupt-on-focus-change will truncate the queued speech
         // unless we give it ~700ms head start).
         // TODO Phase 2: TOML-configurable delay.
@@ -866,7 +705,10 @@ module Program =
         // below; we install before the window is loaded so the
         // keybindings are live for the user's first keypress.
         bindHotkey window HotkeyRegistry.CheckForUpdates (fun () -> runUpdateFlow window)
-        bindHotkey window HotkeyRegistry.RunDiagnostic (fun () -> runDiagnostic window)
+        // Ctrl+Shift+D's bind is in the closure-bind group below
+        // (around line 1537) — its handler captures local
+        // mutables (`hostHandle`, `currentShell`, `screen`) that
+        // aren't in scope here yet.
         bindHotkey window HotkeyRegistry.DraftNewRelease (fun () -> runOpenNewRelease window)
         bindHotkey window HotkeyRegistry.OpenLogsFolder (fun () -> runOpenLogs window)
         bindHotkey window HotkeyRegistry.CopyLatestLog (fun () -> runCopyLatestLog window)
@@ -1528,6 +1370,20 @@ module Program =
                     sprintf "Health check failed: %s" safe,
                     ActivityIds.error)
 
+        // PR #165 — Ctrl+Shift+D (extended diagnostic battery).
+        // The closure is defined here (not at module top) because
+        // it reads `hostHandle`, `currentShell`, and the live
+        // `screen.SequenceNumber` for quiescence detection — all
+        // compose-local. Each resolver runs at hotkey-press time
+        // so a hot-switch between Ctrl+Shift+D presses is picked
+        // up correctly.
+        let runDiagnostic () : unit =
+            Diagnostics.runFullBattery
+                window
+                (fun () -> hostHandle)
+                (fun () -> currentShell)
+                (fun () -> screen.SequenceNumber)
+
         // Stage 7-followup PR-F — wire Ctrl+Shift+H and Ctrl+Shift+B
         // through the unified `bindHotkey` helper (PR-O). Both
         // closures capture compose-local state (lastReadUtc,
@@ -1536,6 +1392,7 @@ module Program =
         // Ctrl+Shift+G toggle (which only needs loggerSink).
         bindHotkey window HotkeyRegistry.HealthCheck runHealthCheck
         bindHotkey window HotkeyRegistry.IncidentMarker runIncidentMarker
+        bindHotkey window HotkeyRegistry.RunDiagnostic runDiagnostic
 
         // Stage 7-followup PR-F — background heartbeat. Every 5
         // seconds, log a single Information-level "Heartbeat" line

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Diagnostics.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Terminal.Core/OutputDispatcher.fs
+++ b/src/Terminal.Core/OutputDispatcher.fs
@@ -109,6 +109,58 @@ module OutputDispatcher =
             | Some channel -> channel.Send effectiveEvent decision.Render
             | None -> ()
 
+    /// Event-tap registry — a list of `OutputEvent -> unit`
+    /// observers fired before profile fan-out. Used by the
+    /// Ctrl+Shift+D diagnostic battery to capture every event
+    /// dispatched during a known time window. Taps are NOT a
+    /// general-purpose hook; they exist for short-lived
+    /// instrumentation runs and have a narrow contract:
+    ///
+    /// - Taps must not throw. The dispatcher swallows tap
+    ///   exceptions to keep production routing intact even when
+    ///   a misbehaving tap is registered. A throwing tap is a
+    ///   bug in the tap, not a reason to drop events.
+    /// - Taps see the raw `OutputEvent` before profiles claim
+    ///   it. They observe; they cannot mutate routing. Per-
+    ///   channel `RenderInstruction` is profile-derived and is
+    ///   therefore not visible to taps — this is intentional;
+    ///   taps verify "the pathway emitted X", not "channel Y
+    ///   rendered X as Z".
+    /// - `installEventTap` returns an `IDisposable`. Disposing
+    ///   removes the tap. Multiple taps can be active
+    ///   simultaneously; each disposes independently.
+    let private tapsLock: obj = obj ()
+    let mutable private nextTapToken: int = 0
+    let mutable private eventTaps: Map<int, OutputEvent -> unit> = Map.empty
+
+    /// Register an event-tap that fires for every dispatched
+    /// `OutputEvent` (both `dispatch` and `dispatchTick`-routed
+    /// events) until disposed. Each registration is keyed by a
+    /// unique integer token so disposing one subscription cannot
+    /// accidentally remove another even when the caller passes
+    /// identical (capture-free) lambdas to multiple
+    /// `installEventTap` calls.
+    let installEventTap (tap: OutputEvent -> unit) : IDisposable =
+        let token =
+            lock tapsLock (fun () ->
+                let t = nextTapToken
+                nextTapToken <- t + 1
+                eventTaps <- eventTaps |> Map.add t tap
+                t)
+        { new IDisposable with
+            member _.Dispose () =
+                lock tapsLock (fun () ->
+                    eventTaps <- eventTaps |> Map.remove token) }
+
+    /// Fire all registered taps for one event. Snapshot the
+    /// map under the lock so a concurrent dispose doesn't
+    /// mutate the iteration target.
+    let private fireTaps (event: OutputEvent) : unit =
+        let snapshot = lock tapsLock (fun () -> eventTaps)
+        for KeyValue(_, tap) in snapshot do
+            try tap event
+            with _ -> ()
+
     /// Dispatch one `OutputEvent` through the active profile set
     /// and into each profile-decided channel. Each profile's
     /// `Apply` returns an array of `(effectiveEvent, decisions)`
@@ -117,6 +169,7 @@ module OutputDispatcher =
     /// when a mode-change forces a pending-stream flush). The
     /// dispatcher routes each pair through `routePair`.
     let dispatch (event: OutputEvent) : unit =
+        fireTaps event
         let profileSet = ProfileRegistry.getActiveProfileSet ()
         for profile in profileSet do
             let pairs = profile.Apply event
@@ -141,4 +194,5 @@ module OutputDispatcher =
         for profile in profileSet do
             let pairs = profile.Tick now
             for (effectiveEvent, decisions) in pairs do
+                fireTaps effectiveEvent
                 routePair effectiveEvent decisions

--- a/tests/Tests.Unit/OutputDispatcherTests.fs
+++ b/tests/Tests.Unit/OutputDispatcherTests.fs
@@ -282,3 +282,111 @@ let ``dispatchTick fans out across multiple Tick-emitting profiles`` () =
     OutputDispatcher.dispatchTick DateTimeOffset.UtcNow
     Assert.Equal(2, calls.Count)
     resetRegistries ()
+
+// ---- installEventTap (PR #165 — Ctrl+Shift+D diagnostic) ----------
+//
+// The Diagnostics module installs short-lived taps to capture
+// every OutputEvent flowing through the dispatcher during a
+// known time window. These tests pin the tap-registry mechanics:
+// register-fires-tap, dispose-stops-firing, multi-tap fan-out,
+// throwing-tap-doesnt-break-routing.
+
+[<Fact>]
+let ``installEventTap fires for every dispatched OutputEvent`` () =
+    resetRegistries ()
+    let captured = ResizeArray<OutputEvent>()
+    use _ = OutputDispatcher.installEventTap (fun ev -> captured.Add(ev))
+    let channel, _ = recordingChannel "tap-test"
+    OutputDispatcher.ChannelRegistry.register channel
+    let profile = passthroughProfile "tap-prof" "tap-test"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    let ev1 = buildEvent SemanticCategory.StreamChunk "first"
+    let ev2 = buildEvent SemanticCategory.StreamChunk "second"
+    OutputDispatcher.dispatch ev1
+    OutputDispatcher.dispatch ev2
+    Assert.Equal(2, captured.Count)
+    Assert.Equal("first", captured.[0].Payload)
+    Assert.Equal("second", captured.[1].Payload)
+    resetRegistries ()
+
+[<Fact>]
+let ``installEventTap returns IDisposable that stops firing on Dispose`` () =
+    resetRegistries ()
+    let captured = ResizeArray<OutputEvent>()
+    let sub = OutputDispatcher.installEventTap (fun ev -> captured.Add(ev))
+    let channel, _ = recordingChannel "tap-test"
+    OutputDispatcher.ChannelRegistry.register channel
+    let profile = passthroughProfile "tap-prof" "tap-test"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "before")
+    sub.Dispose()
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "after")
+    Assert.Equal(1, captured.Count)
+    Assert.Equal("before", captured.[0].Payload)
+    resetRegistries ()
+
+[<Fact>]
+let ``installEventTap supports multiple simultaneous subscriptions`` () =
+    resetRegistries ()
+    let captured1 = ResizeArray<OutputEvent>()
+    let captured2 = ResizeArray<OutputEvent>()
+    use _ = OutputDispatcher.installEventTap (fun ev -> captured1.Add(ev))
+    use _ = OutputDispatcher.installEventTap (fun ev -> captured2.Add(ev))
+    let channel, _ = recordingChannel "tap-test"
+    OutputDispatcher.ChannelRegistry.register channel
+    let profile = passthroughProfile "tap-prof" "tap-test"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "shared")
+    Assert.Equal(1, captured1.Count)
+    Assert.Equal(1, captured2.Count)
+    Assert.Equal("shared", captured1.[0].Payload)
+    Assert.Equal("shared", captured2.[0].Payload)
+    resetRegistries ()
+
+[<Fact>]
+let ``disposing one tap does not affect other simultaneous taps`` () =
+    resetRegistries ()
+    let captured1 = ResizeArray<OutputEvent>()
+    let captured2 = ResizeArray<OutputEvent>()
+    let sub1 = OutputDispatcher.installEventTap (fun ev -> captured1.Add(ev))
+    use _ = OutputDispatcher.installEventTap (fun ev -> captured2.Add(ev))
+    let channel, _ = recordingChannel "tap-test"
+    OutputDispatcher.ChannelRegistry.register channel
+    let profile = passthroughProfile "tap-prof" "tap-test"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "first")
+    sub1.Dispose()
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "second")
+    Assert.Equal(1, captured1.Count)
+    Assert.Equal(2, captured2.Count)
+    resetRegistries ()
+
+[<Fact>]
+let ``throwing tap does not break dispatch or other taps`` () =
+    resetRegistries ()
+    let goodCaptured = ResizeArray<OutputEvent>()
+    use _ = OutputDispatcher.installEventTap (fun _ ->
+        raise (System.InvalidOperationException("tap blew up")))
+    use _ = OutputDispatcher.installEventTap (fun ev -> goodCaptured.Add(ev))
+    let channel, channelCalls = recordingChannel "tap-test"
+    OutputDispatcher.ChannelRegistry.register channel
+    let profile = passthroughProfile "tap-prof" "tap-test"
+    OutputDispatcher.ProfileRegistry.setActiveProfileSet [ profile ]
+    // Should not throw despite the bad tap.
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "payload")
+    // Channel still received the event (dispatch wasn't aborted).
+    Assert.Equal(1, channelCalls.Count)
+    // Good tap still received the event.
+    Assert.Equal(1, goodCaptured.Count)
+    Assert.Equal("payload", goodCaptured.[0].Payload)
+    resetRegistries ()
+
+[<Fact>]
+let ``installEventTap with no profiles still fires (taps run before fan-out)`` () =
+    resetRegistries ()
+    let captured = ResizeArray<OutputEvent>()
+    use _ = OutputDispatcher.installEventTap (fun ev -> captured.Add(ev))
+    // No active profiles — dispatch normally would no-op.
+    OutputDispatcher.dispatch (buildEvent SemanticCategory.StreamChunk "no-profiles")
+    Assert.Equal(1, captured.Count)
+    resetRegistries ()


### PR DESCRIPTION
## Summary

Extends Ctrl+Shift+D from a small earcon-replay test into a full self-test battery against the active shell. Goal (per maintainer 2026-05-06): collapse the manual NVDA validation loop ("open shell → run command → listen → describe") into "press hotkey, paste log".

## What runs on press

1. **Process snapshot** — `enumerateShellProcesses` (kept from previous behaviour, moved next to its only caller).
2. **Earcon replay** — bell-ping / error-tone / warning-tone with NVDA labels between each (kept; extracted into the new module).
3. **Per-shell command battery** — writes command bytes via `ConPtyHost.WriteBytes`, captures resulting `OutputEvent`s via a temporary `OutputDispatcher` tap, compares against expected, logs PASS/FAIL with full event detail.
4. **Clipboard copy + summary announce** — diagnostic log content lands directly in the clipboard for paste-into-chat.

## PowerShell test set

| Test | Description | Catches |
|---|---|---|
| T1.Plain | `Write-Host` plain → StreamChunk only | regression guard |
| T2.Red | `Write-Host -ForegroundColor Red` → +ErrorLine | colour detection live |
| T3.Yellow | `Write-Host -ForegroundColor Yellow` → +WarningLine | colour detection live |
| T4.PlainAfterRed | red, then plain — second emit has NO ErrorLine | PR #164 regression guard |
| T5.YellowAfterRed | red, then yellow — second has WarningLine, not ErrorLine | PR #164 regression guard |

Cmd test set: plain `echo`. Claude shell: command battery skipped (non-deterministic AI).

## Crash-safe diagnostic log

Path: `%LOCALAPPDATA%\PtySpeak\logs\YYYY-MM-DD\diagnostic-YYYY-MM-DD-HH-mm-ss-fff.log`. Same parent folder as regular `pty-speak-*.log` so `Ctrl+Shift+L` opens the right area; `diagnostic-` prefix is the distinguisher.

Format mirrors FileLogger: `yyyy-MM-ddTHH:mm:ss.fffZ [LEVEL] [Category] message`. Crash-safety: `StreamWriter.AutoFlush = true` + `FileShare.ReadWrite` + `FileMode.Create`. Every line is on disk before the next is queued — same paradigm as FileLogger's batch flush, just finer granularity for the short-lived run.

## Infrastructure

- **`OutputDispatcher.installEventTap`** — new dispatcher surface. Registers an `OutputEvent -> unit` observer that fires before profile fan-out. Returns `IDisposable`. Tap exceptions swallowed so a misbehaving tap can't break production routing. Tokens keyed in a Map so identical capture-free lambdas each get their own subscription.
- **`Terminal.App.Diagnostics`** — new module owning: `DiagnosticLogWriter`, `DiagnosticEventTap`, test definitions, per-test loop, `runFullBattery` entry. Outermost try/with logs and announces unhandled exceptions so fire-and-forget failures don't go silent.
- **Cleanup** — `runDiagnostic` body + `enumerateShellProcesses` helper deleted from Program.fs (~140 lines including dead commented-out PowerShell-script launch). Ctrl+Shift+D bind moves to the closure-bind group because the new closure captures `hostHandle` / `currentShell` / `screen.SequenceNumber`.

## Test plan

Automated (xUnit):

- [ ] 6 new tests in `OutputDispatcherTests.fs` covering the tap surface — register-fires, dispose-stops, multi-tap fan-out, single-dispose-doesn't-affect-others, throwing-tap-doesn't-break-dispatch, tap-fires-with-no-profiles.

Manual (single press):

- [ ] Cut release with this PR; install; switch to PowerShell.
- [ ] Press `Ctrl+Shift+D`. Listen for "Starting diagnostic..." then ~10s later "Diagnostic complete. 8 of 8 passed. Diagnostic log copied to clipboard."
- [ ] Three earcons (bell, error, warning) audible during the run.
- [ ] Five commands appear in PowerShell history during the run (`Write-Host PtySpeakDiagPlain`, red, yellow, plain-after-red, yellow-after-red — the unique `PtySpeakDiag*` payload makes them easy to find).
- [ ] Paste log into chat. Sanity-check: T4 + T5 explicitly assert the PR #164 hotfix behaviour.
- [ ] Switch to cmd, press `Ctrl+Shift+D` — should run T0 + earcons + T1.Plain only.
- [ ] Switch to claude, press `Ctrl+Shift+D` — should run T0 + earcons, log "Skipped command battery" for the per-shell battery.

`scripts/test-process-cleanup.ps1` stays in the repo and remains manually invokable; the launch from F# is gone (was already commented out since 2026-05-04).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_