### PR TITLE
fix(terminal-core): HeuristicPromptDetector multi-match flapping (Cycle 22a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,61 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 22a): HeuristicPromptDetector multi-match flapping → History flooded to 100/100
+
+**Substrate hotfix.** Manual NVDA validation 2026-05-08
+exposed a regression introduced by Cycle 20a (PR #195): in
+cmd sessions where a prior prompt was still visible above
+the current prompt (i.e. essentially every cmd session
+after the first command), the `HeuristicPromptDetector`
+emitted PromptStart events at ~20Hz, alternating between
+two row indices (e.g. row 6 and row 13). Each emission
+fired the SessionModel state machine's
+"`PromptStart while Active=Some` → finalise prior as
+incomplete" arm, flooding `History` to its 100-tuple cap
+within ~5 seconds.
+
+**Root cause.** Cycle 20a's emission gate was
+`(text, rowIdx) != LastEmitted`, with first-match-wins
+loop semantics. When two rows matched the regex with
+identical text:
+- Tick N: walks rows ascending, emits at row 6.
+  `LastEmitted = ("C:\\Users\\admin>", 6)`.
+- Tick N+1: walks again. Row 6's pair equals last-emitted →
+  skip. Row 13's pair differs → emit. `LastEmitted = (..., 13)`.
+- Tick N+2: row 6's pair now differs from last-emitted →
+  emit. `LastEmitted = (..., 6)`.
+- Forever flap at the tick rate.
+
+**The fix** (this PR). Replace the first-match-wins loop
+with two-pass detection. Pass 1 collects every
+stable+matching row. Pass 2 picks the highest row index
+(the newest prompt — output flows downward in every
+supported shell, so the bottommost match is the active
+prompt) and applies the (text, rowIdx) emission gate to
+that one candidate. Earlier matches are scrollback noise
+and get suppressed by construction.
+
+**Files**:
+- `src/Terminal.Core/HeuristicPromptDetector.fs` —
+  refactored detection loop to two-pass.
+- `tests/Tests.Unit/HeuristicPromptDetectorTests.fs` —
+  updated existing `multiple rows match regex; first
+  stable one emits` test (renamed to `highest-rowIdx
+  stable one emits` with stronger assertion); added 4 new
+  tests covering: identical-text two-row flap suppression
+  (the headline regression guard); three stable rows;
+  scroll-off transition (highest-row content disappears,
+  lower remaining match emits); different-text two-row
+  highest-wins.
+
+**Behaviour change**: the substrate's idle behaviour for
+cmd / PowerShell sessions with prior prompts visible no
+longer floods History. Verifiable by maintainer: cut
+release, type a few commands in cmd, wait, press
+Ctrl+Shift+D — expect History grows by 1 per command (was:
+fills to 100/100 within seconds at idle).
+
 ### Added (Cycle 20b): Tier 1.E2.B — CommandText + OutputText extraction (closes Tier 1)
 
 **Second half of the Tier 1.E2 split** per maintainer

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -46,17 +46,35 @@ open Microsoft.Extensions.Logging
 ///    §282-300 + USER-SETTINGS atlas entries defer to a
 ///    later cycle.
 ///
-/// **Detection algorithm (per-frame)**:
+/// **Detection algorithm (per-frame, two-pass)**:
 ///
+/// PASS 1 — walk every row:
 /// 1. Render row text via `CanonicalState.renderRow`
 ///    (sanitised + trailing-blank-trimmed).
 /// 2. Test against per-shell regex (compiled, module-level
 ///    singleton).
 /// 3. If matches AND `(now - first-match-time) ≥
-///    stabilityMs` AND text differs from
-///    `LastEmittedPromptText` → emit PromptStart.
-/// 4. If matches but window not elapsed OR text equals
-///    last-emitted → no emit, update state.
+///    stabilityMs` → record as a stable match candidate.
+/// 4. If matches but window not yet elapsed OR text changed
+///    → reset the per-row stability timer.
+/// 5. If no longer matches → evict stale per-row entry.
+///
+/// PASS 2 — among all stable matches, pick the highest
+/// rowIdx (the newest prompt — output flows downward in
+/// every supported shell, so the bottommost matching row is
+/// the active prompt). Apply the (text, rowIdx) emission
+/// gate: emit if the pair differs from the last emitted
+/// pair; suppress otherwise.
+///
+/// **Why two-pass** (Cycle 22a fix). A one-pass
+/// "first-match-wins" loop produced infinite emission
+/// flapping when two rows matched the regex with identical
+/// text (e.g. cmd's screen with a prior prompt still
+/// visible above the current one): each tick alternated
+/// which row emitted because the gate `(text, rowIdx) !=
+/// last-emitted` kept satisfying. Picking max-rowIdx among
+/// stable matches eliminates the alternation by
+/// construction.
 ///
 /// **Threading**: detector is mutated only on the
 /// PathwayPump worker thread (single-threaded for
@@ -194,14 +212,28 @@ module HeuristicPromptDetector =
             // Unknown shell — no detection per Q2 resolution.
             None, state
         | Some (regex, stabilityMs) ->
-            // Walk every row; find the first row whose text
-            // matches the regex AND has been stable for the
-            // shell's window. Drop per-row entries for rows
-            // that no longer match (state hygiene).
+            // Cycle 22a — two-pass detection. Pass 1 walks every
+            // row, updates per-row stability state, and collects
+            // every row that's currently stable + matching. Pass
+            // 2 picks the highest-rowIdx among them (the newest
+            // prompt — cmd / PowerShell / Claude all emit output
+            // downward, so the bottommost matching row is the
+            // active one) and applies the (text, rowIdx) gate.
+            //
+            // Cycle 20a's first-match-wins loop produced infinite
+            // flapping when two rows matched the regex with
+            // identical text (e.g. cmd's screen with a prior
+            // prompt still visible above the active one): each
+            // tick alternated which row emitted because the gate
+            // `(text, rowIdx) != LastEmitted` kept satisfying.
+            // Within ~5 seconds, History flooded to 100/100.
+            // Picking max-rowIdx among stable matches eliminates
+            // the alternation by construction — there's exactly
+            // one "current prompt" per tick.
             let mutable nextMatches = state.PerRowMatches
-            let mutable emitted : PromptBoundaryData option = None
-            let mutable emittedText : string option = None
-            let mutable emittedRowIndex : int option = None
+            // PASS 1 — walk rows, update stability state,
+            // collect every stable+matching row.
+            let stableMatches = ResizeArray<int * string>()
             for rowIdx in 0 .. snapshot.Length - 1 do
                 let text = CanonicalState.renderRow snapshot rowIdx
                 if regex.IsMatch(text) then
@@ -209,69 +241,78 @@ module HeuristicPromptDetector =
                     match priorMatch with
                     | Some (priorText, firstSeen) when priorText = text ->
                         let elapsed = now - firstSeen
-                        // Tier 1.E2.A — row-index-aware emission
-                        // gate. A NEW PromptStart fires when the
-                        // (text, rowIdx) pair differs from the
-                        // last emitted pair. Catches:
-                        //   * Different text (today's case): cd
-                        //     changed the prompt path.
-                        //   * Same text, different row: cmd's
-                        //     stable-prompt case where output
-                        //     pushed the prompt to a new row
-                        //     after a command cycle.
-                        // Suppresses:
-                        //   * Same text, same row: cursor blink
-                        //     / refresh / no real activity.
-                        let isNewPrompt =
-                            match
-                                state.LastEmittedPromptText,
-                                state.LastEmittedPromptRowIndex
-                                with
-                            | Some priorText, Some priorRow ->
-                                priorText <> text || priorRow <> rowIdx
-                            | _ -> true   // first emit
-                        if elapsed.TotalMilliseconds >= float stabilityMs
-                           && emitted.IsNone
-                           && isNewPrompt
-                        then
-                            // Stable + new prompt → emit. Source
-                            // stamps the shell's stability window
-                            // as the integer payload.
-                            emitted <-
-                                Some
-                                    { Kind = BoundaryKind.PromptStart
-                                      Source =
-                                        BoundarySource.HeuristicPromptRegex
-                                            stabilityMs
-                                      DetectedAt = now
-                                      CommandId = None
-                                      ExtraParams = Map.empty
-                                      // Tier 1.E: capture the
-                                      // matching row's text for
-                                      // SessionModel PromptText
-                                      // population.
-                                      MatchedRowText = Some text
-                                      // Tier 1.E2.A: capture the
-                                      // matching row's index for
-                                      // (a) the row-index-aware
-                                      // emission gate above and
-                                      // (b) Cycle 20b's CommandText
-                                      // / OutputText extraction at
-                                      // finalize time.
-                                      MatchedRowIndex = Some rowIdx }
-                            emittedText <- Some text
-                            emittedRowIndex <- Some rowIdx
+                        if elapsed.TotalMilliseconds >= float stabilityMs then
+                            stableMatches.Add((rowIdx, text))
                     | _ ->
-                        // First time seeing this text on
-                        // this row, OR text changed —
-                        // restart the stability timer.
+                        // First time seeing this text on this
+                        // row, OR text changed — restart the
+                        // stability timer.
                         nextMatches <-
                             Map.add rowIdx (text, now) nextMatches
                 else
-                    // Row no longer matches; evict stale
-                    // entry to keep the map bounded.
+                    // Row no longer matches; evict stale entry
+                    // to keep the map bounded.
                     if Map.containsKey rowIdx nextMatches then
                         nextMatches <- Map.remove rowIdx nextMatches
+
+            // PASS 2 — pick highest-rowIdx among stable matches,
+            // apply the row-index-aware emission gate.
+            let mutable emitted : PromptBoundaryData option = None
+            let mutable emittedText : string option = None
+            let mutable emittedRowIndex : int option = None
+            if stableMatches.Count > 0 then
+                let firstRow, firstText = stableMatches.[0]
+                let mutable bestRow = firstRow
+                let mutable bestText = firstText
+                for i in 1 .. stableMatches.Count - 1 do
+                    let candidateRow, candidateText = stableMatches.[i]
+                    if candidateRow > bestRow then
+                        bestRow <- candidateRow
+                        bestText <- candidateText
+                // Tier 1.E2.A — row-index-aware emission gate.
+                // A NEW PromptStart fires when the (text, rowIdx)
+                // pair differs from the last emitted pair.
+                // Catches:
+                //   * Different text: `cd` changed the prompt
+                //     path.
+                //   * Same text, different row: cmd's
+                //     stable-prompt case where output pushed
+                //     the prompt to a new row after a command
+                //     cycle.
+                // Suppresses:
+                //   * Same text, same row: cursor blink /
+                //     refresh / no real activity.
+                let isNewPrompt =
+                    match
+                        state.LastEmittedPromptText,
+                        state.LastEmittedPromptRowIndex
+                        with
+                    | Some priorText, Some priorRow ->
+                        priorText <> bestText || priorRow <> bestRow
+                    | _ -> true   // first emit
+                if isNewPrompt then
+                    emitted <-
+                        Some
+                            { Kind = BoundaryKind.PromptStart
+                              Source =
+                                BoundarySource.HeuristicPromptRegex
+                                    stabilityMs
+                              DetectedAt = now
+                              CommandId = None
+                              ExtraParams = Map.empty
+                              // Tier 1.E: capture the matching
+                              // row's text for SessionModel
+                              // PromptText population.
+                              MatchedRowText = Some bestText
+                              // Tier 1.E2.A: capture the matching
+                              // row's index for (a) the
+                              // row-index-aware emission gate
+                              // above and (b) Cycle 20b's
+                              // CommandText / OutputText
+                              // extraction at finalize time.
+                              MatchedRowIndex = Some bestRow }
+                    emittedText <- Some bestText
+                    emittedRowIndex <- Some bestRow
 
             let nextLastEmittedText =
                 match emittedText with

--- a/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
+++ b/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
@@ -293,7 +293,12 @@ let ``prompt at row 5 (not last) detected correctly`` () =
     Assert.True(r.IsSome)
 
 [<Fact>]
-let ``multiple rows match regex; first stable one emits`` () =
+let ``multiple rows match regex; highest-rowIdx stable one emits`` () =
+    // Cycle 22a: among multiple simultaneously-stable matches,
+    // the detector picks the highest row index (the newest
+    // prompt — output flows downward, so the bottommost match
+    // is the active prompt). Earlier matches are scrollback
+    // noise.
     let snap = snapshotOf 3 80 [ "C:\\>"; ""; "D:\\>" ]
     let detector = HeuristicPromptDetector.create ()
     let _, s1 =
@@ -301,9 +306,122 @@ let ``multiple rows match regex; first stable one emits`` () =
     let r, _ =
         HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
     Assert.True(r.IsSome)
-    // (Implementation detail: emits the first row's match;
-    // duplicate suppression then prevents subsequent rows
-    // from emitting on this frame.)
+    let boundary = r.Value
+    // Highest-rowIdx wins: row 2 ("D:\\>") not row 0 ("C:\\>").
+    Assert.Equal(Some 2, boundary.MatchedRowIndex)
+    Assert.Equal(Some "D:\\>", boundary.MatchedRowText)
+
+[<Fact>]
+let ``two stable rows with IDENTICAL text emits once; subsequent ticks do not flap`` () =
+    // Cycle 22a regression guard. The release log 2026-05-08
+    // showed the detector alternating between rowIdx=6 and
+    // rowIdx=13 every ~50ms when cmd had a prior prompt
+    // visible above the current one — both rows passed the
+    // regex with identical text, so the (text, rowIdx) gate
+    // kept satisfying as the row choice flipped. This test
+    // pins the fix: among multiple stable matches with
+    // identical text, the detector emits ONCE (for the
+    // highest row), then suppresses on subsequent ticks.
+    let snap = snapshotOf 14 80
+                [ ""; ""; ""; ""; ""; ""
+                  "C:\\Users\\admin>"  // row 6 — old prompt
+                  ""; ""; ""; ""; ""; ""
+                  "C:\\Users\\admin>"  // row 13 — current prompt
+                ]
+    let detector = HeuristicPromptDetector.create ()
+    // Tick 1: rows seen for the first time; no emit.
+    let r1, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    Assert.True(r1.IsNone)
+    // Tick 2: stability window elapsed; both rows stable.
+    // Highest row 13 emits.
+    let r2, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r2.IsSome)
+    Assert.Equal(Some 13, r2.Value.MatchedRowIndex)
+    // Tick 3: same snapshot, both rows still stable. Highest
+    // row 13 still equals last-emitted (text, rowIdx) → no
+    // emit. The alternation bug would have emitted row 6 here.
+    let r3, s3 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 150) s2
+    Assert.True(r3.IsNone)
+    // Tick 4: still no emit. Pin the no-flap invariant across
+    // multiple ticks.
+    let r4, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 200) s3
+    Assert.True(r4.IsNone)
+
+[<Fact>]
+let ``three stable rows; highest emits`` () =
+    let snap = snapshotOf 16 80
+                [ ""; ""; ""
+                  "C:\\>"  // row 3
+                  ""; ""; ""
+                  "C:\\>"  // row 7
+                  ""; ""; ""; ""; ""; ""; ""
+                  "C:\\>"  // row 15
+                ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r.IsSome)
+    Assert.Equal(Some 15, r.Value.MatchedRowIndex)
+
+[<Fact>]
+let ``highest-row prompt scrolls off; lower remaining match emits`` () =
+    // Two stable matches at rows 5 and 13; highest (13) emits.
+    // Then row 13 scrolls off (becomes blank); only row 5
+    // matches now. Row 5's content is identical to what was
+    // at row 13, so (text, rowIdx) gate fires (different row).
+    let snapBoth = snapshotOf 14 80
+                    [ ""; ""; ""; ""; ""
+                      "C:\\>"  // row 5
+                      ""; ""; ""; ""; ""; ""; ""
+                      "C:\\>"  // row 13
+                    ]
+    let snapOneScrolledOff = snapshotOf 14 80
+                              [ ""; ""; ""; ""; ""
+                                "C:\\>"  // row 5
+                                ""; ""; ""; ""; ""; ""; ""; ""
+                              ]
+    let detector = HeuristicPromptDetector.create ()
+    // Tick 1: first sighting, no emit.
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snapBoth noCursor "cmd" t0 detector
+    // Tick 2: stable, highest (13) emits.
+    let r2, s2 =
+        HeuristicPromptDetector.tryDetect snapBoth noCursor "cmd" (after 100) s1
+    Assert.True(r2.IsSome)
+    Assert.Equal(Some 13, r2.Value.MatchedRowIndex)
+    // Tick 3: row 13 scrolls off. Row 5 was already stable
+    // (carried over from prior snap). Now row 5 is the only
+    // stable match → emit row 5.
+    let r3, _ =
+        HeuristicPromptDetector.tryDetect snapOneScrolledOff noCursor "cmd" (after 200) s2
+    Assert.True(r3.IsSome)
+    Assert.Equal(Some 5, r3.Value.MatchedRowIndex)
+
+[<Fact>]
+let ``two stable rows with DIFFERENT text emits highest`` () =
+    // Variant of the cycle 22a regression test, but text
+    // differs across the rows. Confirms highest-rowIdx wins
+    // regardless of text similarity.
+    let snap = snapshotOf 8 80
+                [ ""
+                  "C:\\>"  // row 1
+                  ""; ""; ""; ""; ""
+                  "D:\\Projects>"  // row 7
+                ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r.IsSome)
+    Assert.Equal(Some 7, r.Value.MatchedRowIndex)
+    Assert.Equal(Some "D:\\Projects>", r.Value.MatchedRowText)
 
 [<Fact>]
 let ``all-blank snapshot returns None`` () =


### PR DESCRIPTION
## Summary

Substrate hotfix for the `HeuristicPromptDetector` multi-match flapping bug exposed by manual NVDA validation 2026-05-08. Cycle 20a's emission gate (`(text, rowIdx) != LastEmitted`) produced infinite emission alternation when two rows matched the regex with identical text — the everyday cmd case where a prior prompt is still visible above the current one.

**Behaviour before fix**: typing in cmd → `History` floods to 100/100 within ~5 seconds at idle. Detector emits PromptStart at ~20Hz alternating between row 6 and row 13 (or whichever two rows match).

**Behaviour after fix**: detector emits at most one PromptStart per command cycle. History grows by 1 per command, as designed.

## What changes

- **`HeuristicPromptDetector.fs`**: replace first-match-wins loop with two-pass detection.
  - Pass 1 walks every row, updates per-row stability state, and collects every row that's currently stable + matching (the existing logic, restructured).
  - Pass 2 picks the highest row index among stable matches (the newest prompt — output flows downward in every supported shell, so the bottommost match is the active prompt) and applies the `(text, rowIdx)` emission gate to that one candidate.
  - Earlier matches are scrollback noise; suppressed by construction.

- **`HeuristicPromptDetectorTests.fs`**:
  - Renamed and strengthened existing `multiple rows match regex; first stable one emits` → `multiple rows match regex; highest-rowIdx stable one emits` with explicit row-index assertion.
  - Added 4 new regression tests:
    1. **`two stable rows with IDENTICAL text emits once; subsequent ticks do not flap`** — the headline regression guard. Reproduces the exact cmd-session bug pattern (two matching rows at indices 6 and 13 with identical text "C:\\Users\\admin>") and asserts no emission flapping across multiple ticks.
    2. **`three stable rows; highest emits`** — confirms highest-row wins among 3+ candidates.
    3. **`highest-row prompt scrolls off; lower remaining match emits`** — confirms scroll-off transition: when the highest-row content disappears, the next-highest stable match becomes the active one.
    4. **`two stable rows with DIFFERENT text emits highest`** — confirms highest-rowIdx wins regardless of text similarity.

## Closes substrate breakage

After Cycle 22a + manual NVDA validation, the SessionModel substrate's idle behaviour for cmd / PowerShell sessions with prior prompts visible no longer floods History. Tier 1 substrate is once again reliable for the everyday case.

## Test plan

- [x] Unit tests pass (CI on windows-latest; existing ~33 detector tests + 4 new = ~37 tests).
- [x] Existing `multiple rows match regex` test updated to reflect new semantics.
- [ ] Manual NVDA validation post-merge:
  - Cut release. Launch pty-speak in cmd. Type `echo hi` + Enter. Wait 5 seconds.
  - Press Ctrl+Shift+D. Expect History grows by 1 (was: floods to 100/100).
  - Run several commands. Expect History increments by 1 per command, not by hundreds.

https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi1Krx7t1XJykSQjUXC5p1)_