### PR TITLE
Tier 1 parameters: bulk_change_threshold, backspace_policy, mode_barrier_flush_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,68 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Tier 1 parameters from suffix-diff UX feedback)
+
+Three parameters from `docs/USER-SETTINGS.md`'s "Suffix-diff
+parameters (PR #166 follow-up)" section now ship as
+configurable, with defaults updated where the old behaviour
+was confirmed problematic during PR #166's release-build
+validation:
+
+- **`bulk_change_threshold`** (was a hard-coded `3` in
+  `StreamPathway.fs`; now `[pathway.stream] bulk_change_threshold`,
+  default 3). Above this many changed rows in a single frame,
+  the suffix-diff stage bypasses per-row LCP and emits the
+  full ChangedText (verbose fallback). Default unchanged;
+  exposed for tuning.
+- **`backspace_policy`** (was hard-coded "Silent" in PR #166;
+  now `[pathway.stream] backspace_policy`, default
+  `"announce_deleted_character"`). PR #166's "rely on NVDA
+  keyboard echo for backspace audibility" assumption was
+  confirmed wrong: NVDA's keyboard echo speaks the *key
+  pressed* (Backspace), not the screen-content change. With
+  the new default, backspacing the `i` from `echo hi` makes
+  pty-speak announce `i` (the deleted segment of the row's
+  rendered text). Legacy `"silent"` preserved as opt-in.
+  Reserved `"announce_deleted_word"` treated identically to
+  `"announce_deleted_character"` in v1.1 (word-boundary work
+  is future).
+- **`mode_barrier_flush_policy`** (was hard-coded verbose in
+  PR #166; now `[pathway.stream] mode_barrier_flush_policy`,
+  default `"summary_only"`). The PR #166 verbose flush at
+  shell-switch / alt-screen / mode-change emitted the
+  previous shell's full screen as a flush event before the
+  new shell's startup — confirmed unpleasant (1200-character
+  flushes of stale history). With the new default, the
+  previous-shell flush is suppressed; the App-layer
+  "switching to X" announce + the new shell's startup output
+  carry the context. Legacy `"verbose"` preserved as opt-in.
+  Subsumes strategic backlog items 23 + 24.
+
+The internal F# DU case `BackspacePolicy.Silent` is exposed
+as `SuppressShrink` to avoid collision with
+`EditDelta.Silent`. The TOML value stays `"silent"`; the
+rename is internal only.
+
+What this addresses from the 2026-05-06 UX session:
+
+- **UX issue #2** (backspace silent + NVDA also silent) —
+  fixed by `backspace_policy` default change.
+- **UX issue #5** (shell-switch reads previous shell's
+  content) — fixed by `mode_barrier_flush_policy` default
+  change.
+- UX issues #1 (double-announce), #3 (cursor movement
+  silent), #4 (stuttering on rapid typing) remain — they
+  need the Phase 2 input framework substrate (echo
+  correlation, cursor-aware diff, per-input-vs-output
+  ActivityIds) and are documented in `USER-SETTINGS.md` as
+  Tier 2 parameters.
+
+Files: `src/Terminal.Core/StreamPathway.fs`,
+`src/Terminal.Core/Config.fs`,
+`tests/Tests.Unit/StreamPathwayTests.fs`,
+`tests/Tests.Unit/ConfigTests.fs`.
+
 ### Added (sub-row suffix-diff at StreamPathway emit)
 
 When typing `echo hi` at a shell prompt, NVDA used to read the

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -92,7 +92,27 @@ module Config =
           /// false` disables the supplementary
           /// ErrorLine/WarningLine OutputEvents and the
           /// associated error-tone/warning-tone earcons.
-          ColorDetection: bool option }
+          ColorDetection: bool option
+          /// PR #168 — Tier 1 parameter from
+          /// `docs/USER-SETTINGS.md` "Suffix-diff parameters".
+          /// `None` falls back to the default (3). Above this
+          /// many changed rows in one frame, the suffix-diff
+          /// stage bypasses per-row LCP and emits the full
+          /// ChangedText (verbose fallback).
+          BulkChangeThreshold: int option
+          /// PR #168 — backspace policy for the suffix-diff
+          /// Shrink branch. `None` falls back to the default
+          /// (`AnnounceDeletedCharacter`). TOML values:
+          /// `"silent"`, `"announce_deleted_character"`,
+          /// `"announce_deleted_word"`. Unknown / non-string
+          /// values log a Warning and fall back.
+          BackspacePolicy: StreamPathway.BackspacePolicy option
+          /// PR #168 — mode-barrier flush policy. `None` falls
+          /// back to the default (`SummaryOnly`). TOML values:
+          /// `"verbose"`, `"summary_only"`, `"suppressed"`.
+          /// Unknown / non-string values log a Warning and
+          /// fall back.
+          ModeBarrierFlushPolicy: StreamPathway.ModeBarrierFlushPolicy option }
 
     /// The top-level config record. `ShellOverrides` is keyed
     /// by lowercase shell-id strings (`"cmd"`, `"claude"`,
@@ -119,7 +139,13 @@ module Config =
               SpinnerWindowMs = None
               SpinnerThreshold = None
               MaxAnnounceChars = None
-              ColorDetection = None } }
+              ColorDetection = None
+              // PR #168 — Tier 1 parameters from
+              // `docs/USER-SETTINGS.md`'s "Suffix-diff
+              // parameters" section.
+              BulkChangeThreshold = None
+              BackspacePolicy = None
+              ModeBarrierFlushPolicy = None } }
 
     /// The default config file path —
     /// `%LOCALAPPDATA%\PtySpeak\config.toml`. Mirrors the
@@ -185,7 +211,11 @@ module Config =
               "spinner_window_ms"
               "spinner_threshold"
               "max_announce_chars"
-              "color_detection" ]
+              "color_detection"
+              // PR #168 — Tier 1 parameters.
+              "bulk_change_threshold"
+              "backspace_policy"
+              "mode_barrier_flush_policy" ]
 
     /// Internal — known shell-id keys for `[shell.<id>]`.
     /// Mirrors `ShellRegistry.parseEnvVar`'s lowercase
@@ -265,11 +295,50 @@ module Config =
                         key)
                 None
             | Some b -> Some b
+        // PR #168 — enum-string parsers for backspace_policy
+        // and mode_barrier_flush_policy. Unknown / non-string
+        // values log a Warning and return None (falls back to
+        // default).
+        let readBackspacePolicy (key: string) : StreamPathway.BackspacePolicy option =
+            match tryGetString table key with
+            | None ->
+                if table.ContainsKey(key) then
+                    logger.LogWarning(
+                        "Config: [pathway.stream] {Key} is non-string; ignored.",
+                        key)
+                None
+            | Some "silent" -> Some StreamPathway.SuppressShrink
+            | Some "announce_deleted_character" -> Some StreamPathway.AnnounceDeletedCharacter
+            | Some "announce_deleted_word" -> Some StreamPathway.AnnounceDeletedWord
+            | Some other ->
+                logger.LogWarning(
+                    "Config: [pathway.stream] {Key} = '{Value}' is not one of 'silent' / 'announce_deleted_character' / 'announce_deleted_word'; ignored.",
+                    key, other)
+                None
+        let readModeBarrierFlushPolicy (key: string) : StreamPathway.ModeBarrierFlushPolicy option =
+            match tryGetString table key with
+            | None ->
+                if table.ContainsKey(key) then
+                    logger.LogWarning(
+                        "Config: [pathway.stream] {Key} is non-string; ignored.",
+                        key)
+                None
+            | Some "verbose" -> Some StreamPathway.Verbose
+            | Some "summary_only" -> Some StreamPathway.SummaryOnly
+            | Some "suppressed" -> Some StreamPathway.Suppressed
+            | Some other ->
+                logger.LogWarning(
+                    "Config: [pathway.stream] {Key} = '{Value}' is not one of 'verbose' / 'summary_only' / 'suppressed'; ignored.",
+                    key, other)
+                None
         { DebounceWindowMs = readField "debounce_window_ms"
           SpinnerWindowMs = readField "spinner_window_ms"
           SpinnerThreshold = readField "spinner_threshold"
           MaxAnnounceChars = readField "max_announce_chars"
-          ColorDetection = readBool "color_detection" }
+          ColorDetection = readBool "color_detection"
+          BulkChangeThreshold = readField "bulk_change_threshold"
+          BackspacePolicy = readBackspacePolicy "backspace_policy"
+          ModeBarrierFlushPolicy = readModeBarrierFlushPolicy "mode_barrier_flush_policy" }
 
     /// Internal — parse the `[shell.X]` family into
     /// `Map<string, ShellPathwayConfig>`. Unknown shell keys
@@ -456,4 +525,10 @@ module Config =
           MaxAnnounceChars =
             Option.defaultValue defaults.MaxAnnounceChars ov.MaxAnnounceChars
           ColorDetection =
-            Option.defaultValue defaults.ColorDetection ov.ColorDetection }
+            Option.defaultValue defaults.ColorDetection ov.ColorDetection
+          BulkChangeThreshold =
+            Option.defaultValue defaults.BulkChangeThreshold ov.BulkChangeThreshold
+          BackspacePolicy =
+            Option.defaultValue defaults.BackspacePolicy ov.BackspacePolicy
+          ModeBarrierFlushPolicy =
+            Option.defaultValue defaults.ModeBarrierFlushPolicy ov.ModeBarrierFlushPolicy }

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -56,6 +56,63 @@ module StreamPathway =
     /// stopgap) is kept but its load-bearing role diminishes
     /// post-Phase-A because most diffs are small (one or two
     /// rows of new text).
+    /// Backspace policy — what `computeRowSuffixDelta` does
+    /// when a row shrinks (backspace, line clear, Ctrl+W
+    /// word-delete, etc.). PR #168 (Tier 1 parameters from
+    /// `docs/USER-SETTINGS.md`'s "Suffix-diff parameters"
+    /// section). Default `AnnounceDeletedCharacter` replaces
+    /// PR #166's silent-on-shrink default, which assumed
+    /// NVDA's keyboard echo would handle backspace audibility
+    /// — confirmed wrong on 2026-05-06 release-build
+    /// validation.
+    ///
+    /// The case name `SuppressShrink` (rather than `Silent`)
+    /// avoids collision with `EditDelta.Silent`. The TOML key
+    /// for this case stays `"silent"`; the rename is internal
+    /// only.
+    type BackspacePolicy =
+        /// PR #166's original behaviour: shrink → no emit.
+        /// Useful only if NVDA gains a "speak deletions"
+        /// setting in the future. TOML value: `"silent"`.
+        | SuppressShrink
+        /// Default. Row shrink emits the deleted segment
+        /// (the part of `previousText` beyond the longest-
+        /// common-prefix with `currentText`). For a single
+        /// backspace, that's one character; for Ctrl+W it
+        /// would be the deleted word. TOML value:
+        /// `"announce_deleted_character"`.
+        | AnnounceDeletedCharacter
+        /// Reserved for future word-boundary-aware behaviour.
+        /// In v1.1, treated identically to
+        /// `AnnounceDeletedCharacter` (the deleted segment is
+        /// emitted as-is). TOML value: `"announce_deleted_word"`.
+        | AnnounceDeletedWord
+
+    /// Mode-barrier flush policy — what `onModeBarrier` does
+    /// with any pending diff at shell-switch / alt-screen /
+    /// mode-change. PR #168. Default `SummaryOnly` replaces
+    /// PR #166's verbose flush — confirmed unpleasant on
+    /// 2026-05-06 release-build validation (1200-character
+    /// flushes of stale shell history).
+    type ModeBarrierFlushPolicy =
+        /// PR #166's original behaviour. Emit the previous
+        /// shell's full screen as a flush event before the new
+        /// shell's startup. Preserves verbose context at
+        /// discontinuities; jarring in practice.
+        | Verbose
+        /// Default. Suppress the previous-shell flush; rely
+        /// on the App-layer "switching to X" announce + the
+        /// new shell's startup output for context. Subsumes
+        /// strategic backlog items 23 + 24.
+        | SummaryOnly
+        /// Silent on barrier; the new shell's startup output
+        /// is the user's only signal that anything changed.
+        /// At the StreamPathway level, identical behaviour to
+        /// `SummaryOnly`; the difference materialises at the
+        /// App-layer (which announces "switching to X" under
+        /// `SummaryOnly` but stays silent under `Suppressed`).
+        | Suppressed
+
     type Parameters =
         { DebounceWindowMs: int
           SpinnerWindowMs: int
@@ -71,14 +128,38 @@ module StreamPathway =
           /// emit, identical to the post-revert behaviour. The
           /// TOML config schema exposes this as
           /// `[pathway.stream] color_detection`.
-          ColorDetection: bool }
+          ColorDetection: bool
+          /// PR #168 — when the row-level diff reports more
+          /// changed rows than this threshold in a single
+          /// frame, the suffix-diff stage bypasses per-row LCP
+          /// and emits the full `ChangedText` (the pre-PR-#166
+          /// verbose path). Catches scrolls, screen clears,
+          /// and TUI repaints with one heuristic. Default 3 is
+          /// conservative: typing produces 1 changed row;
+          /// Enter usually produces 1-2; small pastes 2-3.
+          /// Scrolls affect ~30 rows — engages the fallback.
+          /// TOML key: `[pathway.stream] bulk_change_threshold`.
+          BulkChangeThreshold: int
+          /// PR #168 — what to do when a row shrinks (backspace
+          /// etc.). See `BackspacePolicy`. Default
+          /// `AnnounceDeletedCharacter`. TOML key:
+          /// `[pathway.stream] backspace_policy`.
+          BackspacePolicy: BackspacePolicy
+          /// PR #168 — what to do at mode-barrier flush time.
+          /// See `ModeBarrierFlushPolicy`. Default
+          /// `SummaryOnly`. TOML key:
+          /// `[pathway.stream] mode_barrier_flush_policy`.
+          ModeBarrierFlushPolicy: ModeBarrierFlushPolicy }
 
     let defaultParameters: Parameters =
         { DebounceWindowMs = 200
           SpinnerWindowMs = 1000
           SpinnerThreshold = 5
           MaxAnnounceChars = 500
-          ColorDetection = true }
+          ColorDetection = true
+          BulkChangeThreshold = 3
+          BackspacePolicy = AnnounceDeletedCharacter
+          ModeBarrierFlushPolicy = SummaryOnly }
 
     type private SpinnerKey = int * uint64
 
@@ -361,7 +442,11 @@ module StreamPathway =
     /// all stay on the suffix-diff path. Scroll affects ~30
     /// rows; screen clear all of them — both engage the
     /// fallback.
-    let private BulkChangeThreshold : int = 3
+    ///
+    /// PR #168 — moved from a top-level `let private` constant
+    /// to `Parameters.BulkChangeThreshold`. The default value
+    /// (3) lives in `defaultParameters` above; the constant
+    /// binding is removed to avoid two sources of truth.
 
     /// Result of the sub-row suffix-diff stage for one row.
     type internal EditDelta =
@@ -392,15 +477,24 @@ module StreamPathway =
     /// - identical text → `Silent` (no displayable change)
     /// - previous empty → `Suffix current` (Initial — first
     ///   time we've emitted this row)
-    /// - current shorter than previous → `Silent` (Shrink;
-    ///   v1 leaves backspace audibility to NVDA's keyboard
-    ///   echo per Default 1 in the plan)
+    /// - current shorter than previous (Shrink — backspace,
+    ///   line clear, Ctrl+W) → behaviour depends on
+    ///   `backspacePolicy`:
+    ///     - `SuppressShrink`: returns `Silent` (PR #166's
+    ///       behaviour; relies on NVDA keyboard echo for
+    ///       backspace feedback, which doesn't actually fire
+    ///       for screen-content shrinks)
+    ///     - `AnnounceDeletedCharacter` /
+    ///       `AnnounceDeletedWord`: returns `Suffix
+    ///       deletedText` where `deletedText` is the part of
+    ///       `previousText` beyond the longest-common-prefix
     /// - common prefix covers all of current → `Silent`
     ///   (attribute-only differences land here when the
     ///   per-row hash differs but the rendered text is the
     ///   same)
     /// - otherwise → `Suffix (current beyond common prefix)`
     let internal computeRowSuffixDelta
+            (backspacePolicy: BackspacePolicy)
             (currentText: string)
             (previousText: string)
             : EditDelta
@@ -410,7 +504,14 @@ module StreamPathway =
         elif previousText.Length = 0 then
             Suffix currentText
         elif currentText.Length < previousText.Length then
-            Silent
+            // Shrink case — apply policy.
+            match backspacePolicy with
+            | SuppressShrink -> Silent
+            | AnnounceDeletedCharacter | AnnounceDeletedWord ->
+                let commonLen = longestCommonPrefixLength currentText previousText
+                let deleted = previousText.Substring(commonLen)
+                if String.IsNullOrEmpty deleted then Silent
+                else Suffix deleted
         else
             let commonLen = longestCommonPrefixLength currentText previousText
             if commonLen = currentText.Length then
@@ -444,12 +545,13 @@ module StreamPathway =
     /// short-circuits empty per `NvdaChannel.fs:87` but the
     /// CONTRACT is to not emit empty payloads).
     let private assembleSuffixPayload
+            (parameters: Parameters)
             (snapshot: Cell[][])
             (diff: CanonicalState.CanonicalDiff)
             (lastRowText: string[])
             : string
             =
-        if diff.ChangedRows.Length > BulkChangeThreshold then
+        if diff.ChangedRows.Length > parameters.BulkChangeThreshold then
             // Stage 8b — bulk-change fallback. Defer to the
             // existing ChangedText; downstream behaviour is the
             // pre-PR-#166 verbose emit.
@@ -463,7 +565,12 @@ module StreamPathway =
                     let previousText =
                         if rowIdx < lastRowText.Length then lastRowText.[rowIdx]
                         else ""
-                    match computeRowSuffixDelta currentText previousText with
+                    let delta =
+                        computeRowSuffixDelta
+                            parameters.BackspacePolicy
+                            currentText
+                            previousText
+                    match delta with
                     | Suffix text -> parts.Add(text)
                     | Silent -> ()
             String.concat "\n" parts
@@ -583,6 +690,7 @@ module StreamPathway =
                         // baseline the suffix-diff reads).
                         let payload =
                             assembleSuffixPayload
+                                parameters
                                 canonical.Snapshot
                                 diff
                                 state.LastEmittedRowText
@@ -698,7 +806,7 @@ module StreamPathway =
                         match pendingSnapshot with
                         | ValueSome snap ->
                             let p =
-                                assembleSuffixPayload snap diff state.LastEmittedRowText
+                                assembleSuffixPayload parameters snap diff state.LastEmittedRowText
                             state.LastEmittedRowText <- renderAllRows snap
                             p
                         | ValueNone ->
@@ -731,16 +839,34 @@ module StreamPathway =
     /// content) and resets row-hash baselines (so the
     /// post-mode-change first emit treats every row as
     /// "new").
+    ///
+    /// PR #168 — `ModeBarrierFlushPolicy` controls whether the
+    /// flush is verbose (PR #166's behaviour, emit
+    /// `diff.ChangedText` for the previous shell's full
+    /// screen) or suppressed (default `SummaryOnly` /
+    /// `Suppressed` — return `[||]`, rely on the App-layer
+    /// shell-switch announce + the new shell's startup output
+    /// for context). At the StreamPathway level
+    /// `SummaryOnly` and `Suppressed` are identical; the
+    /// difference materialises at the App-layer
+    /// shell-switch announce (which is the maintainer's
+    /// future TOML-driven concern, not a StreamPathway
+    /// concern).
     let internal onModeBarrier
+            (parameters: Parameters)
             (state: State)
             (now: DateTimeOffset)
             : OutputEvent[]
             =
         let flushed =
-            match state.PendingDiff with
-            | ValueSome diff when diff.ChangedRows.Length > 0 ->
-                [| streamOutputEvent diff.ChangedText |]
-            | _ -> [||]
+            match parameters.ModeBarrierFlushPolicy with
+            | Verbose ->
+                match state.PendingDiff with
+                | ValueSome diff when diff.ChangedRows.Length > 0 ->
+                    [| streamOutputEvent diff.ChangedText |]
+                | _ -> [||]
+            | SummaryOnly | Suppressed ->
+                [||]
         // Phase A.2 — clear PendingColor WITHOUT emitting the
         // supplementary ErrorLine/WarningLine. Mode barriers are
         // themselves discontinuities (alt-screen toggle, vim
@@ -829,7 +955,7 @@ module StreamPathway =
                 onTimerTick parameters state now
           OnModeBarrier =
             fun now ->
-                onModeBarrier state now
+                onModeBarrier parameters state now
           Reset =
             fun () -> resetState state
           SetBaseline =
@@ -862,7 +988,7 @@ module StreamPathway =
                     onTimerTick parameters state now
               OnModeBarrier =
                 fun now ->
-                    onModeBarrier state now
+                    onModeBarrier parameters state now
               Reset =
                 fun () -> resetState state
               SetBaseline =

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -333,3 +333,94 @@ let ``non-bool color_detection logs Warning and falls back to default`` () =
     let resolved = Config.resolveStreamParameters config
     Assert.True(resolved.ColorDetection)
     Assert.True(logger.HasLevel(LogLevel.Warning))
+
+// ---- PR #168 — Tier 1 parameters ---------------------------------
+
+[<Fact>]
+let ``defaultConfig resolveStreamParameters has BulkChangeThreshold = 3`` () =
+    let resolved = Config.resolveStreamParameters Config.defaultConfig
+    Assert.Equal(3, resolved.BulkChangeThreshold)
+
+[<Fact>]
+let ``defaultConfig resolveStreamParameters has BackspacePolicy = AnnounceDeletedCharacter`` () =
+    let resolved = Config.resolveStreamParameters Config.defaultConfig
+    Assert.Equal(StreamPathway.AnnounceDeletedCharacter, resolved.BackspacePolicy)
+
+[<Fact>]
+let ``defaultConfig resolveStreamParameters has ModeBarrierFlushPolicy = SummaryOnly`` () =
+    let resolved = Config.resolveStreamParameters Config.defaultConfig
+    Assert.Equal(StreamPathway.SummaryOnly, resolved.ModeBarrierFlushPolicy)
+
+[<Fact>]
+let ``[pathway.stream] bulk_change_threshold = 5 flows through resolveStreamParameters`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nbulk_change_threshold = 5\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(5, resolved.BulkChangeThreshold)
+
+[<Fact>]
+let ``[pathway.stream] backspace_policy = silent maps to SuppressShrink`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nbackspace_policy = \"silent\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.SuppressShrink, resolved.BackspacePolicy)
+
+[<Fact>]
+let ``[pathway.stream] backspace_policy = announce_deleted_character maps to AnnounceDeletedCharacter`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nbackspace_policy = \"announce_deleted_character\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.AnnounceDeletedCharacter, resolved.BackspacePolicy)
+
+[<Fact>]
+let ``[pathway.stream] backspace_policy = announce_deleted_word maps to AnnounceDeletedWord`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nbackspace_policy = \"announce_deleted_word\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.AnnounceDeletedWord, resolved.BackspacePolicy)
+
+[<Fact>]
+let ``unknown backspace_policy value logs Warning and falls back to default`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nbackspace_policy = \"chirp\"\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.AnnounceDeletedCharacter, resolved.BackspacePolicy)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+[<Fact>]
+let ``[pathway.stream] mode_barrier_flush_policy = verbose maps to Verbose`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nmode_barrier_flush_policy = \"verbose\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.Verbose, resolved.ModeBarrierFlushPolicy)
+
+[<Fact>]
+let ``[pathway.stream] mode_barrier_flush_policy = summary_only maps to SummaryOnly`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nmode_barrier_flush_policy = \"summary_only\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.SummaryOnly, resolved.ModeBarrierFlushPolicy)
+
+[<Fact>]
+let ``[pathway.stream] mode_barrier_flush_policy = suppressed maps to Suppressed`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nmode_barrier_flush_policy = \"suppressed\"\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.Suppressed, resolved.ModeBarrierFlushPolicy)
+
+[<Fact>]
+let ``unknown mode_barrier_flush_policy value logs Warning and falls back to default`` () =
+    let toml =
+        "schema_version = 1\n[pathway.stream]\nmode_barrier_flush_policy = \"warbly\"\n"
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveStreamParameters config
+    Assert.Equal(StreamPathway.SummaryOnly, resolved.ModeBarrierFlushPolicy)
+    Assert.True(logger.HasLevel(LogLevel.Warning))

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -60,6 +60,25 @@ let private at (msFromEpoch: int) : DateTimeOffset =
 let private canonicalAt (snapshot: Cell[][]) (seq: int64) : CanonicalState.Canonical =
     CanonicalState.create snapshot seq
 
+// PR #168 — many existing tests were written against PR #166's
+// verbose-flush mode-barrier default. Tier 1 parameters change
+// the default to `SummaryOnly` (no flush). Tests that
+// specifically verify the verbose-flush behaviour use this
+// helper to opt into the old policy explicitly; tests that
+// verify state-clear-only behaviour use `defaultParameters`.
+let private verboseFlushParameters : StreamPathway.Parameters =
+    { StreamPathway.defaultParameters with
+        ModeBarrierFlushPolicy = StreamPathway.Verbose }
+
+// PR #168 — likewise, the Shrink branch of `computeRowSuffixDelta`
+// used to be unconditionally Silent. The new default (announce
+// the deleted segment) is captured by `defaultParameters`'s
+// `BackspacePolicy = AnnounceDeletedCharacter`. Tests that
+// verify the SuppressShrink behaviour use this helper.
+let private suppressShrinkParameters : StreamPathway.Parameters =
+    { StreamPathway.defaultParameters with
+        BackspacePolicy = StreamPathway.SuppressShrink }
+
 // ---- Frame dedup ----------------------------------------------------
 
 [<Fact>]
@@ -325,7 +344,7 @@ let ``onModeBarrier resets LastRowHashes and HashHistory (PR-M, Issue #117)`` ()
         "LastRowHashes should be populated after first frame")
     Assert.True(state.HashHistory.Count > 0,
         "HashHistory should be populated after first frame")
-    let _ = StreamPathway.onModeBarrier state (at 100)
+    let _ = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 100)
     Assert.True(state.LastRowHashes.IsNone,
         "LastRowHashes should be reset to None after mode barrier")
     Assert.Equal(0, state.HashHistory.Count)
@@ -357,20 +376,25 @@ let ``spinner per-key history is GC'd after spinnerWindow elapses`` () =
 
 [<Fact>]
 let ``onModeBarrier flushes pending accumulator first`` () =
+    // PR #168 — uses `verboseFlushParameters` to opt into
+    // the pre-PR-#168 verbose-flush behaviour. The new
+    // default (`SummaryOnly`) suppresses the flush; the
+    // pre-PR-#168 verbose case is still a valid policy and
+    // this test pins it.
     let state = StreamPathway.createState ()
     let snap1 = snapshotOf 1 5 [ "hello" ]
     let snap2 = snapshotOf 1 5 [ "world" ]
     // Leading-edge emit at t=0.
     let _ =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
+            verboseFlushParameters state (at 0) (canonicalAt snap1 0L)
     // Within debounce — accumulates.
     let r2 =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
+            verboseFlushParameters state (at 50) (canonicalAt snap2 1L)
     Assert.Equal(0, r2.Length)
-    // Mode barrier flushes the pending diff.
-    let result = StreamPathway.onModeBarrier state (at 100)
+    // Mode barrier flushes the pending diff (Verbose policy).
+    let result = StreamPathway.onModeBarrier verboseFlushParameters state (at 100)
     Assert.Equal(1, result.Length)
     Assert.Contains("world", result.[0].Payload)
     Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
@@ -378,7 +402,7 @@ let ``onModeBarrier flushes pending accumulator first`` () =
 [<Fact>]
 let ``onModeBarrier with no pending returns no events`` () =
     let state = StreamPathway.createState ()
-    let result = StreamPathway.onModeBarrier state (at 0)
+    let result = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 0)
     Assert.Equal(0, result.Length)
 
 [<Fact>]
@@ -395,7 +419,7 @@ let ``onModeBarrier resets frame-dedup state`` () =
     Assert.Equal(0, dup.Length)
     // ...but a mode barrier resets the dedup state, so the
     // same content emits again afterward.
-    let _ = StreamPathway.onModeBarrier state (at 600)
+    let _ = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 600)
     let after =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 1000) (canonicalAt snap 2L)
@@ -739,20 +763,27 @@ let ``red snapshot accumulated within debounce → onTimerTick emits both events
 
 [<Fact>]
 let ``onModeBarrier with PendingColor clears it without emitting colour event`` () =
+    // PR #168 — uses `verboseFlushParameters` because this
+    // test specifically verifies "the flush emits StreamChunk
+    // but NOT the colour event". With the new SummaryOnly
+    // default no flush would happen at all, so the
+    // colour-event-suppression assertion would be trivially
+    // true (no events emitted period). The Verbose path is
+    // where the suppression matters.
     let state = StreamPathway.createState ()
     let snap1 = redSnapshotOf 1 10 [ "E" ]
     let snap2 = redSnapshotOf 1 10 [ "Err" ]
     // Leading-edge emit (resets PendingColor inside).
     let _ =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
+            verboseFlushParameters state (at 0) (canonicalAt snap1 0L)
     // Within debounce — accumulates with PendingColor = ValueSome "red".
     let _ =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
+            verboseFlushParameters state (at 50) (canonicalAt snap2 1L)
     Assert.Equal(ValueSome "red", state.PendingColor)
     // Mode barrier flushes the pending diff but NOT the colour event.
-    let result = StreamPathway.onModeBarrier state (at 100)
+    let result = StreamPathway.onModeBarrier verboseFlushParameters state (at 100)
     Assert.Equal(1, result.Length)
     Assert.Equal(SemanticCategory.StreamChunk, result.[0].Semantic)
     Assert.Equal(ValueNone, state.PendingColor)
@@ -837,40 +868,86 @@ let ``longestCommonPrefixLength — one is prefix of the other`` () =
     Assert.Equal(3, StreamPathway.longestCommonPrefixLength "abc" "abcdef")
     Assert.Equal(3, StreamPathway.longestCommonPrefixLength "abcdef" "abc")
 
+// PR #168 — `computeRowSuffixDelta` takes a `BackspacePolicy` as
+// its first argument. Most cases (Identical / Initial / Append /
+// Replace) are policy-agnostic; the policy only affects the
+// Shrink branch. Tests pass `AnnounceDeletedCharacter` (the new
+// default) where the policy doesn't matter.
+
 [<Fact>]
 let ``computeRowSuffixDelta — identical text returns Silent`` () =
-    let result = StreamPathway.computeRowSuffixDelta "abc" "abc"
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "abc" "abc"
     Assert.Equal(StreamPathway.Silent, result)
 
 [<Fact>]
 let ``computeRowSuffixDelta — empty previous returns Suffix of full current`` () =
-    let result = StreamPathway.computeRowSuffixDelta "Hello" ""
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "Hello" ""
     Assert.Equal(StreamPathway.Suffix "Hello", result)
 
 [<Fact>]
 let ``computeRowSuffixDelta — append at end returns suffix only`` () =
     let result =
-        StreamPathway.computeRowSuffixDelta "> echo hi" "> echo h"
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "> echo hi" "> echo h"
     Assert.Equal(StreamPathway.Suffix "i", result)
 
 [<Fact>]
 let ``computeRowSuffixDelta — multi-character append returns full new suffix`` () =
     let result =
-        StreamPathway.computeRowSuffixDelta "PtySpeakDiagPlain" "PtySpeak"
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "PtySpeakDiagPlain" "PtySpeak"
     Assert.Equal(StreamPathway.Suffix "DiagPlain", result)
 
 [<Fact>]
-let ``computeRowSuffixDelta — current shorter than previous returns Silent (Shrink)`` () =
-    // Backspace case — relies on NVDA keyboard echo per Default 1.
-    let result = StreamPathway.computeRowSuffixDelta "> echo h" "> echo hi"
+let ``computeRowSuffixDelta — Shrink under SuppressShrink returns Silent`` () =
+    // PR #166's original behaviour. Preserved as opt-in
+    // policy under PR #168.
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.SuppressShrink "> echo h" "> echo hi"
     Assert.Equal(StreamPathway.Silent, result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — Shrink under AnnounceDeletedCharacter returns Suffix of deleted segment`` () =
+    // PR #168's new default. Single-character delete:
+    // previous "> echo hi", current "> echo h" → deleted "i"
+    // → Suffix "i".
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "> echo h" "> echo hi"
+    Assert.Equal(StreamPathway.Suffix "i", result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — Shrink under AnnounceDeletedCharacter handles multi-character delete`` () =
+    // Ctrl+W or similar produces a longer delete.
+    // previous "echo world", current "echo " → deleted "world"
+    // → Suffix "world". User hears the whole deleted segment.
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "echo " "echo world"
+    Assert.Equal(StreamPathway.Suffix "world", result)
+
+[<Fact>]
+let ``computeRowSuffixDelta — Shrink under AnnounceDeletedWord behaves identically to AnnounceDeletedCharacter in v1_1`` () =
+    // PR #168 reserves AnnounceDeletedWord for future
+    // word-boundary work. v1.1 treats both identically.
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedWord "echo " "echo world"
+    Assert.Equal(StreamPathway.Suffix "world", result)
 
 [<Fact>]
 let ``computeRowSuffixDelta — replace case returns suffix beyond common prefix`` () =
     // V1 over-reports mid-line edits — documents the
     // limitation as expected behaviour. Cursor-aware diff
     // (v2) would scope the announce to the cursor position.
-    let result = StreamPathway.computeRowSuffixDelta "abXc" "abc"
+    let result =
+        StreamPathway.computeRowSuffixDelta
+            StreamPathway.AnnounceDeletedCharacter "abXc" "abc"
     Assert.Equal(StreamPathway.Suffix "Xc", result)
 
 [<Fact>]
@@ -962,9 +1039,37 @@ let ``bulk-change fallback engages when more than 3 rows change`` () =
     Assert.Contains("row4", r2.[0].Payload)
 
 [<Fact>]
-let ``backspace case (row shrinks) produces empty payload and no emit`` () =
+let ``backspace case under SuppressShrink policy produces empty payload and no emit`` () =
     // After typing "> echo hi", backspace produces
-    // "> echo h" — Shrink case, Silent, no announcement.
+    // "> echo h" — Shrink case. Under the legacy
+    // `SuppressShrink` policy (PR #166's behaviour),
+    // pty-speak emits nothing; the user relies on NVDA's
+    // keyboard echo for backspace feedback. PR #168 changed
+    // the default to `AnnounceDeletedCharacter` (see the
+    // companion test below), but the SuppressShrink path is
+    // still a valid policy and pinned here.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "> echo hi" ]
+    let snap2 = snapshotOf 1 20 [ "> echo h" ]
+    let r1 =
+        StreamPathway.processCanonicalState
+            suppressShrinkParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    let r2 =
+        StreamPathway.processCanonicalState
+            suppressShrinkParameters state (at 500)
+            (canonicalAt snap2 1L)
+    // No emit — empty payload short-circuits.
+    Assert.Empty(r2)
+
+[<Fact>]
+let ``backspace case under default AnnounceDeletedCharacter policy emits the deleted segment`` () =
+    // PR #168 — new default. After backspacing the `i`
+    // from `> echo hi`, the StreamPathway emits a
+    // StreamChunk with payload `i` (the segment of the
+    // previous-emit text beyond the longest-common-prefix
+    // with the current text).
     let state = StreamPathway.createState ()
     let snap1 = snapshotOf 1 20 [ "> echo hi" ]
     let snap2 = snapshotOf 1 20 [ "> echo h" ]
@@ -977,8 +1082,9 @@ let ``backspace case (row shrinks) produces empty payload and no emit`` () =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 500)
             (canonicalAt snap2 1L)
-    // No emit — empty payload short-circuits.
-    Assert.Empty(r2)
+    Assert.Equal(1, r2.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, r2.[0].Semantic)
+    Assert.Equal("i", r2.[0].Payload)
 
 [<Fact>]
 let ``first emit on a fresh pathway treats every row as Initial`` () =
@@ -994,29 +1100,118 @@ let ``first emit on a fresh pathway treats every row as Initial`` () =
     Assert.Equal("Hello world", r.[0].Payload)
 
 [<Fact>]
-let ``onModeBarrier flushes verbose, then clears LastEmittedRowText`` () =
-    // Mode barriers are discontinuities. The flushed pending
-    // diff uses ChangedText (verbose), not suffix-diff. After
-    // the barrier, LastEmittedRowText is empty so the next
-    // emit treats every row as Initial.
+let ``onModeBarrier under Verbose policy flushes pending, then clears LastEmittedRowText`` () =
+    // PR #168 — uses `verboseFlushParameters` to opt into
+    // the pre-PR-#168 verbose-flush behaviour (the test
+    // documents that policy's mechanics — the SummaryOnly
+    // / Suppressed default emits nothing on barrier).
+    // Mode barriers are discontinuities. The flushed
+    // pending diff uses ChangedText (verbose), not
+    // suffix-diff. After the barrier, LastEmittedRowText
+    // is empty so the next emit treats every row as
+    // Initial.
     let state = StreamPathway.createState ()
     let snap1 = snapshotOf 1 20 [ "> echo h" ]
     let snap2 = snapshotOf 1 20 [ "> echo hi" ]
     // Leading-edge emit primes the cache.
     let _ =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 0)
+            verboseFlushParameters state (at 0)
             (canonicalAt snap1 0L)
     // Within debounce — accumulate (PendingDiff set).
     let _ =
         StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 50)
+            verboseFlushParameters state (at 50)
             (canonicalAt snap2 1L)
     // Mode barrier flushes pending. Verbose payload
     // (ChangedText) — not suffix-diff'd.
-    let flushed = StreamPathway.onModeBarrier state (at 100)
+    let flushed = StreamPathway.onModeBarrier verboseFlushParameters state (at 100)
     Assert.Equal(1, flushed.Length)
     // Verbose flush carries the full row content.
     Assert.Equal("> echo hi", flushed.[0].Payload)
     // After barrier, cache is cleared.
     Assert.Equal(0, state.LastEmittedRowText.Length)
+
+// ---- Tier 1 parameters (PR #168) ----------------------------------
+
+[<Fact>]
+let ``onModeBarrier under SummaryOnly default returns no flush events`` () =
+    // PR #168 — new default. Mode barrier with pending diff
+    // suppresses the previous-shell flush; the App-layer
+    // shell-switch announce + the new shell's startup
+    // output carry the context.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 5 [ "hello" ]
+    let snap2 = snapshotOf 1 5 [ "world" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt snap1 0L)
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50) (canonicalAt snap2 1L)
+    // Default ModeBarrierFlushPolicy = SummaryOnly. Flush
+    // suppressed — pending diff is cleared without an emit.
+    let result = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 100)
+    Assert.Empty(result)
+
+[<Fact>]
+let ``onModeBarrier under Suppressed policy returns no flush events`` () =
+    // PR #168 — `Suppressed` policy is identical to
+    // `SummaryOnly` at the StreamPathway level (the
+    // difference materialises at the App-layer
+    // shell-switch announce).
+    let suppressedParameters =
+        { StreamPathway.defaultParameters with
+            ModeBarrierFlushPolicy = StreamPathway.Suppressed }
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 1 5 [ "hello" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            suppressedParameters state (at 0) (canonicalAt snap 0L)
+    let result = StreamPathway.onModeBarrier suppressedParameters state (at 100)
+    Assert.Empty(result)
+
+[<Fact>]
+let ``BulkChangeThreshold is configurable via Parameters`` () =
+    // PR #168 — was a top-level `let private = 3` constant;
+    // now a Parameters field. With threshold = 1, even a
+    // 2-row diff engages the bulk-change fallback.
+    let aggressiveParameters =
+        { StreamPathway.defaultParameters with
+            BulkChangeThreshold = 1 }
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 2 5 [ ""; "" ]
+    let snap2 = snapshotOf 2 5 [ "row0"; "row1" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            aggressiveParameters state (at 0) (canonicalAt snap1 0L)
+    let r2 =
+        StreamPathway.processCanonicalState
+            aggressiveParameters state (at 500) (canonicalAt snap2 1L)
+    Assert.Equal(1, r2.Length)
+    // Bulk-change fallback engaged because 2 > threshold 1.
+    // Payload is the full ChangedText (verbose) with both
+    // rows joined by '\n'.
+    Assert.Contains("row0", r2.[0].Payload)
+    Assert.Contains("row1", r2.[0].Payload)
+
+[<Fact>]
+let ``BulkChangeThreshold = 30 keeps even large diffs on suffix-diff path`` () =
+    // PR #168 — opposite extreme. Threshold above the
+    // typical row count keeps everything on the suffix
+    // path. With a 5-row first emit (Initial = full text),
+    // the per-row suffixes still concatenate to the full
+    // content, so payload is the same as bulk-change in
+    // this Initial case. The test mainly exercises the
+    // parametrization wiring.
+    let permissiveParameters =
+        { StreamPathway.defaultParameters with
+            BulkChangeThreshold = 30 }
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 5 10 [ "a"; "b"; "c"; "d"; "e" ]
+    let r =
+        StreamPathway.processCanonicalState
+            permissiveParameters state (at 0) (canonicalAt snap 0L)
+    Assert.Equal(1, r.Length)
+    Assert.Contains("a", r.[0].Payload)
+    Assert.Contains("e", r.[0].Payload)


### PR DESCRIPTION
## Summary

Three parameters from `docs/USER-SETTINGS.md`'s "Suffix-diff parameters (PR #166 follow-up)" section now ship as TOML-configurable, with defaults updated where PR #166's release-build validation (2026-05-06) confirmed the old behaviour was problematic.

| Parameter | Status | Default change | TOML key |
|---|---|---|---|
| `bulk_change_threshold` | Was hard-coded `3` | None (just exposed) | `[pathway.stream] bulk_change_threshold` |
| `backspace_policy` | Was hard-coded "Silent" | `Silent` → `"announce_deleted_character"` | `[pathway.stream] backspace_policy` |
| `mode_barrier_flush_policy` | Was hard-coded verbose | `Verbose` → `"summary_only"` | `[pathway.stream] mode_barrier_flush_policy` |

## What changes for users

**Before this PR**:

- Backspacing produced no announcement from pty-speak. PR #166 assumed NVDA's keyboard echo would handle backspace audibility — confirmed wrong (NVDA's keyboard echo speaks the *key pressed*, not the screen-content change).
- Switching shells with Ctrl+Shift+1/2/3 announced the previous shell's full screen (~1200 chars of stale history) before the new shell's startup.

**After this PR**:

- Backspacing announces the deleted character. Backspacing `i` from `echo hi` → user hears `i`.
- Shell-switch is summary-only — the previous shell's content is suppressed; the App-layer "switching to X" announce + the new shell's startup output carry the context.

Subsumes strategic backlog items 23 + 24 (shell-switch barrier-flush issues).

## What this PR does NOT change

- UX issue #1 (double-announce) — needs Phase 2 echo correlation; documented as Tier 2 parameter `echo_correlation.policy`.
- UX issue #3 (arrow keys silent) — needs Phase 2 cursor-aware diff; documented as Tier 2 parameter `cursor_announcement.enabled`.
- UX issue #4 (stuttering on rapid typing) — needs Phase 2 per-input-vs-output ActivityIds; documented as Tier 2 parameter `notification.processing.input_echo`.

These remain in the catalog awaiting the Phase 2 input framework substrate.

## Implementation

- **`src/Terminal.Core/StreamPathway.fs`** — two new F# DUs (`BackspacePolicy = SuppressShrink | AnnounceDeletedCharacter | AnnounceDeletedWord`; `ModeBarrierFlushPolicy = Verbose | SummaryOnly | Suppressed`). Three new fields on `Parameters` record. `computeRowSuffixDelta` takes `BackspacePolicy` as first argument; `assembleSuffixPayload` and `onModeBarrier` take the full `Parameters` record. The deprecated `BulkChangeThreshold` private constant is removed (default lives in `defaultParameters`).
- **`src/Terminal.Core/Config.fs`** — `StreamParameterOverrides` gets three new optional fields with TOML parsers (`bulk_change_threshold`: int; `backspace_policy` / `mode_barrier_flush_policy`: enum string with Warning logs on unknown values). `resolveStreamParameters` falls back to defaults. `knownStreamKeys` extended.
- **F# DU naming**: `BackspacePolicy.Silent` is exposed as `SuppressShrink` to avoid collision with `EditDelta.Silent`. The TOML value stays `"silent"`; the rename is internal only.

## Test plan

Automated:

- [ ] Existing 600+ unit tests still pass after the `computeRowSuffixDelta` and `onModeBarrier` signature changes.
- [ ] **18 new tests** cover the three parameters:
  - `StreamPathwayTests`: 7 new tests (BackspacePolicy variants on Shrink, AnnounceDeletedWord parity with AnnounceDeletedCharacter for v1.1, BulkChangeThreshold parametrization at 1 and 30, SummaryOnly + Suppressed default behaviour).
  - `ConfigTests`: 11 new tests (default-resolution per parameter, TOML round-trip per enum value, unknown-value Warning behaviour).

Manual NVDA validation (deferred to maintainer):

- [ ] Cut release; install
- [ ] Type `echo hi`; backspace twice. Expect: pty-speak announces `i`, then `h` (the deleted characters)
- [ ] Run a `dir` or anything with multi-line output, then switch shells with Ctrl+Shift+2 / +3 / +1. Expect: NVDA reads the new shell's startup output, NOT the previous shell's screen contents
- [ ] Customise `%LOCALAPPDATA%\PtySpeak\config.toml` with `[pathway.stream] backspace_policy = "silent"` and verify backspace returns to the PR #166 silent behaviour
- [ ] Likewise verify `mode_barrier_flush_policy = "verbose"` restores the PR #166 verbose flush
- [ ] Run Ctrl+Shift+D diagnostic battery — existing T1-T5 PowerShell + T1 cmd should still pass

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_