### PR TITLE
feat: Tier 1.D-cleanup + default-shell TOML override (Cycle 19, bundled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,113 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added + Changed (Cycle 19): Tier 1.D-cleanup + default-shell TOML override (bundled)
+
+**Two small named follow-ups bundled per maintainer
+direction 2026-05-08.** Both items sat on the strategic
+backlog after Cycle 17 / 18; combining them into a single
+PR avoids two near-identical doc-+-test churn cycles.
+
+#### Part 1 — Tier 1.D-cleanup: consolidate detector invocation sites
+
+**Refactor only; zero behaviour change.**
+
+Cycle 17 (PR #192) introduced the channel-driven actor
+model + tick-driven `handleTick` helper to close the
+detector idle-gap hole. That cycle left detector-invocation
+logic duplicated across `handleRowsChanged` (frame-driven)
+and `handleTick` (tick-driven) — same 4-arg shape (shell key
++ detection time + `tryDetect` + state update + dispatch on
+`Some`).
+
+Cycle 19 factors the duplication into a shared `runDetector`
+helper inside the consumer task body. Both call sites
+become 1-line invocations:
+
+```fsharp
+let runDetector
+        (snapshot: Cell[][])
+        (cursorPos: int * int)
+        (now: DateTime)
+        : unit
+        =
+    let shellKey = shellIdToConfigKey currentShellId
+    let boundary, nextDetector =
+        HeuristicPromptDetector.tryDetect
+            snapshot cursorPos shellKey now promptDetector
+    promptDetector <- nextDetector
+    match boundary with
+    | Some data -> handlePromptBoundary data
+    | None -> ()
+```
+
+Helper closes over `currentShellId` + `promptDetector`
+(composition-root mutables). Safe because all callers run
+on the single notification-consumer thread per the
+channel-driven actor model. Net diff: ~+25 LOC helper /
+~-30 LOC removed from the two call sites.
+
+#### Part 2 — Default-shell TOML override (item 33)
+
+**New TOML configuration option for startup-shell selection.**
+
+User-visible behaviour change: `[startup] default_shell`
+in `%LOCALAPPDATA%\PtySpeak\config.toml` now overrides the
+`PTYSPEAK_SHELL` environment variable. Use case
+(maintainer's 2026-05-08 NVDA validation): after running
+`setx PTYSPEAK_SHELL claude` for prior testing, every
+launch defaulted to Claude Code. Clearing the env var
+required a fresh shell + relaunch dance. With Cycle 19,
+setting `[startup] default_shell = "cmd"` in the TOML
+overrides the env var — no `setx` choreography needed.
+
+**Precedence (highest → lowest)**:
+1. **`[startup] default_shell` TOML override** (NEW).
+2. `PTYSPEAK_SHELL` environment variable.
+3. Built-in `cmd` default.
+
+**Recognised values**: `cmd` / `powershell` / `pwsh` /
+`claude` (case-insensitive). Validated at parse time
+against `Config.knownShellKeys`; unknown values produce a
+`LogWarning` and the override falls through to env var.
+
+**Files modified**:
+
+- `src/Terminal.Core/Config.fs` — adds
+  `StartupOverrides` record + `DefaultShell: string option`
+  field; `parseStartupOverrides` parser; `resolveDefaultShell`
+  helper. The "Config loaded from..." log line now includes
+  startup-override summary.
+- `src/Terminal.App/Program.fs` — `resolveStartupShell`
+  consults `Config.resolveDefaultShell config` BEFORE the
+  env var. Logs at Information when the override fires
+  (so post-hoc diagnosis via Ctrl+Shift+; is trivial).
+- `tests/Tests.Unit/ConfigTests.fs` — 6 new tests
+  covering: `defaultConfig.resolveDefaultShell = None`;
+  `[startup] default_shell = "cmd"` parses + resolves;
+  case-insensitive (`"PowerShell"` → `Some "powershell"`);
+  unknown value (`"bash"`) logs Warning + drops; missing
+  key returns None; unknown subkey logs Warning but
+  doesn't corrupt parse.
+- `docs/USER-SETTINGS.md` — Default-shell parameter atlas
+  section gains the new TOML resolution step + use case +
+  schema snippet.
+
+**Architectural alignment**: matches the
+[`docs/CHANNEL-ARCHITECTURE.md`](docs/CHANNEL-ARCHITECTURE.md)
++ [`docs/CUSTOMIZATION-MODEL.md`](docs/CUSTOMIZATION-MODEL.md)
+principle of user-introspectable + user-customizable
+substrate seams. The startup-shell choice is one such seam;
+exposing it via TOML is the natural application of the
+principle at this layer.
+
+**Out of scope**:
+- TOML hot-reload (changes still require restart).
+- Default-shell preference UI (palette / menu — Phase 2).
+- Per-shell override (`[shell.cmd] default = true` style)
+  — single global default suffices for v1.
+- Spec changes (per CLAUDE.md spec-immutability).
+
 ### Added (Cycle 18): Channel Architecture research-stage doc
 
 **Sixth research-stage doc.** Formalises the maintainer's

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -305,15 +305,35 @@ shipped set:
 
 Resolution lives in `compose ()` (`src/Terminal.App/Program.fs`):
 
-1. Read `PTYSPEAK_SHELL` env var. Recognised values: `cmd`,
+1. **Cycle 19** — Read `[startup] default_shell` from
+   `%LOCALAPPDATA%\PtySpeak\config.toml`. When set to a
+   recognised shell id (`cmd` / `claude` / `powershell` /
+   `pwsh`; case-insensitive; validated against
+   `knownShellKeys`), this override wins over the env var.
+   Unrecognised values produce a `LogWarning` at parse time
+   and the override falls through.
+2. Read `PTYSPEAK_SHELL` env var. Recognised values: `cmd`,
    `claude`, `powershell`, `pwsh` (after trim, case-insensitive).
    Unrecognised non-empty values produce a `LogWarning` and fall
    back to the default.
-2. Default: `Cmd`.
-3. Resolve via `ShellRegistry.tryFind`. If the resolver returns
+3. Default: `Cmd`.
+4. Resolve via `ShellRegistry.tryFind`. If the resolver returns
    `Error` (e.g. Claude Code not installed), log a warning at
    `Information`-adjacent severity and fall back to `Cmd`.
-4. Log the chosen shell + resolved command line at `Information`.
+5. Log the chosen shell + resolved command line at `Information`.
+
+**Cycle 19 use case**: maintainer has `PTYSPEAK_SHELL=claude`
+set from prior testing + wants `cmd` as the durable default
+without manipulating env vars. Setting
+`[startup] default_shell = "cmd"` in the TOML solves this
+without changing system state.
+
+**Schema snippet**:
+
+```toml
+[startup]
+default_shell = "cmd"   # cmd / powershell / pwsh / claude
+```
 
 The Stage 7 PR-A env-scrub block from `Terminal.Pty.Native.EnvBlock`
 is applied uniformly to whichever shell is selected — adding new

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1088,29 +1088,44 @@ module Program =
                 emitted.Length)
             dispatchPathwayEvents emitted
 
+        // SessionModel Tier 1.D-cleanup (Cycle 19) — shared
+        // detector invocation. Was duplicated across
+        // `handleRowsChanged` (frame-driven path) and
+        // `handleTick` (50ms tick-driven path; introduced in
+        // Cycle 17 to close the idle-gap hole). Both call
+        // sites had identical 4-arg shape:
+        //   shellKey + detectionTime + tryDetect + state
+        //   update + dispatch on Some.
+        // Helper closes over `currentShellId` + `promptDetector`
+        // (composition-root mutables; safe because all callers
+        // run on the single notification-consumer thread per
+        // the channel-driven actor model from Cycle 17).
+        let runDetector
+                (snapshot: Cell[][])
+                (cursorPos: int * int)
+                (now: DateTime)
+                : unit
+                =
+            let shellKey = shellIdToConfigKey currentShellId
+            let boundary, nextDetector =
+                HeuristicPromptDetector.tryDetect
+                    snapshot cursorPos shellKey now promptDetector
+            promptDetector <- nextDetector
+            match boundary with
+            | Some data -> handlePromptBoundary data
+            | None -> ()
+
         let handleRowsChanged () : unit =
             let seq, cursorPos, snapshot = screen.SnapshotRows(0, screen.Rows)
             // SessionModel Tier 1.D — heuristic prompt-
             // boundary detection. Runs BEFORE pathway
             // consumption so the SessionModel state machine
             // advances ahead of any pathway query against
-            // currentSession. Detector is per-shell-keyed;
-            // unknown shells produce no boundary (Q2:
-            // ON for cmd / PowerShell / Claude; OFF for
-            // unknown).
-            let shellKey = shellIdToConfigKey currentShellId
-            let detectionTime = DateTime.UtcNow
-            let boundary, nextDetector =
-                HeuristicPromptDetector.tryDetect
-                    snapshot
-                    cursorPos
-                    shellKey
-                    detectionTime
-                    promptDetector
-            promptDetector <- nextDetector
-            match boundary with
-            | Some data -> handlePromptBoundary data
-            | None -> ()
+            // currentSession. See `runDetector` for the
+            // shared invocation logic; Cycle 19 factored it
+            // out of `handleRowsChanged` + `handleTick` to
+            // remove duplication.
+            runDetector snapshot cursorPos (DateTime.UtcNow)
             let canonical = CanonicalState.create snapshot cursorPos seq
             let emitted = activePathway.Consume canonical
             pumpLog.LogDebug(
@@ -1226,19 +1241,11 @@ module Program =
         // promptDetector / activePathway mutations.
         let handleTick (now: DateTimeOffset) : unit =
             let _, cursorPos, snapshot = screen.SnapshotRows(0, screen.Rows)
-            let shellKey = shellIdToConfigKey currentShellId
-            let detectionTime = now.UtcDateTime
-            let boundary, nextDetector =
-                HeuristicPromptDetector.tryDetect
-                    snapshot
-                    cursorPos
-                    shellKey
-                    detectionTime
-                    promptDetector
-            promptDetector <- nextDetector
-            match boundary with
-            | Some data -> handlePromptBoundary data
-            | None -> ()
+            // Cycle 19 — shared `runDetector` helper. Cycle 17
+            // introduced this tick-driven invocation to close
+            // the idle-gap hole; the inline body has been
+            // factored out for parity with `handleRowsChanged`.
+            runDetector snapshot cursorPos now.UtcDateTime
             let emitted = activePathway.Tick now
             if emitted.Length > 0 then
                 dispatchPathwayEvents emitted
@@ -1404,6 +1411,14 @@ module Program =
         // typo. PR-C added Ctrl+Shift+1 (cmd) / Ctrl+Shift+2 hotkeys;
         // PR-J reordered: Ctrl+Shift+1 = cmd, +2 = PowerShell, +3 =
         // claude.
+        //
+        // Cycle 19 — `[startup] default_shell` TOML override.
+        // Precedence (highest → lowest): TOML config → env var
+        // → cmd built-in default. Use case: maintainer has
+        // `PTYSPEAK_SHELL=claude` set from prior testing + wants
+        // cmd as durable default without manipulating env vars.
+        // Setting `[startup] default_shell = "cmd"` in the TOML
+        // wins over the env var.
         let resolveStartupShell () : ShellRegistry.Shell * string =
             let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
             // Distinguish "unset" from "set to garbage" so the
@@ -1423,12 +1438,38 @@ module Program =
                     log.LogWarning(
                         "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude, powershell, pwsh.",
                         v)
+            // Cycle 19 — TOML config takes precedence. When set,
+            // we use it directly without consulting the env
+            // var. The Config-side parser already validated the
+            // value against `knownShellKeys`; here we just map
+            // `string → ShellId` via `parseEnvVar`.
+            let configShell =
+                match Config.resolveDefaultShell config with
+                | Some shellKey ->
+                    match ShellRegistry.parseEnvVar shellKey with
+                    | Some id ->
+                        log.LogInformation(
+                            "Startup shell resolved from [startup] default_shell = \"{Shell}\" (overriding PTYSPEAK_SHELL).",
+                            shellKey)
+                        Some id
+                    | None ->
+                        // Defensive — Config-side parser already
+                        // filtered against `knownShellKeys`, so this
+                        // arm shouldn't fire. Log + fall through.
+                        log.LogWarning(
+                            "Config: [startup] default_shell = \"{Shell}\" passed schema validation but parseEnvVar rejected it; falling through to PTYSPEAK_SHELL.",
+                            shellKey)
+                        None
+                | None -> None
             let requested =
-                match ShellRegistry.parseEnvVar envVar with
+                match configShell with
                 | Some id -> id
                 | None ->
-                    logIfUnrecognised ()
-                    ShellRegistry.Cmd
+                    match ShellRegistry.parseEnvVar envVar with
+                    | Some id -> id
+                    | None ->
+                        logIfUnrecognised ()
+                        ShellRegistry.Cmd
             // `tryFind` only returns None for ids not registered in
             // `builtIns`; both Cmd and Claude are registered, so this
             // is unreachable for the requested id, but the cmd-fallback

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -114,6 +114,21 @@ module Config =
           /// fall back.
           ModeBarrierFlushPolicy: StreamPathway.ModeBarrierFlushPolicy option }
 
+    /// Cycle 19 — `[startup]` TOML section: composition-root
+    /// startup-shell override. When `DefaultShell` is `Some`,
+    /// the composition root's `resolveStartupShell` uses it
+    /// in PREFERENCE to the `PTYSPEAK_SHELL` env var. Use
+    /// case: maintainer has `PTYSPEAK_SHELL=claude` set from
+    /// prior testing + wants cmd as durable default without
+    /// manipulating env vars (per the 2026-05-08 testing
+    /// session). String-keyed (lowercase shell id) per the
+    /// existing `ShellOverrides` discipline; valid values
+    /// match `ShellRegistry.parseEnvVar`'s recognition list
+    /// (`"cmd"`, `"powershell"`, `"pwsh"`, `"claude"`).
+    /// Unknown values logged + dropped at parse time.
+    type StartupOverrides =
+        { DefaultShell: string option }
+
     /// The top-level config record. `ShellOverrides` is keyed
     /// by lowercase shell-id strings (`"cmd"`, `"claude"`,
     /// `"powershell"` — mirrors `ShellRegistry.parseEnvVar`'s
@@ -123,7 +138,8 @@ module Config =
     type Config =
         { SchemaVersion: int
           ShellOverrides: Map<string, ShellPathwayConfig>
-          StreamOverrides: StreamParameterOverrides }
+          StreamOverrides: StreamParameterOverrides
+          StartupOverrides: StartupOverrides }
 
     /// The all-defaults Config — equivalent to "no config file
     /// present". `defaultConfig` is the authoritative source
@@ -145,7 +161,9 @@ module Config =
               // parameters" section.
               BulkChangeThreshold = None
               BackspacePolicy = None
-              ModeBarrierFlushPolicy = None } }
+              ModeBarrierFlushPolicy = None }
+          StartupOverrides =
+            { DefaultShell = None } }
 
     /// The default config file path —
     /// `%LOCALAPPDATA%\PtySpeak\config.toml`. Mirrors the
@@ -374,6 +392,50 @@ module Config =
                                 |> Map.add key { PathwayId = pathwayId }
             result
 
+    /// Cycle 19 — parse `[startup]` table. Recognises only
+    /// `default_shell` today; unknown keys logged + dropped.
+    /// Validates the value against the same shell-id allowlist
+    /// `parseShellOverrides` uses (`knownShellKeys`); unknown
+    /// shell names are logged + dropped (composition root
+    /// falls through to env-var or cmd default).
+    let private parseStartupOverrides
+            (logger: ILogger)
+            (root: TomlTable)
+            : StartupOverrides
+            =
+        match tryGetTable root "startup" with
+        | None -> defaultConfig.StartupOverrides
+        | Some startupTable ->
+            // Warn on unknown keys to help typo-spotting.
+            let knownStartupKeys = Set.ofList [ "default_shell" ]
+            for key in startupTable.Keys do
+                if not (knownStartupKeys.Contains(key)) then
+                    logger.LogWarning(
+                        "Config: [startup] unknown key '{Key}'; ignored.",
+                        key)
+            let defaultShell =
+                match tryGetString startupTable "default_shell" with
+                | None -> None
+                | Some value ->
+                    let lowered = value.ToLowerInvariant()
+                    if knownShellKeys.Contains(lowered) then
+                        Some lowered
+                    else
+                        logger.LogWarning(
+                            "Config: [startup] default_shell '{Value}' is not a recognised shell id; ignored. Recognised: {Known}.",
+                            value,
+                            String.concat ", " knownShellKeys)
+                        None
+            { DefaultShell = defaultShell }
+
+    /// Cycle 19 — resolve the startup-shell preference. Returns
+    /// `Some shellKey` when `[startup] default_shell` was set
+    /// to a recognised shell id; `None` otherwise (composition
+    /// root then falls through to `PTYSPEAK_SHELL` env var or
+    /// the cmd built-in default).
+    let resolveDefaultShell (config: Config) : string option =
+        config.StartupOverrides.DefaultShell
+
     /// Internal — parse the schema_version field. Missing → 1
     /// with Warning. Newer than CurrentSchemaVersion → Error +
     /// raises so the caller can fall back to defaults. Older
@@ -474,10 +536,13 @@ module Config =
                                 | None -> defaultConfig.StreamOverrides
                                 | Some streamTable ->
                                     parseStreamOverrides logger streamTable
+                        let startupOverrides =
+                            parseStartupOverrides logger model
                         let result =
                             { SchemaVersion = version
                               ShellOverrides = shellOverrides
-                              StreamOverrides = streamOverrides }
+                              StreamOverrides = streamOverrides
+                              StartupOverrides = startupOverrides }
                         // One Information line summarising the
                         // resolved config so post-hoc diagnosis
                         // via Ctrl+Shift+; is trivial. The
@@ -491,9 +556,13 @@ module Config =
                                 |> Map.toSeq
                                 |> Seq.map (fun (k, v) -> sprintf "%s→%s" k v.PathwayId)
                                 |> String.concat ", "
+                        let startupSummary =
+                            match result.StartupOverrides.DefaultShell with
+                            | Some shell -> sprintf "default_shell=%s" shell
+                            | None -> "no startup overrides"
                         logger.LogInformation(
-                            "Config loaded from {Path}: {Overrides}.",
-                            filePath, overrideSummary)
+                            "Config loaded from {Path}: {Overrides}; {Startup}.",
+                            filePath, overrideSummary, startupSummary)
                         result
 
     /// Resolve the pathway ID for a given shell key (lowercase:

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -424,3 +424,48 @@ let ``unknown mode_barrier_flush_policy value logs Warning and falls back to def
     let resolved = Config.resolveStreamParameters config
     Assert.Equal(StreamPathway.SummaryOnly, resolved.ModeBarrierFlushPolicy)
     Assert.True(logger.HasLevel(LogLevel.Warning))
+
+// =====================================================================
+// Cycle 19 — `[startup] default_shell` TOML override
+// =====================================================================
+
+[<Fact>]
+let ``defaultConfig resolveDefaultShell returns None`` () =
+    Assert.Equal(None, Config.resolveDefaultShell Config.defaultConfig)
+
+[<Fact>]
+let ``[startup] default_shell = "cmd" parses + resolves`` () =
+    let toml =
+        "schema_version = 1\n[startup]\ndefault_shell = \"cmd\"\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(Some "cmd", Config.resolveDefaultShell config)
+
+[<Fact>]
+let ``[startup] default_shell case-insensitive (uppercase folds to lowercase)`` () =
+    let toml =
+        "schema_version = 1\n[startup]\ndefault_shell = \"PowerShell\"\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(Some "powershell", Config.resolveDefaultShell config)
+
+[<Fact>]
+let ``[startup] default_shell unknown value logs Warning + drops override`` () =
+    let toml =
+        "schema_version = 1\n[startup]\ndefault_shell = \"bash\"\n"
+    let config, logger = loadFromText toml
+    Assert.Equal(None, Config.resolveDefaultShell config)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+
+[<Fact>]
+let ``[startup] missing default_shell key returns None`` () =
+    let toml = "schema_version = 1\n[startup]\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(None, Config.resolveDefaultShell config)
+
+[<Fact>]
+let ``[startup] unknown key logs Warning but does not corrupt parse`` () =
+    let toml =
+        "schema_version = 1\n[startup]\ndefault_shell = \"cmd\"\nunknown_setting = 42\n"
+    let config, logger = loadFromText toml
+    Assert.Equal(Some "cmd", Config.resolveDefaultShell config)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+


### PR DESCRIPTION
## Summary

Two small named follow-ups bundled per maintainer direction
2026-05-08. Both sat on the strategic backlog after Cycle 17
/ 18; combining into a single PR avoids two near-identical
doc-+-test churn cycles.

## Part 1 — Tier 1.D-cleanup: consolidate detector invocation

**Refactor only; zero behaviour change.**

Cycle 17 (PR #192) introduced the channel-driven actor model
+ tick-driven `handleTick` helper to close the detector
idle-gap hole. That cycle left detector-invocation logic
duplicated across `handleRowsChanged` (frame-driven) and
`handleTick` (tick-driven) — same 4-arg shape (shell key +
detection time + `tryDetect` + state update + dispatch on
`Some`).

Cycle 19 factors the duplication into a shared `runDetector`
helper inside the consumer task body. Both call sites become
1-line invocations:

```fsharp
let runDetector
        (snapshot: Cell[][])
        (cursorPos: int * int)
        (now: DateTime)
        : unit
        =
    let shellKey = shellIdToConfigKey currentShellId
    let boundary, nextDetector =
        HeuristicPromptDetector.tryDetect
            snapshot cursorPos shellKey now promptDetector
    promptDetector <- nextDetector
    match boundary with
    | Some data -> handlePromptBoundary data
    | None -> ()
```

Helper closes over `currentShellId` + `promptDetector`
(composition-root mutables). Safe because all callers run on
the single notification-consumer thread per the
channel-driven actor model.

## Part 2 — Default-shell TOML override (item 33)

**New TOML configuration option for startup-shell selection.**

User-visible behaviour change: `[startup] default_shell`
in `%LOCALAPPDATA%\PtySpeak\config.toml` now overrides the
`PTYSPEAK_SHELL` environment variable.

**Use case** (maintainer's 2026-05-08 NVDA validation):
after running `setx PTYSPEAK_SHELL claude` for prior testing,
every launch defaulted to Claude Code. Clearing the env var
required a fresh-shell + relaunch dance. With Cycle 19,
setting `[startup] default_shell = "cmd"` in the TOML
overrides the env var — no `setx` choreography needed.

**Precedence (highest → lowest)**:
1. **`[startup] default_shell` TOML override** (NEW).
2. `PTYSPEAK_SHELL` environment variable.
3. Built-in `cmd` default.

**Recognised values**: `cmd` / `powershell` / `pwsh` /
`claude` (case-insensitive). Validated at parse time
against `Config.knownShellKeys`; unknown values produce a
`LogWarning` and the override falls through to env var.

**Schema snippet** (added to `docs/USER-SETTINGS.md`):

```toml
[startup]
default_shell = "cmd"   # cmd / powershell / pwsh / claude
```

## Files modified

| File | Change | LOC |
|---|---|---|
| `src/Terminal.Core/Config.fs` | New `StartupOverrides` record + `DefaultShell` field; `parseStartupOverrides` parser; `resolveDefaultShell` helper; updated default-config + load summary | +79 |
| `src/Terminal.App/Program.fs` | New `runDetector` helper; refactored `handleRowsChanged` + `handleTick`; updated `resolveStartupShell` to consult Config before env var | +105 / -41 |
| `tests/Tests.Unit/ConfigTests.fs` | 6 new tests covering startup-override behaviour | +45 |
| `docs/USER-SETTINGS.md` | Default-shell parameter atlas section gains the new TOML resolution step + use case + schema snippet | +28 |
| `CHANGELOG.md` | `[Unreleased]` entry under Added + Changed | +107 |

**Total**: ~323 LOC across 5 files; single-concern PR
(bundled per maintainer direction).

## Tests added

6 new tests in `tests/Tests.Unit/ConfigTests.fs`:

- `defaultConfig.resolveDefaultShell = None`.
- `[startup] default_shell = "cmd"` parses + resolves.
- `[startup] default_shell` case-insensitive (`"PowerShell"` →
  `Some "powershell"`).
- `[startup] default_shell` unknown value (`"bash"`) logs
  Warning + drops override.
- `[startup]` missing `default_shell` key returns None.
- `[startup]` unknown subkey logs Warning but doesn't corrupt
  parse.

## Architectural alignment

Matches the
[`docs/CHANNEL-ARCHITECTURE.md`](docs/CHANNEL-ARCHITECTURE.md)
+ [`docs/CUSTOMIZATION-MODEL.md`](docs/CUSTOMIZATION-MODEL.md)
principle of user-introspectable + user-customizable
substrate seams. The startup-shell choice is one such seam;
exposing it via TOML is the natural application of the
principle at this layer.

## Out of scope

- TOML hot-reload (changes still require restart).
- Default-shell preference UI (palette / menu — Phase 2).
- Per-shell override syntax (`[shell.cmd] default = true`)
  — single global default suffices for v1.
- Spec changes (per CLAUDE.md spec-immutability).

## Test plan

- [ ] CI build green on windows-latest (`dotnet build` with
  TreatWarningsAsErrors).
- [ ] All ~673 existing tests + 6 new = ~679 tests pass.
- [ ] No spec changes.
- [ ] Markdown link check + workflow lint pass.
- [ ] **Manual NVDA validation** (post-merge): cut release,
  confirm `setx PTYSPEAK_SHELL claude` is still set, drop
  `[startup]\ndefault_shell = "cmd"` into
  `%LOCALAPPDATA%\PtySpeak\config.toml`, relaunch pty-speak.
  Expected: cmd opens (TOML overrode env var). Verifiable
  in the FileLogger debug stream where the
  "Startup shell resolved from [startup] default_shell"
  Information line should fire.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_