### PR TITLE
feat(terminal-core): SessionModel Tier 1.A — substrate skeleton (Cycle 11; FIRST POST-AUDIT IMPLEMENTATION CYCLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,127 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 11): SessionModel Tier 1.A — substrate skeleton
+
+**FIRST POST-AUDIT IMPLEMENTATION CYCLE.** Lands the
+SessionModel substrate skeleton per
+`docs/SESSION-MODEL.md` (item 28 design).
+
+**Tier 1.A scope: data types only; zero behaviour
+change.** No producer of `PromptBoundary` events; the
+PathwayPump's notification consumer routes the new
+case to a no-op arm. Tier 1.B (next cycle) ships the
+OSC 133 producer + `CanonicalState.CursorPosition`
+field; Tier 1.C wires the SessionModel state machine +
+heuristic fallback + composition root integration;
+Tier 1.D adds diagnostic battery extension + corpus
+tests.
+
+Files modified / created:
+
+- `src/Terminal.Core/Types.fs` — adds
+  `BoundaryKind` (`PromptStart` / `CommandStart` /
+  `OutputStart` / `CommandFinished of int option`),
+  `BoundarySource` (`Osc133` /
+  `HeuristicPromptRegex of int` /
+  `HeuristicClaudeInkBox`), `PromptBoundaryData`
+  record, and `ScreenNotification.PromptBoundary of
+  PromptBoundaryData` case.
+- `src/Terminal.Core/SessionModel.fs` (NEW) — module
+  with `ActiveTupleState`, `SessionTuple`,
+  `ActiveSessionTuple`, `T` types + `create` /
+  `createDefault` factories + `apply` no-op stub.
+  String-keyed shell field per assembly-boundary
+  discipline (mirrors `Config.fs`).
+- `src/Terminal.Core/Terminal.Core.fsproj` — register
+  `SessionModel.fs` immediately after `Types.fs`.
+- `src/Terminal.Core/DisplayPathway.fs` — add
+  `OnPromptBoundary: PromptBoundaryData -> OutputEvent[]`
+  field to `T` record (protocol method; no-op default
+  in shipping pathways).
+- `src/Terminal.Core/StreamPathway.fs` — implement
+  `OnPromptBoundary = fun _ -> [||]` in both `create`
+  and `createWithExposedState` factories.
+- `src/Terminal.Core/TuiPathway.fs` — implement
+  `OnPromptBoundary = fun _ -> [||]` in `create`
+  factory.
+- `src/Terminal.Core/OutputEventBuilder.fs` — add
+  `| PromptBoundary _ ->` arm to `fromScreenNotification`
+  exhaustive match; routes to existing
+  `SemanticCategory.PromptDetected` reservation with
+  empty payload + Polite priority.
+- `src/Terminal.App/Program.fs` — add
+  `| PromptBoundary _ -> ()` no-op arm to the
+  PathwayPump notification consumer loop. Tier 1.C
+  replaces this with `SessionModel.apply` dispatch +
+  pathway `OnPromptBoundary` invocation.
+- `tests/Tests.Unit/SessionModelTests.fs` (NEW) — 18
+  tests pinning the data shapes, the
+  `ScreenNotification.PromptBoundary` round-trip, the
+  `SessionModel.create` / `createDefault` initial
+  state, the no-op `apply` contract for every
+  `BoundaryKind`, and `SessionTuple`'s multi-line
+  command + `int option` exit-code shape.
+- `tests/Tests.Unit/Tests.Unit.fsproj` — register
+  `SessionModelTests.fs` immediately after
+  `CanonicalStateTests.fs`.
+
+**SESSION-MODEL.md open-question resolutions** (per the
+2026-05-07 audit walk-through; SESSION-MODEL.md
+updated to mark resolved):
+
+- **Q1** (cursor in CanonicalState — additive or
+  breaking?): ADDITIVE; deferred to Tier 1.B (Tier 1.A
+  doesn't touch CanonicalState).
+- **Q2** (heuristic fallback default — on or off?): ON
+  for known shells (cmd, PowerShell, claude); OFF for
+  unknown. Implementation in Tier 1.C.
+- **Q3** (SessionModel reset on alt-screen entry?):
+  PAUSE; resume on exit. Implementation in Tier 1.C.
+- **Q4** (multi-line commands — per line or as one?):
+  ONE string with embedded newlines. **Implemented in
+  this PR** via `SessionTuple.CommandText: string`.
+- **Q6** (echo correlation interaction): separate
+  concerns. Echo correlation (Phase 2) and SessionModel
+  (this) share the active tuple but use it differently.
+- **Q7** (AI summarisation — at C or D?): at
+  `CommandFinished` (D); streaming summarisation
+  deferred to a future Phase 3 cycle.
+- **Q8** (exit-code semantics): NO. Substrate captures
+  value verbatim; pathways interpret. **Implemented in
+  this PR** via `SessionTuple.ExitCode: int option`.
+
+All 8 SESSION-MODEL.md questions are now resolved (Q5
+was resolved in Cycle 8, PR #182).
+
+**Pre-emptive grep for pattern-match completeness**:
+TWO existing match sites required new `PromptBoundary`
+arms (per F# 9 + TreatWarningsAsErrors):
+
+1. `src/Terminal.Core/OutputEventBuilder.fs`:
+   `fromScreenNotification` — exhaustive match; added
+   `| PromptBoundary _ -> OutputEvent.create
+   SemanticCategory.PromptDetected Priority.Polite ...`
+2. `src/Terminal.App/Program.fs`: PathwayPump consumer
+   loop — added `| PromptBoundary _ -> ()` no-op arm.
+
+`PathwaySelector.fs` has a wildcard `| _ -> Keep` so no
+change needed there.
+
+No spec changes (per CLAUDE.md spec-immutability — Track
+C audit recommended that spec/ updates for SessionModel
+ship when SessionModel implementation begins; the
+substrate audit's recommendation is to defer spec
+re-authoring to a coordinated post-Phase-2 cycle).
+
+**Sequencing**: Cycle 11 of post-audit work. **First
+post-audit implementation cycle**. Subsequent cycles
+ship Tier 1.B (OSC 133 producer + cursor field), Tier
+1.C (state machine + heuristic fallback + composition),
+Tier 1.D (diagnostic battery + corpus). After Tier 1
+ships in full, SessionModel Tier 2 (persistence) and
+Tier 3 (pathway integration) follow.
+
 ### Changed + Added (Cycle 10): pre-implementation cleanup bundle
 
 Bundles four post-audit fixup deliverables into one PR

--- a/docs/SESSION-MODEL.md
+++ b/docs/SESSION-MODEL.md
@@ -1297,45 +1297,93 @@ defer the rest).
 These are genuine design questions; the maintainer's
 input is welcome before implementation cycles start.
 
-### Q1: Cursor in CanonicalState — additive or breaking?
+### Q1: Cursor in CanonicalState — additive or breaking? — ✅ Resolved 2026-05-07 (Tier 1.B)
 
-Adding `CursorPosition: (int * int)` to the Canonical
-record is breaking for any consumer that destructures
-it. We could add it as a `voption` field for backward
-compat, or bump the record version with a migration
-path. Recommend: add as required field; update all
-consumers (limited surface — StreamPathway, TuiPathway,
-test code).
+**Resolution**: **ADDITIVE; deferred to Tier 1.B**.
+Tier 1.A doesn't touch CanonicalState (no producer that
+needs cursor position yet). Tier 1.B adds
+`CursorPosition: (int * int)` as a required field on
+the `Canonical` record + updates the limited consumer
+surface (StreamPathway, TuiPathway, test code) in the
+same PR. Mechanical update.
 
-### Q2: Heuristic fallback default — on or off?
+**Rationale**: keeping Tier 1.A scoped to "data types
+only" means the cursor field is unnecessary in the first
+PR. Bundling it with Tier 1.B (where the OSC 133
+producer + heuristic fallback need cursor position to
+attribute boundaries to specific row positions) groups
+related changes.
 
-For shells that don't emit OSC 133, should heuristic
-fallback be on by default or off? Trade-off: on
-provides degraded service even when unconfigured; off
-requires explicit opt-in but never produces
-false-positive tuples. Recommend: ON by default for
-known shells (cmd, PowerShell, claude); OFF for
-unknown shells.
+**Original question**: Adding `CursorPosition: (int * int)`
+to the Canonical record is breaking for any consumer
+that destructures it. We could add it as a `voption`
+field for backward compat, or bump the record version
+with a migration path. Recommend: add as required
+field; update all consumers (limited surface —
+StreamPathway, TuiPathway, test code).
 
-### Q3: SessionModel reset on alt-screen entry?
+### Q2: Heuristic fallback default — on or off? — ✅ Resolved 2026-05-07 (Tier 1.C)
 
-When user enters vim (alt-screen toggle), should
-SessionModel pause / reset? The vim "session" isn't a
-command/output cycle. Recommend: pause — SessionModel
-notes "alt-screen active; no boundary detection until
-exit". On alt-screen exit, resume from where we left
-off. Don't lose tuples that were complete before vim
-opened.
+**Resolution**: **ON by default for known shells (cmd,
+PowerShell, claude); OFF for unknown shells**.
+Implementation in Tier 1.C when the heuristic-fallback
+module ships.
 
-### Q4: Multi-line commands — capture per line or as one?
+**Rationale** (per maintainer agreement, audit walk-
+through): without OSC 133, heuristic is the only signal
+for cmd / PowerShell / Claude (none emit OSC 133 by
+default); OFF means SessionModel produces nothing for
+the everyday case. Future shells gain heuristics on
+opt-in.
 
-For commands that span multiple lines (here-docs,
-multi-line strings, line-continuations), should
-SessionTuple's `CommandText` be one string with
-embedded newlines, or an array of lines? Recommend:
-one string with newlines. Easier to serialise; matches
-the original byte stream's structure. Pathways that
-want per-line iteration can split.
+**Original question**: For shells that don't emit OSC
+133, should heuristic fallback be on by default or off?
+Trade-off: on provides degraded service even when
+unconfigured; off requires explicit opt-in but never
+produces false-positive tuples. Recommend: ON by
+default for known shells (cmd, PowerShell, claude);
+OFF for unknown shells.
+
+### Q3: SessionModel reset on alt-screen entry? — ✅ Resolved 2026-05-07 (Tier 1.C)
+
+**Resolution**: **PAUSE on alt-screen entry; resume on
+exit** without losing prior tuples. Implementation in
+Tier 1.C when the SessionModel state machine ships.
+
+**Rationale** (per maintainer agreement, audit walk-
+through): vim / less / TUI sessions aren't
+command-output cycles; pausing avoids false-positive
+boundary detection during alt-screen activity.
+
+**Original question**: When user enters vim (alt-screen
+toggle), should SessionModel pause / reset? The vim
+"session" isn't a command/output cycle. Recommend:
+pause — SessionModel notes "alt-screen active; no
+boundary detection until exit". On alt-screen exit,
+resume from where we left off. Don't lose tuples that
+were complete before vim opened.
+
+### Q4: Multi-line commands — capture per line or as one? — ✅ Resolved 2026-05-07 (Tier 1.A)
+
+**Resolution**: **ONE string with embedded newlines**.
+Captured in `SessionTuple.CommandText: string` per the
+Tier 1.A type definition (PR #185 — first post-audit
+implementation cycle).
+
+**Rationale**: easier serialisation; matches the
+original byte stream's structure; pathways that want
+per-line iteration can split. Matches existing F# +
+.NET string conventions (`Split('\n')` is
+single-allocation).
+
+**Original question**: For commands that span multiple
+lines (here-docs, multi-line strings, line-
+continuations), should SessionTuple's `CommandText` be
+one string with embedded newlines, or an array of
+lines? Recommend: one string with newlines. Easier to
+serialise; matches the original byte stream's
+structure. Pathways that want per-line iteration can
+split.
 
 ### Q5: How does shell-switch interact with active tuple? — ✅ Resolved 2026-05-07
 
@@ -1370,37 +1418,76 @@ C. Error out.
 Recommend: B. Preserves user history; never silently
 loses data.
 
-### Q6: Echo correlation interaction
+### Q6: Echo correlation interaction — ✅ Resolved 2026-05-07 (Tier 1)
 
-The Phase 2 input framework's echo correlation needs
-to know "what is the user editing right now". The
-active tuple's `EditingCommand` state provides this.
-But the echo correlation also tracks per-keystroke
-timing. Open: should the echo-correlation tracker BE
-the SessionModel's command-text-capture mechanism, or
-should they be separate? Recommend: separate. Echo
-correlation is about input-to-output matching; the
-SessionModel's command capture is about
-boundary-to-boundary text accumulation. They share
-the active tuple but use it differently.
+**Resolution**: **separate concerns**. Echo correlation
+(Phase 2 input framework) tracks per-keystroke timing /
+input-to-output matching; SessionModel
+(this substrate) tracks boundary-to-boundary text
+accumulation. They share the active tuple via the
+SessionModel's exposed `Active` field but use it
+differently.
 
-### Q7: Per-output-block AI summarisation — at C or at D?
+**Rationale**: tighter coupling would prematurely
+constrain the input framework's design. Phase 2's echo-
+correlation work is its own substrate cycle; sharing
+the active tuple is sufficient integration.
 
-For AiInterpretedPathway: when does the AI summary
-fire — at OutputStart (so it can summarise as output
-streams in)? At CommandFinished (so it has the full
-output)? Recommend: at CommandFinished. Streaming
-summarisation is much harder; defer.
+**Original question**: The Phase 2 input framework's
+echo correlation needs to know "what is the user
+editing right now". The active tuple's `EditingCommand`
+state provides this. But the echo correlation also
+tracks per-keystroke timing. Open: should the
+echo-correlation tracker BE the SessionModel's
+command-text-capture mechanism, or should they be
+separate? Recommend: separate. Echo correlation is
+about input-to-output matching; the SessionModel's
+command capture is about boundary-to-boundary text
+accumulation. They share the active tuple but use it
+differently.
 
-### Q8: Should SessionModel know about exit codes' meaning?
+### Q7: Per-output-block AI summarisation — at C or at D? — ✅ Resolved 2026-05-07 (Tier 3+)
 
-A non-zero exit code typically indicates failure but
-not always (some commands use exit codes as semantic
-return values, e.g. `grep` returns 1 for "no match").
-Should SessionModel categorise exit codes? Recommend:
-no. SessionModel records the value; pathways /
-consumers interpret. Future per-shell rules could be
-added if needed.
+**Resolution**: **at CommandFinished (D)**; streaming
+summarisation deferred to a future Phase 3 cycle. Tier 1
+captures `OutputText` continuously between
+`OutputStart` and `CommandFinished`; the
+AiInterpretedPathway (when it ships) consumes the full
+`OutputText` post-finalisation.
+
+**Rationale** (per maintainer agreement, audit walk-
+through): streaming summarisation is much harder
+(requires partial-output AI prompts; risks
+hallucination at low context); the simpler "summarise
+on finish" path ships first. Streaming-summary
+revisited if the simpler version proves insufficient.
+
+**Original question**: For AiInterpretedPathway: when
+does the AI summary fire — at OutputStart (so it can
+summarise as output streams in)? At CommandFinished
+(so it has the full output)? Recommend: at
+CommandFinished. Streaming summarisation is much
+harder; defer.
+
+### Q8: Should SessionModel know about exit codes' meaning? — ✅ Resolved 2026-05-07 (Tier 1.A)
+
+**Resolution**: **NO**. SessionModel records the value
+verbatim as `int option`; pathways / consumers
+interpret semantically (e.g. "exit 0 = success",
+"exit 1 = grep no-match", per-shell idioms).
+
+**Implementation in Tier 1.A** (PR #185): `SessionTuple.ExitCode: int option`
+captures the value or `None` when not reported by the
+shell. Future per-shell or per-context rules could be
+added in CUSTOMIZATION-MODEL substrate (item 31).
+
+**Original question**: A non-zero exit code typically
+indicates failure but not always (some commands use
+exit codes as semantic return values, e.g. `grep`
+returns 1 for "no match"). Should SessionModel
+categorise exit codes? Recommend: no. SessionModel
+records the value; pathways / consumers interpret.
+Future per-shell rules could be added if needed.
 
 ## Out of scope
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1055,6 +1055,21 @@ module Program =
                                     | ModeChanged _ -> handleModeChanged peek
                                     | ParserError _
                                     | Bell -> handleSimpleNotification peek
+                                    | PromptBoundary _ ->
+                                        // SessionModel Tier 1.A:
+                                        // no producer + no
+                                        // consumer wired yet.
+                                        // Tier 1.B adds the OSC
+                                        // 133 producer in
+                                        // Screen.Apply; Tier 1.C
+                                        // wires SessionModel.apply
+                                        // here. For now the
+                                        // PathwayPump silently
+                                        // discards PromptBoundary
+                                        // events (none arrive
+                                        // today since no producer
+                                        // exists).
+                                        ()
                     with
                     | :? OperationCanceledException -> ()
                     | ex ->

--- a/src/Terminal.Core/DisplayPathway.fs
+++ b/src/Terminal.Core/DisplayPathway.fs
@@ -90,4 +90,22 @@ module DisplayPathway =
           /// OutputEvents — it only updates internal hash state.
           /// Pathways without baseline state (TuiPathway) treat
           /// it as a no-op.
-          SetBaseline: CanonicalState.Canonical -> unit }
+          SetBaseline: CanonicalState.Canonical -> unit
+          /// **SessionModel Tier 1.A** — called when a
+          /// `ScreenNotification.PromptBoundary` event arrives
+          /// (Tier 1.B's OSC 133 producer + Tier 1.C's
+          /// heuristic fallback are the future producers; Tier
+          /// 1.A reserves the protocol method only). The
+          /// pathway responds to a boundary event by emitting
+          /// any associated OutputEvents (e.g. a future
+          /// SessionConsumer pathway might emit a
+          /// `CommandSubmitted` semantic event on
+          /// `BoundaryKind.CommandStart`).
+          ///
+          /// **Tier 1.A scope: no-op default**. Both shipping
+          /// pathways (StreamPathway, TuiPathway) return `[||]`
+          /// from `OnPromptBoundary` because neither integrates
+          /// SessionModel data yet. Future pathways (ReplPathway,
+          /// FormPathway, ClaudeCodePathway, SessionConsumer)
+          /// override with non-trivial implementations.
+          OnPromptBoundary: PromptBoundaryData -> OutputEvent[] }

--- a/src/Terminal.Core/OutputEventBuilder.fs
+++ b/src/Terminal.Core/OutputEventBuilder.fs
@@ -90,3 +90,22 @@ module OutputEventBuilder =
                 Priority.Assertive
                 producerId
                 ""
+        | PromptBoundary _ ->
+            // SessionModel Tier 1.A: route to the existing
+            // SemanticCategory.PromptDetected reservation.
+            // Empty payload (the boundary is a pure signal —
+            // no human-readable text to announce). Priority =
+            // Polite (subordinate to streaming output;
+            // boundaries are structure markers, not
+            // user-attention events). Tier 1.B's OSC 133
+            // producer + Tier 1.C's heuristic fallback are the
+            // future producers; this builder arm exists today
+            // to satisfy F#'s exhaustive-match requirement +
+            // give the FileLogger an audit trail for any
+            // PromptBoundary events that flow through the
+            // dispatcher in subsequent cycles.
+            OutputEvent.create
+                SemanticCategory.PromptDetected
+                Priority.Polite
+                producerId
+                ""

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -1,0 +1,215 @@
+namespace Terminal.Core
+
+open System
+open System.Collections.Generic
+
+/// Tier 1.A — SessionModel substrate skeleton.
+///
+/// The SessionModel is the structured-history substrate per
+/// `docs/SESSION-MODEL.md`: it captures (prompt, command,
+/// output, exit-code) tuples sourced from OSC 133 escape
+/// sequences with heuristic fallback. Sits at "Stage 3.5"
+/// between notification emission (Stage 3) and canonical-state
+/// synthesis (Stage 4) per the PIPELINE-NARRATIVE 12-stage
+/// vocabulary.
+///
+/// **Tier 1.A scope: types only**. The state machine is
+/// deferred to Tier 1.C; Tier 1.A ships a placeholder `apply`
+/// function that returns state unchanged. This lets future
+/// PRs override the function without protocol churn — every
+/// caller gets the same `T` shape today + tomorrow.
+///
+/// **Tier 1 sequencing**:
+/// - Tier 1.A (this file) — types + `create` + no-op `apply`
+/// - Tier 1.B — OSC 133 producer in `Screen.Apply`;
+///   `CanonicalState.CursorPosition` field added
+/// - Tier 1.C — heuristic fallback module + non-trivial
+///   `apply` state machine + composition wiring in Program.fs
+/// - Tier 1.D — diagnostic battery extension + corpus tests
+///
+/// **Per-shell-session model**. Each Ctrl+Shift+1/2/3
+/// hot-switch creates a fresh SessionModel instance for the
+/// new shell (per Q5 resolution 2026-05-07). Unified history
+/// across shells is a future opt-in TOML setting.
+///
+/// **Why string-keyed shell**. The substrate stays free of
+/// `Terminal.Pty.ShellRegistry`'s `ShellId` DU dependency to
+/// preserve the existing assembly boundary (mirrors the
+/// `Terminal.Core.Config` precedent). The composition root
+/// in `Terminal.App.Program` translates `ShellId → string` at
+/// SessionModel construction time.
+[<RequireQualifiedAccess>]
+module SessionModel =
+
+    /// State of the active SessionTuple. Mirrors the
+    /// boundary-kind progression but as a state machine: the
+    /// active tuple advances through these states as
+    /// `BoundaryKind` events arrive. After
+    /// `BoundaryKind.CommandFinished`, the tuple is moved to
+    /// the History queue (no `Complete` state needed).
+    ///
+    /// Tier 1.A captures the type; Tier 1.C wires transitions.
+    type ActiveTupleState =
+        /// Initial state. No prompt boundary has been
+        /// observed yet; the SessionModel is waiting for the
+        /// first `PromptStart`.
+        | AwaitingPromptStart
+        /// `PromptStart` received; the user is editing at the
+        /// prompt. Waiting for `CommandStart` (Enter).
+        | AwaitingCommandStart
+        /// `CommandStart` received; the command has been
+        /// submitted. Waiting for `OutputStart` (the shell
+        /// echoes the command then begins streaming output).
+        | EditingCommand
+        /// `OutputStart` received; the command's output is
+        /// streaming. Waiting for `CommandFinished`.
+        | OutputStreaming
+
+    /// One completed shell-interaction tuple. Immutable;
+    /// constructed when `CommandFinished` arrives.
+    ///
+    /// **Per Q4 resolution 2026-05-07**: multi-line commands
+    /// (here-docs, `\` continuation) are stored as ONE string
+    /// with embedded newlines in `CommandText`. Easier
+    /// serialisation; pathways re-split if line-level access
+    /// is needed.
+    ///
+    /// **Per Q8 resolution 2026-05-07**: `ExitCode` is
+    /// `int option` — the substrate captures the value
+    /// verbatim (or `None` when the shell didn't report
+    /// one). Pathways interpret semantically (e.g. "exit 0
+    /// = success" mapping happens in pathway code, not
+    /// substrate).
+    type SessionTuple =
+        { /// Unique tuple identifier; survives serialisation.
+          Id: Guid
+          /// OSC 133 `aid=<command-id>` parameter, if shell
+          /// supplied one. Lets cross-session correlation
+          /// happen without timing-window heuristics. None
+          /// when not supplied (most cases today).
+          CommandId: string option
+          /// Which shell produced this tuple. String-keyed
+          /// per assembly-boundary discipline (see module
+          /// docstring).
+          ShellId: string
+          /// Wall-clock when `PromptStart` was detected.
+          PromptStartedAt: DateTime
+          /// Wall-clock when `CommandStart` was detected.
+          /// `None` when the tuple closed before
+          /// `CommandStart` (e.g. user pressed Ctrl+C at the
+          /// prompt; rare).
+          CommandStartedAt: DateTime option
+          /// Wall-clock when `OutputStart` was detected.
+          /// `None` when the command finished before
+          /// `OutputStart` (e.g. instant-completing alias).
+          OutputStartedAt: DateTime option
+          /// Wall-clock when `CommandFinished` was detected.
+          /// `None` when the tuple is still active (only
+          /// possible on the `Active` field; finalised tuples
+          /// in `History` always have this set).
+          CommandFinishedAt: DateTime option
+          /// Text rendered at the prompt before
+          /// `CommandStart`. Captured at the
+          /// `PromptStart → CommandStart` transition.
+          PromptText: string
+          /// Text the user typed between the prompt and
+          /// Enter. Multi-line via embedded newlines (Q4).
+          CommandText: string
+          /// Output bytes (rendered) between `OutputStart`
+          /// and `CommandFinished`.
+          OutputText: string
+          /// Process exit code. None when not reported by
+          /// the shell. Substrate captures verbatim (Q8).
+          ExitCode: int option
+          /// Detection-source provenance per boundary kind.
+          /// Records which `BoundarySource` produced each
+          /// transition — useful for diagnostics +
+          /// confidence-aware future pathway logic.
+          Sources: Map<BoundaryKind, BoundarySource>
+          /// Other OSC 133 parameters (`k=`, `cl=`, custom
+          /// shell extensions) preserved verbatim. Tier 1
+          /// stores but doesn't interpret.
+          ExtraParams: Map<string, string> }
+
+    /// Active (in-flight) SessionTuple. Mutable view: the
+    /// tuple's fields are populated incrementally as
+    /// `BoundaryKind` events arrive. When `CommandFinished`
+    /// arrives the tuple is finalised + moved to History.
+    type ActiveSessionTuple =
+        { /// The tuple data (in-progress; some fields may
+          /// be unset).
+          Tuple: SessionTuple
+          /// State machine cursor.
+          State: ActiveTupleState }
+
+    /// SessionModel state for a single shell session. One
+    /// instance per Ctrl+Shift+1/2/3 hot-switch (per Q5
+    /// resolution 2026-05-07).
+    ///
+    /// **Tier 1.A scope**: skeleton record + `create`
+    /// factory + no-op `apply`. Tier 1.C wires the state
+    /// machine (transitions, History pruning, etc.).
+    type T =
+        { /// Which shell this SessionModel tracks. String-
+          /// keyed (see module docstring).
+          ShellId: string
+          /// Stable session identifier. Survives across
+          /// individual tuple boundaries; re-rolled on shell
+          /// hot-switch.
+          SessionId: Guid
+          /// Wall-clock when this SessionModel was created
+          /// (typically at shell-spawn or hot-switch).
+          SessionStartedAt: DateTime
+          /// Bounded ring buffer of completed tuples. Oldest
+          /// tuples evicted when the queue exceeds
+          /// `MaxHistorySize`. Tier 1.A constructs as empty
+          /// `Queue<>`; Tier 1.C populates via `apply`.
+          History: Queue<SessionTuple>
+          /// Maximum tuples retained in History. Default
+          /// 100 per SESSION-MODEL.md §4. Construction-time
+          /// parameter; Tier 1.A doesn't enforce yet (no
+          /// state machine).
+          MaxHistorySize: int
+          /// In-flight tuple, if any. `None` between
+          /// `CommandFinished` and the next `PromptStart`.
+          Active: ActiveSessionTuple option }
+
+    /// Default history size. Per SESSION-MODEL.md §4
+    /// recommendation. Tier 1.A captures the constant; Tier
+    /// 1.C enforces the bound during `apply`.
+    [<Literal>]
+    let DefaultMaxHistorySize: int = 100
+
+    /// Construct a new SessionModel for the given shell.
+    /// Caller supplies a stable shell-key string (e.g.
+    /// `"cmd"`, `"powershell"`, `"claude"`); the composition
+    /// root translates `ShellId → string` at construction
+    /// time per the assembly-boundary convention.
+    ///
+    /// **Tier 1.A note**: `apply` is a no-op stub; calling
+    /// `create` then dispatching `BoundaryKind` events via
+    /// `apply` returns state unchanged. Tier 1.C ships the
+    /// real state machine.
+    let create (shellId: string) (maxHistorySize: int) : T =
+        { ShellId = shellId
+          SessionId = Guid.NewGuid()
+          SessionStartedAt = DateTime.UtcNow
+          History = Queue<SessionTuple>()
+          MaxHistorySize = maxHistorySize
+          Active = None }
+
+    /// Convenience overload: construct with the default
+    /// max-history-size (100).
+    let createDefault (shellId: string) : T =
+        create shellId DefaultMaxHistorySize
+
+    /// **Tier 1.A: no-op stub.** Receives a
+    /// `PromptBoundaryData` event and returns the state
+    /// unchanged. Tier 1.C overrides this with the real
+    /// state machine (transitions, `Active` mutation,
+    /// `History` enqueue + bound enforcement).
+    ///
+    /// The signature is locked here so future cycles can
+    /// extend the implementation without protocol churn.
+    let apply (state: T) (_boundary: PromptBoundaryData) : T =
+        state

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -985,7 +985,13 @@ module StreamPathway =
           Reset =
             fun () -> resetState state
           SetBaseline =
-            fun canonical -> seedBaseline state canonical }
+            fun canonical -> seedBaseline state canonical
+          OnPromptBoundary =
+            // SessionModel Tier 1.A: no-op default. StreamPathway
+            // doesn't yet integrate SessionModel data; future
+            // pathways (ReplPathway, ClaudeCodePathway) override
+            // with non-trivial implementations.
+            fun _boundary -> [||] }
 
     /// Test-only — expose the state for direct manipulation in
     /// the test harness. Production code never calls this.
@@ -1018,5 +1024,9 @@ module StreamPathway =
               Reset =
                 fun () -> resetState state
               SetBaseline =
-                fun canonical -> seedBaseline state canonical }
+                fun canonical -> seedBaseline state canonical
+              OnPromptBoundary =
+                // SessionModel Tier 1.A: no-op default (mirrors
+                // the production `create` factory above).
+                fun _boundary -> [||] }
         pathway, state

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Types.fs" />
+    <Compile Include="SessionModel.fs" />
     <Compile Include="Screen.fs" />
     <Compile Include="AnnounceSanitiser.fs" />
     <Compile Include="UpdateMessages.fs" />

--- a/src/Terminal.Core/TuiPathway.fs
+++ b/src/Terminal.Core/TuiPathway.fs
@@ -93,4 +93,13 @@ module TuiPathway =
                 // No baseline to seed — TuiPathway is stateless
                 // and its `Consume` always returns `[||]`
                 // regardless of the canonical state.
-                () }
+                ()
+          OnPromptBoundary =
+            // SessionModel Tier 1.A: no-op default. TuiPathway
+            // (alt-screen) doesn't yet integrate SessionModel
+            // data — alt-screen TUIs (vim, less) typically
+            // don't emit OSC 133 boundaries, and the
+            // review-cursor navigation model is orthogonal to
+            // tuple-based history. Future pathways may
+            // override.
+            fun _boundary -> [||] }

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -1,5 +1,6 @@
 namespace Terminal.Core
 
+open System
 open System.Text
 
 // Stage 4.5 — expose `internal` types in Terminal.Core to the
@@ -190,6 +191,86 @@ type Earcon =
 type AccessibilityMarker =
     | Placeholder
 
+/// SessionModel Tier 1.A — substrate-level types describing a
+/// prompt-boundary event detected from OSC 133 markup OR a
+/// per-shell heuristic fallback. Carried on
+/// `ScreenNotification.PromptBoundary` between the
+/// parser/screen subsystem and the SessionModel state machine
+/// that consumes it.
+///
+/// **Tier 1.A scope**: types only. There is no producer (Tier
+/// 1.B will add OSC 133 detection in `Screen.Apply`'s OSC
+/// dispatch + a heuristic-fallback module). There is no
+/// consumer (Tier 1.C wires the SessionModel state machine).
+/// The `ScreenNotification.PromptBoundary` case lands today
+/// so future PRs can attach producer + consumer without DU
+/// churn.
+///
+/// See `docs/SESSION-MODEL.md` §3 (OSC 133 protocol) + §4
+/// (data model) for the canonical design.
+type BoundaryKind =
+    /// OSC 133 ;A — prompt is about to be drawn. Marks the
+    /// transition from previous output to a new editing area.
+    | PromptStart
+    /// OSC 133 ;B — user just submitted a command at the prompt
+    /// (Enter pressed). Marks the transition from EditingCommand
+    /// to OutputStreaming.
+    | CommandStart
+    /// OSC 133 ;C — output for the just-submitted command is
+    /// about to start streaming.
+    | OutputStart
+    /// OSC 133 ;D [;<exit_code>] — command finished. Optional
+    /// exit code (None when the shell didn't report one;
+    /// substrate captures the value verbatim — pathways
+    /// interpret semantically per SESSION-MODEL Q8 resolution).
+    | CommandFinished of exitCode: int option
+
+/// How a `PromptBoundary` event was detected. Recorded on the
+/// `SessionTuple.Sources` map so consumers can distinguish
+/// "the shell told us via OSC 133" from "we inferred this
+/// via a heuristic" — useful for diagnostics + future
+/// confidence-aware pathway logic.
+type BoundarySource =
+    /// Shell emitted an OSC 133 escape sequence
+    /// (`ESC ] 133 ; <kind> [; <params>] BEL`). Highest
+    /// confidence; preferred when available.
+    | Osc133
+    /// Heuristic regex-based detection on a row whose content
+    /// has been stable for `stabilityMs` milliseconds. Used for
+    /// shells that don't emit OSC 133 (cmd, PowerShell by
+    /// default, Claude). Tier 1.C ships per-shell regexes;
+    /// Tier 1.A reserves the type only.
+    | HeuristicPromptRegex of stabilityMs: int
+    /// Heuristic detection of Claude Code's Ink-rendered
+    /// prompt box (rectangular SGR region with stable border
+    /// characters). Reserved for Tier 1.C heuristic fallback
+    /// where Claude is the active shell.
+    | HeuristicClaudeInkBox
+
+/// Payload for `ScreenNotification.PromptBoundary` events.
+/// Pure data — no behaviour. Construction sites: future Tier
+/// 1.B OSC 133 dispatcher in `Screen.Apply` + future Tier 1.C
+/// heuristic fallback module.
+type PromptBoundaryData =
+    { /// Which kind of boundary this is.
+      Kind: BoundaryKind
+      /// How the boundary was detected.
+      Source: BoundarySource
+      /// When the boundary was detected (UTC). Used by
+      /// `SessionTuple` to populate `PromptStartedAt` /
+      /// `CommandStartedAt` / `OutputStartedAt` /
+      /// `CommandFinishedAt` per the kind.
+      DetectedAt: DateTime
+      /// OSC 133 `aid=<command-id>` parameter, if present.
+      /// Lets the SessionModel correlate boundaries across
+      /// shells / sessions (Phase 2 distributed-tracing
+      /// territory; Tier 1 stores but doesn't interpret).
+      CommandId: string option
+      /// Other OSC 133 parameters (`k=`, `cl=`, etc.) preserved
+      /// verbatim. Future shells / extensions may attach
+      /// custom keys. Tier 1 stores but doesn't interpret.
+      ExtraParams: Map<string, string> }
+
 /// Notifications emitted by the parser/screen subsystem onto
 /// a `Channel<ScreenNotification>` consumed by the UIA peer
 /// for `RaiseNotificationEvent`. The audit-cycle PR-B added
@@ -247,6 +328,14 @@ type ScreenNotification =
     /// release, same pattern as ModeChanged, so the channel
     /// publish doesn't extend the gate's hold.
     | Bell
+    /// SessionModel Tier 1.A — prompt-boundary event detected
+    /// from OSC 133 markup or a heuristic fallback. Tier 1.A
+    /// reserves the case (no producer + no consumer); Tier 1.B
+    /// adds the OSC 133 producer in `Screen.Apply`; Tier 1.C
+    /// wires the SessionModel consumer. Today's pathway pump
+    /// receives this case via its no-op arm and discards it.
+    /// See `docs/SESSION-MODEL.md` for the canonical design.
+    | PromptBoundary of PromptBoundaryData
 
 /// Discriminator for which `TerminalModes` bit just flipped.
 /// Mirrors the field names on the `TerminalModes` record so the

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -1,0 +1,275 @@
+module PtySpeak.Tests.Unit.SessionModelTests
+
+open System
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// SessionModel Tier 1.A — substrate skeleton behavioural pinning
+// ---------------------------------------------------------------------
+//
+// Tier 1.A scope: types only. Tests pin:
+//   * The substrate types (`BoundaryKind`, `BoundarySource`,
+//     `PromptBoundaryData`) construct cleanly + round-trip
+//     through pattern matches.
+//   * `ScreenNotification.PromptBoundary` is a fully-typed
+//     case carrying `PromptBoundaryData`.
+//   * `SessionModel.create` returns the documented initial
+//     state (empty History, no Active tuple, fresh
+//     SessionId).
+//   * `SessionModel.createDefault` uses
+//     `DefaultMaxHistorySize`.
+//   * `SessionModel.apply` is a no-op stub (Tier 1.A
+//     contract): returns state unchanged for any boundary.
+//
+// State-machine tests (Active state transitions, History
+// enqueue/eviction) ship in Tier 1.C when the real `apply`
+// state machine lands.
+
+// ---------------------------------------------------------------------
+// BoundaryKind cases
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``BoundaryKind.PromptStart constructs cleanly`` () =
+    let kind = BoundaryKind.PromptStart
+    match kind with
+    | BoundaryKind.PromptStart -> ()
+    | _ -> Assert.Fail("Expected PromptStart")
+
+[<Fact>]
+let ``BoundaryKind.CommandStart constructs cleanly`` () =
+    let kind = BoundaryKind.CommandStart
+    match kind with
+    | BoundaryKind.CommandStart -> ()
+    | _ -> Assert.Fail("Expected CommandStart")
+
+[<Fact>]
+let ``BoundaryKind.OutputStart constructs cleanly`` () =
+    let kind = BoundaryKind.OutputStart
+    match kind with
+    | BoundaryKind.OutputStart -> ()
+    | _ -> Assert.Fail("Expected OutputStart")
+
+[<Fact>]
+let ``BoundaryKind.CommandFinished carries optional exit code`` () =
+    let kindWithExit = BoundaryKind.CommandFinished (Some 1)
+    let kindNoExit = BoundaryKind.CommandFinished None
+    match kindWithExit, kindNoExit with
+    | BoundaryKind.CommandFinished (Some 1), BoundaryKind.CommandFinished None -> ()
+    | _ -> Assert.Fail("Expected exit-code variants")
+
+// ---------------------------------------------------------------------
+// BoundarySource cases
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``BoundarySource.Osc133 constructs cleanly`` () =
+    let source = BoundarySource.Osc133
+    match source with
+    | BoundarySource.Osc133 -> ()
+    | _ -> Assert.Fail("Expected Osc133")
+
+[<Fact>]
+let ``BoundarySource.HeuristicPromptRegex carries stability ms`` () =
+    let source = BoundarySource.HeuristicPromptRegex 200
+    match source with
+    | BoundarySource.HeuristicPromptRegex stabilityMs ->
+        Assert.Equal(200, stabilityMs)
+    | _ -> Assert.Fail("Expected HeuristicPromptRegex")
+
+[<Fact>]
+let ``BoundarySource.HeuristicClaudeInkBox constructs cleanly`` () =
+    let source = BoundarySource.HeuristicClaudeInkBox
+    match source with
+    | BoundarySource.HeuristicClaudeInkBox -> ()
+    | _ -> Assert.Fail("Expected HeuristicClaudeInkBox")
+
+// ---------------------------------------------------------------------
+// PromptBoundaryData record
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``PromptBoundaryData record literal constructs all fields`` () =
+    let now = DateTime.UtcNow
+    let data : PromptBoundaryData =
+        { Kind = BoundaryKind.PromptStart
+          Source = BoundarySource.Osc133
+          DetectedAt = now
+          CommandId = Some "abc-123"
+          ExtraParams = Map.ofList [ "k", "v" ] }
+    Assert.Equal(BoundaryKind.PromptStart, data.Kind)
+    Assert.Equal(BoundarySource.Osc133, data.Source)
+    Assert.Equal(now, data.DetectedAt)
+    Assert.Equal(Some "abc-123", data.CommandId)
+    Assert.Equal<Map<string, string>>(Map.ofList [ "k", "v" ], data.ExtraParams)
+
+[<Fact>]
+let ``PromptBoundaryData supports None CommandId and empty ExtraParams`` () =
+    let data : PromptBoundaryData =
+        { Kind = BoundaryKind.CommandFinished (Some 0)
+          Source = BoundarySource.HeuristicPromptRegex 100
+          DetectedAt = DateTime.UtcNow
+          CommandId = None
+          ExtraParams = Map.empty }
+    Assert.Equal(None, data.CommandId)
+    Assert.True(Map.isEmpty data.ExtraParams)
+
+// ---------------------------------------------------------------------
+// ScreenNotification.PromptBoundary
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``ScreenNotification.PromptBoundary round-trips through pattern match`` () =
+    let data : PromptBoundaryData =
+        { Kind = BoundaryKind.OutputStart
+          Source = BoundarySource.Osc133
+          DetectedAt = DateTime.UtcNow
+          CommandId = None
+          ExtraParams = Map.empty }
+    let notification = ScreenNotification.PromptBoundary data
+    match notification with
+    | ScreenNotification.PromptBoundary roundTripped ->
+        Assert.Equal(BoundaryKind.OutputStart, roundTripped.Kind)
+        Assert.Equal(BoundarySource.Osc133, roundTripped.Source)
+    | _ -> Assert.Fail("Expected PromptBoundary case")
+
+// ---------------------------------------------------------------------
+// SessionModel.ActiveTupleState cases
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``ActiveTupleState cases enumerate as expected`` () =
+    let states =
+        [ SessionModel.ActiveTupleState.AwaitingPromptStart
+          SessionModel.ActiveTupleState.AwaitingCommandStart
+          SessionModel.ActiveTupleState.EditingCommand
+          SessionModel.ActiveTupleState.OutputStreaming ]
+    Assert.Equal(4, states.Length)
+
+// ---------------------------------------------------------------------
+// SessionModel.create + createDefault
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``SessionModel.create initialises empty History + None Active`` () =
+    let model = SessionModel.create "cmd" 50
+    Assert.Equal("cmd", model.ShellId)
+    Assert.Equal(50, model.MaxHistorySize)
+    Assert.Equal(0, model.History.Count)
+    Assert.Equal(None, model.Active)
+
+[<Fact>]
+let ``SessionModel.create issues a fresh SessionId per instance`` () =
+    let a = SessionModel.create "cmd" 50
+    let b = SessionModel.create "cmd" 50
+    Assert.NotEqual(a.SessionId, b.SessionId)
+
+[<Fact>]
+let ``SessionModel.create stamps SessionStartedAt close to now`` () =
+    let before = DateTime.UtcNow
+    let model = SessionModel.create "cmd" 50
+    let after = DateTime.UtcNow
+    Assert.True(model.SessionStartedAt >= before.AddMilliseconds(-1.0))
+    Assert.True(model.SessionStartedAt <= after.AddMilliseconds(1.0))
+
+[<Fact>]
+let ``SessionModel.createDefault uses DefaultMaxHistorySize (100)`` () =
+    let model = SessionModel.createDefault "powershell"
+    Assert.Equal(SessionModel.DefaultMaxHistorySize, model.MaxHistorySize)
+    Assert.Equal(100, model.MaxHistorySize)
+    Assert.Equal("powershell", model.ShellId)
+
+// ---------------------------------------------------------------------
+// SessionModel.apply (Tier 1.A no-op contract)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``SessionModel.apply returns state unchanged in Tier 1.A`` () =
+    let original = SessionModel.create "cmd" 50
+    let boundary : PromptBoundaryData =
+        { Kind = BoundaryKind.PromptStart
+          Source = BoundarySource.Osc133
+          DetectedAt = DateTime.UtcNow
+          CommandId = None
+          ExtraParams = Map.empty }
+    let updated = SessionModel.apply original boundary
+    // Reference equality holds: Tier 1.A's apply is the identity.
+    Assert.True(obj.ReferenceEquals(original, updated))
+    // And every field matches.
+    Assert.Equal(original.ShellId, updated.ShellId)
+    Assert.Equal(original.SessionId, updated.SessionId)
+    Assert.Equal(original.MaxHistorySize, updated.MaxHistorySize)
+    Assert.Equal(0, updated.History.Count)
+    Assert.Equal(None, updated.Active)
+
+[<Fact>]
+let ``SessionModel.apply is a no-op for every BoundaryKind`` () =
+    let model = SessionModel.create "claude" 100
+    let boundaries =
+        [ BoundaryKind.PromptStart
+          BoundaryKind.CommandStart
+          BoundaryKind.OutputStart
+          BoundaryKind.CommandFinished None
+          BoundaryKind.CommandFinished (Some 0)
+          BoundaryKind.CommandFinished (Some 1) ]
+    let now = DateTime.UtcNow
+    for kind in boundaries do
+        let boundary : PromptBoundaryData =
+            { Kind = kind
+              Source = BoundarySource.Osc133
+              DetectedAt = now
+              CommandId = None
+              ExtraParams = Map.empty }
+        let updated = SessionModel.apply model boundary
+        Assert.Equal(0, updated.History.Count)
+        Assert.Equal(None, updated.Active)
+
+// ---------------------------------------------------------------------
+// SessionTuple shape (Q4 multi-line; Q8 ExitCode int option)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``SessionTuple.CommandText supports multi-line via embedded newlines (Q4)`` () =
+    let tuple : SessionModel.SessionTuple =
+        { Id = Guid.NewGuid()
+          CommandId = None
+          ShellId = "cmd"
+          PromptStartedAt = DateTime.UtcNow
+          CommandStartedAt = None
+          OutputStartedAt = None
+          CommandFinishedAt = None
+          PromptText = ">"
+          // Multi-line command stored as one string with \n.
+          CommandText = "echo a\necho b\necho c"
+          OutputText = ""
+          ExitCode = None
+          Sources = Map.empty
+          ExtraParams = Map.empty }
+    let lines = tuple.CommandText.Split('\n')
+    Assert.Equal(3, lines.Length)
+    Assert.Equal("echo a", lines.[0])
+    Assert.Equal("echo b", lines.[1])
+    Assert.Equal("echo c", lines.[2])
+
+[<Fact>]
+let ``SessionTuple.ExitCode is int option (Q8 — substrate captures verbatim)`` () =
+    let success : SessionModel.SessionTuple =
+        { Id = Guid.NewGuid()
+          CommandId = None
+          ShellId = "cmd"
+          PromptStartedAt = DateTime.UtcNow
+          CommandStartedAt = None
+          OutputStartedAt = None
+          CommandFinishedAt = None
+          PromptText = ""
+          CommandText = ""
+          OutputText = ""
+          ExitCode = Some 0
+          Sources = Map.empty
+          ExtraParams = Map.empty }
+    let unreported = { success with ExitCode = None }
+    let failure = { success with ExitCode = Some 127 }
+    Assert.Equal(Some 0, success.ExitCode)
+    Assert.Equal(None, unreported.ExitCode)
+    Assert.Equal(Some 127, failure.ExitCode)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="WordBoundaryTests.fs" />
     <Compile Include="AnnounceSanitiserTests.fs" />
     <Compile Include="CanonicalStateTests.fs" />
+    <Compile Include="SessionModelTests.fs" />
     <Compile Include="StreamPathwayTests.fs" />
     <Compile Include="TuiPathwayTests.fs" />
     <Compile Include="PathwaySelectorTests.fs" />


### PR DESCRIPTION
## Summary

**FIRST POST-AUDIT IMPLEMENTATION CYCLE.** Lands the
SessionModel substrate skeleton per
`docs/SESSION-MODEL.md` (item 28 design).

**Tier 1.A scope: data types only; zero behaviour
change.** No producer of `PromptBoundary` events; the
PathwayPump's notification consumer routes the new case
to a no-op arm. Tier 1.B (next cycle) ships the OSC 133
producer + `CanonicalState.CursorPosition` field;
Tier 1.C wires the SessionModel state machine +
heuristic fallback + composition root; Tier 1.D adds
diagnostic battery extension.

## What's new

### New types (in `src/Terminal.Core/Types.fs`)

```fsharp
type BoundaryKind =
    | PromptStart
    | CommandStart
    | OutputStart
    | CommandFinished of exitCode: int option

type BoundarySource =
    | Osc133
    | HeuristicPromptRegex of stabilityMs: int
    | HeuristicClaudeInkBox

type PromptBoundaryData =
    { Kind: BoundaryKind
      Source: BoundarySource
      DetectedAt: DateTime
      CommandId: string option
      ExtraParams: Map<string, string> }

// New ScreenNotification case:
| PromptBoundary of PromptBoundaryData
```

### New module `src/Terminal.Core/SessionModel.fs`

Types: `ActiveTupleState`, `SessionTuple`,
`ActiveSessionTuple`, `T`. Factories: `create` /
`createDefault`. State machine: `apply` no-op stub
(Tier 1.C overrides). String-keyed shell field per the
assembly-boundary discipline (mirrors `Config.fs`).

### Protocol method on `DisplayPathway.T`

```fsharp
OnPromptBoundary: PromptBoundaryData -> OutputEvent[]
```

Both shipping pathways (`StreamPathway`, `TuiPathway`)
implement no-op default `fun _ -> [||]`.

### Pre-emptive pattern-match completeness

Two existing match sites required new arms (per F# 9 +
TreatWarningsAsErrors):

1. `OutputEventBuilder.fromScreenNotification` — exhaustive
   match; new `| PromptBoundary _ ->` arm routes to
   `SemanticCategory.PromptDetected` with empty payload +
   Polite priority.
2. `Program.fs` PathwayPump consumer — new
   `| PromptBoundary _ -> ()` no-op arm.

`PathwaySelector.fs` has a wildcard `| _ -> Keep` so no
change needed there.

### Tests

18 tests in `tests/Tests.Unit/SessionModelTests.fs` pin:
- Type construction for all DU cases.
- `ScreenNotification.PromptBoundary` round-trip.
- `SessionModel.create` initial state (empty History,
  None Active, fresh SessionId, recent
  SessionStartedAt).
- `SessionModel.createDefault` uses
  `DefaultMaxHistorySize` (100).
- `SessionModel.apply` no-op contract for every
  `BoundaryKind`.
- `SessionTuple.CommandText` multi-line via embedded
  newlines (Q4 resolution).
- `SessionTuple.ExitCode: int option` (Q8 resolution).

## Open-question resolutions

All 8 SESSION-MODEL.md open questions resolved (Q5 was
resolved in Cycle 8 PR #182):

| # | Question | Resolution |
|---|---|---|
| Q1 | Cursor in CanonicalState — additive or breaking? | ADDITIVE; deferred to Tier 1.B |
| Q2 | Heuristic fallback default — on or off? | ON for known shells; deferred to Tier 1.C |
| Q3 | SessionModel reset on alt-screen entry? | PAUSE; resume on exit; deferred to Tier 1.C |
| Q4 | Multi-line commands — per line or as one? | **ONE string with embedded newlines** (this PR) |
| Q5 | Shell-switch with active tuple? | per-shell-session; opt-in unified (PR #182) |
| Q6 | Echo correlation interaction | separate concerns |
| Q7 | AI summarisation — at C or D? | at CommandFinished (D) |
| Q8 | Exit-code semantics | **NO** (this PR) — substrate captures verbatim |

## What this PR does NOT do

- **No producer** of `PromptBoundary` events (Tier 1.B
  adds OSC 133 detection in `Screen.Apply`).
- **No CanonicalState cursor field** (Tier 1.B per Q1).
- **No SessionModel state machine** (Tier 1.C; `apply`
  is a placeholder).
- **No heuristic fallback module** (Tier 1.C).
- **No composition root SessionModel instantiation**
  (Tier 1.C).
- **No diagnostic battery extension** (Tier 1.D).
- **No spec changes** (per CLAUDE.md spec-immutability;
  Track C audit recommendation: defer spec re-authoring
  to a coordinated post-Phase-2 cycle).

## Sequencing

```
✅ Audit phase (Cycles 1-6): PRs #172, #175-#180
✅ Cycles 7-10: post-audit cleanup (PRs #181-#184)
─────────────────────────────────────────────────────
Cycle 11: SessionModel Tier 1.A — substrate skeleton (THIS PR)
Cycle 12: SessionModel Tier 1.B — OSC 133 producer + cursor field
Cycle 13: SessionModel Tier 1.C — state machine + heuristic + composition
Cycle 14: SessionModel Tier 1.D — diagnostic battery + corpus tests
─────────────────────────────────────────────────────
Cycle 15+: Tier 2 (persistence) + Tier 3 (pathway integration)
Cycle 21+: Phase 2 input framework cycle
```

## Test plan

Code PR; F# / .NET 9 / WPF target. Per CLAUDE.md no-local-
build constraint, validation falls to CI on
windows-latest.

- [x] Pre-emptive pattern-match completeness verified
      via grep across 3 sites (OutputEventBuilder,
      PathwaySelector, Program.fs); all match sites
      handle `PromptBoundary` or wildcard.
- [x] CanonicalState consumers unchanged (Tier 1.A
      doesn't touch CanonicalState; Q1 deferred to
      Tier 1.B).
- [x] All 18 new SessionModelTests should pass; 531
      pre-existing tests should remain unaffected.
- [x] CHANGELOG.md `[Unreleased]` entry at top.
- [x] SESSION-MODEL.md open questions marked resolved.
- [ ] CI build green.
- [ ] CI test pass (existing 531 + new 18 = 549 total).
- [ ] CI markdown link check passes.
- [ ] CI workflow lint passes.

## Manual NVDA validation

Tier 1.A introduces zero behaviour change. NVDA
validation matrix unchanged from current `main`
baseline. Tier 1.B (OSC 133 producer) + Tier 1.C
(consumer wiring) require NVDA validation per
`docs/ACCESSIBILITY-TESTING.md`.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_