### PR TITLE
spec: rename StreamProfile → PassThroughProfile (Track C D1, ADR-authorised)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (spec): rename StreamProfile → PassThroughProfile (Track C D1, ADR-authorised)
+
+`spec/event-and-output-framework.md` — apply the
+`StreamProfile` → `PassThroughProfile` rename surfaced
+by Track C audit finding D1 (per
+`docs/AUDIT-SPEC-ALIGNMENT.md`). 7 occurrences renamed
+across the spec body (module declaration at line 824,
+the Coalescer-becomes-Profile narrative in §D.4, the
+Stages 8a-8f retrofit list).
+
+The module was originally drafted in spec as
+`StreamProfile`; during the post-Phase-A substrate
+migration the module shipped under the name
+`PassThroughProfile` (better captures the pass-through
+semantics; the actual streaming logic lives in the
+StreamPathway substrate). Spec retroactively updated
+to match shipped code.
+
+A short historical-context note was added in §D.4
+(adjacent to the original "Coalescer.fs becomes …"
+line) explaining the rename + citing this audit
+finding + maintainer ADR.
+
+**ADR provenance**: maintainer authorised this spec
+edit during the 2026-05-07 audit walk-through (per
+`docs/AUDIT-SPEC-ALIGNMENT.md` Tier 2 / D1
+recommendation). CLAUDE.md spec-immutability rule
+honoured — explicit maintainer authorisation before
+editing.
+
+No code changes; no other doc changes.
+
+**Sequencing**: Cycle 9 of post-audit work. Closes
+the only ADR-required item from Track C audit. Next
+cycle bundles the remaining audit-fixup queue (Track D
+atlas-side + Track E doc-currency + ARCHITECTURE
+refresh + PROJECT-PLAN successor) into a single
+pre-implementation cleanup PR.
+
 ### Changed (Resolve Cluster 1-4 open questions in research-stage docs)
 
 Apply maintainer's audit-walk-through decisions

--- a/spec/event-and-output-framework.md
+++ b/spec/event-and-output-framework.md
@@ -821,7 +821,7 @@ type Profile = {
     Reset: unit -> unit                     // Called when shell switches
 }
 
-module StreamProfile =
+module PassThroughProfile =
     type Parameters = {
         DebounceWindowMs: int      // PR-N: was module global
         SpinnerWindowMs: int       // PR-N: was module global
@@ -1235,7 +1235,7 @@ framework. It's a function in `Terminal.Core/SemanticMapper.fs`
    have built (which already passes through `AnnounceSanitiser`).
 
 The Coalescer's debounce / spinner-suppress / max-announce-chars
-logic moves into `StreamProfile.Apply`. The drain task is replaced
+logic moves into `PassThroughProfile.Apply`. The drain task is replaced
 by the dispatcher's per-channel queue drains.
 
 ### D.2 ScreenNotification → OutputEvent mapping table
@@ -1278,21 +1278,32 @@ acceptance gate.
 
 ### D.4 The Coalescer-becomes-Profile ratification
 
+> **Naming note** (audit Cycle 9, 2026-05-07): the
+> profile module was originally drafted in this spec as
+> `StreamProfile`. During the post-Phase-A substrate
+> migration the module shipped under the name
+> `PassThroughProfile` (better captures the pass-through
+> semantics; the actual streaming logic lives in the new
+> StreamPathway substrate). This spec was retroactively
+> updated 2026-05-07 to match shipped code per Track C
+> audit finding D1; ADR-authorised by maintainer in the
+> 2026-05-07 audit walk-through.
+
 PR-N added per-shell-instance Coalescer state and a docstring
 contract. Stage 8b promotes that contract to a profile:
 
-- `Coalescer.fs` becomes `StreamProfile.fs`.
+- `Coalescer.fs` becomes `PassThroughProfile.fs`.
 - The constants (debounce window 200 ms, spinner window 1000 ms,
   spinner threshold 5, max announce chars 500) become
-  `StreamProfile.Parameters` fields.
+  `PassThroughProfile.Parameters` fields.
 - The construction site (`new Coalescer(...)` per shell session)
-  becomes `StreamProfile.create parameters`.
+  becomes `PassThroughProfile.create parameters`.
 - `Coalescer.append` becomes the producer-side translation
   (`SemanticMapper.toOutputEvent`).
 - `Coalescer.drain` becomes the dispatcher's per-channel drain.
 
 The signature change is mechanical. The behaviour change is zero
-when the v1 `StreamProfile.Parameters` defaults match the current
+when the v1 `PassThroughProfile.Parameters` defaults match the current
 constants — which is the explicit requirement of stage 8b.
 
 ## Part E — Out of scope, verification, open questions
@@ -1362,7 +1373,7 @@ PRs (one per sub-stage) will touch the file groups below.
   (NEW), `src/Terminal.Core/NvdaChannel.fs` (NEW), removal of
   direct `Announce` calls from `Program.fs` in favour of dispatcher
 - Stage 8b: `src/Terminal.Core/Coalescer.fs` →
-  `src/Terminal.Core/StreamProfile.fs` rename + per-instance
+  `src/Terminal.Core/PassThroughProfile.fs` rename + per-instance
   parameter refactor; `src/Terminal.Core/ProfileRegistry.fs`
   (NEW)
 - Stage 8c: `src/Terminal.Core/FileLogger.fs` (extend to consume


### PR DESCRIPTION
## Summary

Apply the `StreamProfile` → `PassThroughProfile` rename
surfaced by Track C audit finding D1 (per
`docs/AUDIT-SPEC-ALIGNMENT.md`). 7 occurrences renamed
across the spec body.

**Standalone PR** for clean ADR audit trail in git
history (CLAUDE.md spec-immutability rule).

## Provenance

- **Track C audit (PR #177)** identified the D1
  finding: spec at line 824 says `StreamProfile`; code
  ships as `PassThroughProfile` (renamed during
  post-Phase-A substrate migration).
- **Maintainer ADR**: explicitly authorised during the
  2026-05-07 audit walk-through under Cluster 1
  agreement.
- **Cycle 9** of post-audit work.

## Changes

`spec/event-and-output-framework.md`:
- Module declaration (line 824): `module StreamProfile =`
  → `module PassThroughProfile =`
- §D.4 "Coalescer-becomes-Profile ratification" — 4
  occurrences renamed in the migration narrative.
- §D.5 retrofit list (Stage 8b row) — 1 occurrence
  renamed.
- Plus an `Apply` reference in §D.1.

A **historical-context note** added in §D.4 explaining
the rename + citing Track C D1 + maintainer ADR. The
note preserves the only `StreamProfile` mention in the
spec (intentional, for migration-history clarity).

## What this PR does NOT do

- No code changes.
- No other doc changes.
- No audit-fixup queue work (Cycle 10 bundles those).

## Sequencing

```
✅ Cycle 7: Customization Model research stage (PR #181)
✅ Cycle 8: Resolve Cluster 1-4 open questions (PR #182)
Cycle 9: Track C D1 spec rename                (THIS PR)
Cycle 10: Pre-implementation cleanup bundle
  (Track D atlas-side + Track E doc-currency +
   ARCHITECTURE refresh + PROJECT-PLAN successor)
Cycle X: SessionModel Tier 1 implementation
  (FIRST POST-AUDIT IMPLEMENTATION CYCLE)
```

## Test plan

Spec-only PR; no code changes.

- [x] `grep "StreamProfile" spec/event-and-output-framework.md`
      returns only the historical-note line.
- [x] CHANGELOG.md `[Unreleased] ### Changed` entry at top.
- [ ] CI markdown link check passes.
- [ ] Build + workflow lint pass (no code changes).

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_