### PR TITLE
docs(diagnostics): announce "K of N command history entries" instead of "K tuples"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 20a-followup): Diagnostic announce wording — "command history entries"
+
+**Tiny accessibility-clarity follow-up** to Cycle 20a per
+maintainer feedback 2026-05-08: after Cycle 20a's headline
+behaviour change made the SessionModel `History.Count`
+visibly grow on every command, the maintainer reported the
+spoken announce wording felt opaque ("tuples" reads as
+jargon; the cap wasn't audible). One-line change in
+`Diagnostics.fs`:
+
+Before:
+> "Diagnostic complete. 1 of 1 passed. SessionModel: 2
+> tuples, active state AwaitingCommandStart. Diagnostic log
+> copied to clipboard."
+
+After:
+> "Diagnostic complete. 1 of 1 passed. SessionModel: 2 of
+> 100 command history entries, active state
+> AwaitingCommandStart. Diagnostic log copied to clipboard."
+
+Adds ~3 spoken words. The "K of N" phrasing surfaces the
+`MaxHistorySize` cap (default 100) so the maintainer can
+hear "approaching cap" pressure without paste-into-chat
+log inspection. "Command history entries" replaces "tuples"
+as the user-facing term.
+
+**Files modified**: `src/Terminal.App/Diagnostics.fs` (one
+substrate-fragment template, two arms — Some-state +
+None-state — updated symmetrically).
+
+**No code-test changes**: the diagnostic battery's pure
+helpers (`captureSessionModel`, `formatSessionModelSnapshot`)
+are unchanged; only the announce-formatting template
+inside `runFullBattery`'s body shifted. Per the Track B
+audit pattern, composition-root announce strings aren't
+unit-tested; verification is the maintainer's NVDA-listen.
+
 ### Changed (Cycle 20a): Tier 1.E2.A — row-index-aware detector emission
 
 **First half of the Tier 1.E2 split** per maintainer

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -856,17 +856,27 @@ module Diagnostics =
                     // maintainer hears substrate state alongside
                     // the battery summary; full multi-line state
                     // is in the (clipboard-copied) log.
+                    //
+                    // Cycle 20a-followup: announce "K of N command
+                    // history entries" rather than the older "K
+                    // tuples". Replaces jargon with a phrase that
+                    // matches the substrate's user-facing meaning
+                    // (history length) + reports the cap so the
+                    // maintainer can hear "approaching cap"
+                    // pressure without paste-into-chat.
                     let substrateFragment =
                         match sessionSnapshot.ActiveState with
                         | Some state ->
                             sprintf
-                                " SessionModel: %d tuples, active state %s."
+                                " SessionModel: %d of %d command history entries, active state %s."
                                 sessionSnapshot.HistoryCount
+                                sessionSnapshot.MaxHistorySize
                                 state
                         | None ->
                             sprintf
-                                " SessionModel: %d tuples, no active state."
+                                " SessionModel: %d of %d command history entries, no active state."
                                 sessionSnapshot.HistoryCount
+                                sessionSnapshot.MaxHistorySize
                     let summaryLine =
                         if total = 0 then
                             sprintf


### PR DESCRIPTION
## Summary

**Tiny accessibility-clarity follow-up** to Cycle 20a per
maintainer feedback 2026-05-08.

After Cycle 20a's headline behaviour change made the
SessionModel `History.Count` visibly grow on every command,
the maintainer reported the spoken announce wording felt
opaque — "tuples" reads as jargon, and the
`MaxHistorySize` cap wasn't audible from the announce alone
(only via paste-into-chat log inspection).

## Change

One-line template change in `Diagnostics.fs`. The
substrate-fragment in the diagnostic-battery summary
announce now reads:

**Before**:
> "Diagnostic complete. 1 of 1 passed. SessionModel: 2
> tuples, active state AwaitingCommandStart. Diagnostic
> log copied to clipboard."

**After**:
> "Diagnostic complete. 1 of 1 passed. SessionModel: 2 of
> 100 command history entries, active state
> AwaitingCommandStart. Diagnostic log copied to
> clipboard."

Two arms updated symmetrically: `Some state` + `None`
(no-active-state) variants.

## Why this change

Two motivations:

1. **"Command history entries" replaces "tuples"** —
   matches the substrate's user-facing meaning rather than
   the F#-level type-name jargon.
2. **"K of N" phrasing surfaces the cap** — maintainer can
   hear "approaching cap" pressure via the announce alone.
   No paste-into-chat needed for capacity diagnosis.

Adds ~3 spoken words to the announce; well within NVDA's
~10-second-read budget.

## No tests affected

Per the Track B audit pattern, composition-root announce
strings aren't unit-tested. Verification is the
maintainer's NVDA-listen post-merge: cut release; press
Ctrl+Shift+D; confirm the new wording.

The pure helpers (`captureSessionModel`,
`formatSessionModelSnapshot`) are unchanged. Only the
announce-formatting template inside `runFullBattery`'s
body shifted.

## Test plan

- [ ] CI build green on windows-latest.
- [ ] All ~689 existing tests pass (no test changes).
- [ ] Markdown link check + workflow lint pass.
- [ ] Manual NVDA validation post-merge: maintainer cuts
  release, presses Ctrl+Shift+D, confirms the new
  wording reads naturally.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_