### PR TITLE
Sub-row suffix-diff at StreamPathway emit (item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,101 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (sub-row suffix-diff at StreamPathway emit)
+
+When typing `echo hi` at a shell prompt, NVDA used to read the
+entire row on every keystroke (`> echo h`, then `> echo hi`).
+Each character meant hearing the full prompt + command line
+again. After this change, NVDA reads only the new content
+since the last emit — `h`, then `i`. The verbose-readback
+issue (GitHub #115/#139) regresses to "single-character
+announcement on each keystroke" as intended in Phase A.
+
+#### Behaviour
+
+| Action | Before this PR | After this PR |
+|---|---|---|
+| Type `e` at a fresh prompt | Reads `> e` | Reads `e` (or `> e` on first prompt emit) |
+| Type `c` after `e` | Reads `> ec` | Reads `c` |
+| Type Enter on a populated line | Reads the full historical command + new prompt | Reads only the new content (next prompt + maybe output) |
+| Press Backspace on `echo hi` | Reads `> echo h` | Silent (NVDA's own keyboard echo handles it) |
+| Paste a multi-line script (5+ lines) | Reads the full content | Reads the full content (bulk-change fallback engages) |
+| Switch shell with Ctrl+Shift+1/2/3 | Reads the new shell's startup output | Reads the new shell's startup output (mode-barrier flush stays verbose) |
+
+#### Implementation
+
+A new computational stage **sub-row suffix detection** sits
+between the existing row-level diff (stage 7) and the
+announcement payload assembly (stage 9). For each changed row
+it reads the rendered text, compares against the cached
+text-at-last-emit, and computes the longest-common-prefix.
+The suffix beyond that prefix is what gets announced.
+
+Three propose-defaults the maintainer approved
+(redirectable on next iteration):
+
+1. **Backspace silent.** Row shrink → no announcement; NVDA
+   keyboard-echo handles the feedback at the keyboard layer.
+2. **Bulk-change threshold N=3.** When more than 3 rows
+   change in a single frame (scroll, screen clear, TUI
+   repaint, multi-line paste), bypass suffix-diff and emit
+   the full ChangedText. The maintainer benefits from full
+   context at discontinuities; suffix-diff against a stale
+   baseline would produce gibberish.
+3. **Defer autosuggestion-aware diff to v2.** Fish-shell and
+   zsh-autosuggestion-style ghost text (grey-foreground hint
+   beyond cursor) over-reports under v1's pure-text LCP.
+   Documented limitation; SGR-attribute-aware filtering is a
+   follow-up.
+
+#### Known v1 limitations
+
+- **Mid-line insertion over-reports.** Cursor-left + type X
+  into `> echo h` → `> echXo h` announces `Xo h` instead of
+  just `X`. v2 (cursor-aware diff) fixes.
+- **Powerline / Starship / oh-my-posh prompt redraws
+  over-report.** Async git-status or kube-context segments
+  resolve mid-keystroke and rewrite the PS1; LCP common
+  prefix collapses; the whole line gets re-announced.
+- **Right-aligned RPROMPT (zsh) over-reports.** Same family.
+- **Autosuggestions over-report** (per Default 3 above).
+
+#### Files
+
+- `src/Terminal.Core/CanonicalState.fs` — extracted
+  `renderRow snapshot rowIdx : string` helper from
+  `renderChangedRows` so both the existing concatenated-text
+  path and the new per-row suffix path share the trim +
+  sanitise logic.
+- `src/Terminal.Core/StreamPathway.fs` — added the
+  `EditDelta` discriminated union (`Suffix of string |
+  Silent`), `longestCommonPrefixLength`,
+  `computeRowSuffixDelta`, `BulkChangeThreshold` (=3),
+  `assembleSuffixPayload`, `renderAllRows`. Extended
+  `State` with `LastEmittedRowText: string[]` and
+  `PendingSnapshot: Cell[][] voption`. Wired into all five
+  state-update sites: leading-edge emit (in
+  `processCanonicalState`), trailing-edge tick (in
+  `onTimerTick`), mode-barrier flush, `resetState`, and
+  `seedBaseline`.
+- `tests/Tests.Unit/StreamPathwayTests.fs` — 14 new tests
+  covering the algorithm (`longestCommonPrefixLength`,
+  `computeRowSuffixDelta`) and the integration behaviour
+  (typing-at-prompt, multi-keystroke debounce, bulk-change
+  fallback, backspace silent, first-emit-Initial, mode-
+  barrier-clears-cache).
+
+PR #164's regression tests (red row outside changed-rows scope
+→ no ErrorLine emit) survive the refactor — confirms the
+Phase A.2 hotfix interaction is preserved.
+
+The diagnostic battery's existing T1-T5 PowerShell tests are
+unchanged and continue to validate the colour-detection +
+emit-shape regression coverage. New T6/T7 tests for suffix-
+diff specifically are deferred to a follow-up PR (the v1
+verification path is unit tests for the algorithm + manual
+NVDA matrix for the UX).
+
 ### Added (Ctrl+Shift+D extended diagnostic battery)
 
 Ctrl+Shift+D now runs a self-test battery against the active

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -405,6 +405,46 @@ empty `tests/Tests.Ui/` project reserves the path for FlaUI work.
   product stays screen-reader-agnostic, then confirm with a real screen
   reader.
 
+### Tests with semantic-laden assertions need updating when semantics change
+
+PR #166 (sub-row suffix-diff at StreamPathway emit) surfaced
+this rule: when a layer's output semantics change — for example,
+"announce the full row" becomes "announce only the suffix since
+last emit" — every test that asserts on the OUTPUT CONTENT of
+that layer needs updating in the same PR. The compiler can't
+catch semantic regressions; CI surfaces them via failing
+assertions on payload strings.
+
+The failure mode in PR #166 was specific:
+`Assert.Contains("abc", trailingPayload)` was correct under
+verbose-emit (the trailing-edge announced the full burst). Under
+suffix-diff, the trailing-edge announces only `"bc"` because the
+leading-edge already emitted `"a"`. Both behaviours are correct
+for their respective designs; the test was keyed to the older
+one.
+
+**Rule for emit-layer changes:**
+
+1. **Don't loosen the assertions to "make CI green".** A change
+   from `Assert.Equal("abc", payload)` to
+   `Assert.Contains("c", payload)` masks regressions instead of
+   reflecting new semantics. Update assertions to match the
+   NEW expected behaviour exactly.
+2. **Add a sanity-check assertion that recovers the prior intent
+   under the new model.** Example from PR #166: after asserting
+   `r1.Payload = "a"` and `tick.Payload = "bc"` separately,
+   add `Assert.Equal("abc", r1.Payload + tick.Payload)` — this
+   confirms the burst's full content still reaches NVDA, just
+   split across two events.
+3. **Document the semantic change in a code comment on the
+   updated test.** Explain WHY the assertion changed so future
+   readers don't misinterpret the new shape as a bug fix on
+   the test side.
+
+This rule applies to any layer whose output is "what NVDA
+hears" — StreamPathway, the future ReplPathway, ClaudeCodePathway,
+FormPathway, and any post-pathway profile transformations.
+
 ### Test fixtures: CSI / OSC / DCS sequences
 
 Existing tests in `VtParserTests.fs` and `ScreenTests.fs` embed a

--- a/src/Terminal.Core/CanonicalState.fs
+++ b/src/Terminal.Core/CanonicalState.fs
@@ -52,6 +52,32 @@ module CanonicalState =
         { ChangedRows = [||]
           ChangedText = "" }
 
+    /// Render a single row to its announcement-text form:
+    /// trim trailing blank cells, walk cells to char string,
+    /// sanitise via `AnnounceSanitiser`. Identical to the
+    /// per-row block inside `renderChangedRows`; extracted so
+    /// callers (including StreamPathway's suffix-diff path)
+    /// can ask for one row at a time.
+    ///
+    /// Returns `""` for out-of-range row indices — the caller
+    /// is responsible for guarding against negative or beyond-
+    /// snapshot indices, but a defensive fallback avoids index
+    /// exceptions.
+    let internal renderRow (snapshot: Cell[][]) (rowIdx: int) : string =
+        if rowIdx < 0 || rowIdx >= snapshot.Length then
+            ""
+        else
+            let row = snapshot.[rowIdx]
+            // Trim trailing blank cells in the row so end-of-
+            // line padding doesn't leak into the announcement.
+            let mutable lastCh = -1
+            for c in 0 .. row.Length - 1 do
+                if row.[c].Ch.Value <> int ' ' then lastCh <- c
+            let rowSb = StringBuilder()
+            for c in 0 .. lastCh do
+                rowSb.Append(row.[c].Ch.ToString()) |> ignore
+            AnnounceSanitiser.sanitise (rowSb.ToString())
+
     /// Render only the rows whose indices appear in
     /// `changedRows`. Mirrors `Coalescer.renderRows`'s per-row
     /// sanitisation + trailing-blank-cell trim, but operates
@@ -71,19 +97,8 @@ module CanonicalState =
             let mutable first = true
             for rowIdx in changedRows do
                 if rowIdx >= 0 && rowIdx < snapshot.Length then
-                    let row = snapshot.[rowIdx]
-                    // Trim trailing blank cells in the row so
-                    // end-of-line padding doesn't leak into the
-                    // announcement.
-                    let mutable lastCh = -1
-                    for c in 0 .. row.Length - 1 do
-                        if row.[c].Ch.Value <> int ' ' then lastCh <- c
-                    let rowSb = StringBuilder()
-                    for c in 0 .. lastCh do
-                        rowSb.Append(row.[c].Ch.ToString()) |> ignore
-                    let sanitised = AnnounceSanitiser.sanitise (rowSb.ToString())
                     if not first then sb.Append('\n') |> ignore
-                    sb.Append(sanitised) |> ignore
+                    sb.Append(renderRow snapshot rowIdx) |> ignore
                     first <- false
             sb.ToString()
 

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -99,22 +99,45 @@ module StreamPathway =
     ///   leading-edge or trailing-edge emit.
     type State =
         { mutable LastEmittedRowHashes: uint64[]
+          /// Per-row rendered text at the moment of last emit.
+          /// PR #166 — added for sub-row suffix-diff (the
+          /// announcement payload-assembly stage compares each
+          /// changed row's current text against this baseline
+          /// to compute the longest-common-prefix and emit only
+          /// the suffix that's new since last emit). Updated
+          /// at exactly the same conditional-branch sites as
+          /// `LastEmittedRowHashes` — leading-edge emit,
+          /// trailing-edge tick, mode-barrier flush, baseline
+          /// seed, and `resetState`. Empty array means "no
+          /// emit history yet"; the next emit treats every row
+          /// as Initial (its full text is the suffix).
+          mutable LastEmittedRowText: string[]
           mutable LastFrameHash: uint64 voption
           mutable LastFlushAt: DateTimeOffset voption
           mutable PendingDiff: CanonicalState.CanonicalDiff voption
           mutable PendingFrameHash: uint64 voption
           mutable PendingColor: string voption
+          /// PR #166 — snapshot reference held during the
+          /// debounce-accumulate window so the trailing-edge
+          /// tick can compute the suffix-diff against the
+          /// latest snapshot without re-receiving it from the
+          /// pump. Cleared at every emit + reset site
+          /// alongside `PendingDiff`. Reference-only (no copy);
+          /// stays alive only for the debounce window.
+          mutable PendingSnapshot: Cell[][] voption
           mutable LastRowHashes: uint64[] voption
           PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
           HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
 
     let internal createState () : State =
         { LastEmittedRowHashes = [||]
+          LastEmittedRowText = [||]
           LastFrameHash = ValueNone
           LastFlushAt = ValueNone
           PendingDiff = ValueNone
           PendingFrameHash = ValueNone
           PendingColor = ValueNone
+          PendingSnapshot = ValueNone
           LastRowHashes = ValueNone
           PerRowHistory = Dictionary()
           HashHistory = Dictionary() }
@@ -301,6 +324,150 @@ module StreamPathway =
             id
             text
 
+    // -------------------------------------------------------------
+    // Sub-row suffix-diff (PR #166).
+    //
+    // Goal: when row N of the screen changes from "> echo h" to
+    // "> echo hi", emit only the new "i" rather than the full
+    // "> echo hi" again. The current row-level diff
+    // (CanonicalState.computeDiff) tells us WHICH rows changed
+    // and gives us the ChangedText of all of them concatenated.
+    // The suffix-diff stage takes that information PLUS the
+    // per-row text we last emitted (cached in
+    // `state.LastEmittedRowText`) and produces the cumulative
+    // new content per row.
+    //
+    // Algorithm: per-row longest-common-prefix. If a row shrank
+    // (backspace) we stay silent. If too many rows changed at
+    // once (scroll, screen-clear, TUI repaint), we fall back to
+    // emitting the full ChangedText — see BulkChangeThreshold.
+    //
+    // Spec: docs/SESSION-HANDOFF.md vocabulary glossary stages
+    // 8 (sub-row suffix detection), 8b (bulk-change fallback),
+    // and 9 (announcement payload assembly).
+    // -------------------------------------------------------------
+
+    /// Bulk-change fallback threshold. If the row-level diff
+    /// reports more rows changed than this, we bypass the
+    /// per-row suffix-diff stage and emit the full ChangedText
+    /// (the previous verbose behaviour). Catches scroll, screen
+    /// clears, and TUI repaints with one heuristic — the
+    /// maintainer benefits from full context at those
+    /// discontinuities, where suffix-diff would produce
+    /// gibberish from a stale baseline.
+    ///
+    /// 3 is conservative: typing produces 1 changed row;
+    /// Enter usually produces 1-2; small pastes 2-3 — they
+    /// all stay on the suffix-diff path. Scroll affects ~30
+    /// rows; screen clear all of them — both engage the
+    /// fallback.
+    let private BulkChangeThreshold : int = 3
+
+    /// Result of the sub-row suffix-diff stage for one row.
+    type internal EditDelta =
+        /// Suffix to announce. Always non-empty when this case
+        /// is selected. May be a single character ("i" after
+        /// typing 'i'), a multi-character segment, or the full
+        /// row text (for first-emit / Initial cases).
+        | Suffix of string
+        /// No announcement for this row. Used when the row is
+        /// unchanged, shrank (backspace; rely on NVDA keyboard
+        /// echo), or differs only in attributes (no displayable
+        /// text difference).
+        | Silent
+
+    /// Length of the longest common prefix of two strings.
+    /// Returns 0 for "no common prefix" (including when either
+    /// input is empty), `min(a.Length, b.Length)` when one is
+    /// a prefix of the other.
+    let internal longestCommonPrefixLength (a: string) (b: string) : int =
+        let n = min a.Length b.Length
+        let mutable i = 0
+        while i < n && a.[i] = b.[i] do
+            i <- i + 1
+        i
+
+    /// Compute the EditDelta for one row. Pure function;
+    /// doesn't touch state. Cases:
+    /// - identical text → `Silent` (no displayable change)
+    /// - previous empty → `Suffix current` (Initial — first
+    ///   time we've emitted this row)
+    /// - current shorter than previous → `Silent` (Shrink;
+    ///   v1 leaves backspace audibility to NVDA's keyboard
+    ///   echo per Default 1 in the plan)
+    /// - common prefix covers all of current → `Silent`
+    ///   (attribute-only differences land here when the
+    ///   per-row hash differs but the rendered text is the
+    ///   same)
+    /// - otherwise → `Suffix (current beyond common prefix)`
+    let internal computeRowSuffixDelta
+            (currentText: string)
+            (previousText: string)
+            : EditDelta
+            =
+        if currentText = previousText then
+            Silent
+        elif previousText.Length = 0 then
+            Suffix currentText
+        elif currentText.Length < previousText.Length then
+            Silent
+        else
+            let commonLen = longestCommonPrefixLength currentText previousText
+            if commonLen = currentText.Length then
+                Silent
+            else
+                Suffix (currentText.Substring(commonLen))
+
+    /// Render every row of `snapshot` to its announcement-text
+    /// form. Used when updating `state.LastEmittedRowText` at
+    /// emit sites — caches every row's current text so the
+    /// next emit can compute per-row suffix-diffs against a
+    /// known baseline. Cost: O(rows × cols) on every emit;
+    /// cheap given the 30×120 default screen size.
+    let private renderAllRows (snapshot: Cell[][]) : string[] =
+        let result = Array.zeroCreate<string> snapshot.Length
+        for i in 0 .. snapshot.Length - 1 do
+            result.[i] <- CanonicalState.renderRow snapshot i
+        result
+
+    /// Stage 9 — announcement-payload assembly. Decides
+    /// between bulk-change fallback (verbose ChangedText) and
+    /// per-row suffix-diff. Returns the final string the
+    /// StreamChunk OutputEvent will carry.
+    ///
+    /// Payload-empty contract: if every changed row produced
+    /// `Silent` (e.g. all rows shrank, or all attribute-only
+    /// differences), the returned string is `""`. The caller
+    /// MUST check for empty before emitting — emitting an
+    /// empty StreamChunk would still cause downstream
+    /// processing (FileLoggerChannel logs it; NvdaChannel
+    /// short-circuits empty per `NvdaChannel.fs:87` but the
+    /// CONTRACT is to not emit empty payloads).
+    let private assembleSuffixPayload
+            (snapshot: Cell[][])
+            (diff: CanonicalState.CanonicalDiff)
+            (lastRowText: string[])
+            : string
+            =
+        if diff.ChangedRows.Length > BulkChangeThreshold then
+            // Stage 8b — bulk-change fallback. Defer to the
+            // existing ChangedText; downstream behaviour is the
+            // pre-PR-#166 verbose emit.
+            diff.ChangedText
+        else
+            // Stage 8 — per-row suffix-diff.
+            let parts = ResizeArray<string>()
+            for rowIdx in diff.ChangedRows do
+                if rowIdx >= 0 && rowIdx < snapshot.Length then
+                    let currentText = CanonicalState.renderRow snapshot rowIdx
+                    let previousText =
+                        if rowIdx < lastRowText.Length then lastRowText.[rowIdx]
+                        else ""
+                    match computeRowSuffixDelta currentText previousText with
+                    | Suffix text -> parts.Add(text)
+                    | Silent -> ()
+            String.concat "\n" parts
+
     /// Phase A.2 — build the supplementary colour-event for a
     /// flushed diff. Returns `None` for plain frames (caller
     /// emits only the StreamChunk); `Some ErrorLine` for red,
@@ -398,6 +565,7 @@ module StreamPathway =
                         state.PendingDiff <- ValueNone
                         state.PendingFrameHash <- ValueNone
                         state.PendingColor <- ValueNone
+                        state.PendingSnapshot <- ValueNone
                         logger.LogDebug(
                             "Suppressed (empty-diff). FrameHash=0x{Hash:X16}", frameHash)
                         [||]
@@ -408,21 +576,46 @@ module StreamPathway =
                         state.PendingDiff <- ValueNone
                         state.PendingFrameHash <- ValueNone
                         state.PendingColor <- ValueNone
+                        state.PendingSnapshot <- ValueNone
+                        // PR #166 — sub-row suffix-diff. Compute
+                        // the payload BEFORE updating
+                        // LastEmittedRowText (which is the
+                        // baseline the suffix-diff reads).
+                        let payload =
+                            assembleSuffixPayload
+                                canonical.Snapshot
+                                diff
+                                state.LastEmittedRowText
                         state.LastEmittedRowHashes <- rowHashes
-                        let capped = capAnnounce parameters diff.ChangedText
-                        logger.LogInformation(
-                            "Emit StreamChunk (leading-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
-                            frameHash, diff.ChangedRows.Length, capped.Length,
-                            (match dominantColor with Some c -> c | None -> "none"))
-                        // Phase A.2 — emit a supplementary
-                        // ErrorLine/WarningLine event when the
-                        // diff's changed rows are colour-dominant.
-                        // EarconProfile claims it semantically;
-                        // NvdaChannel skips the empty payload so no
-                        // double-announce.
-                        match dominantColor |> Option.bind colorOutputEvent with
-                        | Some colorEvt -> [| streamOutputEvent capped; colorEvt |]
-                        | None -> [| streamOutputEvent capped |]
+                        state.LastEmittedRowText <- renderAllRows canonical.Snapshot
+                        let capped = capAnnounce parameters payload
+                        if String.IsNullOrEmpty capped then
+                            // Suffix-diff produced no audible
+                            // content (every changed row was
+                            // Silent — typically backspace, or
+                            // attribute-only differences). The
+                            // dominant-colour earcon for this
+                            // frame is also dampened: silent +
+                            // colour-tone would announce a tone
+                            // for content the user can't hear.
+                            logger.LogDebug(
+                                "Suppressed (suffix-diff Silent, leading-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows}",
+                                frameHash, diff.ChangedRows.Length)
+                            [||]
+                        else
+                            logger.LogInformation(
+                                "Emit StreamChunk (leading-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
+                                frameHash, diff.ChangedRows.Length, capped.Length,
+                                (match dominantColor with Some c -> c | None -> "none"))
+                            // Phase A.2 — emit a supplementary
+                            // ErrorLine/WarningLine event when the
+                            // diff's changed rows are colour-dominant.
+                            // EarconProfile claims it semantically;
+                            // NvdaChannel skips the empty payload so no
+                            // double-announce.
+                            match dominantColor |> Option.bind colorOutputEvent with
+                            | Some colorEvt -> [| streamOutputEvent capped; colorEvt |]
+                            | None -> [| streamOutputEvent capped |]
                 else
                     // Within debounce: accumulate the diff;
                     // trailing edge will flush. Stash the dominant
@@ -438,6 +631,14 @@ module StreamPathway =
                         match dominantColor with
                         | Some c -> ValueSome c
                         | None -> ValueNone
+                    // PR #166 — stash the snapshot so the
+                    // trailing-edge tick can compute the
+                    // suffix-diff payload at flush time. Latest
+                    // snapshot wins (matches PendingDiff
+                    // semantics — only the most recent pending
+                    // frame survives until the trailing-edge
+                    // window expires).
+                    state.PendingSnapshot <- ValueSome canonical.Snapshot
                     logger.LogDebug(
                         "Accumulated (within debounce window). FrameHash=0x{Hash:X16} Color={Color}",
                         frameHash,
@@ -467,12 +668,15 @@ module StreamPathway =
                 // Phase A.2 — capture the pending colour BEFORE
                 // resetting state so it survives the same
                 // condition-block that promotes the diff.
+                // PR #166 — capture pending snapshot too.
                 let pendingColor = state.PendingColor
+                let pendingSnapshot = state.PendingSnapshot
                 state.LastFrameHash <- ValueSome hash
                 state.LastFlushAt <- ValueSome now
                 state.PendingDiff <- ValueNone
                 state.PendingFrameHash <- ValueNone
                 state.PendingColor <- ValueNone
+                state.PendingSnapshot <- ValueNone
                 if diff.ChangedRows.Length = 0 then
                     [||]
                 else
@@ -483,18 +687,40 @@ module StreamPathway =
                     match state.LastRowHashes with
                     | ValueSome rh -> state.LastEmittedRowHashes <- rh
                     | ValueNone -> ()
-                    let capped = capAnnounce parameters diff.ChangedText
-                    let colorEvt =
-                        match pendingColor with
-                        | ValueSome c -> colorOutputEvent c
-                        | ValueNone -> None
-                    logger.LogInformation(
-                        "Emit StreamChunk (trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
-                        hash, diff.ChangedRows.Length, capped.Length,
-                        (match pendingColor with ValueSome c -> c | ValueNone -> "none"))
-                    match colorEvt with
-                    | Some evt -> [| streamOutputEvent capped; evt |]
-                    | None -> [| streamOutputEvent capped |]
+                    // PR #166 — sub-row suffix-diff at trailing
+                    // edge. Computed once (not per-accumulate
+                    // keystroke); uses the captured-pending
+                    // snapshot. If the snapshot is unexpectedly
+                    // absent (defensive — should always be set
+                    // when PendingDiff is set), fall back to the
+                    // pre-PR-166 verbose `ChangedText`.
+                    let payload =
+                        match pendingSnapshot with
+                        | ValueSome snap ->
+                            let p =
+                                assembleSuffixPayload snap diff state.LastEmittedRowText
+                            state.LastEmittedRowText <- renderAllRows snap
+                            p
+                        | ValueNone ->
+                            diff.ChangedText
+                    let capped = capAnnounce parameters payload
+                    if String.IsNullOrEmpty capped then
+                        logger.LogDebug(
+                            "Suppressed (suffix-diff Silent, trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows}",
+                            hash, diff.ChangedRows.Length)
+                        [||]
+                    else
+                        let colorEvt =
+                            match pendingColor with
+                            | ValueSome c -> colorOutputEvent c
+                            | ValueNone -> None
+                        logger.LogInformation(
+                            "Emit StreamChunk (trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
+                            hash, diff.ChangedRows.Length, capped.Length,
+                            (match pendingColor with ValueSome c -> c | ValueNone -> "none"))
+                        match colorEvt with
+                        | Some evt -> [| streamOutputEvent capped; evt |]
+                        | None -> [| streamOutputEvent capped |]
             else
                 [||]
         | _ -> [||]
@@ -526,10 +752,18 @@ module StreamPathway =
         state.PendingDiff <- ValueNone
         state.PendingFrameHash <- ValueNone
         state.PendingColor <- ValueNone
+        state.PendingSnapshot <- ValueNone
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueSome now
         state.LastRowHashes <- ValueNone
         state.LastEmittedRowHashes <- [||]
+        // PR #166 — clear per-row text cache so the post-
+        // barrier first emit treats every row as Initial
+        // (full text becomes the "suffix"). The barrier flush
+        // above used `diff.ChangedText` (verbose); the next
+        // emit through `processCanonicalState` will pick up
+        // suffix-diff against an empty baseline.
+        state.LastEmittedRowText <- [||]
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()
         flushed
@@ -539,11 +773,13 @@ module StreamPathway =
     /// post-flush portion of `OnModeBarrier`.
     let private resetState (state: State) : unit =
         state.LastEmittedRowHashes <- [||]
+        state.LastEmittedRowText <- [||]
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueNone
         state.PendingDiff <- ValueNone
         state.PendingFrameHash <- ValueNone
         state.PendingColor <- ValueNone
+        state.PendingSnapshot <- ValueNone
         state.LastRowHashes <- ValueNone
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()
@@ -564,6 +800,18 @@ module StreamPathway =
         // ValueNone and accumulate spinner-history entries
         // for the seeded frame's content.
         state.LastRowHashes <- ValueSome canonical.RowHashes
+        // PR #166 — eagerly render the seeded snapshot so
+        // suffix-diff has a baseline. Without this, the first
+        // emit after a hot-switch-with-baseline would treat
+        // every row as Initial (full content as "suffix") and
+        // re-announce the entire shell screen — defeating the
+        // verbose-readback fix that hot-switch is supposed to
+        // sidestep.
+        state.LastEmittedRowText <-
+            let result = Array.zeroCreate<string> canonical.Snapshot.Length
+            for i in 0 .. canonical.Snapshot.Length - 1 do
+                result.[i] <- CanonicalState.renderRow canonical.Snapshot i
+            result
 
     /// Construct a StreamPathway. The pathway captures
     /// `parameters` in its closure; v1 ships a single

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -796,3 +796,212 @@ let ``red row outside diff scope produces no ErrorLine emit`` () =
     // actually changed (row 1).
     Assert.Contains("later", r2.[0].Payload)
     Assert.DoesNotContain("Error", r2.[0].Payload)
+
+// ---- Sub-row suffix-diff (PR #166 — item 1) ---------------------
+
+[<Fact>]
+let ``longestCommonPrefixLength — empty inputs return 0`` () =
+    Assert.Equal(0, StreamPathway.longestCommonPrefixLength "" "")
+    Assert.Equal(0, StreamPathway.longestCommonPrefixLength "" "abc")
+    Assert.Equal(0, StreamPathway.longestCommonPrefixLength "abc" "")
+
+[<Fact>]
+let ``longestCommonPrefixLength — identical strings return their length`` () =
+    Assert.Equal(3, StreamPathway.longestCommonPrefixLength "abc" "abc")
+    Assert.Equal(0, StreamPathway.longestCommonPrefixLength "" "")
+    Assert.Equal(1, StreamPathway.longestCommonPrefixLength "a" "a")
+
+[<Fact>]
+let ``longestCommonPrefixLength — diverging strings`` () =
+    Assert.Equal(2, StreamPathway.longestCommonPrefixLength "abc" "abd")
+    Assert.Equal(0, StreamPathway.longestCommonPrefixLength "abc" "xyz")
+    Assert.Equal(1, StreamPathway.longestCommonPrefixLength "ab" "ax")
+
+[<Fact>]
+let ``longestCommonPrefixLength — one is prefix of the other`` () =
+    Assert.Equal(3, StreamPathway.longestCommonPrefixLength "abc" "abcdef")
+    Assert.Equal(3, StreamPathway.longestCommonPrefixLength "abcdef" "abc")
+
+[<Fact>]
+let ``computeRowSuffixDelta — identical text returns Silent`` () =
+    let result = StreamPathway.computeRowSuffixDelta "abc" "abc"
+    Assert.Equal(StreamPathway.Silent, result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — empty previous returns Suffix of full current`` () =
+    let result = StreamPathway.computeRowSuffixDelta "Hello" ""
+    Assert.Equal(StreamPathway.Suffix "Hello", result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — append at end returns suffix only`` () =
+    let result =
+        StreamPathway.computeRowSuffixDelta "> echo hi" "> echo h"
+    Assert.Equal(StreamPathway.Suffix "i", result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — multi-character append returns full new suffix`` () =
+    let result =
+        StreamPathway.computeRowSuffixDelta "PtySpeakDiagPlain" "PtySpeak"
+    Assert.Equal(StreamPathway.Suffix "DiagPlain", result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — current shorter than previous returns Silent (Shrink)`` () =
+    // Backspace case — relies on NVDA keyboard echo per Default 1.
+    let result = StreamPathway.computeRowSuffixDelta "> echo h" "> echo hi"
+    Assert.Equal(StreamPathway.Silent, result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — replace case returns suffix beyond common prefix`` () =
+    // V1 over-reports mid-line edits — documents the
+    // limitation as expected behaviour. Cursor-aware diff
+    // (v2) would scope the announce to the cursor position.
+    let result = StreamPathway.computeRowSuffixDelta "abXc" "abc"
+    Assert.Equal(StreamPathway.Suffix "Xc", result)
+
+[<Fact>]
+let ``typing at prompt: suffix-diff emits only new character, not full row`` () =
+    // The everyday case PR #166 fixes. snap1 has "> echo h",
+    // snap2 has "> echo hi". Leading-edge emit on snap2
+    // (after debounce window elapsed) should emit "i", not
+    // "> echo hi".
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "> echo h" ]
+    let snap2 = snapshotOf 1 20 [ "> echo hi" ]
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    Assert.Equal("> echo h", r1.[0].Payload)
+    // Wait past debounce window so the next emit is leading-edge,
+    // not accumulate.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 500)
+            (canonicalAt snap2 1L)
+    Assert.Equal(1, r2.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, r2.[0].Semantic)
+    // The fix: payload is just "i", not "> echo hi".
+    Assert.Equal("i", r2.[0].Payload)
+
+[<Fact>]
+let ``multi-keystroke debounce accumulates suffix at trailing-edge flush`` () =
+    // Three keystrokes within the 200ms debounce window.
+    // Leading-edge emits the first; the next two accumulate;
+    // trailing-edge tick should emit the cumulative suffix.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "> echo h" ]
+    let snap2 = snapshotOf 1 20 [ "> echo hi" ]
+    let snap3 = snapshotOf 1 20 [ "> echo hi " ]
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    Assert.Equal("> echo h", r1.[0].Payload)
+    // Within debounce — accumulates.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50)
+            (canonicalAt snap2 1L)
+    Assert.Empty(r2)
+    let r3 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 100)
+            (canonicalAt snap3 2L)
+    Assert.Empty(r3)
+    // Trailing-edge tick after debounce window elapses.
+    let tick = StreamPathway.onTimerTick StreamPathway.defaultParameters state (at 250)
+    Assert.Equal(1, tick.Length)
+    // Cumulative suffix from the last-emitted "> echo h" to
+    // current "> echo hi ": just "i ". Note trailing space is
+    // preserved here because rowOf doesn't trim — the screen
+    // grid contains spaces beyond, but renderRow trims those.
+    // The suffix is what's beyond the common prefix in the
+    // RENDERED text.
+    Assert.Equal("i", tick.[0].Payload.TrimEnd())
+
+[<Fact>]
+let ``bulk-change fallback engages when more than 3 rows change`` () =
+    // 5 changed rows triggers bulk-change fallback. Payload
+    // should be the full ChangedText (verbose), not per-row
+    // suffixes.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 5 10 [ ""; ""; ""; ""; "" ]
+    let snap2 = snapshotOf 5 10 [ "row0"; "row1"; "row2"; "row3"; "row4" ]
+    // First emit primes the cache.
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    // Second emit — 5 rows change, above threshold of 3.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 500)
+            (canonicalAt snap2 1L)
+    Assert.Equal(1, r2.Length)
+    // Bulk-change fallback emits the full ChangedText, which
+    // contains every changed row joined by '\n'.
+    Assert.Contains("row0", r2.[0].Payload)
+    Assert.Contains("row1", r2.[0].Payload)
+    Assert.Contains("row4", r2.[0].Payload)
+
+[<Fact>]
+let ``backspace case (row shrinks) produces empty payload and no emit`` () =
+    // After typing "> echo hi", backspace produces
+    // "> echo h" — Shrink case, Silent, no announcement.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "> echo hi" ]
+    let snap2 = snapshotOf 1 20 [ "> echo h" ]
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 500)
+            (canonicalAt snap2 1L)
+    // No emit — empty payload short-circuits.
+    Assert.Empty(r2)
+
+[<Fact>]
+let ``first emit on a fresh pathway treats every row as Initial`` () =
+    // Empty LastEmittedRowText + first snapshot. Suffix per row
+    // = full row text. Concatenated → full snapshot text.
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 1 20 [ "Hello world" ]
+    let r =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap 0L)
+    Assert.Equal(1, r.Length)
+    Assert.Equal("Hello world", r.[0].Payload)
+
+[<Fact>]
+let ``onModeBarrier flushes verbose, then clears LastEmittedRowText`` () =
+    // Mode barriers are discontinuities. The flushed pending
+    // diff uses ChangedText (verbose), not suffix-diff. After
+    // the barrier, LastEmittedRowText is empty so the next
+    // emit treats every row as Initial.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "> echo h" ]
+    let snap2 = snapshotOf 1 20 [ "> echo hi" ]
+    // Leading-edge emit primes the cache.
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    // Within debounce — accumulate (PendingDiff set).
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50)
+            (canonicalAt snap2 1L)
+    // Mode barrier flushes pending. Verbose payload
+    // (ChangedText) — not suffix-diff'd.
+    let flushed = StreamPathway.onModeBarrier state (at 100)
+    Assert.Equal(1, flushed.Length)
+    // Verbose flush carries the full row content.
+    Assert.Equal("> echo hi", flushed.[0].Payload)
+    // After barrier, cache is cleared.
+    Assert.Equal(0, state.LastEmittedRowText.Length)

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -115,6 +115,16 @@ let ``leading-edge emit produces a StreamChunk OutputEvent`` () =
 
 [<Fact>]
 let ``burst within debounce window collapses to leading + trailing emit`` () =
+    // Burst-within-debounce semantics post-PR-#166 (suffix-
+    // diff): the leading-edge emits the first frame's
+    // suffix-diff vs. the empty cache (Initial → "a"). The
+    // next two frames accumulate (no emit). The trailing-edge
+    // emits the suffix-diff vs. the last-emit baseline ("a"),
+    // which is "bc" — the new content since that baseline.
+    // Cumulative announcement across both emits = "a" + "bc"
+    // = "abc"; this preserves the original test intent (the
+    // burst's full content reaches NVDA) while reflecting
+    // the new suffix-diff semantics.
     let state = StreamPathway.createState ()
     let snap1 = snapshotOf 3 5 [ "a" ]
     let snap2 = snapshotOf 3 5 [ "ab" ]
@@ -123,6 +133,7 @@ let ``burst within debounce window collapses to leading + trailing emit`` () =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
     Assert.Equal(1, r1.Length)
+    Assert.Equal("a", r1.[0].Payload)
     let r2 =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
@@ -135,7 +146,11 @@ let ``burst within debounce window collapses to leading + trailing emit`` () =
         StreamPathway.onTimerTick
             StreamPathway.defaultParameters state (at 250)
     Assert.Equal(1, tick.Length)
-    Assert.Contains("abc", tick.[0].Payload)
+    Assert.Equal("bc", tick.[0].Payload)
+    // Sanity check on the original test intent — cumulative
+    // payload across leading + trailing recovers the full
+    // burst content "abc".
+    Assert.Equal("abc", r1.[0].Payload + tick.[0].Payload)
 
 [<Fact>]
 let ``trailing-edge tick with nothing pending is a no-op`` () =


### PR DESCRIPTION
## Summary

When typing `echo hi` at a shell prompt, NVDA used to read the entire row on every keystroke (`> echo h`, then `> echo hi`). Each keystroke meant hearing the full prompt + command line again. After this PR, NVDA reads only the new content since last emit — `h`, then `i`. The verbose-readback issue (GitHub #115/#139) regresses to "single-character announcement on each keystroke" as Phase A intended.

This is the highest daily-UX impact item in the backlog (item 1) and the foundation for **Phase 2's ReplPathway** (which needs character-level edit awareness).

## Vocabulary — proposing a glossary

This PR also begins a **stage glossary** as a trial run for item 19's Pipeline-Narrative research. The pipeline this PR touches:

| # | Stage | Module |
|---|---|---|
| 7 | Row-level diff | `CanonicalState.computeDiff` |
| **8** | **Sub-row suffix detection** *(NEW)* | `StreamPathway` (`EditDelta`, `computeRowSuffixDelta`) |
| **8b** | **Bulk-change fallback** *(NEW)* | `StreamPathway` (`BulkChangeThreshold`) |
| 9 | Announcement payload assembly | `StreamPathway` (`assembleSuffixPayload`) |

If these names work in this design discussion, they're candidates for the canonical glossary.

## Behaviour

| Action | Before | After |
|---|---|---|
| Type `e` at fresh prompt | `> e` (whole row) | `e` |
| Type `c` after `e` | `> ec` | `c` |
| Press Backspace | reads truncated row | silent (NVDA keyboard-echo handles it) |
| Press Enter on populated line | full historical command + new prompt | only the new content |
| Paste 5+ line script | full content | full content (bulk-change fallback engages) |
| Switch shell | new shell startup | new shell startup (mode-barrier flush stays verbose) |

## Defaults (redirectable on next iteration)

1. **Backspace silent** — NVDA's keyboard-echo handles backspace feedback at the keyboard layer; emitting "deleted i" would duplicate.
2. **Bulk-change threshold N=3** — when more than 3 rows change in one frame (scroll, screen clear, TUI repaint, multi-line paste), bypass suffix-diff and emit verbose.
3. **Autosuggestion-aware diff deferred to v2** — fish/zsh ghost text (grey-foreground beyond cursor) over-reports under v1 LCP. SGR-attribute filtering is a follow-up.

## Known v1 limitations (documented)

- **Mid-line insertion over-reports.** Cursor-left + type X into `> echo h` → `> echXo h` announces `Xo h` instead of `X`. v2 (cursor-aware) fixes.
- **Powerline / Starship / oh-my-posh prompt redraws over-report.** Async git-status segments rewrite the PS1; LCP common prefix collapses.
- **Right-aligned RPROMPT (zsh) over-reports.** Same family.
- **Autosuggestions over-report** (per Default 3 above).

## Implementation

- `src/Terminal.Core/CanonicalState.fs` — extracted `renderRow snapshot rowIdx` helper from `renderChangedRows`; both paths share the trim + sanitise logic.
- `src/Terminal.Core/StreamPathway.fs`:
    - `EditDelta` discriminated union (`Suffix of string | Silent`)
    - `longestCommonPrefixLength`, `computeRowSuffixDelta`, `BulkChangeThreshold = 3`
    - `assembleSuffixPayload`, `renderAllRows` helpers
    - State extended with `LastEmittedRowText: string[]` + `PendingSnapshot: Cell[][] voption`
    - Wired into all 5 update sites: leading-edge emit, trailing-edge tick, mode-barrier flush (clears cache; flush itself stays verbose), `resetState`, `seedBaseline` (eagerly populates cache so hot-switch doesn't re-announce the seeded screen)
- 14 new xUnit tests covering algorithm + integration behaviour

## Test plan

Automated:

- [ ] `longestCommonPrefixLength` — empty/identical/diverging/prefix cases (4 tests)
- [ ] `computeRowSuffixDelta` — Silent/Initial/Append/Shrink/Replace cases (5 tests)
- [ ] **Typing at prompt produces single-character suffix** (the headline regression test)
- [ ] Multi-keystroke debounce accumulates correctly at trailing-edge
- [ ] Bulk-change fallback engages when >3 rows change
- [ ] Backspace produces empty payload (Silent)
- [ ] First emit treats every row as Initial
- [ ] `onModeBarrier` flushes verbose, clears cache
- [ ] **PR #164 regression guards survive** (red row outside diff scope still doesn't emit ErrorLine)

Manual NVDA validation matrix (deferred to maintainer):

- [ ] Cut release with PR; install
- [ ] Type `echo hi` character by character → NVDA reads each new char, not the full row
- [ ] Press Enter → NVDA reads new content, not historical
- [ ] Press Backspace → silent (or NVDA keyboard echo if enabled)
- [ ] Paste a 5-line script → NVDA reads full content (bulk-change fallback)
- [ ] Run Ctrl+Shift+D diagnostic battery → existing T1-T5 PowerShell + T1 cmd still pass
- [ ] Test `Clear-Host` → NVDA reads cleared state (bulk-change fallback)
- [ ] Switch shell with Ctrl+Shift+1/2/3 → mode-barrier flush still verbose

## Sequencing

Foundation for ReplPathway (Phase 2) and content-type triggers downstream. The diagnostic battery's automated regression coverage (PR #165) lets us refactor StreamPathway with confidence we'd notice a regression in the colour-detection or emit-shape behaviours.

After this lands: items 2 (canonical-state serialization) and 19 (pipeline-narrative research) are next plan-mode candidates.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_