### PR TITLE
feat(terminal-core): SessionModel Tier 1.C — state machine + composition (Cycle 13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,130 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 13): SessionModel Tier 1.C — state machine + composition wiring
+
+**Third post-audit implementation cycle.** Replaces the
+Tier 1.A no-op `SessionModel.apply` stub with the real
+state-machine; wires `currentSession` into
+`Program.fs`'s composition root + PathwayPump; recreates
+on Ctrl+Shift+1/2/3 hot-switch with `finalizeIncomplete`
+beforehand per Q5 resolution.
+
+**Per Cycle 13 plan-mode narrowed scope**: state machine
++ composition only. Heuristic-fallback module (Tier
+1.D), text accumulation (Tier 1.E), and diagnostic-
+battery extension (Tier 1.F) ship in subsequent cycles.
+
+**State machine behaviour**:
+- `apply` now advances the active tuple's state through
+  `AwaitingPromptStart → AwaitingCommandStart →
+  EditingCommand → OutputStreaming → finalised`
+  transitions per the SESSION-MODEL.md §4 specification.
+- Defensive transitions (orphan boundaries, repeated
+  boundaries, out-of-order boundaries) log at Warning
+  level + soft-fail to preserve substrate health; never
+  crash.
+- `MaxHistorySize` ring-buffer eviction enforces the cap
+  on `History` enqueue (FIFO; oldest-first eviction).
+- Sources map records the `(BoundaryKind, BoundarySource)`
+  pair for each boundary that touched the tuple.
+- `CommandId` + `ExtraParams` from boundary metadata
+  hoist onto the active tuple; `CommandId` conflicts log
+  Warning + preserve the existing value.
+
+**New Tier 1.C surface**:
+- `SessionModel.IsAltScreenActive: bool` field on `T`
+  (Q3 partial — when `true`, `apply` returns state
+  unchanged; full PathwayPump-side wiring deferred to
+  Tier 1.D alongside heuristic-fallback wiring).
+- `SessionModel.enterAltScreen` / `exitAltScreen`
+  helpers (Q3 partial).
+- `SessionModel.finalizeIncomplete: T -> DateTime -> T`
+  helper (Q5 — moves any in-flight active tuple to
+  History with `ExitCode = None` + supplied
+  `CommandFinishedAt`).
+
+**Composition wiring** (`Program.fs`):
+- `mutable currentSession : SessionModel.T` declared
+  alongside `currentShellId`. Initialised with a `cmd`
+  placeholder; re-created at the startup-shell alignment
+  block once `chosenShell` resolves; re-created again on
+  Ctrl+Shift+1/2/3 hot-switch.
+- New `handlePromptBoundary` PathwayPump helper
+  advances `currentSession` via `SessionModel.apply` +
+  dispatches to `activePathway.OnPromptBoundary`. Stream
+  / Tui pathways currently return `[||]` (no-op
+  overrides from Tier 1.A); Phase 2 pathways
+  (ReplPathway, ClaudeCodePathway, FormPathway) will
+  override with non-trivial logic.
+- The PromptBoundary arm in the PathwayPump notification
+  consumer (added in Tier 1.A as `()`) now calls
+  `handlePromptBoundary boundary`.
+- `switchToShell`'s `Ok newHost` branch calls
+  `SessionModel.finalizeIncomplete currentSession
+  DateTime.UtcNow` BEFORE recreating with the new
+  shell's key. Tier 1.C has no persistence so the
+  finalised tuple is structurally discarded with the
+  prior SessionModel; Tier 2 (persistence) will use this
+  seam to flush History before recreation.
+
+**User-visible behaviour change**: zero. Stream / Tui
+pathways still return `[||]` from `OnPromptBoundary`;
+no NVDA announcements depend on SessionModel state. The
+substrate is structurally complete + observable via the
+diagnostic battery (Tier 1.F territory) + future
+pathway overrides. Internal observability arrives with
+Tier 1.D (heuristic fallback produces boundaries for
+cmd / PowerShell / Claude).
+
+**Tests added**: ~30 new tests in
+`tests/Tests.Unit/SessionModelTests.fs` covering the
+state machine across categories:
+- Happy path (4 tests): PromptStart → CommandStart →
+  OutputStart → CommandFinished progression.
+- Sequence pinning (5 tests): full A→B→C→D yields one
+  tuple; two sequences yield two; CommandId hoists;
+  ExtraParams merge with later-wins; Sources map
+  records each boundary.
+- Defensive transitions (10 tests): orphan boundaries
+  ignored; PromptStart while Active interrupts +
+  restarts; OutputStart after PromptStart tolerates
+  skipped CommandStart; duplicate boundaries refresh
+  timestamps; CommandFinished from EditingCommand
+  finalises without OutputStartedAt; CommandId conflict
+  preserves earlier value.
+- Ring buffer (4 tests): bounded at MaxHistorySize;
+  FIFO eviction on overflow; order preserved;
+  MaxHistorySize=0 is no-op-without-crash.
+- Alt-screen guard (4 tests): apply returns unchanged
+  when IsAltScreenActive; enterAltScreen / exitAltScreen
+  toggle the flag; apply resumes after exitAltScreen.
+- finalizeIncomplete (4 tests): moves Active to History
+  with CommandFinishedAt; no-op when Active=None;
+  preserves accumulated metadata; sets ExitCode=None.
+
+**SESSION-MODEL.md updates**: Q3 marked as Tier 1.C
+partial (field + helpers shipped; PathwayPump wiring
+deferred to Tier 1.D). Q5 marked as Tier 1.C shipped
+(per-shell-session model + finalizeIncomplete helper).
+Q2 (heuristic fallback) marked as deferred from Tier
+1.C to Tier 1.D per the narrowed-scope split. Change-log
+table entry added for 2026-05-08.
+
+**Out of scope** (deferred to subsequent Tier 1
+sub-cycles):
+- Heuristic prompt-boundary fallback for shells without
+  OSC 133 support (Tier 1.D).
+- Text accumulation (`PromptText` / `CommandText` /
+  `OutputText` populated from screen content; Tier 1.E).
+- PathwayPump-side `enterAltScreen` / `exitAltScreen`
+  wiring (Tier 1.D — bundled with heuristic-fallback
+  composition).
+- Diagnostic battery extension (Tier 1.F).
+- Pathway `OnPromptBoundary` non-trivial overrides
+  (Phase 2 / Tier 3).
+- Persistence (Tier 2).
+
 ### Added (Cycle 12): SessionModel Tier 1.B — OSC 133 producer + cursor field
 
 **Second post-audit implementation cycle.** Lands the OSC

--- a/docs/SESSION-MODEL.md
+++ b/docs/SESSION-MODEL.md
@@ -1324,12 +1324,15 @@ with a migration path. Recommend: add as required
 field; update all consumers (limited surface —
 StreamPathway, TuiPathway, test code).
 
-### Q2: Heuristic fallback default — on or off? — ✅ Resolved 2026-05-07 (Tier 1.C)
+### Q2: Heuristic fallback default — on or off? — ✅ Resolved 2026-05-07 (Tier 1.D)
 
 **Resolution**: **ON by default for known shells (cmd,
 PowerShell, claude); OFF for unknown shells**.
-Implementation in Tier 1.C when the heuristic-fallback
-module ships.
+Implementation deferred from Tier 1.C to Tier 1.D
+(narrowed-scope split during Cycle 13 planning):
+Tier 1.C ships the SessionModel state machine + composition
+wiring; Tier 1.D ships the heuristic-fallback module that
+attaches to ScreenNotifications without OSC 133 markers.
 
 **Rationale** (per maintainer agreement, audit walk-
 through): without OSC 133, heuristic is the only signal
@@ -1346,11 +1349,18 @@ produces false-positive tuples. Recommend: ON by
 default for known shells (cmd, PowerShell, claude);
 OFF for unknown shells.
 
-### Q3: SessionModel reset on alt-screen entry? — ✅ Resolved 2026-05-07 (Tier 1.C)
+### Q3: SessionModel reset on alt-screen entry? — ✅ Resolved 2026-05-07 (Tier 1.C partial; full wiring Tier 1.D)
 
 **Resolution**: **PAUSE on alt-screen entry; resume on
-exit** without losing prior tuples. Implementation in
-Tier 1.C when the SessionModel state machine ships.
+exit** without losing prior tuples. Tier 1.C ships the
+`IsAltScreenActive` field on `SessionModel.T` plus
+`enterAltScreen` / `exitAltScreen` helpers + an
+`apply` guard that returns state unchanged when the
+flag is set. Composition-root wiring (toggle the flag
+from the PathwayPump's `ScreenNotification.ModeChanged`
+arm) ships in Tier 1.D alongside the heuristic-fallback
+module — both wirings touch the same dispatch seam, so
+bundling keeps the change single-concern.
 
 **Rationale** (per maintainer agreement, audit walk-
 through): vim / less / TUI sessions aren't
@@ -1387,7 +1397,7 @@ serialise; matches the original byte stream's
 structure. Pathways that want per-line iteration can
 split.
 
-### Q5: How does shell-switch interact with active tuple? — ✅ Resolved 2026-05-07
+### Q5: How does shell-switch interact with active tuple? — ✅ Resolved 2026-05-07 (Tier 1.C shipped)
 
 **Resolution**: **per-shell-session SessionModel by
 default**. Each Ctrl+Shift+1/2/3 hot-switch starts a
@@ -1398,6 +1408,16 @@ original question — persist as incomplete with
 `CommandFinishedAt = shell-switch-time`). **Opt-in
 unified history as TOML setting** for power users who
 want cross-shell tuple aggregation.
+
+**Tier 1.C implementation**: `SessionModel.finalizeIncomplete:
+T -> DateTime -> T` helper moves any active tuple to
+History with `ExitCode = None`. Composition root in
+`switchToShell` calls `finalizeIncomplete` BEFORE
+recreating `currentSession` with the new shell's key.
+Tier 1.C has no persistence so the finalised tuple is
+structurally discarded with the prior SessionModel; Tier
+2 (persistence) will use the same finalize seam to flush
+History to disk before recreation.
 
 **Cross-reference**: INTERACTION-MODEL.md Q6 captures
 the same decision at the architectural-framing layer
@@ -1555,6 +1575,8 @@ This doc references / is referenced by:
 | Date | Change |
 |---|---|
 | 2026-05-06 | Initial design. OSC 133 protocol scope, heuristic fallback for cmd / PowerShell / Claude Code, data model (SessionModel + SessionTuple + ActiveSessionTuple + BoundaryKind), pipeline integration (Stage 3.5 insertion + new ScreenNotification variant + new DisplayPathway protocol method), pathway-by-pathway integration (StreamPathway, TuiPathway, ReplPathway, FormPathway, ClaudeCodePathway, AiInterpretedPathway, SessionConsumer), persistence story (memory-only / session-log / always modes; JSONL or msgpack format), query API, implementation precedence (7 tiers), 8 open questions. ~1500 lines. |
+| 2026-05-07 | Cluster 1-4 open questions resolved per audit walk-through (Q1/Q3/Q4/Q5/Q6/Q7/Q8 resolved; Q2 deferred to Tier 1.D). |
+| 2026-05-08 | Tier 1.C state machine + composition wiring shipped. `SessionModel.apply` no-op replaced with full state machine (13+ transitions covering happy path + defensive paths). `IsAltScreenActive` field + `enterAltScreen`/`exitAltScreen` helpers added (Q3 partial — full wiring deferred to Tier 1.D). `finalizeIncomplete` helper added (Q5 — finalises in-flight active tuple as incomplete on shell-switch). Composition root in `Program.fs` declares + recreates `currentSession`; replaces no-op PromptBoundary arm with `handlePromptBoundary` that advances state machine + dispatches active-pathway `OnPromptBoundary`. Q2 (heuristic fallback) deferred to Tier 1.D per narrowed-scope split. |
 
 
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -943,6 +943,19 @@ module Program =
         let mutable currentShellId : ShellRegistry.ShellId =
             ShellRegistry.Cmd
 
+        // SessionModel Tier 1.C — structured-history substrate.
+        // One instance per shell session; replaced on
+        // Ctrl+Shift+1/2/3 hot-switch (per Q5 resolution
+        // 2026-05-07: per-shell-session model). Initialised
+        // with a `cmd` placeholder; the startup-shell alignment
+        // block (~30 lines below) re-creates with the resolved
+        // shell key alongside `currentShellId`. Mutated on the
+        // PathwayPump worker thread (single-threaded for
+        // notification consumption); composition root reads
+        // it only via the pump.
+        let mutable currentSession : SessionModel.T =
+            SessionModel.createDefault (shellIdToConfigKey ShellRegistry.Cmd)
+
         // PathwayPump — Phase A replacement for TranslatorPump.
         // Reads raw ScreenNotifications and routes by case:
         //   - RowsChanged: snapshot the screen → build a
@@ -980,6 +993,23 @@ module Program =
             let emitted = activePathway.Consume canonical
             pumpLog.LogDebug(
                 "PathwayPump RowsChanged → {Pathway}.Consume → {Count} events.",
+                activePathway.Id,
+                emitted.Length)
+            dispatchPathwayEvents emitted
+
+        // SessionModel Tier 1.C — PromptBoundary handler. Advances
+        // the SessionModel state machine with the boundary, then
+        // dispatches to the active pathway's `OnPromptBoundary`.
+        // Stream / Tui pathways currently return `[||]` (no-op
+        // overrides from Tier 1.A); Phase 2 pathways
+        // (ReplPathway, ClaudeCodePathway, FormPathway) will
+        // override with non-trivial logic.
+        let handlePromptBoundary (boundary: PromptBoundaryData) : unit =
+            currentSession <- SessionModel.apply currentSession boundary
+            let emitted = activePathway.OnPromptBoundary boundary
+            pumpLog.LogDebug(
+                "PathwayPump PromptBoundary {Kind} → {Pathway}.OnPromptBoundary → {Count} events.",
+                boundary.Kind,
                 activePathway.Id,
                 emitted.Length)
             dispatchPathwayEvents emitted
@@ -1067,21 +1097,22 @@ module Program =
                                     | ModeChanged _ -> handleModeChanged peek
                                     | ParserError _
                                     | Bell -> handleSimpleNotification peek
-                                    | PromptBoundary _ ->
-                                        // SessionModel Tier 1.A:
-                                        // no producer + no
-                                        // consumer wired yet.
-                                        // Tier 1.B adds the OSC
-                                        // 133 producer in
-                                        // Screen.Apply; Tier 1.C
-                                        // wires SessionModel.apply
-                                        // here. For now the
-                                        // PathwayPump silently
-                                        // discards PromptBoundary
-                                        // events (none arrive
-                                        // today since no producer
-                                        // exists).
-                                        ()
+                                    | PromptBoundary boundary ->
+                                        // SessionModel Tier 1.C —
+                                        // advance the state
+                                        // machine + dispatch to
+                                        // active pathway's
+                                        // OnPromptBoundary. Tier
+                                        // 1.B's OSC 133 producer
+                                        // emits these from
+                                        // shells that opt in;
+                                        // Tier 1.D will add the
+                                        // heuristic-fallback
+                                        // module so cmd /
+                                        // PowerShell / Claude
+                                        // also produce boundaries
+                                        // without OSC 133 support.
+                                        handlePromptBoundary boundary
                     with
                     | :? OperationCanceledException -> ()
                     | ex ->
@@ -1241,6 +1272,15 @@ module Program =
         // resolves to the correct pathway for the running
         // shell.
         currentShellId <- chosenShell.Id
+
+        // SessionModel Tier 1.C — re-create with the resolved
+        // startup shell key. The placeholder declared above
+        // (with `cmd` key) is replaced here once `chosenShell`
+        // is known; no boundaries can have arrived yet (the
+        // ConPty isn't spawned until `wirePostSpawn`), so
+        // recreating discards no observable state.
+        currentSession <-
+            SessionModel.createDefault (shellIdToConfigKey chosenShell.Id)
 
         // Stage 7-followup PR-I — `chosenShell` is the value chosen
         // at startup and never changes. Hot-switching shells
@@ -1694,6 +1734,39 @@ module Program =
                                         // pathway, not the
                                         // pre-switch shell's.
                                         currentShellId <- shell.Id
+                                        // SessionModel Tier 1.C —
+                                        // per-shell-session
+                                        // recreation (per Q5
+                                        // resolution 2026-05-07).
+                                        // Finalise the prior
+                                        // shell's in-flight active
+                                        // tuple as incomplete
+                                        // (CommandFinishedAt =
+                                        // shell-switch-time;
+                                        // ExitCode = None) before
+                                        // recreating. Tier 1.C has
+                                        // no persistence so the
+                                        // finalised tuple is
+                                        // structurally
+                                        // discarded with the prior
+                                        // SessionModel; Tier 2's
+                                        // persistence will use
+                                        // this seam to flush
+                                        // History before
+                                        // recreation. The
+                                        // finalize-then-recreate
+                                        // ordering preserves the
+                                        // invariant that no tuple
+                                        // ever leaves the
+                                        // substrate without a
+                                        // CommandFinishedAt.
+                                        currentSession <-
+                                            SessionModel.finalizeIncomplete
+                                                currentSession
+                                                DateTime.UtcNow
+                                        currentSession <-
+                                            SessionModel.createDefault
+                                                (shellIdToConfigKey shell.Id)
                                         // Phase A — swap the active
                                         // pathway for the new shell.
                                         // `Reset` clears any pending

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -2,6 +2,7 @@ namespace Terminal.Core
 
 open System
 open System.Collections.Generic
+open Microsoft.Extensions.Logging
 
 /// Tier 1.A — SessionModel substrate skeleton.
 ///

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -147,8 +147,9 @@ module SessionModel =
     /// resolution 2026-05-07).
     ///
     /// **Tier 1.A scope**: skeleton record + `create`
-    /// factory + no-op `apply`. Tier 1.C wires the state
-    /// machine (transitions, History pruning, etc.).
+    /// factory + no-op `apply`. **Tier 1.C** ships the real
+    /// state machine (transitions, History ring-buffer
+    /// enforcement, alt-screen guard).
     type T =
         { /// Which shell this SessionModel tracks. String-
           /// keyed (see module docstring).
@@ -162,21 +163,30 @@ module SessionModel =
           SessionStartedAt: DateTime
           /// Bounded ring buffer of completed tuples. Oldest
           /// tuples evicted when the queue exceeds
-          /// `MaxHistorySize`. Tier 1.A constructs as empty
-          /// `Queue<>`; Tier 1.C populates via `apply`.
+          /// `MaxHistorySize`. Tier 1.C populates via
+          /// `apply`'s state machine.
           History: Queue<SessionTuple>
           /// Maximum tuples retained in History. Default
-          /// 100 per SESSION-MODEL.md §4. Construction-time
-          /// parameter; Tier 1.A doesn't enforce yet (no
-          /// state machine).
+          /// 100 per SESSION-MODEL.md §4. Tier 1.C enforces
+          /// the bound during `apply`'s tuple-finalisation
+          /// branch.
           MaxHistorySize: int
           /// In-flight tuple, if any. `None` between
           /// `CommandFinished` and the next `PromptStart`.
-          Active: ActiveSessionTuple option }
+          Active: ActiveSessionTuple option
+          /// **Tier 1.C — Q3 partial**: when `true`, `apply`
+          /// returns state unchanged (boundary events are
+          /// ignored during alt-screen / TUI sessions per Q3
+          /// resolution 2026-05-07). Tier 1.D wires
+          /// `enterAltScreen` / `exitAltScreen` to the
+          /// PathwayPump's `ScreenNotification.ModeChanged`
+          /// arm; Tier 1.C ships the field + helpers but does
+          /// not yet toggle them from composition root.
+          IsAltScreenActive: bool }
 
     /// Default history size. Per SESSION-MODEL.md §4
-    /// recommendation. Tier 1.A captures the constant; Tier
-    /// 1.C enforces the bound during `apply`.
+    /// recommendation. Tier 1.C enforces the bound during
+    /// `apply`.
     [<Literal>]
     let DefaultMaxHistorySize: int = 100
 
@@ -185,31 +195,258 @@ module SessionModel =
     /// `"cmd"`, `"powershell"`, `"claude"`); the composition
     /// root translates `ShellId → string` at construction
     /// time per the assembly-boundary convention.
-    ///
-    /// **Tier 1.A note**: `apply` is a no-op stub; calling
-    /// `create` then dispatching `BoundaryKind` events via
-    /// `apply` returns state unchanged. Tier 1.C ships the
-    /// real state machine.
     let create (shellId: string) (maxHistorySize: int) : T =
         { ShellId = shellId
           SessionId = Guid.NewGuid()
           SessionStartedAt = DateTime.UtcNow
           History = Queue<SessionTuple>()
           MaxHistorySize = maxHistorySize
-          Active = None }
+          Active = None
+          IsAltScreenActive = false }
 
     /// Convenience overload: construct with the default
     /// max-history-size (100).
     let createDefault (shellId: string) : T =
         create shellId DefaultMaxHistorySize
 
-    /// **Tier 1.A: no-op stub.** Receives a
-    /// `PromptBoundaryData` event and returns the state
-    /// unchanged. Tier 1.C overrides this with the real
-    /// state machine (transitions, `Active` mutation,
-    /// `History` enqueue + bound enforcement).
+    /// **Tier 1.C — Q3 partial**: mark the session as in
+    /// alt-screen mode. While active, `apply` returns the
+    /// state unchanged (boundaries ignored during vim /
+    /// less / TUI sessions per Q3 resolution 2026-05-07).
+    /// Tier 1.D wires this to the PathwayPump's
+    /// `ScreenNotification.ModeChanged` arm.
+    let enterAltScreen (state: T) : T =
+        { state with IsAltScreenActive = true }
+
+    /// **Tier 1.C — Q3 partial**: clear the alt-screen
+    /// flag; subsequent boundaries advance the state
+    /// machine again.
+    let exitAltScreen (state: T) : T =
+        { state with IsAltScreenActive = false }
+
+    /// FNV-1a-style log helper bound at module level so
+    /// state-machine warnings reach FileLogger via the
+    /// existing `Logger.get` indirection. Logger captures
+    /// the call-site context for diagnostics.
+    let private logger = Logger.get "Terminal.Core.SessionModel"
+
+    /// Build a brand-new SessionTuple with `PromptStartedAt`
+    /// set + the supplied boundary's CommandId / ExtraParams /
+    /// Sources captured. Other timestamps are `None` until
+    /// later boundaries advance the active tuple.
+    let private newTuple
+            (shellId: string)
+            (boundary: PromptBoundaryData)
+            : SessionTuple
+            =
+        { Id = Guid.NewGuid()
+          CommandId = boundary.CommandId
+          ShellId = shellId
+          PromptStartedAt = boundary.DetectedAt
+          CommandStartedAt = None
+          OutputStartedAt = None
+          CommandFinishedAt = None
+          PromptText = ""
+          CommandText = ""
+          OutputText = ""
+          ExitCode = None
+          Sources = Map.ofList [ boundary.Kind, boundary.Source ]
+          ExtraParams = boundary.ExtraParams }
+
+    /// Merge a boundary's metadata into an existing active
+    /// tuple. CommandId hoists if previously `None`;
+    /// duplicate sets log a warning. ExtraParams merge with
+    /// later-boundary keys overwriting earlier values
+    /// (boundaries are ordered; later wins). Sources
+    /// accumulate the (Kind, Source) pair.
+    let private mergeBoundary
+            (active: ActiveSessionTuple)
+            (boundary: PromptBoundaryData)
+            : ActiveSessionTuple
+            =
+        let tuple = active.Tuple
+        let commandId =
+            match tuple.CommandId, boundary.CommandId with
+            | None, Some _ -> boundary.CommandId
+            | Some existing, Some incoming when existing <> incoming ->
+                logger.LogWarning(
+                    "SessionModel boundary CommandId conflict: existing={Existing} incoming={Incoming}; preserving existing.",
+                    existing, incoming)
+                Some existing
+            | _ -> tuple.CommandId
+        let extraParams =
+            // Later boundary overwrites; F# Map.add does this.
+            Map.fold (fun acc k v -> Map.add k v acc)
+                tuple.ExtraParams boundary.ExtraParams
+        let sources = Map.add boundary.Kind boundary.Source tuple.Sources
+        { active with
+            Tuple =
+                { tuple with
+                    CommandId = commandId
+                    ExtraParams = extraParams
+                    Sources = sources } }
+
+    /// Move an active tuple to the History ring buffer with
+    /// the supplied finalisation timestamp. Enforces
+    /// `MaxHistorySize` by dequeueing the oldest tuple
+    /// before enqueueing the new one. When `MaxHistorySize`
+    /// is `0`, the tuple is dropped silently (no history
+    /// retained).
+    let private finalizeAndEnqueue
+            (state: T)
+            (tuple: SessionTuple)
+            (finishedAt: DateTime)
+            (exitCode: int option)
+            : T
+            =
+        let finalised =
+            { tuple with
+                CommandFinishedAt = Some finishedAt
+                ExitCode = exitCode }
+        if state.MaxHistorySize <= 0 then
+            { state with Active = None }
+        else
+            // Ring-buffer eviction: drop oldest until under
+            // the cap, then enqueue.
+            while state.History.Count >= state.MaxHistorySize do
+                state.History.Dequeue() |> ignore
+            state.History.Enqueue(finalised)
+            { state with Active = None }
+
+    /// **Tier 1.C — Q5 helper**: finalise any in-flight
+    /// active tuple as incomplete (`CommandFinishedAt =
+    /// finishedAt`, `ExitCode = None`) and move it to the
+    /// History. Used by the composition root on shell
+    /// hot-switch (per Q5 resolution: per-shell-session
+    /// SessionModel; shell-switch finalises prior shell's
+    /// active tuple as interrupted before recreating a
+    /// fresh SessionModel).
+    let finalizeIncomplete (state: T) (finishedAt: DateTime) : T =
+        match state.Active with
+        | None -> state
+        | Some active ->
+            finalizeAndEnqueue state active.Tuple finishedAt None
+
+    /// **Tier 1.C — real state machine.** Applies a
+    /// `PromptBoundaryData` event to the SessionModel,
+    /// producing the next state. Pure function (records
+    /// are immutable; `History` mutates inside the function
+    /// but the queue itself is captured by reference and
+    /// the returned `T` shares that queue — callers are
+    /// expected to treat the returned `T` as the canonical
+    /// state and discard prior references).
     ///
-    /// The signature is locked here so future cycles can
-    /// extend the implementation without protocol churn.
-    let apply (state: T) (_boundary: PromptBoundaryData) : T =
-        state
+    /// Transitions per SESSION-MODEL.md §4 + the Tier 1.C
+    /// plan's transition table. Defensive transitions log
+    /// at Warning level + soft-fail (preserve substrate
+    /// health; never crash).
+    ///
+    /// **Q3 alt-screen guard**: when `IsAltScreenActive`,
+    /// returns state unchanged. The composition root is
+    /// expected to toggle `enterAltScreen` / `exitAltScreen`
+    /// (Tier 1.D wiring).
+    let apply (state: T) (boundary: PromptBoundaryData) : T =
+        if state.IsAltScreenActive then
+            // Q3 — boundaries ignored during alt-screen.
+            state
+        else
+            let kind = boundary.Kind
+            let detectedAt = boundary.DetectedAt
+            match state.Active, kind with
+            // === AwaitingPromptStart ===
+            | None, BoundaryKind.PromptStart ->
+                let tuple = newTuple state.ShellId boundary
+                let active =
+                    { Tuple = tuple
+                      State = ActiveTupleState.AwaitingCommandStart }
+                { state with Active = Some active }
+            | None, BoundaryKind.CommandStart ->
+                logger.LogWarning(
+                    "SessionModel CommandStart with no Active tuple; ignored.")
+                state
+            | None, BoundaryKind.OutputStart ->
+                logger.LogWarning(
+                    "SessionModel OutputStart with no Active tuple; ignored.")
+                state
+            | None, BoundaryKind.CommandFinished _ ->
+                logger.LogWarning(
+                    "SessionModel CommandFinished with no Active tuple; ignored.")
+                state
+            // === Active = Some — replaces / advances by kind ===
+            | Some active, BoundaryKind.PromptStart ->
+                // Interrupted: finalise prior as incomplete,
+                // start a new tuple.
+                logger.LogInformation(
+                    "SessionModel PromptStart while Active={State}; finalising prior as incomplete.",
+                    active.State)
+                let withPrior =
+                    finalizeAndEnqueue state active.Tuple detectedAt None
+                let tuple = newTuple state.ShellId boundary
+                let nextActive =
+                    { Tuple = tuple
+                      State = ActiveTupleState.AwaitingCommandStart }
+                { withPrior with Active = Some nextActive }
+            | Some active, BoundaryKind.CommandStart ->
+                let merged = mergeBoundary active boundary
+                match active.State with
+                | ActiveTupleState.AwaitingCommandStart ->
+                    let nextTuple =
+                        { merged.Tuple with
+                            CommandStartedAt = Some detectedAt }
+                    let nextActive =
+                        { merged with
+                            Tuple = nextTuple
+                            State = ActiveTupleState.EditingCommand }
+                    { state with Active = Some nextActive }
+                | ActiveTupleState.EditingCommand ->
+                    // Re-submit / re-emit; refresh timestamp.
+                    logger.LogWarning(
+                        "SessionModel duplicate CommandStart in EditingCommand; refreshing CommandStartedAt.")
+                    let nextTuple =
+                        { merged.Tuple with
+                            CommandStartedAt = Some detectedAt }
+                    { state with Active = Some { merged with Tuple = nextTuple } }
+                | ActiveTupleState.OutputStreaming
+                | ActiveTupleState.AwaitingPromptStart ->
+                    logger.LogWarning(
+                        "SessionModel CommandStart in unexpected state {State}; ignored.",
+                        active.State)
+                    { state with Active = Some merged }
+            | Some active, BoundaryKind.OutputStart ->
+                let merged = mergeBoundary active boundary
+                match active.State with
+                | ActiveTupleState.AwaitingCommandStart ->
+                    // Skipped CommandStart; tolerate.
+                    logger.LogWarning(
+                        "SessionModel OutputStart with no prior CommandStart; tolerating skip.")
+                    let nextTuple =
+                        { merged.Tuple with
+                            OutputStartedAt = Some detectedAt }
+                    let nextActive =
+                        { merged with
+                            Tuple = nextTuple
+                            State = ActiveTupleState.OutputStreaming }
+                    { state with Active = Some nextActive }
+                | ActiveTupleState.EditingCommand ->
+                    let nextTuple =
+                        { merged.Tuple with
+                            OutputStartedAt = Some detectedAt }
+                    let nextActive =
+                        { merged with
+                            Tuple = nextTuple
+                            State = ActiveTupleState.OutputStreaming }
+                    { state with Active = Some nextActive }
+                | ActiveTupleState.OutputStreaming ->
+                    logger.LogWarning(
+                        "SessionModel duplicate OutputStart in OutputStreaming; refreshing OutputStartedAt.")
+                    let nextTuple =
+                        { merged.Tuple with
+                            OutputStartedAt = Some detectedAt }
+                    { state with Active = Some { merged with Tuple = nextTuple } }
+                | ActiveTupleState.AwaitingPromptStart ->
+                    // Should not be observable; guarded above
+                    // by `None, OutputStart` arm.
+                    state
+            | Some active, BoundaryKind.CommandFinished exitCode ->
+                let merged = mergeBoundary active boundary
+                finalizeAndEnqueue state merged.Tuple detectedAt exitCode

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <Compile Include="Types.fs" />
-    <Compile Include="SessionModel.fs" />
     <Compile Include="Osc133.fs" />
     <Compile Include="Screen.fs" />
     <Compile Include="AnnounceSanitiser.fs" />
     <Compile Include="UpdateMessages.fs" />
     <Compile Include="FileLogger.fs" />
+    <Compile Include="SessionModel.fs" />
     <Compile Include="Coalescer.fs" />
     <Compile Include="OutputEventTypes.fs" />
     <Compile Include="OutputEventBuilder.fs" />

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -5,29 +5,69 @@ open Xunit
 open Terminal.Core
 
 // ---------------------------------------------------------------------
-// SessionModel Tier 1.A — substrate skeleton behavioural pinning
+// SessionModel Tier 1.C — state machine + composition wiring
 // ---------------------------------------------------------------------
 //
-// Tier 1.A scope: types only. Tests pin:
-//   * The substrate types (`BoundaryKind`, `BoundarySource`,
-//     `PromptBoundaryData`) construct cleanly + round-trip
-//     through pattern matches.
-//   * `ScreenNotification.PromptBoundary` is a fully-typed
-//     case carrying `PromptBoundaryData`.
-//   * `SessionModel.create` returns the documented initial
-//     state (empty History, no Active tuple, fresh
-//     SessionId).
-//   * `SessionModel.createDefault` uses
-//     `DefaultMaxHistorySize`.
-//   * `SessionModel.apply` is a no-op stub (Tier 1.A
-//     contract): returns state unchanged for any boundary.
+// Tier 1.C ships the real `apply` state machine (replacing the
+// Tier 1.A no-op stub) plus per-Q3-partial alt-screen helpers and
+// the per-Q5 `finalizeIncomplete` helper that the composition root
+// calls on Ctrl+Shift+1/2/3 hot-switch.
 //
-// State-machine tests (Active state transitions, History
-// enqueue/eviction) ship in Tier 1.C when the real `apply`
-// state machine lands.
+// Tests pin:
+//   * Substrate types (`BoundaryKind`, `BoundarySource`,
+//     `PromptBoundaryData`) construct cleanly + round-trip
+//     through pattern matches (preserved from Tier 1.A).
+//   * `ScreenNotification.PromptBoundary` is a fully-typed
+//     case carrying `PromptBoundaryData` (preserved).
+//   * `SessionModel.create` returns the documented initial
+//     state; `createDefault` uses `DefaultMaxHistorySize`
+//     (preserved).
+//   * The state machine's happy path (PromptStart →
+//     CommandStart → OutputStart → CommandFinished).
+//   * Sequence pinning (multi-tuple flows; CommandId +
+//     ExtraParams + Sources accumulate per boundary).
+//   * Defensive transitions (orphan boundaries; repeated
+//     boundaries; out-of-order boundaries).
+//   * Ring-buffer eviction at `MaxHistorySize`.
+//   * Alt-screen guard (`IsAltScreenActive` short-circuits).
+//   * `finalizeIncomplete` (per Q5; shell-switch path).
+//
+// Heuristic-fallback wiring + composition-root behaviour ship
+// in Tier 1.D + later cycles.
 
 // ---------------------------------------------------------------------
-// BoundaryKind cases
+// Test fixture builders
+// ---------------------------------------------------------------------
+
+let private boundary
+        (kind: BoundaryKind)
+        (detectedAt: DateTime)
+        : PromptBoundaryData
+        =
+    { Kind = kind
+      Source = BoundarySource.Osc133
+      DetectedAt = detectedAt
+      CommandId = None
+      ExtraParams = Map.empty }
+
+let private boundaryWith
+        (kind: BoundaryKind)
+        (detectedAt: DateTime)
+        (commandId: string option)
+        (extras: (string * string) list)
+        : PromptBoundaryData
+        =
+    { Kind = kind
+      Source = BoundarySource.Osc133
+      DetectedAt = detectedAt
+      CommandId = commandId
+      ExtraParams = Map.ofList extras }
+
+let private t0 = DateTime(2026, 5, 8, 12, 0, 0, DateTimeKind.Utc)
+let private after (ms: int) = t0.AddMilliseconds(float ms)
+
+// ---------------------------------------------------------------------
+// BoundaryKind cases (preserved from Tier 1.A)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -60,7 +100,7 @@ let ``BoundaryKind.CommandFinished carries optional exit code`` () =
     | _ -> Assert.Fail("Expected exit-code variants")
 
 // ---------------------------------------------------------------------
-// BoundarySource cases
+// BoundarySource cases (preserved from Tier 1.A)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -86,7 +126,7 @@ let ``BoundarySource.HeuristicClaudeInkBox constructs cleanly`` () =
     | _ -> Assert.Fail("Expected HeuristicClaudeInkBox")
 
 // ---------------------------------------------------------------------
-// PromptBoundaryData record
+// PromptBoundaryData record (preserved from Tier 1.A)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -116,7 +156,7 @@ let ``PromptBoundaryData supports None CommandId and empty ExtraParams`` () =
     Assert.True(Map.isEmpty data.ExtraParams)
 
 // ---------------------------------------------------------------------
-// ScreenNotification.PromptBoundary
+// ScreenNotification.PromptBoundary (preserved from Tier 1.A)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -148,7 +188,7 @@ let ``ActiveTupleState cases enumerate as expected`` () =
     Assert.Equal(4, states.Length)
 
 // ---------------------------------------------------------------------
-// SessionModel.create + createDefault
+// SessionModel.create + createDefault (preserved from Tier 1.A)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -158,6 +198,11 @@ let ``SessionModel.create initialises empty History + None Active`` () =
     Assert.Equal(50, model.MaxHistorySize)
     Assert.Equal(0, model.History.Count)
     Assert.Equal(None, model.Active)
+
+[<Fact>]
+let ``SessionModel.create initialises IsAltScreenActive=false`` () =
+    let model = SessionModel.create "cmd" 50
+    Assert.False(model.IsAltScreenActive)
 
 [<Fact>]
 let ``SessionModel.create issues a fresh SessionId per instance`` () =
@@ -181,52 +226,7 @@ let ``SessionModel.createDefault uses DefaultMaxHistorySize (100)`` () =
     Assert.Equal("powershell", model.ShellId)
 
 // ---------------------------------------------------------------------
-// SessionModel.apply (Tier 1.A no-op contract)
-// ---------------------------------------------------------------------
-
-[<Fact>]
-let ``SessionModel.apply returns state unchanged in Tier 1.A`` () =
-    let original = SessionModel.create "cmd" 50
-    let boundary : PromptBoundaryData =
-        { Kind = BoundaryKind.PromptStart
-          Source = BoundarySource.Osc133
-          DetectedAt = DateTime.UtcNow
-          CommandId = None
-          ExtraParams = Map.empty }
-    let updated = SessionModel.apply original boundary
-    // Reference equality holds: Tier 1.A's apply is the identity.
-    Assert.True(obj.ReferenceEquals(original, updated))
-    // And every field matches.
-    Assert.Equal(original.ShellId, updated.ShellId)
-    Assert.Equal(original.SessionId, updated.SessionId)
-    Assert.Equal(original.MaxHistorySize, updated.MaxHistorySize)
-    Assert.Equal(0, updated.History.Count)
-    Assert.Equal(None, updated.Active)
-
-[<Fact>]
-let ``SessionModel.apply is a no-op for every BoundaryKind`` () =
-    let model = SessionModel.create "claude" 100
-    let boundaries =
-        [ BoundaryKind.PromptStart
-          BoundaryKind.CommandStart
-          BoundaryKind.OutputStart
-          BoundaryKind.CommandFinished None
-          BoundaryKind.CommandFinished (Some 0)
-          BoundaryKind.CommandFinished (Some 1) ]
-    let now = DateTime.UtcNow
-    for kind in boundaries do
-        let boundary : PromptBoundaryData =
-            { Kind = kind
-              Source = BoundarySource.Osc133
-              DetectedAt = now
-              CommandId = None
-              ExtraParams = Map.empty }
-        let updated = SessionModel.apply model boundary
-        Assert.Equal(0, updated.History.Count)
-        Assert.Equal(None, updated.Active)
-
-// ---------------------------------------------------------------------
-// SessionTuple shape (Q4 multi-line; Q8 ExitCode int option)
+// SessionTuple shape (preserved from Tier 1.A — Q4 + Q8)
 // ---------------------------------------------------------------------
 
 [<Fact>]
@@ -240,7 +240,6 @@ let ``SessionTuple.CommandText supports multi-line via embedded newlines (Q4)`` 
           OutputStartedAt = None
           CommandFinishedAt = None
           PromptText = ">"
-          // Multi-line command stored as one string with \n.
           CommandText = "echo a\necho b\necho c"
           OutputText = ""
           ExitCode = None
@@ -273,3 +272,495 @@ let ``SessionTuple.ExitCode is int option (Q8 — substrate captures verbatim)``
     Assert.Equal(Some 0, success.ExitCode)
     Assert.Equal(None, unreported.ExitCode)
     Assert.Equal(Some 127, failure.ExitCode)
+
+// =====================================================================
+// Tier 1.C — state machine: happy path
+// =====================================================================
+
+[<Fact>]
+let ``apply PromptStart from AwaitingPromptStart populates Active + advances state`` () =
+    let initial = SessionModel.create "cmd" 50
+    let updated = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    match updated.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.AwaitingCommandStart,
+            active.State)
+        Assert.Equal(t0, active.Tuple.PromptStartedAt)
+        Assert.Equal("cmd", active.Tuple.ShellId)
+        Assert.Equal(0, updated.History.Count)
+    | None -> Assert.Fail("Expected Active = Some after PromptStart")
+
+[<Fact>]
+let ``apply CommandStart after PromptStart advances to EditingCommand`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    match s2.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.EditingCommand,
+            active.State)
+        Assert.Equal(Some (after 100), active.Tuple.CommandStartedAt)
+    | None -> Assert.Fail("Expected Active after CommandStart")
+
+[<Fact>]
+let ``apply OutputStart after CommandStart advances to OutputStreaming`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let s3 = SessionModel.apply s2 (boundary BoundaryKind.OutputStart (after 200))
+    match s3.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.OutputStreaming,
+            active.State)
+        Assert.Equal(Some (after 200), active.Tuple.OutputStartedAt)
+    | None -> Assert.Fail("Expected Active after OutputStart")
+
+[<Fact>]
+let ``apply CommandFinished moves Active to History + resets to AwaitingPromptStart`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let s3 = SessionModel.apply s2 (boundary BoundaryKind.OutputStart (after 200))
+    let s4 =
+        SessionModel.apply
+            s3
+            (boundary (BoundaryKind.CommandFinished (Some 0)) (after 300))
+    Assert.Equal(None, s4.Active)
+    Assert.Equal(1, s4.History.Count)
+    let finalised = s4.History.ToArray().[0]
+    Assert.Equal(Some (after 300), finalised.CommandFinishedAt)
+    Assert.Equal(Some 0, finalised.ExitCode)
+
+// =====================================================================
+// Tier 1.C — state machine: sequence pinning
+// =====================================================================
+
+[<Fact>]
+let ``Full A->B->C->D sequence yields one complete tuple in History`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundary BoundaryKind.PromptStart t0
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    Assert.Equal(None, final.Active)
+    Assert.Equal(1, final.History.Count)
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(t0, tuple.PromptStartedAt)
+    Assert.Equal(Some (after 100), tuple.CommandStartedAt)
+    Assert.Equal(Some (after 200), tuple.OutputStartedAt)
+    Assert.Equal(Some (after 300), tuple.CommandFinishedAt)
+    Assert.Equal(Some 0, tuple.ExitCode)
+
+[<Fact>]
+let ``Two full sequences yield 2 tuples in order`` () =
+    let initial = SessionModel.create "cmd" 50
+    let firstSeq =
+        [ boundary BoundaryKind.PromptStart t0
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 300) ]
+    let secondSeq =
+        [ boundary BoundaryKind.PromptStart (after 400)
+          boundary BoundaryKind.CommandStart (after 500)
+          boundary BoundaryKind.OutputStart (after 600)
+          boundary (BoundaryKind.CommandFinished (Some 1)) (after 700) ]
+    let final =
+        firstSeq @ secondSeq
+        |> List.fold SessionModel.apply initial
+    Assert.Equal(2, final.History.Count)
+    let arr = final.History.ToArray()
+    Assert.Equal(t0, arr.[0].PromptStartedAt)
+    Assert.Equal(after 400, arr.[1].PromptStartedAt)
+    Assert.Equal(Some 0, arr.[0].ExitCode)
+    Assert.Equal(Some 1, arr.[1].ExitCode)
+
+[<Fact>]
+let ``History preserves DetectedAt timestamps in order`` () =
+    let initial = SessionModel.create "cmd" 50
+    let seqs =
+        [ for offsetMs in [ 0; 1000; 2000 ] do
+            yield boundary BoundaryKind.PromptStart (after offsetMs)
+            yield boundary BoundaryKind.CommandStart (after (offsetMs + 100))
+            yield boundary BoundaryKind.OutputStart (after (offsetMs + 200))
+            yield
+                boundary
+                    (BoundaryKind.CommandFinished (Some 0))
+                    (after (offsetMs + 300)) ]
+    let final = seqs |> List.fold SessionModel.apply initial
+    Assert.Equal(3, final.History.Count)
+    let arr = final.History.ToArray()
+    Assert.True(arr.[0].PromptStartedAt < arr.[1].PromptStartedAt)
+    Assert.True(arr.[1].PromptStartedAt < arr.[2].PromptStartedAt)
+
+[<Fact>]
+let ``CommandId from boundaries lands on the tuple`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundaryWith BoundaryKind.PromptStart t0 (Some "id-1") []
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(Some "id-1", tuple.CommandId)
+
+[<Fact>]
+let ``ExtraParams from boundaries merge onto the tuple (later wins)`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundaryWith BoundaryKind.PromptStart t0 None [ "k1", "v1" ]
+          boundaryWith BoundaryKind.CommandStart (after 100) None [ "k2", "v2" ]
+          boundaryWith
+              BoundaryKind.OutputStart
+              (after 200)
+              None
+              [ "k1", "overwrite" ]
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(Some "overwrite", Map.tryFind "k1" tuple.ExtraParams)
+    Assert.Equal(Some "v2", Map.tryFind "k2" tuple.ExtraParams)
+
+[<Fact>]
+let ``Sources map records (Kind, Source) for each boundary`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ { Kind = BoundaryKind.PromptStart
+            Source = BoundarySource.Osc133
+            DetectedAt = t0
+            CommandId = None
+            ExtraParams = Map.empty }
+          { Kind = BoundaryKind.CommandStart
+            Source = BoundarySource.HeuristicPromptRegex 100
+            DetectedAt = after 100
+            CommandId = None
+            ExtraParams = Map.empty }
+          { Kind = BoundaryKind.OutputStart
+            Source = BoundarySource.HeuristicClaudeInkBox
+            DetectedAt = after 200
+            CommandId = None
+            ExtraParams = Map.empty }
+          { Kind = BoundaryKind.CommandFinished (Some 0)
+            Source = BoundarySource.Osc133
+            DetectedAt = after 300
+            CommandId = None
+            ExtraParams = Map.empty } ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(
+        Some BoundarySource.Osc133,
+        Map.tryFind BoundaryKind.PromptStart tuple.Sources)
+    Assert.Equal(
+        Some (BoundarySource.HeuristicPromptRegex 100),
+        Map.tryFind BoundaryKind.CommandStart tuple.Sources)
+    Assert.Equal(
+        Some BoundarySource.HeuristicClaudeInkBox,
+        Map.tryFind BoundaryKind.OutputStart tuple.Sources)
+    Assert.Equal(
+        Some BoundarySource.Osc133,
+        Map.tryFind (BoundaryKind.CommandFinished (Some 0)) tuple.Sources)
+
+// =====================================================================
+// Tier 1.C — state machine: defensive transitions
+// =====================================================================
+
+[<Fact>]
+let ``PromptStart while Active finalises prior as incomplete + starts new`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    // Second PromptStart while EditingCommand — interrupt + restart.
+    let s3 =
+        SessionModel.apply s2 (boundary BoundaryKind.PromptStart (after 200))
+    Assert.Equal(1, s3.History.Count)
+    let prior = s3.History.ToArray().[0]
+    Assert.Equal(Some (after 200), prior.CommandFinishedAt)
+    Assert.Equal(None, prior.ExitCode)
+    match s3.Active with
+    | Some active ->
+        Assert.Equal(after 200, active.Tuple.PromptStartedAt)
+        Assert.Equal(
+            SessionModel.ActiveTupleState.AwaitingCommandStart,
+            active.State)
+    | None -> Assert.Fail("Expected new Active after interrupting PromptStart")
+
+[<Fact>]
+let ``CommandStart from AwaitingPromptStart (no Active) is logged + ignored`` () =
+    let initial = SessionModel.create "cmd" 50
+    let updated =
+        SessionModel.apply
+            initial
+            (boundary BoundaryKind.CommandStart t0)
+    Assert.Equal(None, updated.Active)
+    Assert.Equal(0, updated.History.Count)
+
+[<Fact>]
+let ``OutputStart from AwaitingPromptStart (no Active) is logged + ignored`` () =
+    let initial = SessionModel.create "cmd" 50
+    let updated =
+        SessionModel.apply initial (boundary BoundaryKind.OutputStart t0)
+    Assert.Equal(None, updated.Active)
+    Assert.Equal(0, updated.History.Count)
+
+[<Fact>]
+let ``CommandFinished from AwaitingPromptStart (no Active) is logged + ignored`` () =
+    let initial = SessionModel.create "cmd" 50
+    let updated =
+        SessionModel.apply
+            initial
+            (boundary (BoundaryKind.CommandFinished (Some 0)) t0)
+    Assert.Equal(None, updated.Active)
+    Assert.Equal(0, updated.History.Count)
+
+[<Fact>]
+let ``OutputStart in AwaitingCommandStart tolerates skipped CommandStart`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    // Skip CommandStart; jump straight to OutputStart.
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.OutputStart (after 100))
+    match s2.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.OutputStreaming,
+            active.State)
+        Assert.Equal(Some (after 100), active.Tuple.OutputStartedAt)
+        Assert.Equal(None, active.Tuple.CommandStartedAt)
+    | None -> Assert.Fail("Expected Active after tolerated OutputStart")
+
+[<Fact>]
+let ``Duplicate CommandStart in EditingCommand refreshes CommandStartedAt`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let s3 = SessionModel.apply s2 (boundary BoundaryKind.CommandStart (after 200))
+    match s3.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.EditingCommand,
+            active.State)
+        Assert.Equal(Some (after 200), active.Tuple.CommandStartedAt)
+    | None -> Assert.Fail("Expected Active to remain after duplicate CommandStart")
+
+[<Fact>]
+let ``Duplicate OutputStart in OutputStreaming refreshes OutputStartedAt`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let s3 = SessionModel.apply s2 (boundary BoundaryKind.OutputStart (after 200))
+    let s4 = SessionModel.apply s3 (boundary BoundaryKind.OutputStart (after 250))
+    match s4.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.OutputStreaming,
+            active.State)
+        Assert.Equal(Some (after 250), active.Tuple.OutputStartedAt)
+    | None -> Assert.Fail("Expected Active to remain after duplicate OutputStart")
+
+[<Fact>]
+let ``CommandStart while OutputStreaming is logged + ignored (Active preserved)`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let s3 = SessionModel.apply s2 (boundary BoundaryKind.OutputStart (after 200))
+    let s4 = SessionModel.apply s3 (boundary BoundaryKind.CommandStart (after 250))
+    match s4.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.OutputStreaming,
+            active.State)
+        // CommandStartedAt is NOT refreshed when CommandStart fires
+        // in OutputStreaming (the boundary is anomalous).
+        Assert.Equal(Some (after 100), active.Tuple.CommandStartedAt)
+    | None -> Assert.Fail("Expected Active to remain after anomalous CommandStart")
+
+[<Fact>]
+let ``CommandFinished with exit code populates ExitCode`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundary BoundaryKind.PromptStart t0
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished (Some 127)) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(Some 127, tuple.ExitCode)
+
+[<Fact>]
+let ``CommandFinished with no exit code yields None ExitCode`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundary BoundaryKind.PromptStart t0
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished None) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(None, tuple.ExitCode)
+
+[<Fact>]
+let ``CommandFinished from EditingCommand finalises without OutputStartedAt`` () =
+    // Instant-completing alias; CommandFinished arrives before
+    // OutputStart.
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundary BoundaryKind.PromptStart t0
+          boundary BoundaryKind.CommandStart (after 100)
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 200) ]
+        |> List.fold SessionModel.apply initial
+    Assert.Equal(1, final.History.Count)
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(None, tuple.OutputStartedAt)
+    Assert.Equal(Some (after 200), tuple.CommandFinishedAt)
+
+[<Fact>]
+let ``CommandId conflict on later boundary preserves earlier value`` () =
+    let initial = SessionModel.create "cmd" 50
+    let final =
+        [ boundaryWith BoundaryKind.PromptStart t0 (Some "first") []
+          boundaryWith BoundaryKind.CommandStart (after 100) (Some "second") []
+          boundary BoundaryKind.OutputStart (after 200)
+          boundary (BoundaryKind.CommandFinished (Some 0)) (after 300) ]
+        |> List.fold SessionModel.apply initial
+    let tuple = final.History.ToArray().[0]
+    Assert.Equal(Some "first", tuple.CommandId)
+
+// =====================================================================
+// Tier 1.C — state machine: ring-buffer eviction
+// =====================================================================
+
+let private fullSequence (initial: SessionModel.T) (offsetMs: int) =
+    [ boundary BoundaryKind.PromptStart (after offsetMs)
+      boundary BoundaryKind.CommandStart (after (offsetMs + 50))
+      boundary BoundaryKind.OutputStart (after (offsetMs + 100))
+      boundary
+          (BoundaryKind.CommandFinished (Some 0))
+          (after (offsetMs + 150)) ]
+    |> List.fold SessionModel.apply initial
+
+[<Fact>]
+let ``History bounded at MaxHistorySize`` () =
+    let initial = SessionModel.create "cmd" 3
+    let mutable state = initial
+    for i in 0 .. 4 do
+        state <- fullSequence state (i * 1000)
+    Assert.Equal(3, state.History.Count)
+
+[<Fact>]
+let ``MaxHistorySize=2 keeps newest two; oldest dropped (FIFO)`` () =
+    let initial = SessionModel.create "cmd" 2
+    let mutable state = initial
+    for i in 0 .. 2 do
+        state <- fullSequence state (i * 1000)
+    Assert.Equal(2, state.History.Count)
+    let arr = state.History.ToArray()
+    // First sequence (offset 0) should have been evicted; remaining
+    // should start at offset 1000.
+    Assert.Equal(after 1000, arr.[0].PromptStartedAt)
+    Assert.Equal(after 2000, arr.[1].PromptStartedAt)
+
+[<Fact>]
+let ``History order preserved after eviction`` () =
+    let initial = SessionModel.create "cmd" 2
+    let mutable state = initial
+    for i in 0 .. 4 do
+        state <- fullSequence state (i * 1000)
+    let arr = state.History.ToArray()
+    Assert.True(arr.[0].PromptStartedAt < arr.[1].PromptStartedAt)
+
+[<Fact>]
+let ``MaxHistorySize=0 keeps no history but doesn't crash`` () =
+    let initial = SessionModel.create "cmd" 0
+    let final = fullSequence initial 0
+    Assert.Equal(0, final.History.Count)
+    Assert.Equal(None, final.Active)
+
+// =====================================================================
+// Tier 1.C — Q3 alt-screen guard
+// =====================================================================
+
+[<Fact>]
+let ``apply with IsAltScreenActive=true returns state unchanged`` () =
+    let initial =
+        SessionModel.enterAltScreen (SessionModel.create "cmd" 50)
+    let updated =
+        SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    Assert.True(obj.ReferenceEquals(initial, updated))
+    Assert.Equal(None, updated.Active)
+    Assert.Equal(0, updated.History.Count)
+
+[<Fact>]
+let ``enterAltScreen toggles flag true`` () =
+    let initial = SessionModel.create "cmd" 50
+    let alt = SessionModel.enterAltScreen initial
+    Assert.True(alt.IsAltScreenActive)
+
+[<Fact>]
+let ``exitAltScreen toggles flag false`` () =
+    let initial = SessionModel.enterAltScreen (SessionModel.create "cmd" 50)
+    let normal = SessionModel.exitAltScreen initial
+    Assert.False(normal.IsAltScreenActive)
+
+[<Fact>]
+let ``apply resumes after exitAltScreen`` () =
+    let initial = SessionModel.enterAltScreen (SessionModel.create "cmd" 50)
+    // Boundary while alt-screen — ignored.
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    Assert.Equal(None, s1.Active)
+    // Exit alt-screen + send PromptStart again.
+    let s2 = SessionModel.exitAltScreen s1
+    let s3 =
+        SessionModel.apply s2 (boundary BoundaryKind.PromptStart (after 100))
+    Assert.True(s3.Active.IsSome)
+
+// =====================================================================
+// Tier 1.C — Q5 finalizeIncomplete (shell-switch helper)
+// =====================================================================
+
+[<Fact>]
+let ``finalizeIncomplete with Active=Some moves to History with CommandFinishedAt set`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let finalised = SessionModel.finalizeIncomplete s2 (after 200)
+    Assert.Equal(None, finalised.Active)
+    Assert.Equal(1, finalised.History.Count)
+    let tuple = finalised.History.ToArray().[0]
+    Assert.Equal(Some (after 200), tuple.CommandFinishedAt)
+
+[<Fact>]
+let ``finalizeIncomplete with Active=None is no-op`` () =
+    let initial = SessionModel.create "cmd" 50
+    let finalised = SessionModel.finalizeIncomplete initial (after 100)
+    Assert.Equal(None, finalised.Active)
+    Assert.Equal(0, finalised.History.Count)
+
+[<Fact>]
+let ``finalizeIncomplete preserves accumulated metadata`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 =
+        SessionModel.apply
+            initial
+            (boundaryWith
+                BoundaryKind.PromptStart
+                t0
+                (Some "interrupt-test")
+                [ "user", "alice" ])
+    let s2 = SessionModel.apply s1 (boundary BoundaryKind.CommandStart (after 100))
+    let finalised = SessionModel.finalizeIncomplete s2 (after 200)
+    let tuple = finalised.History.ToArray().[0]
+    Assert.Equal(Some "interrupt-test", tuple.CommandId)
+    Assert.Equal(Some "alice", Map.tryFind "user" tuple.ExtraParams)
+    Assert.Equal(Some (after 100), tuple.CommandStartedAt)
+
+[<Fact>]
+let ``finalizeIncomplete sets ExitCode=None`` () =
+    let initial = SessionModel.create "cmd" 50
+    let s1 = SessionModel.apply initial (boundary BoundaryKind.PromptStart t0)
+    let finalised = SessionModel.finalizeIncomplete s1 (after 100)
+    let tuple = finalised.History.ToArray().[0]
+    Assert.Equal(None, tuple.ExitCode)


### PR DESCRIPTION
## Summary

Replaces the Tier 1.A no-op `SessionModel.apply` stub with the
real state machine; wires `currentSession` into `Program.fs`'s
composition root + PathwayPump; recreates on Ctrl+Shift+1/2/3
hot-switch with `finalizeIncomplete` beforehand per Q5.

**Per the Cycle 13 plan-mode narrowed-scope split**: state
machine + composition only. Heuristic-fallback module (Tier 1.D),
text accumulation (Tier 1.E), and diagnostic battery extension
(Tier 1.F) ship in subsequent cycles.

**Behaviour change**: zero user-visible. Stream / Tui pathways
still return `[||]` from `OnPromptBoundary`. The substrate is
structurally complete + observable via future pathway overrides
+ the diagnostic battery (Tier 1.F territory). Internal
observability arrives with Tier 1.D when heuristic fallback
produces boundaries for cmd / PowerShell / Claude.

## State machine

- 13+ transition arms covering happy path
  (`AwaitingPromptStart → AwaitingCommandStart → EditingCommand
  → OutputStreaming → finalised`) plus defensive paths.
- Defensive transitions log at Warning level + soft-fail to
  preserve substrate health; never crash.
- `MaxHistorySize` ring-buffer eviction enforces the cap on
  enqueue (FIFO; oldest-first eviction).
- `Sources` map records `(BoundaryKind, BoundarySource)` for each
  boundary that touched the tuple.
- `CommandId` + `ExtraParams` from boundary metadata hoist onto
  the active tuple; `CommandId` conflicts log Warning + preserve
  the existing value.

## New Tier 1.C surface

- `SessionModel.IsAltScreenActive: bool` field on `T` (Q3
  partial — when `true`, `apply` returns state unchanged; full
  PathwayPump-side wiring deferred to Tier 1.D alongside
  heuristic-fallback wiring).
- `SessionModel.enterAltScreen` / `exitAltScreen` helpers (Q3
  partial).
- `SessionModel.finalizeIncomplete: T -> DateTime -> T` helper
  (Q5 — moves any in-flight active tuple to History with
  `ExitCode = None` + supplied `CommandFinishedAt`).

## Composition wiring (`Program.fs`)

- `mutable currentSession : SessionModel.T` declared alongside
  `currentShellId`. Initialised with a `cmd` placeholder;
  re-created at the startup-shell alignment block once
  `chosenShell` resolves; re-created again on Ctrl+Shift+1/2/3
  hot-switch.
- New `handlePromptBoundary` PathwayPump helper advances
  `currentSession` via `SessionModel.apply` + dispatches to
  `activePathway.OnPromptBoundary`.
- PromptBoundary arm in the pump notification consumer (`()` in
  Tier 1.A) now calls `handlePromptBoundary boundary`.
- `switchToShell`'s `Ok newHost` branch calls
  `SessionModel.finalizeIncomplete currentSession DateTime.UtcNow`
  BEFORE recreating with the new shell's key. Tier 1.C has no
  persistence so the finalised tuple is structurally discarded
  with the prior SessionModel; Tier 2 (persistence) will use
  this seam to flush History before recreation.

## Tests added

~30 new tests in `tests/Tests.Unit/SessionModelTests.fs` covering:

- **Happy path** (4 tests): PromptStart → CommandStart →
  OutputStart → CommandFinished progression.
- **Sequence pinning** (5 tests): full A→B→C→D yields one tuple;
  two sequences yield two; CommandId hoists; ExtraParams merge
  with later-wins; Sources map records each boundary.
- **Defensive transitions** (10 tests): orphan boundaries
  ignored; PromptStart while Active interrupts + restarts;
  OutputStart after PromptStart tolerates skipped CommandStart;
  duplicate boundaries refresh timestamps; CommandFinished from
  EditingCommand finalises without OutputStartedAt; CommandId
  conflict preserves earlier value.
- **Ring buffer** (4 tests): bounded at MaxHistorySize; FIFO
  eviction on overflow; order preserved; MaxHistorySize=0 is
  no-op-without-crash.
- **Alt-screen guard** (4 tests): apply returns unchanged when
  IsAltScreenActive; enter/exit helpers toggle the flag; apply
  resumes after exitAltScreen.
- **finalizeIncomplete** (4 tests): moves Active to History with
  CommandFinishedAt; no-op when Active=None; preserves
  accumulated metadata; sets ExitCode=None.

## Doc updates

`docs/SESSION-MODEL.md`:
- Q3 marked as Tier 1.C partial (field + helpers shipped;
  PathwayPump wiring deferred to Tier 1.D).
- Q5 marked as Tier 1.C shipped (per-shell-session model +
  finalizeIncomplete helper).
- Q2 (heuristic fallback) marked as deferred from Tier 1.C to
  Tier 1.D per the narrowed-scope split.
- Change-log entry added for 2026-05-08.

## Out of scope (deferred to subsequent Tier 1 sub-cycles)

- Heuristic prompt-boundary fallback for shells without OSC 133
  support (Tier 1.D).
- Text accumulation (`PromptText` / `CommandText` / `OutputText`
  populated from screen content; Tier 1.E).
- PathwayPump-side `enterAltScreen` / `exitAltScreen` wiring
  (Tier 1.D — bundled with heuristic-fallback composition).
- Diagnostic battery extension (Tier 1.F).
- Pathway `OnPromptBoundary` non-trivial overrides (Phase 2 /
  Tier 3).
- Persistence (Tier 2).

## Test plan

- [ ] CI build green on windows-latest (`dotnet build` with
  TreatWarningsAsErrors).
- [ ] All existing tests pass + ~30 new SessionModel state-machine
  tests pass (~600+ total).
- [ ] Pre-commit grep confirms all `SessionModel.*` API calls
  consistent across src + tests.
- [ ] Manual NVDA validation: zero user-visible change expected
  (pathways still no-op `OnPromptBoundary`); regression check
  matrix unchanged from Cycle 12 baseline.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_