### PR TITLE
Fix shell-switch flush regression: preserve baselines under SummaryOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,84 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (shell-switch flush regression — PR #168 didn't fully resolve UX issue #5)
+
+PR #168 changed the default `mode_barrier_flush_policy` from
+verbose to `"summary_only"` to suppress the previous-shell
+flush at shell-switch. Maintainer release-build validation
+2026-05-06 confirmed that change worked at the
+`onModeBarrier` level — but a SECOND code path was still
+emitting the previous shell's screen content via
+`processCanonicalState`'s bulk-change fallback. The user log
+showed a 1610-character emit of the previous `dir` listing
+fired immediately after the shell-switch, before the new
+shell painted its startup output.
+
+**Root cause**: `onModeBarrier` was clearing
+`LastEmittedRowHashes` and `LastEmittedRowText` regardless of
+policy (PR #166's behaviour, designed for the verbose-flush
+case where post-barrier "Initial" emits made sense). Under
+`SummaryOnly`, the cleared baselines made the next
+`processCanonicalState` pass see the diff as "all 30 rows
+changed" (against empty hashes) → above `BulkChangeThreshold`
+(3) → bulk-change fallback engages → emits `ChangedText`
+(the previous shell's content).
+
+**Fix**: under `SummaryOnly` and `Suppressed`, preserve the
+hash and text baselines at barrier time. The post-barrier
+first emit's diff is then grounded against pre-barrier state
+— rows still showing the previous shell's content match the
+cache and produce 0-row diffs. When the new shell paints,
+those rows DO change, and suffix-diff catches the new
+content correctly.
+
+Under `Verbose`, baselines are still cleared (preserves
+PR #166's "user heard the flush, post-barrier emits Initial-
+treat the new content" semantics).
+
+#### Files
+
+- `src/Terminal.Core/StreamPathway.fs` — `onModeBarrier`
+  now branches on `ModeBarrierFlushPolicy`: clears baselines
+  under `Verbose`, preserves under `SummaryOnly` /
+  `Suppressed`. ~25 LOC change.
+- `tests/Tests.Unit/StreamPathwayTests.fs` — 5 new tests:
+  - "post-barrier first emit under SummaryOnly does NOT
+    re-announce stale screen content" (the regression
+    guard).
+  - "post-barrier first emit under SummaryOnly emits new
+    content when screen actually changes" (companion
+    positive case).
+  - "post-barrier first emit under Verbose policy does
+    re-announce (Initial)" (verifies Verbose path
+    unchanged).
+  - "backspace with pause emits the deleted character"
+    (pins the v1.1 backspace baseline for the simple
+    case).
+  - "backspace + retype within debounce window collapses
+    to Replace" (documents the v1.1 debounce-collapsing
+    limitation as expected behaviour — see USER-SETTINGS).
+
+### Documented (v1.1 backspace debounce-collapsing limitation)
+
+`docs/USER-SETTINGS.md`'s `stream.suffixDiff.backspacePolicy`
+entry now includes a "Known v1.1 limitation: rapid backspace
++ retype is silenced (debounce-collapsing)" subsection.
+
+When the user backspaces and re-types within the 200ms
+debounce window, the cumulative leading-edge / trailing-edge
+emit sees the FINAL state, computes the suffix via the
+Append/Replace branch (not Shrink), and silently drops the
+deleted segment. Pause-after-backspace works correctly;
+rapid edit-mid-debounce gets absorbed.
+
+The structural fix is **Phase 2's echo correlation**, which
+tracks outgoing keystrokes independently of screen mutations
+and can surface "Backspace was pressed" as an explicit
+event. Documented here so v1.1 users have realistic
+expectations and so the limitation is captured for the
+Phase 2 design space.
+
 ### Changed (Tier 1 parameters from suffix-diff UX feedback)
 
 Three parameters from `docs/USER-SETTINGS.md`'s "Suffix-diff

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -1005,6 +1005,70 @@ currentText previousText)` — already computed adjacently.
 - Tests: extend the `computeRowSuffixDelta` unit tests to
   pin both default and silent-mode behaviour.
 
+#### Known v1.1 limitation: rapid backspace + retype is silenced (debounce-collapsing)
+
+**Status as of PR #169 (2026-05-06)**: this limitation is
+inherent to the LCP-based suffix-diff design when combined
+with the debounce window. Documented here so future PRs
+don't regress without authorisation.
+
+**The scenario**: user types `echo hi`, then quickly
+backspaces twice and types ` X` — final state is `echo X`.
+All within the 200ms debounce window. The leading-edge
+emit fires once per debounce window; the trailing-edge
+processes accumulated state.
+
+**Why backspace is silenced under `AnnounceDeletedCharacter`**:
+the diff at trailing-edge time compares `current` ("echo X",
+6 chars) against `previousText` ("echo hi", 7 chars). Since
+`current.Length < previousText.Length`, the function would
+enter the Shrink branch and emit the deleted segment. So
+single backspace (without retype) DOES work.
+
+But: **rapid backspace + retype** like the example above
+produces a final `current` length that may equal or exceed
+`previousText` length. In the example, "echo X" is only one
+char shorter — but with 2 backspaces + 2 retyped chars, the
+final lengths could be equal. When `current.Length >=
+previousText.Length`, the function falls through to the
+Append/Replace branch:
+
+- LCP("echo X", "echo hi") = 5 ("echo " — the trailing space
+  matches)
+- Suffix = "X"
+
+The deleted "hi" is **silenced** because the LCP-based diff
+doesn't surface it. The user hears "X" (the retyped content)
+but no audible signal that "hi" was deleted.
+
+**This is the v1.1 debounce-collapsing limitation**: any
+backspace event that gets followed within 200ms by enough
+retyping to bring `current.Length >= previousText.Length` is
+absorbed by the cumulative leading-edge / trailing-edge
+emit.
+
+**Workarounds**:
+
+1. **Pause after backspace before retyping** — if the user
+   pauses for more than 200ms after backspace, the trailing-
+   edge emits the Shrink case (deleted segment) before the
+   retyping arrives. The retyping then becomes its own
+   emit. Both events surface audibly.
+2. **`backspace_policy = "silent"`** for users who only ever
+   backspace + retype quickly — the silent mode is honest
+   about not announcing the operation, rather than silently
+   dropping the deletion's audible signal in favour of the
+   retyping content.
+
+**Real fix**: the **Phase 2 input framework's echo correlation**
+solves this structurally. With keystroke tracking,
+pty-speak can detect "the user pressed Backspace at time T"
+as an explicit event, independent of the screen mutation
+that follows. The deletion event surfaces audibly even when
+collapsed into the same debounce window as a retype. See
+the `stream.echoCorrelation.policy` entry below for the
+substrate.
+
 ### `stream.echoCorrelation.policy` (not yet implemented)
 
 #### Current state

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -882,14 +882,40 @@ module StreamPathway =
         state.LastFrameHash <- ValueNone
         state.LastFlushAt <- ValueSome now
         state.LastRowHashes <- ValueNone
-        state.LastEmittedRowHashes <- [||]
-        // PR #166 — clear per-row text cache so the post-
-        // barrier first emit treats every row as Initial
-        // (full text becomes the "suffix"). The barrier flush
-        // above used `diff.ChangedText` (verbose); the next
-        // emit through `processCanonicalState` will pick up
-        // suffix-diff against an empty baseline.
-        state.LastEmittedRowText <- [||]
+        // PR #169 — under `SummaryOnly` / `Suppressed`,
+        // preserve `LastEmittedRowHashes` and `LastEmittedRowText`
+        // so the next `processCanonicalState` pass diffs against
+        // pre-barrier state. PR #168's change to the default
+        // suppressed `onModeBarrier`'s explicit flush, but the
+        // post-barrier first emit was still re-announcing the
+        // previous shell's content via `processCanonicalState`'s
+        // bulk-change fallback (diff against empty hashes →
+        // "all 30 rows changed" → > BulkChangeThreshold →
+        // emit ChangedText verbose). Confirmed in 2026-05-06
+        // release-build validation: 1610-character emits of
+        // stale `dir` listings on shell-switch.
+        //
+        // Preserving the baselines means the post-barrier first
+        // emit's diff sees only the rows that ACTUALLY changed
+        // since pre-barrier — typically the rows the new shell
+        // paints over. Rows still showing the previous shell's
+        // content (between barrier and new-shell-paint) match
+        // the cached state and don't emit. When the new shell
+        // paints, those rows DO change, and suffix-diff catches
+        // the new content correctly.
+        //
+        // Under `Verbose`, the explicit flush already announces
+        // the previous content, so clearing the cache is
+        // appropriate — post-barrier emits SHOULD treat every
+        // row as Initial under that policy, matching the
+        // verbose-flush expectation that the user hears
+        // "previous content + new content".
+        match parameters.ModeBarrierFlushPolicy with
+        | Verbose ->
+            state.LastEmittedRowHashes <- [||]
+            state.LastEmittedRowText <- [||]
+        | SummaryOnly | Suppressed ->
+            ()  // Preserve baselines for grounded post-barrier diff.
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()
         flushed

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -1215,3 +1215,159 @@ let ``BulkChangeThreshold = 30 keeps even large diffs on suffix-diff path`` () =
     Assert.Equal(1, r.Length)
     Assert.Contains("a", r.[0].Payload)
     Assert.Contains("e", r.[0].Payload)
+
+// ---- PR #169 — shell-switch flush regression guard ---------------
+
+[<Fact>]
+let ``post-barrier first emit under SummaryOnly does NOT re-announce stale screen content`` () =
+    // PR #169 — regression guard. PR #168 changed the
+    // default ModeBarrierFlushPolicy to SummaryOnly, but
+    // the post-barrier `processCanonicalState` was still
+    // emitting the previous shell's screen content via
+    // bulk-change fallback (diff against empty hashes →
+    // all rows changed → > threshold → ChangedText). This
+    // test pins the fix: under SummaryOnly the barrier
+    // preserves the cache, so the next pass against the
+    // SAME screen content sees a 0-row diff and emits
+    // nothing.
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 5 10 [ "row0"; "row1"; "row2"; "row3"; "row4" ]
+    // Initial emit primes the cache.
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt snap 0L)
+    // Mode barrier (e.g. shell-switch) — under SummaryOnly
+    // default, returns no events.
+    let barrierResult =
+        StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 100)
+    Assert.Empty(barrierResult)
+    // Post-barrier: same screen content (new shell hasn't
+    // painted yet). Diff against preserved cache = 0 rows
+    // changed → no emit.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 600) (canonicalAt snap 1L)
+    Assert.Empty(r2)
+
+[<Fact>]
+let ``post-barrier first emit under SummaryOnly emits new content when screen actually changes`` () =
+    // PR #169 — companion to the regression guard. After
+    // the barrier preserves the cache, when the new shell
+    // ACTUALLY paints (changes screen content), the diff
+    // sees the new rows and emits them.
+    let state = StreamPathway.createState ()
+    let oldShellSnap = snapshotOf 5 10 [ "old0"; "old1"; "old2"; "old3"; "old4" ]
+    let newShellSnap = snapshotOf 5 10 [ "new0"; "new1"; "new2"; "new3"; "new4" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt oldShellSnap 0L)
+    let _ = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 100)
+    // New shell paints — all rows differ from cached
+    // baseline. Bulk-change fallback engages (5 > 3),
+    // emits ChangedText with the new content.
+    let r =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 600) (canonicalAt newShellSnap 1L)
+    Assert.Equal(1, r.Length)
+    Assert.Contains("new0", r.[0].Payload)
+    Assert.Contains("new4", r.[0].Payload)
+    Assert.DoesNotContain("old0", r.[0].Payload)
+
+[<Fact>]
+let ``post-barrier first emit under Verbose policy does re-announce (Initial) per PR #166`` () =
+    // PR #169 — Verbose policy preserves PR #166's
+    // post-barrier-Initial behaviour. The explicit verbose
+    // flush already announces the previous content, so the
+    // post-barrier first emit Initial-treats every row.
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 2 10 [ "row0"; "row1" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            verboseFlushParameters state (at 0) (canonicalAt snap 0L)
+    let _ = StreamPathway.onModeBarrier verboseFlushParameters state (at 100)
+    // Post-barrier under Verbose: cache cleared. Next pass
+    // sees all rows as Initial → emits full content.
+    let r =
+        StreamPathway.processCanonicalState
+            verboseFlushParameters state (at 600) (canonicalAt snap 1L)
+    Assert.Equal(1, r.Length)
+    Assert.Contains("row0", r.[0].Payload)
+
+[<Fact>]
+let ``backspace with pause emits the deleted character (Tier 1 baseline test)`` () =
+    // PR #169 regression test — the simple "type, pause,
+    // backspace, pause" case should produce the deleted
+    // character emit. The 2026-05-06 maintainer report
+    // suggested backspace wasn't audible; this test pins
+    // the simple case explicitly so we can distinguish
+    // "v1.1 backspace works as designed" from "v1.1
+    // backspace is broken". Rapid backspace+retype is a
+    // separate (debounce-collapsing) limitation documented
+    // in USER-SETTINGS.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "echo hi" ]
+    let snap2 = snapshotOf 1 20 [ "echo h" ]
+    // Initial emit; cache primed with "echo hi".
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    Assert.Equal("echo hi", r1.[0].Payload)
+    // Backspace — row shrinks. Pause is implicit (next
+    // call is past debounce window). Emit should be the
+    // deleted character.
+    let r2 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 500)
+            (canonicalAt snap2 1L)
+    Assert.Equal(1, r2.Length)
+    Assert.Equal(SemanticCategory.StreamChunk, r2.[0].Semantic)
+    Assert.Equal("i", r2.[0].Payload)
+
+[<Fact>]
+let ``backspace + retype within debounce window collapses to Replace (debounce-collapsing limitation)`` () =
+    // PR #169 documents the v1.1 limitation: when
+    // backspace + retype happen within the debounce
+    // window, the leading-edge sees the cumulative state
+    // and computes the suffix via the Replace branch
+    // (current and previous lengths equal), NOT the
+    // Shrink branch. The deleted character is silenced
+    // because the LCP-based diff doesn't surface it.
+    //
+    // Real fix: Phase 2 echo correlation, which tracks
+    // outgoing keystrokes and can surface "backspace was
+    // pressed" as an explicit event. v1.1 lives with
+    // this limitation.
+    //
+    // Test pins the limitation as expected behaviour so
+    // any future change is intentional.
+    let state = StreamPathway.createState ()
+    let snap1 = snapshotOf 1 20 [ "echo hi" ]
+    // Final state after backspace + retype: same length
+    // as previous (7 chars), common prefix is "echo " (5
+    // chars), so it lands in the Replace branch (current
+    // and previous lengths equal, not Shrink).
+    let snap2 = snapshotOf 1 20 [ "echo XY" ]
+    let r1 =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0)
+            (canonicalAt snap1 0L)
+    Assert.Equal(1, r1.Length)
+    // Within debounce — accumulates.
+    let r2a =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 50)
+            (canonicalAt snap2 1L)
+    Assert.Empty(r2a)
+    // Trailing-edge tick — debounce window elapsed.
+    // Computes suffix-diff against last-emitted "echo hi".
+    // Both 7 chars, common prefix "echo " (5), suffix "XY".
+    // The deleted "hi" is silenced under the Replace branch.
+    let tick = StreamPathway.onTimerTick StreamPathway.defaultParameters state (at 250)
+    Assert.Equal(1, tick.Length)
+    Assert.Equal("XY", tick.[0].Payload)
+    // Documented limitation: "hi" (the deleted segment)
+    // is NOT in the announced payload, even though
+    // semantically the user deleted "hi" and added "XY".
+    Assert.DoesNotContain("hi", tick.[0].Payload)

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -406,24 +406,82 @@ let ``onModeBarrier with no pending returns no events`` () =
     Assert.Equal(0, result.Length)
 
 [<Fact>]
-let ``onModeBarrier resets frame-dedup state`` () =
+let ``onModeBarrier resets frame-dedup state under Verbose policy`` () =
+    // PR #169 — verbose policy preserves the legacy
+    // behaviour: barrier clears LastEmittedRowHashes (and
+    // LastFrameHash), so post-barrier first emit treats the
+    // same content as Initial and re-announces it. Verbose
+    // already announced the previous content via the explicit
+    // flush; the post-barrier "everything is fresh" emit
+    // matches the verbose-flush mental model.
+    let state = StreamPathway.createState ()
+    let snap = snapshotOf 1 5 [ "hello" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            verboseFlushParameters state (at 0) (canonicalAt snap 0L)
+    // Frame dedup would normally suppress this repeat...
+    let dup =
+        StreamPathway.processCanonicalState
+            verboseFlushParameters state (at 500) (canonicalAt snap 1L)
+    Assert.Equal(0, dup.Length)
+    // ...but a mode barrier (Verbose) resets the dedup state,
+    // so the same content emits again afterward.
+    let _ = StreamPathway.onModeBarrier verboseFlushParameters state (at 600)
+    let after =
+        StreamPathway.processCanonicalState
+            verboseFlushParameters state (at 1000) (canonicalAt snap 2L)
+    Assert.Equal(1, after.Length)
+
+[<Fact>]
+let ``onModeBarrier under SummaryOnly preserves per-row baselines so unchanged content stays deduped`` () =
+    // PR #169 — under SummaryOnly (the default), the barrier
+    // PRESERVES `LastEmittedRowHashes` and
+    // `LastEmittedRowText` so the post-barrier first emit's
+    // diff is grounded against pre-barrier state. If the
+    // screen still shows the same content immediately after
+    // the barrier (e.g. shell-switch transition window
+    // before the new shell paints), there's no diff and no
+    // emit — exactly the behaviour that fixes the
+    // 1610-character "stale dir output" announce in the
+    // 2026-05-06 release-build validation.
     let state = StreamPathway.createState ()
     let snap = snapshotOf 1 5 [ "hello" ]
     let _ =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 0) (canonicalAt snap 0L)
-    // Frame dedup would normally suppress this repeat...
-    let dup =
-        StreamPathway.processCanonicalState
-            StreamPathway.defaultParameters state (at 500) (canonicalAt snap 1L)
-    Assert.Equal(0, dup.Length)
-    // ...but a mode barrier resets the dedup state, so the
-    // same content emits again afterward.
+    // Mode barrier (SummaryOnly default) preserves per-row
+    // baselines.
     let _ = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 600)
+    // Same content post-barrier → diff is empty → no emit.
+    // This is the post-barrier "transition window" case
+    // where the new shell hasn't painted yet.
     let after =
         StreamPathway.processCanonicalState
             StreamPathway.defaultParameters state (at 1000) (canonicalAt snap 2L)
+    Assert.Empty(after)
+
+[<Fact>]
+let ``onModeBarrier under SummaryOnly emits new content when post-barrier screen actually changes`` () =
+    // PR #169 — when the new shell DOES paint different
+    // content after the barrier, that change is announced
+    // normally via the suffix-diff path. Verifies the
+    // baseline-preservation doesn't accidentally suppress
+    // genuine post-barrier content.
+    let state = StreamPathway.createState ()
+    let snapPre = snapshotOf 1 20 [ "old shell content" ]
+    let snapPost = snapshotOf 1 20 [ "new shell content" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 0) (canonicalAt snapPre 0L)
+    let _ = StreamPathway.onModeBarrier StreamPathway.defaultParameters state (at 600)
+    let after =
+        StreamPathway.processCanonicalState
+            StreamPathway.defaultParameters state (at 1000) (canonicalAt snapPost 2L)
     Assert.Equal(1, after.Length)
+    // The diff is per-row suffix vs the preserved baseline.
+    // LCP("new shell content", "old shell content") = 0
+    // (different first chars). Suffix = "new shell content".
+    Assert.Equal("new shell content", after.[0].Payload)
 
 // ---- Pathway-level wiring (Consume / Tick / Reset) -----------------
 


### PR DESCRIPTION
## Summary

Maintainer release-build validation of PR #168 (2026-05-06) confirmed UX issue #5 (shell-switch reads previous shell's content) was **only partially fixed**. PR #168 made `onModeBarrier`'s direct flush silent under the new `SummaryOnly` default, but a SECOND code path was still emitting the previous shell's content immediately after the barrier.

The maintainer's log showed a **1610-character emit** of the previous `dir` listing fired at `11:13:12.372`, immediately after the shell-switch barrier, before PowerShell painted its startup output. Same UX symptom as before PR #168.

## Root cause

`onModeBarrier` was unconditionally clearing `LastEmittedRowHashes` and `LastEmittedRowText` regardless of policy (PR #166's behaviour, designed for the verbose-flush case where post-barrier "Initial" emits made sense). Under `SummaryOnly`:

1. Barrier fires → baselines cleared
2. Next `processCanonicalState` pass: diff against empty hashes → "all 30 rows changed"
3. 30 > `BulkChangeThreshold = 3` → **bulk-change fallback engages**
4. Emits `ChangedText` (the previous shell's screen content, since the new shell hasn't painted yet)

So PR #168 fixed the explicit barrier-handler flush but missed the implicit post-barrier first-emit path.

## Fix

Under `SummaryOnly` and `Suppressed`, **preserve** the hash and text baselines at barrier time. The post-barrier first emit's diff is then grounded against pre-barrier state — rows still showing the previous shell's content match the cache and produce 0-row diffs. When the new shell paints, those rows DO change, and suffix-diff catches the new content correctly.

Under `Verbose`, baselines still clear (preserves PR #166's verbose-flush + post-barrier-Initial semantics — the explicit flush already announces the previous content, so Initial-emits make sense).

## Also documents the v1.1 backspace debounce-collapsing limitation

The maintainer's log also surfaced a backspace-related observation. When backspace + retype happens within the 200ms debounce window, the leading-edge / trailing-edge sees only the FINAL state. If `current.Length >= previousText.Length` (e.g. 2 backspaces + 2 retyped chars), the function falls into the Append/Replace branch (not Shrink) and emits the new content via LCP-suffix. The deleted segment is silenced.

This is a v1.1 LCP-design property, not addressable in this PR's scope. The structural fix is **Phase 2's echo correlation**, which tracks outgoing keystrokes independently of screen mutations.

Documented under `docs/USER-SETTINGS.md`'s `backspacePolicy` entry as a known limitation with workarounds (pause after backspace; switch to `"silent"` policy if you only ever backspace+retype rapidly). A new test in `StreamPathwayTests.fs` pins the limitation as expected behaviour.

## Test plan

Automated:

- [ ] All 90+ existing tests still pass
- [ ] **5 new tests**:
  - `post-barrier first emit under SummaryOnly does NOT re-announce stale screen content` (the regression guard)
  - `post-barrier first emit under SummaryOnly emits new content when screen actually changes` (companion positive case)
  - `post-barrier first emit under Verbose policy does re-announce (Initial) per PR #166` (verifies Verbose path unchanged)
  - `backspace with pause emits the deleted character` (pins the v1.1 baseline)
  - `backspace + retype within debounce window collapses to Replace` (documents the limitation)

Manual NVDA validation (deferred to maintainer):

- [ ] Cut release; install
- [ ] Run `dir` (or any multi-line output)
- [ ] Switch shells with Ctrl+Shift+2 / +3 / +1
- [ ] Expect: NVDA reads ONLY the new shell's startup output (PowerShell banner / claude UI / cmd banner). The previous `dir` listing is NOT re-announced.
- [ ] Type `echo hi`, **pause** for ~1 second, press Backspace once, **pause** for ~1 second
- [ ] Expect: pty-speak announces `i` (the deleted character) when paused
- [ ] Type `echo hi`, immediately backspace+retype quickly to `echo XY`
- [ ] Expect: pty-speak announces `XY` (the retyped content). The deleted `hi` is silenced — this is the documented v1.1 debounce-collapsing limitation, real fix in Phase 2

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_