### PR TITLE
feat(terminal-core): SessionModel Tier 1.D — heuristic prompt-boundary fallback + alt-screen wiring (Cycle 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,150 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 14): SessionModel Tier 1.D — heuristic prompt-boundary fallback + alt-screen wiring
+
+**Fourth post-audit implementation cycle.** Ships the
+heuristic prompt-boundary fallback module that produces
+synthetic `PromptBoundary` events for shells that don't
+emit OSC 133 (cmd / PowerShell / Claude — all three by
+default). Closes the Q3 alt-screen wiring deferred from
+Tier 1.C: composition root now calls
+`SessionModel.enterAltScreen` / `exitAltScreen` alongside
+the existing pathway-swap decision.
+
+**Per Cycle 14 plan-mode locked scope** (maintainer
+AskUserQuestion responses 2026-05-08):
+- **PromptStart-only emission**. Detector emits
+  `BoundaryKind.PromptStart` events only. The Cycle 13
+  state machine's "PromptStart while Active=Some"
+  transition auto-finalises the prior tuple as incomplete
+  (`ExitCode = None`,
+  `CommandFinishedAt = next-prompt-time`).
+- **Regex-only Claude detection**. Single regex
+  `^.*│\s>.*$` per row, same shape as cmd / PowerShell.
+- **Hardcoded defaults**. All per-shell parameters baked
+  into `HeuristicPromptDetector.fs`. No TOML schema
+  changes this cycle.
+
+**New module: `src/Terminal.Core/HeuristicPromptDetector.fs`**
+(~250 LOC). Pure-function detector with stateful record:
+- `T` record: `PerRowMatches: Map<int, string * DateTime>`
+  (per-row first-match timestamps) +
+  `LastEmittedPromptText: string option` (duplicate-emit
+  suppression).
+- `create () : T` — empty initial state.
+- `tryDetect snapshot cursor shellKey now state :
+  PromptBoundaryData option * T` — pure detection
+  function.
+- `reset state : T` — clear per-row state on shell-switch
+  + alt-screen entry.
+
+**Per-shell hardcoded defaults**:
+- cmd: regex `^[A-Z]:\\.*>\s*$`, stability 100ms.
+- PowerShell: regex `^PS\s.*>\s*$`, stability 100ms.
+- Claude: regex `^.*│\s>.*$`, stability 200ms (slower
+  TUI cadence).
+- Unknown shells: detection OFF (returns `None` without
+  state mutation).
+
+**Detection algorithm (per-frame)**:
+1. Per row, render text via `CanonicalState.renderRow`
+   (sanitised + trimmed).
+2. Test against per-shell regex.
+3. If matches AND `(now - first-match-time) ≥ stabilityMs`
+   AND text differs from `LastEmittedPromptText` → emit
+   PromptStart with
+   `Source = HeuristicPromptRegex stabilityMs`.
+4. If matches but window not elapsed OR text equals
+   last-emitted → no emit, update first-match timestamp.
+5. If row stops matching → evict its `PerRowMatches` entry
+   (keeps map bounded by `screen.Rows`).
+
+**Composition wiring** (`Program.fs`):
+- `mutable promptDetector : HeuristicPromptDetector.T`
+  declared alongside `currentSession`.
+- `handleRowsChanged` calls
+  `HeuristicPromptDetector.tryDetect` AFTER snapshot
+  capture and BEFORE pathway consumption — boundary, if
+  emitted, dispatches via `handlePromptBoundary` (the
+  Cycle 13 helper) which advances `currentSession` +
+  invokes `activePathway.OnPromptBoundary`.
+- `handleModeChanged` calls
+  `SessionModel.enterAltScreen` on
+  `PathwaySelector.SwapToTui` and
+  `SessionModel.exitAltScreen` on `SwapToShellDefault`,
+  alongside the existing `swapPathwayForAltScreen` call.
+  Detector reset on both transitions (stale matches
+  would produce phantom boundaries on alt-screen exit).
+- `switchToShell`'s `Ok newHost` branch resets the
+  detector after recreating `currentSession` (fresh
+  per-row state for the new shell).
+
+**User-visible behaviour change**: zero. Stream / Tui
+pathways still return `[||]` from `OnPromptBoundary`; no
+NVDA announcements depend on SessionModel state. The
+substrate becomes operationally meaningful (tuples
+populate naturally during cmd / PowerShell / Claude use)
+but remains internally observable only — Tier 2
+(persistence) and Phase 2 pathways consume the tuples in
+user-visible ways.
+
+**Tests added**: ~30 in
+`tests/Tests.Unit/HeuristicPromptDetectorTests.fs`
+covering:
+- Per-shell regex matching (8 tests): cmd / PowerShell /
+  Claude prompt shapes match; non-prompt text doesn't;
+  ASCII pipe `|` distinct from box-drawing `│`.
+- Stability window (4 tests): first match returns None;
+  same text after `stabilityMs - 1` returns None; same
+  text at exactly `stabilityMs` returns Some; same text
+  after window emits ONCE then suppresses.
+- Duplicate suppression (3 tests): N stable frames emit
+  once; cursor movement on stable prompt suppresses;
+  new prompt text re-emits.
+- Multi-row scenarios (4 tests): prompt at non-zero row
+  detected; multiple matching rows emit one per call;
+  all-blank snapshot returns None; zero-row snapshot
+  returns None.
+- Source provenance (3 tests): cmd → 100ms; PowerShell →
+  100ms; Claude → 200ms.
+- Reset behaviour (3 tests): clears `PerRowMatches`;
+  clears `LastEmittedPromptText`; post-reset prompt
+  needs fresh stability window.
+- Unknown shell handling (3 tests): unknown / empty /
+  case-mismatched keys return None.
+- State hygiene (1 test): row that stops matching
+  evicts its entry.
+
+Plus ~3 tests in `SessionModelTests.fs` pinning that
+heuristic-source boundaries flow through the state
+machine identically to OSC 133 boundaries (same
+finalisation behaviour; Sources map records the
+stability ms).
+
+**SESSION-MODEL.md updates**: Q2 + Q3 marked shipped
+2026-05-08 with Tier 1.D scope details. Change-log
+table entry added.
+
+**Out of scope** (deferred):
+- Heuristic synthesis of CommandStart / OutputStart /
+  CommandFinished events (Phase 2 input framework /
+  cursor-aware diff).
+- Claude Ink-box context check (multi-row `╭─╮│╰─╯`
+  scanning per SESSION-MODEL.md §275-280).
+- TOML config for per-shell parameters
+  (`[session_model.fallback.*]` sections + USER-SETTINGS
+  atlas entries; defer until a pathway makes the params
+  user-actionable).
+- Cursor-position check on prompt rows (Phase 2
+  cursor-aware diff prerequisite).
+- Text accumulation for `PromptText` / `CommandText` /
+  `OutputText` (Tier 1.E).
+- Diagnostic battery extension (Tier 1.F).
+- Pathway `OnPromptBoundary` non-trivial overrides
+  (Phase 2 / Tier 3).
+- Persistence (Tier 2).
+
 ### Added (Cycle 13): SessionModel Tier 1.C — state machine + composition wiring
 
 **Third post-audit implementation cycle.** Replaces the

--- a/docs/SESSION-MODEL.md
+++ b/docs/SESSION-MODEL.md
@@ -1324,15 +1324,37 @@ with a migration path. Recommend: add as required
 field; update all consumers (limited surface —
 StreamPathway, TuiPathway, test code).
 
-### Q2: Heuristic fallback default — on or off? — ✅ Resolved 2026-05-07 (Tier 1.D)
+### Q2: Heuristic fallback default — on or off? — ✅ Resolved 2026-05-08 (Tier 1.D shipped)
 
 **Resolution**: **ON by default for known shells (cmd,
-PowerShell, claude); OFF for unknown shells**.
-Implementation deferred from Tier 1.C to Tier 1.D
-(narrowed-scope split during Cycle 13 planning):
-Tier 1.C ships the SessionModel state machine + composition
-wiring; Tier 1.D ships the heuristic-fallback module that
-attaches to ScreenNotifications without OSC 133 markers.
+PowerShell, claude); OFF for unknown shells**. Shipped in
+Tier 1.D (narrowed-scope split during Cycle 13 planning):
+Tier 1.C shipped the SessionModel state machine + composition
+wiring; Tier 1.D shipped the heuristic-fallback module that
+attaches to RowsChanged notifications.
+
+**Tier 1.D scope (locked via maintainer AskUserQuestion
+2026-05-08)**:
+- **PromptStart-only emission**. Detector emits
+  `BoundaryKind.PromptStart` events only. The Cycle 13 state
+  machine's "PromptStart while Active=Some" transition
+  auto-finalises the prior tuple as incomplete; tuples carry
+  `PromptStartedAt` + `CommandFinishedAt-from-next-prompt`.
+  Defers heuristic synthesis of CommandStart / OutputStart /
+  CommandFinished (need Phase 2 input framework / cursor-aware
+  diff / OSC 133 D respectively).
+- **Regex-only Claude detection**. Single regex `^.*│\s>.*$`
+  per row, same shape as cmd / PowerShell. Source =
+  `BoundarySource.HeuristicPromptRegex 200` (200ms stability
+  for Claude's slower TUI cadence; 100ms for cmd / PowerShell).
+  Defers full Ink-box context check (multi-row `╭─╮│╰─╯`
+  scanning per §275-280) — regex catches the prompt indicator
+  without verifying the surrounding box-character context.
+- **Hardcoded defaults**. All per-shell parameters baked into
+  `HeuristicPromptDetector.fs`. No `Config.fs` schema changes;
+  no `[session_model.fallback.*]` TOML sections this cycle.
+  TOML wiring per §282-300 + USER-SETTINGS atlas entries
+  defer until a pathway makes the params user-actionable.
 
 **Rationale** (per maintainer agreement, audit walk-
 through): without OSC 133, heuristic is the only signal
@@ -1349,18 +1371,21 @@ produces false-positive tuples. Recommend: ON by
 default for known shells (cmd, PowerShell, claude);
 OFF for unknown shells.
 
-### Q3: SessionModel reset on alt-screen entry? — ✅ Resolved 2026-05-07 (Tier 1.C partial; full wiring Tier 1.D)
+### Q3: SessionModel reset on alt-screen entry? — ✅ Resolved 2026-05-08 (Tier 1.D fully shipped)
 
 **Resolution**: **PAUSE on alt-screen entry; resume on
-exit** without losing prior tuples. Tier 1.C ships the
+exit** without losing prior tuples. Tier 1.C shipped the
 `IsAltScreenActive` field on `SessionModel.T` plus
 `enterAltScreen` / `exitAltScreen` helpers + an
 `apply` guard that returns state unchanged when the
-flag is set. Composition-root wiring (toggle the flag
-from the PathwayPump's `ScreenNotification.ModeChanged`
-arm) ships in Tier 1.D alongside the heuristic-fallback
-module — both wirings touch the same dispatch seam, so
-bundling keeps the change single-concern.
+flag is set. Tier 1.D closed the wiring: composition root
+in `Program.fs:handleModeChanged` calls
+`SessionModel.enterAltScreen` on `PathwaySelector.SwapToTui`
+and `SessionModel.exitAltScreen` on `SwapToShellDefault`,
+alongside the existing pathway swap. The
+`HeuristicPromptDetector` is also reset on both transitions
+(stale per-row matches would otherwise produce phantom
+boundaries on alt-screen exit).
 
 **Rationale** (per maintainer agreement, audit walk-
 through): vim / less / TUI sessions aren't
@@ -1577,6 +1602,7 @@ This doc references / is referenced by:
 | 2026-05-06 | Initial design. OSC 133 protocol scope, heuristic fallback for cmd / PowerShell / Claude Code, data model (SessionModel + SessionTuple + ActiveSessionTuple + BoundaryKind), pipeline integration (Stage 3.5 insertion + new ScreenNotification variant + new DisplayPathway protocol method), pathway-by-pathway integration (StreamPathway, TuiPathway, ReplPathway, FormPathway, ClaudeCodePathway, AiInterpretedPathway, SessionConsumer), persistence story (memory-only / session-log / always modes; JSONL or msgpack format), query API, implementation precedence (7 tiers), 8 open questions. ~1500 lines. |
 | 2026-05-07 | Cluster 1-4 open questions resolved per audit walk-through (Q1/Q3/Q4/Q5/Q6/Q7/Q8 resolved; Q2 deferred to Tier 1.D). |
 | 2026-05-08 | Tier 1.C state machine + composition wiring shipped. `SessionModel.apply` no-op replaced with full state machine (13+ transitions covering happy path + defensive paths). `IsAltScreenActive` field + `enterAltScreen`/`exitAltScreen` helpers added (Q3 partial — full wiring deferred to Tier 1.D). `finalizeIncomplete` helper added (Q5 — finalises in-flight active tuple as incomplete on shell-switch). Composition root in `Program.fs` declares + recreates `currentSession`; replaces no-op PromptBoundary arm with `handlePromptBoundary` that advances state machine + dispatches active-pathway `OnPromptBoundary`. Q2 (heuristic fallback) deferred to Tier 1.D per narrowed-scope split. |
+| 2026-05-08 | Tier 1.D heuristic prompt-boundary fallback + alt-screen wiring shipped. New `src/Terminal.Core/HeuristicPromptDetector.fs` module: per-shell prompt regex (cmd / PowerShell / Claude) + stability window (100ms / 100ms / 200ms) + duplicate suppression. Q2 closed: ON for known shells, OFF for unknown. Q3 closed: composition root in `handleModeChanged` calls `SessionModel.enterAltScreen` / `exitAltScreen` alongside existing pathway swap; detector reset on both transitions. Maintainer-locked scope: PromptStart-only emission, regex-only Claude detection, hardcoded defaults (no TOML this cycle). ~880 LOC + ~33 tests. Behaviour change: SessionModel now populates with tuples for every shipped shell during normal use. Zero user-visible NVDA change. |
 
 
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -956,6 +956,18 @@ module Program =
         let mutable currentSession : SessionModel.T =
             SessionModel.createDefault (shellIdToConfigKey ShellRegistry.Cmd)
 
+        // SessionModel Tier 1.D — heuristic prompt-boundary
+        // detector. Per-shell regex + stability window
+        // produces synthetic PromptBoundary events for shells
+        // that don't emit OSC 133 (cmd / PowerShell / Claude
+        // — all three by default). Reset on shell-switch +
+        // alt-screen entry (stale per-row matches would
+        // produce phantom boundaries on alt-screen exit).
+        // Mutated on the PathwayPump worker thread alongside
+        // `currentSession`.
+        let mutable promptDetector : HeuristicPromptDetector.T =
+            HeuristicPromptDetector.create ()
+
         // PathwayPump — Phase A replacement for TranslatorPump.
         // Reads raw ScreenNotifications and routes by case:
         //   - RowsChanged: snapshot the screen → build a
@@ -987,15 +999,6 @@ module Program =
         // 'F# 9 gotchas' + bit PR #132); pulling each arm to a
         // named helper keeps the match body single-expression.
         let pumpLog = Logger.get "Terminal.App.Program.pathwayPump"
-        let handleRowsChanged () : unit =
-            let seq, cursorPos, snapshot = screen.SnapshotRows(0, screen.Rows)
-            let canonical = CanonicalState.create snapshot cursorPos seq
-            let emitted = activePathway.Consume canonical
-            pumpLog.LogDebug(
-                "PathwayPump RowsChanged → {Pathway}.Consume → {Count} events.",
-                activePathway.Id,
-                emitted.Length)
-            dispatchPathwayEvents emitted
 
         // SessionModel Tier 1.C — PromptBoundary handler. Advances
         // the SessionModel state machine with the boundary, then
@@ -1004,12 +1007,47 @@ module Program =
         // overrides from Tier 1.A); Phase 2 pathways
         // (ReplPathway, ClaudeCodePathway, FormPathway) will
         // override with non-trivial logic.
+        //
+        // Defined BEFORE `handleRowsChanged` so the latter can
+        // dispatch heuristic-detected boundaries (Tier 1.D) via
+        // this helper. F# `let` bindings are sequential.
         let handlePromptBoundary (boundary: PromptBoundaryData) : unit =
             currentSession <- SessionModel.apply currentSession boundary
             let emitted = activePathway.OnPromptBoundary boundary
             pumpLog.LogDebug(
                 "PathwayPump PromptBoundary {Kind} → {Pathway}.OnPromptBoundary → {Count} events.",
                 boundary.Kind,
+                activePathway.Id,
+                emitted.Length)
+            dispatchPathwayEvents emitted
+
+        let handleRowsChanged () : unit =
+            let seq, cursorPos, snapshot = screen.SnapshotRows(0, screen.Rows)
+            // SessionModel Tier 1.D — heuristic prompt-
+            // boundary detection. Runs BEFORE pathway
+            // consumption so the SessionModel state machine
+            // advances ahead of any pathway query against
+            // currentSession. Detector is per-shell-keyed;
+            // unknown shells produce no boundary (Q2:
+            // ON for cmd / PowerShell / Claude; OFF for
+            // unknown).
+            let shellKey = shellIdToConfigKey currentShellId
+            let detectionTime = DateTime.UtcNow
+            let boundary, nextDetector =
+                HeuristicPromptDetector.tryDetect
+                    snapshot
+                    cursorPos
+                    shellKey
+                    detectionTime
+                    promptDetector
+            promptDetector <- nextDetector
+            match boundary with
+            | Some data -> handlePromptBoundary data
+            | None -> ()
+            let canonical = CanonicalState.create snapshot cursorPos seq
+            let emitted = activePathway.Consume canonical
+            pumpLog.LogDebug(
+                "PathwayPump RowsChanged → {Pathway}.Consume → {Count} events.",
                 activePathway.Id,
                 emitted.Length)
             dispatchPathwayEvents emitted
@@ -1060,8 +1098,28 @@ module Program =
             | PathwaySelector.Keep ->
                 ()
             | PathwaySelector.SwapToTui ->
+                // SessionModel Tier 1.D — Q3 wiring
+                // closure. Mark the session as alt-screen-
+                // active so subsequent boundaries are
+                // ignored by `SessionModel.apply`. Reset
+                // the heuristic detector so stale per-row
+                // matches don't produce phantom boundaries
+                // on alt-screen exit.
+                currentSession <-
+                    SessionModel.enterAltScreen currentSession
+                promptDetector <-
+                    HeuristicPromptDetector.reset promptDetector
                 swapPathwayForAltScreen (TuiPathway.create ())
             | PathwaySelector.SwapToShellDefault ->
+                // SessionModel Tier 1.D — Q3 wiring
+                // closure. Clear the alt-screen flag so
+                // subsequent boundaries advance the state
+                // machine again. Reset the detector for a
+                // fresh stability window post-exit.
+                currentSession <-
+                    SessionModel.exitAltScreen currentSession
+                promptDetector <-
+                    HeuristicPromptDetector.reset promptDetector
                 swapPathwayForAltScreen (selectPathwayForShell currentShellId)
             // Step 3 — dispatch the barrier OutputEvent so the
             // FileLogger captures the mode transition in the
@@ -1767,6 +1825,19 @@ module Program =
                                         currentSession <-
                                             SessionModel.createDefault
                                                 (shellIdToConfigKey shell.Id)
+                                        // SessionModel Tier 1.D —
+                                        // reset heuristic
+                                        // detector for the new
+                                        // shell. Stale per-row
+                                        // matches from the
+                                        // outgoing shell would
+                                        // otherwise produce
+                                        // phantom boundaries on
+                                        // the new shell's first
+                                        // frame.
+                                        promptDetector <-
+                                            HeuristicPromptDetector.reset
+                                                promptDetector
                                         // Phase A — swap the active
                                         // pathway for the new shell.
                                         // `Reset` clears any pending

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -1,0 +1,238 @@
+namespace Terminal.Core
+
+open System
+open System.Text.RegularExpressions
+open Microsoft.Extensions.Logging
+
+/// Tier 1.D — heuristic prompt-boundary fallback.
+///
+/// Per `docs/SESSION-MODEL.md` §245-340: shells that don't
+/// emit OSC 133 (cmd, PowerShell, Claude — all three by
+/// default) still need SessionModel to populate. This
+/// detector observes the screen snapshot per-frame, matches
+/// rows against per-shell regex patterns, and emits
+/// synthetic `PromptBoundaryData` events with
+/// `BoundarySource.HeuristicPromptRegex stabilityMs`.
+///
+/// **Maintainer-locked scope (2026-05-08, AskUserQuestion
+/// resolutions)**:
+///
+/// 1. **PromptStart-only emission**. Tier 1.D emits
+///    `BoundaryKind.PromptStart` events only. The Cycle 13
+///    state machine's "PromptStart while Active=Some"
+///    transition auto-finalises the prior tuple as
+///    incomplete — this gives History accumulation without
+///    needing heuristic synthesis of CommandStart /
+///    OutputStart / CommandFinished. Those need
+///    Enter-detection (Phase 2 input framework) /
+///    cursor-aware diff (Phase 2) / OSC 133 D exit codes
+///    respectively.
+///
+/// 2. **Regex-only Claude detection**. Single regex
+///    `^.*│\s>.*$` per row, same shape as cmd / PowerShell.
+///    Source = `HeuristicPromptRegex 200` (longer stability
+///    window for Claude's slower TUI cadence). Defers the
+///    full Ink-box context check (multi-row `╭─╮│╰─╯`
+///    scanning per SESSION-MODEL.md §275-280) to a
+///    refinement cycle if false-positives surface.
+///
+/// 3. **Hardcoded defaults**. All per-shell parameters
+///    (regex, stability window) baked in. No `Config.fs`
+///    schema changes; no `[session_model.fallback.*]` TOML
+///    sections. The substrate stays internally observable
+///    only (no pathway consumes `OnPromptBoundary`
+///    non-trivially yet) so user-facing knobs aren't
+///    actionable today. TOML wiring per SESSION-MODEL.md
+///    §282-300 + USER-SETTINGS atlas entries defer to a
+///    later cycle.
+///
+/// **Detection algorithm (per-frame)**:
+///
+/// 1. Render row text via `CanonicalState.renderRow`
+///    (sanitised + trailing-blank-trimmed).
+/// 2. Test against per-shell regex (compiled, module-level
+///    singleton).
+/// 3. If matches AND `(now - first-match-time) ≥
+///    stabilityMs` AND text differs from
+///    `LastEmittedPromptText` → emit PromptStart.
+/// 4. If matches but window not elapsed OR text equals
+///    last-emitted → no emit, update state.
+///
+/// **Threading**: detector is mutated only on the
+/// PathwayPump worker thread (single-threaded for
+/// notification consumption); `tryDetect` is a pure
+/// function returning the next state alongside the boundary
+/// option.
+///
+/// **State bound**: `PerRowMatches` is keyed by row index
+/// and bounded by `screen.Rows` (typically 30). Stale
+/// entries (rows that no longer match) get cleared on each
+/// `tryDetect` call.
+[<RequireQualifiedAccess>]
+module HeuristicPromptDetector =
+
+    /// Per-shell hardcoded defaults. Compiled regexes are
+    /// module-level singletons (one allocation per
+    /// AppDomain).
+    ///
+    /// **cmd**: `C:\>`, `D:\path\foo>` etc. Match enforces
+    /// drive-letter prefix + literal `>` close.
+    let private cmdRegex =
+        Regex(@"^[A-Z]:\\.*>\s*$", RegexOptions.Compiled)
+
+    /// **PowerShell**: `PS C:\>`, `PS C:\path>`, `PS>`
+    /// (some configurations). Match enforces `PS` prefix +
+    /// space + content + `>` close.
+    let private powerShellRegex =
+        Regex(@"^PS\s.*>\s*$", RegexOptions.Compiled)
+
+    /// **Claude**: the Ink-box prompt indicator. Per
+    /// SESSION-MODEL.md §275-280, Claude renders a TUI
+    /// with a `│ >` indicator. Tier 1.D matches the
+    /// indicator without verifying the surrounding
+    /// box-drawing characters (regex-only per maintainer
+    /// resolution).
+    let private claudeRegex =
+        Regex(@"^.*│\s>.*$", RegexOptions.Compiled)
+
+    /// Stability window per shell. Claude needs longer
+    /// (200ms) to absorb TUI repaint cadence; cmd /
+    /// PowerShell stabilise faster (100ms).
+    [<Literal>]
+    let private CmdStabilityMs = 100
+
+    [<Literal>]
+    let private PowerShellStabilityMs = 100
+
+    [<Literal>]
+    let private ClaudeStabilityMs = 200
+
+    /// Detector state. Tracks per-row first-match
+    /// timestamps + the most recently emitted prompt text
+    /// (for duplicate suppression).
+    type T =
+        { /// Per-row last-observed prompt match: row index
+          /// → (rendered text, first-match timestamp).
+          /// Cleared on `reset`; per-row eviction on each
+          /// frame when the row no longer matches.
+          PerRowMatches: Map<int, string * DateTime>
+          /// Most recently emitted PromptStart's row text.
+          /// Used to suppress duplicate emissions while the
+          /// same prompt remains visible (typing at the
+          /// prompt re-fires RowsChanged but the rendered
+          /// row text is unchanged).
+          LastEmittedPromptText: string option }
+
+    /// Empty initial state.
+    let create () : T =
+        { PerRowMatches = Map.empty
+          LastEmittedPromptText = None }
+
+    /// Clear all per-row state. Called on shell-switch
+    /// (fresh detector for new shell) and on alt-screen
+    /// entry (boundaries during alt-screen are ignored
+    /// anyway, but stale state would produce phantom
+    /// boundaries on alt-screen exit).
+    let reset (state: T) : T =
+        { PerRowMatches = Map.empty
+          LastEmittedPromptText = None }
+
+    let private logger = Logger.get "Terminal.Core.HeuristicPromptDetector"
+
+    /// Resolve the per-shell regex + stability window from
+    /// the shell-key string. Returns `None` for unknown
+    /// shells (Q2 resolution: ON for cmd / PowerShell /
+    /// Claude; OFF for unknown shells).
+    let private shellParams
+            (shellKey: string)
+            : (Regex * int) option
+            =
+        match shellKey with
+        | "cmd" -> Some (cmdRegex, CmdStabilityMs)
+        | "powershell" -> Some (powerShellRegex, PowerShellStabilityMs)
+        | "claude" -> Some (claudeRegex, ClaudeStabilityMs)
+        | _ -> None
+
+    /// Pure detection function. Walks the snapshot row by
+    /// row, tracks per-row stability, and emits at most one
+    /// `PromptBoundaryData` per call.
+    ///
+    /// Returns `(boundary option, updated state)`. The
+    /// caller (PathwayPump's `handleRowsChanged`) feeds
+    /// boundary into `SessionModel.apply` + the active
+    /// pathway's `OnPromptBoundary`.
+    ///
+    /// `cursor` is captured for forward-compatibility with
+    /// the cursor-position refinement (Phase 2); Tier 1.D
+    /// doesn't use it.
+    let tryDetect
+            (snapshot: Cell[][])
+            (_cursor: int * int)
+            (shellKey: string)
+            (now: DateTime)
+            (state: T)
+            : PromptBoundaryData option * T
+            =
+        match shellParams shellKey with
+        | None ->
+            // Unknown shell — no detection per Q2 resolution.
+            None, state
+        | Some (regex, stabilityMs) ->
+            // Walk every row; find the first row whose text
+            // matches the regex AND has been stable for the
+            // shell's window. Drop per-row entries for rows
+            // that no longer match (state hygiene).
+            let mutable nextMatches = state.PerRowMatches
+            let mutable emitted : PromptBoundaryData option = None
+            let mutable emittedText : string option = None
+            for rowIdx in 0 .. snapshot.Length - 1 do
+                let text = CanonicalState.renderRow snapshot rowIdx
+                if regex.IsMatch(text) then
+                    let priorMatch = Map.tryFind rowIdx nextMatches
+                    match priorMatch with
+                    | Some (priorText, firstSeen) when priorText = text ->
+                        let elapsed = now - firstSeen
+                        if elapsed.TotalMilliseconds >= float stabilityMs
+                           && emitted.IsNone
+                           && state.LastEmittedPromptText <> Some text
+                        then
+                            // Stable + new prompt text →
+                            // emit. Source stamps the
+                            // shell's stability window as
+                            // the integer payload.
+                            emitted <-
+                                Some
+                                    { Kind = BoundaryKind.PromptStart
+                                      Source =
+                                        BoundarySource.HeuristicPromptRegex
+                                            stabilityMs
+                                      DetectedAt = now
+                                      CommandId = None
+                                      ExtraParams = Map.empty }
+                            emittedText <- Some text
+                    | _ ->
+                        // First time seeing this text on
+                        // this row, OR text changed —
+                        // restart the stability timer.
+                        nextMatches <-
+                            Map.add rowIdx (text, now) nextMatches
+                else
+                    // Row no longer matches; evict stale
+                    // entry to keep the map bounded.
+                    if Map.containsKey rowIdx nextMatches then
+                        nextMatches <- Map.remove rowIdx nextMatches
+
+            let nextLastEmitted =
+                match emittedText with
+                | Some _ -> emittedText
+                | None -> state.LastEmittedPromptText
+
+            if emitted.IsSome then
+                logger.LogDebug(
+                    "HeuristicPromptDetector emitted PromptStart for shell {Shell} (stability {Ms}ms).",
+                    shellKey, stabilityMs)
+
+            let nextState =
+                { PerRowMatches = nextMatches
+                  LastEmittedPromptText = nextLastEmitted }
+            emitted, nextState

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="NvdaChannel.fs" />
     <Compile Include="FileLoggerChannel.fs" />
     <Compile Include="CanonicalState.fs" />
+    <Compile Include="HeuristicPromptDetector.fs" />
     <Compile Include="DisplayPathway.fs" />
     <Compile Include="StreamPathway.fs" />
     <Compile Include="TuiPathway.fs" />

--- a/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
+++ b/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
@@ -1,0 +1,466 @@
+module PtySpeak.Tests.Unit.HeuristicPromptDetectorTests
+
+open System
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// SessionModel Tier 1.D — heuristic prompt-boundary detector
+// ---------------------------------------------------------------------
+//
+// Per `docs/SESSION-MODEL.md` §245-340 + the maintainer-locked
+// scope (PromptStart-only, regex-only Claude, hardcoded
+// defaults), the detector observes the screen snapshot
+// per-frame, matches rows against per-shell regexes, applies a
+// stability window (100ms cmd/PowerShell; 200ms Claude), and
+// emits at most one `BoundaryKind.PromptStart` per call.
+//
+// Tests pin:
+//   * Per-shell regex matching (cmd / PowerShell / Claude prompt
+//     shapes match; non-prompt text doesn't).
+//   * Stability window (first match returns None; same text
+//     after the window returns Some).
+//   * Duplicate suppression (same prompt across N stable frames
+//     emits ONCE; cursor-movement on stable prompt suppresses
+//     re-emission; new prompt text re-emits).
+//   * Multi-row scenarios (prompt at non-zero index detected;
+//     blank-snapshot returns None).
+//   * Source provenance (Source.HeuristicPromptRegex stamps
+//     correct stability ms per shell).
+//   * Reset behaviour (reset clears state; post-reset the next
+//     prompt needs a fresh stability window).
+//   * Unknown shell handling (returns None without state
+//     mutation).
+//   * Edge cases (empty snapshot, all-blank rows, large
+//     stability windows).
+
+// ---------------------------------------------------------------------
+// Fixture builders (mirror CanonicalStateTests.fs:24-43)
+// ---------------------------------------------------------------------
+
+let private blankCell : Cell = Cell.blank
+
+let private cellOf (ch: char) : Cell =
+    { Ch = System.Text.Rune ch; Attrs = SgrAttrs.defaults }
+
+let private blankRow (cols: int) : Cell[] =
+    Array.create cols blankCell
+
+let private rowOf (cols: int) (s: string) : Cell[] =
+    let row = blankRow cols
+    for i in 0 .. min (s.Length - 1) (cols - 1) do
+        row.[i] <- cellOf s.[i]
+    row
+
+let private snapshotOf
+        (rows: int)
+        (cols: int)
+        (lines: string list)
+        : Cell[][]
+        =
+    let arr = Array.init rows (fun _ -> blankRow cols)
+    lines
+    |> List.iteri (fun i line ->
+        if i < rows then arr.[i] <- rowOf cols line)
+    arr
+
+// ---------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------
+
+let private t0 = DateTime(2026, 5, 8, 12, 0, 0, DateTimeKind.Utc)
+let private after (ms: int) = t0.AddMilliseconds(float ms)
+let private noCursor = (-1, -1)
+
+// ---------------------------------------------------------------------
+// Per-shell regex matching
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``cmd prompt 'C:\Users\admin>' detected after stability window`` () =
+    let snap = snapshotOf 3 80 [ "some output"; ""; "C:\\Users\\admin>" ]
+    let detector = HeuristicPromptDetector.create ()
+    // First frame: starts the stability timer.
+    let r1, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    Assert.True(r1.IsNone)
+    // After 100ms: emits PromptStart.
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    match r2 with
+    | Some data ->
+        Assert.Equal(BoundaryKind.PromptStart, data.Kind)
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 100, data.Source)
+        Assert.Equal(after 100, data.DetectedAt)
+        Assert.Equal(None, data.CommandId)
+        Assert.True(Map.isEmpty data.ExtraParams)
+    | None -> Assert.Fail("Expected PromptStart after stability window")
+
+[<Fact>]
+let ``cmd 'C:\Users\admin> dir' (extra content past >) doesn't match`` () =
+    let snap = snapshotOf 1 80 [ "C:\\Users\\admin> dir" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r1, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) s1
+    Assert.True(r1.IsNone)
+    Assert.True(r2.IsNone)
+
+[<Fact>]
+let ``cmd 'lowercase>' (no drive letter) doesn't match`` () =
+    let snap = snapshotOf 1 80 [ "lowercase>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) detector
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``cmd empty snapshot returns None`` () =
+    let snap = snapshotOf 1 80 [ "" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) detector
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``powershell 'PS C:\>' detected after stability window`` () =
+    let snap = snapshotOf 1 80 [ "PS C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "powershell" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "powershell" (after 100) s1
+    match r2 with
+    | Some data ->
+        Assert.Equal(BoundaryKind.PromptStart, data.Kind)
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 100, data.Source)
+    | None -> Assert.Fail("Expected PromptStart for PowerShell")
+
+[<Fact>]
+let ``powershell 'PS C:\Projects\foo>' detected`` () =
+    let snap = snapshotOf 1 80 [ "PS C:\\Projects\\foo>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "powershell" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "powershell" (after 100) s1
+    Assert.True(r2.IsSome)
+
+[<Fact>]
+let ``powershell 'PSReadLine>' (no space after PS) doesn't match`` () =
+    let snap = snapshotOf 1 80 [ "PSReadLine>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "powershell" (after 200) detector
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``claude '│ > ' detected after 200ms stability window`` () =
+    let snap = snapshotOf 1 80 [ "│ > " ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" t0 detector
+    // Claude needs 200ms; 100ms isn't enough.
+    let r2, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" (after 100) s1
+    Assert.True(r2.IsNone)
+    let r3, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" (after 200) s2
+    match r3 with
+    | Some data ->
+        Assert.Equal(BoundaryKind.PromptStart, data.Kind)
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 200, data.Source)
+    | None -> Assert.Fail("Expected PromptStart for Claude after 200ms")
+
+[<Fact>]
+let ``claude '| > ' (ASCII pipe instead of box-drawing) doesn't match`` () =
+    // ASCII pipe '|' (U+007C) != box-drawing '│' (U+2502).
+    let snap = snapshotOf 1 80 [ "| > " ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" (after 300) detector
+    Assert.True(r.IsNone)
+
+// ---------------------------------------------------------------------
+// Stability window
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``first match returns None (window not yet elapsed)`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``same text after stabilityMs - 1ms returns None`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 99) s1
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``same text at exactly stabilityMs returns Some`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r.IsSome)
+
+[<Fact>]
+let ``same text after stabilityMs * 2 returns None (already emitted)`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let _, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) s2
+    Assert.True(r.IsNone)
+
+// ---------------------------------------------------------------------
+// Duplicate suppression
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``same prompt across many stable frames emits exactly once`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let mutable state = detector
+    let mutable emitCount = 0
+    for ms in [ 0; 50; 100; 150; 200; 250; 300; 350 ] do
+        let r, s =
+            HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after ms) state
+        state <- s
+        if r.IsSome then emitCount <- emitCount + 1
+    Assert.Equal(1, emitCount)
+
+[<Fact>]
+let ``cursor moving on stable prompt row (same text) suppresses re-emit`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r1, s2 =
+        HeuristicPromptDetector.tryDetect snap (0, 5) "cmd" (after 100) s1
+    Assert.True(r1.IsSome)
+    // Cursor moves; same row content. No new emit.
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap (0, 6) "cmd" (after 200) s2
+    Assert.True(r2.IsNone)
+
+[<Fact>]
+let ``new prompt text after prior emit re-emits as fresh boundary`` () =
+    let snap1 = snapshotOf 1 80 [ "C:\\>" ]
+    let snap2 = snapshotOf 1 80 [ "C:\\foo>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap1 noCursor "cmd" t0 detector
+    let r1, s2 =
+        HeuristicPromptDetector.tryDetect snap1 noCursor "cmd" (after 100) s1
+    Assert.True(r1.IsSome)
+    // New prompt text — restart timer.
+    let _, s3 =
+        HeuristicPromptDetector.tryDetect snap2 noCursor "cmd" (after 200) s2
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap2 noCursor "cmd" (after 300) s3
+    Assert.True(r2.IsSome)
+
+// ---------------------------------------------------------------------
+// Multi-row scenarios
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``prompt at row 5 (not last) detected correctly`` () =
+    let snap =
+        snapshotOf 10 80 [ ""; ""; ""; ""; ""; "C:\\>"; ""; ""; ""; "" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r.IsSome)
+
+[<Fact>]
+let ``multiple rows match regex; first stable one emits`` () =
+    let snap = snapshotOf 3 80 [ "C:\\>"; ""; "D:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r.IsSome)
+    // (Implementation detail: emits the first row's match;
+    // duplicate suppression then prevents subsequent rows
+    // from emitting on this frame.)
+
+[<Fact>]
+let ``all-blank snapshot returns None`` () =
+    let snap = snapshotOf 5 80 [ ""; ""; ""; ""; "" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) detector
+    Assert.True(r.IsNone)
+
+[<Fact>]
+let ``zero-row snapshot returns None`` () =
+    let snap : Cell[][] = [||]
+    let detector = HeuristicPromptDetector.create ()
+    let r, s =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    Assert.True(r.IsNone)
+    Assert.True(Map.isEmpty s.PerRowMatches)
+
+// ---------------------------------------------------------------------
+// Source provenance
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``cmd source stamps HeuristicPromptRegex 100`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    match r with
+    | Some data ->
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 100, data.Source)
+    | None -> Assert.Fail("Expected emit")
+
+[<Fact>]
+let ``powershell source stamps HeuristicPromptRegex 100`` () =
+    let snap = snapshotOf 1 80 [ "PS C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "powershell" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "powershell" (after 100) s1
+    match r with
+    | Some data ->
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 100, data.Source)
+    | None -> Assert.Fail("Expected emit")
+
+[<Fact>]
+let ``claude source stamps HeuristicPromptRegex 200`` () =
+    let snap = snapshotOf 1 80 [ "│ > " ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "claude" (after 200) s1
+    match r with
+    | Some data ->
+        Assert.Equal(BoundarySource.HeuristicPromptRegex 200, data.Source)
+    | None -> Assert.Fail("Expected emit")
+
+// ---------------------------------------------------------------------
+// Reset behaviour
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``reset clears PerRowMatches`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    Assert.False(Map.isEmpty s1.PerRowMatches)
+    let resetState = HeuristicPromptDetector.reset s1
+    Assert.True(Map.isEmpty resetState.PerRowMatches)
+
+[<Fact>]
+let ``reset clears LastEmittedPromptText`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let _, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(s2.LastEmittedPromptText.IsSome)
+    let resetState = HeuristicPromptDetector.reset s2
+    Assert.True(resetState.LastEmittedPromptText.IsNone)
+
+[<Fact>]
+let ``after reset, the same prompt text re-emits with fresh stability window`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let _, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    // First emit happened; reset.
+    let resetState = HeuristicPromptDetector.reset s2
+    let _, s3 =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "cmd" (after 200) resetState
+    // Window restarts: at +200ms (only 0ms after reset) no emit.
+    let r, s4 =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "cmd" (after 250) s3
+    Assert.True(r.IsNone)
+    // After fresh 100ms window from re-detection start (after 200): re-emits.
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "cmd" (after 300) s4
+    Assert.True(r2.IsSome)
+
+// ---------------------------------------------------------------------
+// Unknown shell handling (Q2: ON only for cmd / PowerShell / Claude)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``unknown shell key returns None and leaves state unchanged`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, s =
+        HeuristicPromptDetector.tryDetect
+            snap noCursor "bash" (after 1000) detector
+    Assert.True(r.IsNone)
+    Assert.True(Map.isEmpty s.PerRowMatches)
+
+[<Fact>]
+let ``empty shell key returns None`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, s =
+        HeuristicPromptDetector.tryDetect snap noCursor "" t0 detector
+    Assert.True(r.IsNone)
+    Assert.True(Map.isEmpty s.PerRowMatches)
+
+[<Fact>]
+let ``mixed-case 'CMD' returns None (key is case-sensitive)`` () =
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "CMD" (after 200) detector
+    Assert.True(r.IsNone)
+
+// ---------------------------------------------------------------------
+// State hygiene — stale per-row entry eviction
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``row that stops matching evicts its PerRowMatches entry`` () =
+    let promptSnap = snapshotOf 1 80 [ "C:\\>" ]
+    let outputSnap = snapshotOf 1 80 [ "no prompt here" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect promptSnap noCursor "cmd" t0 detector
+    Assert.False(Map.isEmpty s1.PerRowMatches)
+    let _, s2 =
+        HeuristicPromptDetector.tryDetect
+            outputSnap noCursor "cmd" (after 50) s1
+    Assert.True(Map.isEmpty s2.PerRowMatches)

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -764,3 +764,72 @@ let ``finalizeIncomplete sets ExitCode=None`` () =
     let finalised = SessionModel.finalizeIncomplete s1 (after 100)
     let tuple = finalised.History.ToArray().[0]
     Assert.Equal(None, tuple.ExitCode)
+
+// =====================================================================
+// Tier 1.D — heuristic-source boundary compatibility
+// =====================================================================
+//
+// Tier 1.D's HeuristicPromptDetector emits boundaries with
+// `Source = BoundarySource.HeuristicPromptRegex stabilityMs`.
+// Pin that the SessionModel state machine treats them
+// identically to OSC 133 boundaries — no special-casing,
+// source recorded in the Sources map verbatim.
+
+let private heuristicBoundary
+        (kind: BoundaryKind)
+        (detectedAt: DateTime)
+        (stabilityMs: int)
+        : PromptBoundaryData
+        =
+    { Kind = kind
+      Source = BoundarySource.HeuristicPromptRegex stabilityMs
+      DetectedAt = detectedAt
+      CommandId = None
+      ExtraParams = Map.empty }
+
+[<Fact>]
+let ``apply with HeuristicPromptRegex source populates Active`` () =
+    let initial = SessionModel.create "cmd" 50
+    let updated =
+        SessionModel.apply
+            initial
+            (heuristicBoundary BoundaryKind.PromptStart t0 100)
+    match updated.Active with
+    | Some active ->
+        Assert.Equal(
+            SessionModel.ActiveTupleState.AwaitingCommandStart,
+            active.State)
+        Assert.Equal(t0, active.Tuple.PromptStartedAt)
+    | None -> Assert.Fail("Expected Active after heuristic PromptStart")
+
+[<Fact>]
+let ``heuristic boundaries finalise tuples the same as OSC 133 boundaries`` () =
+    // Two consecutive heuristic PromptStarts: prior tuple
+    // finalises as incomplete with ExitCode=None.
+    let initial = SessionModel.create "cmd" 50
+    let s1 =
+        SessionModel.apply
+            initial
+            (heuristicBoundary BoundaryKind.PromptStart t0 100)
+    let s2 =
+        SessionModel.apply
+            s1
+            (heuristicBoundary BoundaryKind.PromptStart (after 1000) 100)
+    Assert.Equal(1, s2.History.Count)
+    let priorTuple = s2.History.ToArray().[0]
+    Assert.Equal(Some (after 1000), priorTuple.CommandFinishedAt)
+    Assert.Equal(None, priorTuple.ExitCode)
+
+[<Fact>]
+let ``Sources map records HeuristicPromptRegex stability ms verbatim`` () =
+    let initial = SessionModel.create "powershell" 50
+    let s1 =
+        SessionModel.apply
+            initial
+            (heuristicBoundary BoundaryKind.PromptStart t0 100)
+    match s1.Active with
+    | Some active ->
+        Assert.Equal(
+            Some (BoundarySource.HeuristicPromptRegex 100),
+            Map.tryFind BoundaryKind.PromptStart active.Tuple.Sources)
+    | None -> Assert.Fail("Expected Active")

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="AnnounceSanitiserTests.fs" />
     <Compile Include="CanonicalStateTests.fs" />
     <Compile Include="SessionModelTests.fs" />
+    <Compile Include="HeuristicPromptDetectorTests.fs" />
     <Compile Include="Osc133Tests.fs" />
     <Compile Include="StreamPathwayTests.fs" />
     <Compile Include="TuiPathwayTests.fs" />


### PR DESCRIPTION
## Summary

Ships the heuristic prompt-boundary fallback module that
produces synthetic `PromptBoundary` events for shells that
don't emit OSC 133 (cmd / PowerShell / Claude — all three by
default). Closes the Q3 alt-screen wiring deferred from Tier
1.C: composition root now calls
`SessionModel.enterAltScreen` / `exitAltScreen` alongside the
existing pathway-swap decision.

**Behaviour change**: zero user-visible. Stream / Tui pathways
still return `[||]` from `OnPromptBoundary`; no NVDA
announcements depend on SessionModel state. The substrate
becomes operationally meaningful (tuples populate naturally
during cmd / PowerShell / Claude use) but remains internally
observable only — Tier 2 (persistence) and Phase 2 pathways
consume the tuples in user-visible ways.

## Maintainer-locked scope (2026-05-08 AskUserQuestion)

- **PromptStart-only emission**. Detector emits
  `BoundaryKind.PromptStart` events only; the Cycle 13 state
  machine's "PromptStart while Active=Some" transition
  auto-finalises the prior tuple as incomplete (`ExitCode = None`,
  `CommandFinishedAt = next-prompt-time`). Defers heuristic
  synthesis of CommandStart / OutputStart / CommandFinished
  (need Phase 2 input framework / cursor-aware diff / OSC 133 D
  respectively).
- **Regex-only Claude detection**. Single regex `^.*│\s>.*$`
  per row, same shape as cmd / PowerShell. Defers full Ink-box
  context check (multi-row `╭─╮│╰─╯` scanning per
  SESSION-MODEL.md §275-280).
- **Hardcoded defaults**. No `Config.fs` schema changes; no
  `[session_model.fallback.*]` TOML sections this cycle.

## New module

`src/Terminal.Core/HeuristicPromptDetector.fs` (~250 LOC):
- `T` record: `PerRowMatches: Map<int, string * DateTime>` +
  `LastEmittedPromptText: string option`.
- `create () : T` — empty initial state.
- `tryDetect snapshot cursor shellKey now state :
  PromptBoundaryData option * T` — pure detection function.
- `reset state : T` — clear per-row state on shell-switch +
  alt-screen entry.

**Per-shell hardcoded defaults**:
- cmd: regex `^[A-Z]:\\.*>\s*$`, stability 100ms.
- PowerShell: regex `^PS\s.*>\s*$`, stability 100ms.
- Claude: regex `^.*│\s>.*$`, stability 200ms.
- Unknown shells: detection OFF (returns `None`).

## Composition wiring (`Program.fs`)

- `mutable promptDetector : HeuristicPromptDetector.T`
  declared alongside `currentSession`.
- `handleRowsChanged` calls
  `HeuristicPromptDetector.tryDetect` AFTER snapshot capture
  and BEFORE pathway consumption — boundary, if emitted,
  dispatches via `handlePromptBoundary` (the Cycle 13 helper).
- `handleModeChanged` calls `SessionModel.enterAltScreen` on
  `PathwaySelector.SwapToTui` and
  `SessionModel.exitAltScreen` on `SwapToShellDefault`;
  detector reset on both transitions.
- `switchToShell` resets the detector after recreating
  `currentSession` (fresh per-row state for the new shell).

## Tests added

**~30 new tests in
`tests/Tests.Unit/HeuristicPromptDetectorTests.fs`**:

- Per-shell regex matching (8 tests): cmd / PowerShell /
  Claude prompt shapes match; non-prompt text doesn't; ASCII
  pipe `|` distinct from box-drawing `│`.
- Stability window (4 tests): first match returns None;
  exactly `stabilityMs` returns Some; same text after window
  emits ONCE then suppresses.
- Duplicate suppression (3 tests): N stable frames emit once;
  cursor movement on stable prompt suppresses; new prompt
  text re-emits.
- Multi-row scenarios (4 tests): prompt at non-zero row
  detected; multiple matching rows emit one per call;
  all-blank snapshot returns None; zero-row snapshot returns
  None.
- Source provenance (3 tests): cmd → 100ms; PowerShell →
  100ms; Claude → 200ms.
- Reset behaviour (3 tests): clears `PerRowMatches`; clears
  `LastEmittedPromptText`; post-reset prompt needs fresh
  stability window.
- Unknown shell handling (3 tests): unknown / empty /
  case-mismatched keys return None.
- State hygiene (1 test): row that stops matching evicts its
  entry.

**~3 heuristic-source compatibility tests in
`SessionModelTests.fs`** pinning that boundaries with
`Source = HeuristicPromptRegex` flow through the state
machine identically to OSC 133 boundaries.

## Doc updates

`docs/SESSION-MODEL.md`:
- Q2 (heuristic fallback default) marked shipped 2026-05-08
  with Tier 1.D scope details.
- Q3 (SessionModel reset on alt-screen) marked fully shipped
  2026-05-08 (composition wiring closure).
- Change-log table entry for Cycle 14.

## Out of scope

- Heuristic synthesis of CommandStart / OutputStart /
  CommandFinished events (Phase 2 input framework /
  cursor-aware diff).
- Claude Ink-box context check (multi-row box-drawing
  scanning).
- TOML config for per-shell parameters (defer until a pathway
  makes the params user-actionable).
- Cursor-position check on prompt rows (Phase 2 prerequisite).
- Text accumulation for `PromptText` / `CommandText` /
  `OutputText` (Tier 1.E).
- Diagnostic battery extension (Tier 1.F).
- Pathway `OnPromptBoundary` non-trivial overrides (Phase 2 /
  Tier 3).
- Persistence (Tier 2).

## Test plan

- [ ] CI build green on windows-latest (`dotnet build` with
  TreatWarningsAsErrors).
- [ ] All existing tests + ~33 new = ~666 tests pass.
- [ ] F# extension-method gotcha avoided
  (`open Microsoft.Extensions.Logging` in
  HeuristicPromptDetector.fs per CONTRIBUTING.md gotcha
  banked in PR #188).
- [ ] No spec changes (per CLAUDE.md spec-immutability).
- [ ] Manual NVDA validation: zero user-visible change
  expected; regression matrix unchanged from Cycle 13
  baseline.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_