### PR TITLE
docs(claude): poll CI every 30s; webhooks unreliable in this env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,21 @@ minutes of wasted CI cycle plus a noisier git history.
   CI failures, comments, and merges land in the conversation
   automatically). Other PR-creation channels do not trigger the
   subscription.
+- **Webhook events are unreliable in this maintainer's environment —
+  poll CI every 30 seconds.** Confirmed across many sessions: PR
+  activity webhooks frequently fail to arrive when CI completes,
+  leaving the agent stuck in "waiting for events that won't come".
+  The workaround: after pushing a PR (or a fixup commit), start a
+  poll loop that calls `mcp__github__pull_request_read` with
+  `method: get_check_runs` every 30 seconds until every check's
+  `status` is `completed`. Implementation: `Bash` with
+  `run_in_background: true` running `sleep 30`; the harness
+  notifies on completion; check status; repeat. **Don't poll faster
+  than 30s** — it wastes API calls and the actual CI feedback
+  cadence is multi-minute. **Don't sleep longer between polls** —
+  the maintainer's working rhythm depends on prompt CI follow-up.
+  Webhook events still arrive sometimes; treat them as a free
+  early-exit signal but don't depend on them.
 - **Standing merge rule:** once CI is green on a PR, merge it
   without re-asking (per maintainer authorization). Use squash-merge.
   Update local main + delete the local branch after.


### PR DESCRIPTION
## Summary

Per maintainer feedback (2026-05-09): `<github-webhook-activity>` events frequently fail to arrive when CI completes in this maintainer's environment, leaving the agent stuck "waiting for events that won't come" across many sessions.

Add a working-rule under "PR creation and webhook subscription" in `CLAUDE.md` making **30-second CI polling the durable default** after a PR push or fixup commit. Implementation pattern is spelled out inline so a new agent can adopt the rhythm without reinventing it:

- `Bash` with `run_in_background: true` running `sleep 30`.
- Harness notifies on completion.
- Call `mcp__github__pull_request_read` with `method: get_check_runs`.
- Repeat until every check's `status` is `completed`.

Cadence justified inline: faster than 30s wastes API calls against the multi-minute CI feedback loop; slower disrupts the maintainer's working rhythm. Webhook events still arrive sometimes; treat them as a free early-exit signal but don't depend on them.

Doc-only PR; no code changes.

## Test plan

- [ ] `markdown-link-check` CI green (no new outbound links added).
- [ ] `actionlint` CI green (no workflow changes).
- [ ] Build/test CI green (no F# changes).
- [ ] Read-back: a future Claude session, after pushing a PR, polls every 30s instead of waiting indefinitely for webhook activity.

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_