### PR TITLE
docs(contributing): bank Cycle 13 F# extension-method gotcha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,6 +385,52 @@ new code.
   in CI. Future cross-language tuple changes should
   start with the broader grep.
 
+- **F# does not auto-import C# extension methods —
+  `open` the namespace explicitly.** `ILogger.LogWarning`
+  / `LogInformation` / `LogDebug` / etc. are NOT members
+  of `Microsoft.Extensions.Logging.ILogger`; they're
+  extension methods declared on
+  `Microsoft.Extensions.Logging.LoggerExtensions`. F#
+  doesn't auto-discover extension methods the way C#
+  does (where any `using` of the declaring namespace
+  brings them into scope). The consuming F# module must
+  `open Microsoft.Extensions.Logging` even if it already
+  references `ILogger` via another path (e.g. through a
+  field type from a different module).
+
+  Symptom (CI build break under
+  `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`):
+
+  ```
+  error FS0039: The type 'ILogger' does not define
+  the field, constructor or member 'LogWarning'.
+  ```
+
+  Fix is one line — add the `open` to the consuming
+  module:
+
+  ```fsharp
+  open System
+  open System.Collections.Generic
+  open Microsoft.Extensions.Logging   // ← required for LogWarning / LogInformation / LogDebug
+  ```
+
+  Same pattern applies to any C# extension method
+  surface (LINQ extensions on `IEnumerable<T>`, EF Core
+  extensions on `DbSet<T>`, etc.) — the namespace
+  declaring the static class with the
+  `[<Extension>]`-annotated methods must be opened, not
+  just the namespace declaring the receiver type.
+
+  Cycle 13 (PR #187) burned a CI cycle on this:
+  SessionModel.fs called `logger.LogWarning(...)` /
+  `LogInformation(...)` from inside the new state
+  machine; CI failed 9× FS0039. Config.fs (the working
+  precedent) had `open Microsoft.Extensions.Logging` at
+  the top; SessionModel.fs didn't. When introducing a
+  new module that calls `ILogger` extension methods,
+  copy the `open` from a known-working consumer.
+
 ### WPF gotchas learned in practice
 
 - **`FrameworkElement` does NOT have a `Background` property.** Only


### PR DESCRIPTION
## Summary

Banks the F# extension-method gotcha that broke Cycle 13 PR
#187's first CI run (9× `FS0039: 'ILogger' does not define the
field, constructor or member 'LogWarning'`).

Cause: `LogWarning` / `LogInformation` / `LogDebug` are
extension methods on
`Microsoft.Extensions.Logging.LoggerExtensions`. F# doesn't
auto-discover extension methods the way C# does (where any
`using` of the declaring namespace brings them into scope) —
the consuming F# module must `open
Microsoft.Extensions.Logging` explicitly even if it already
references `ILogger` via another path.

## Changes

`CONTRIBUTING.md`: new bullet under
"### F# gotchas learned in practice", placed right after the
Cycle 12 F#/C# tuple-shape entry. Covers:

- The exact CI error text (so future sessions can grep for it).
- One-line fix with code sample.
- Generalised note that the same applies to any C# extension
  method surface (LINQ on `IEnumerable<T>`, EF Core on
  `DbSet<T>`, etc.) — opening the receiver type's namespace is
  not sufficient; the namespace declaring the static class
  with the `[<Extension>]`-annotated methods must be opened.
- Reference to Config.fs as the working precedent (it had
  `open Microsoft.Extensions.Logging` from the start;
  SessionModel.fs didn't).
- Cycle / PR citation per the established CONTRIBUTING.md
  pattern.

## Out of scope

Doc-only. No code changes. No spec changes.

## Test plan

- [ ] CI Markdown link check + workflow lint pass (no code
  changes; no `dotnet build` should be triggered).
- [ ] Section ordering preserved: F# 9 nullness → record-literal
  inference → NUL bytes → sequence-in-match-arm → tuple-shape
  → **extension methods (NEW)** → WPF gotchas section header.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_