### PR TITLE
feat(terminal-core): env-var value sanitisation for SessionTuple persistence (Cycle 24d-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,92 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 24d-2): env-var value sanitisation for SessionTuple persistence
+
+Closes the Cycle 24d sub-cycle. Adds VALUE-based redaction
+of env-var-derived secrets in persisted SessionTuple text
+fields, complementing Stage 7's NAME-only env-scrub at the
+child-process spawn boundary.
+
+**Threat model**: a shell expands an env var into output —
+e.g. `echo $GITHUB_TOKEN` substitutes the literal token
+value `ghp_abc123...` into stdout. The terminal sees the
+expanded value (NOT the variable name); without sanitisation
+the SessionLogWriter would persist that value to the
+on-disk JSONL. NAME-only matching can't catch this case;
+once the shell has expanded, the literal name is gone.
+
+**What ships**:
+
+- New `Terminal.Core.SessionSanitiser` module with public
+  surface: `register`, `registerFromEnvironment`, `sanitise`,
+  `sanitiseTuple`, `clear` (for tests), `MinValueLength`,
+  `isDenied` (internal — Stage 7 deny-list parity).
+- Composition root in `Program.fs` calls
+  `registerFromEnvironment` at startup unconditionally
+  (cheap; the registered values are only consulted by the
+  sink's `writeOne`, which never runs when no sink exists).
+  Per `LOGGING.md`, the registration count is logged at
+  Information level — never the names or values.
+- `SessionLogWriter.writeOne` calls
+  `SessionSanitiser.sanitiseTuple` before
+  `SessionModel.formatTupleAsJsonl`. The substrate's
+  in-memory History keeps unsanitised text (user can
+  recover their own commands via `Ctrl+Shift+Y`); only the
+  persistence layer redacts.
+
+**Locked design** (per the Cycle 24d-2 plan):
+
+- **Deny-list pattern**: lifted verbatim from
+  `Terminal.Pty.Native.isDenied` (Stage 7 PO-5). Suffix
+  match on uppercase names: `*_TOKEN`, `*_SECRET`, `*_KEY`,
+  `*_PASSWORD`. `ANTHROPIC_API_KEY` exempted (Claude Code's
+  primary credential, same precedent).
+- **Min-length threshold**: 16 chars. Avoids false
+  positives on short common values (e.g. `BANK_API_KEY=admin`
+  would NOT register).
+- **Redaction marker**: `<REDACTED:UPPERCASE_NAME>`.
+  Decades-stable; angle brackets are unambiguous in shell
+  output; colon-delimited for regex parseability by future
+  replay tools.
+- **Substring-overlap safety**: registered values sorted by
+  length DESC so the longer value is matched first if one
+  is a substring of another.
+- **Sanitised fields**: `CommandText`, `OutputText`,
+  `PromptText`, and every `ExtraParams` value. Conservative.
+- **Threading**: lock-guarded module-level state; safe from
+  any thread.
+
+**21 new xUnit `[<Fact>]` tests** in
+`tests/Tests.Unit/SessionSanitiserTests.fs` cover:
+- `MinValueLength` threshold behaviour.
+- Empty / whitespace value skip.
+- Marker format pinning.
+- Single + multi-value redaction.
+- Same-value-multiple-times handling.
+- Substring-overlap safety (longer wins).
+- `isDenied` parity with Stage 7 — every pattern + the
+  `ANTHROPIC_API_KEY` exemption + non-match cases
+  (`KEYBOARD_LAYOUT`, `KEYS_TO_THE_KINGDOM`, `PATH`).
+- `sanitiseTuple` field application (CommandText,
+  OutputText, PromptText, ExtraParams values, key
+  pass-through, non-text-field invariance).
+- `clear` test isolation.
+- `registerFromEnvironment` happy path + non-match skip +
+  short-value skip.
+
+`docs/SESSION-MODEL.md` adds an "Env-var-value sanitisation
+(Cycle 24d-2)" sub-section under §"Persistence modes"
+documenting the threat model, registration source, marker
+format stability, and known limitations (registered at
+startup; not retroactively scanned).
+
+**Limitations** (documented in SESSION-MODEL.md):
+- Env vars set after launch are NOT retroactively scrubbed.
+- Pattern-based detection (e.g. AWS-key regex
+  `^AKIA[0-9A-Z]{16}$`) is out of scope; future cycles can
+  add this if demand surfaces.
+
 ### Changed (Cycle 24d-1): SessionLog file writer — `Always` mode synchronous flush
 
 Implements true audit-grade durability for the `Always`

--- a/docs/SESSION-MODEL.md
+++ b/docs/SESSION-MODEL.md
@@ -1149,6 +1149,55 @@ Schema migration runtime ships in Cycle 25+ (the
 deserializer). Cycle 24b only emits version 1; the
 versioning hook is the future-proofing handle.
 
+### Env-var-value sanitisation (Cycle 24d-2)
+
+Before each tuple is written to disk, the
+`SessionLogWriterSink` runs it through
+`SessionSanitiser.sanitiseTuple`
+(`src/Terminal.Core/SessionSanitiser.fs`). The sanitiser
+replaces any occurrence of a registered env-var value with
+the marker `<REDACTED:UPPERCASE_NAME>` in the tuple's
+`commandText`, `outputText`, `promptText`, and every
+`extraParams` value. The substrate's in-memory History keeps
+unsanitised text (the user can recover their own commands
+via `Ctrl+Shift+Y`); only the persistence layer redacts.
+
+**Registration**: at startup, the composition root calls
+`SessionSanitiser.registerFromEnvironment` which enumerates
+the process environment and registers values for every var
+whose name matches the Stage 7 deny-list pattern (suffix
+match on uppercase: `*_TOKEN`, `*_SECRET`, `*_KEY`,
+`*_PASSWORD`; `ANTHROPIC_API_KEY` exempted as Claude Code's
+primary credential — same precedent as
+`Terminal.Pty.Native.isDenied`). Registration is silent for
+values shorter than 16 chars (the `MinValueLength`
+threshold) to avoid false-positive redactions on common
+short values like `BANK_API_KEY=admin`.
+
+**Threat model**: a shell expands an env var into output
+(e.g. `echo $GITHUB_TOKEN` substitutes the literal token
+value into stdout). Stage 7's NAME-only env-scrub at the
+spawn boundary prevents the CHILD shell from seeing the
+deny-listed env vars; this sanitiser is the complement —
+when pty-speak's parent process inherits a deny-listed env
+var, and the user types a command that echoes its value,
+the on-disk artefact won't contain the secret. NAME-only
+matching can't catch this case because once the shell has
+expanded the variable, the literal name is gone.
+
+**Marker format** is decades-stable. Future replay tools
+parse `<REDACTED:([A-Z_]+)>` to identify which credential
+was redacted. The format is documented here so it can't
+change without a coordinated migration; if it ever does,
+the change increments `JsonlSchemaVersion`.
+
+**Limitations**: the sanitiser captures values at startup;
+env vars set after launch are NOT retroactively scrubbed.
+Restart-to-update is the documented cost. Future cycles
+can add per-tuple env re-scan if demand surfaces. Pattern-
+based detection (e.g. AWS-key regex `^AKIA[0-9A-Z]{16}$`)
+is also out of scope today.
+
 ### Cross-session loading
 
 Future read API: pty-speak exposes a CLI command (or

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -940,6 +940,21 @@ module Program =
             SessionPersistence.formatToString persistenceConfig.Format,
             persistenceConfig.MaxSessionSizeMb)
 
+        // Cycle 24d-2 — register env-var-value redaction
+        // patterns. Reads the process env at startup, captures
+        // values for any name matching the Stage 7 deny-list
+        // pattern (`*_TOKEN`, `*_SECRET`, `*_KEY`,
+        // `*_PASSWORD`; `ANTHROPIC_API_KEY` exempted), and
+        // registers values ≥ 16 chars. Run unconditionally
+        // (even for `MemoryOnly` mode — cheap; the registered
+        // values are only consulted by the sink's `writeOne`,
+        // which never runs when no sink exists). Per
+        // LOGGING.md "log counts, never names or values", the
+        // count is logged at Information level inside
+        // `registerFromEnvironment`.
+        SessionSanitiser.registerFromEnvironment log
+        |> ignore
+
         // Cycle 24c — construct the SessionLogWriter sink for
         // the initial shell session when persistence is
         // requested. `MemoryOnly` skips construction entirely

--- a/src/Terminal.Core/SessionLogWriter.fs
+++ b/src/Terminal.Core/SessionLogWriter.fs
@@ -210,13 +210,25 @@ type SessionLogWriterSink
                 let writeOne (request: SessionLogWriteRequest) =
                     let tuple = request.Tuple
                     try
+                        // Cycle 24d-2 — sanitise env-var values
+                        // out of tuple text fields BEFORE
+                        // serialization. The substrate's
+                        // in-memory History keeps unsanitised
+                        // text (the user can recover their own
+                        // commands via Ctrl+Shift+Y); only the
+                        // persistence layer redacts. This is
+                        // the layered design — substrate stays
+                        // honest, persistence boundary applies
+                        // the privacy policy.
+                        let sanitised =
+                            SessionSanitiser.sanitiseTuple tuple
                         // Serialize THEN open the writer; if the
                         // serializer throws (lone-surrogate
                         // contract per Cycle 24b), we don't waste
                         // a file handle. Sync caller (if any)
                         // gets the exception via the TCS so they
                         // learn the write failed.
-                        let line = SessionModel.formatTupleAsJsonl tuple
+                        let line = SessionModel.formatTupleAsJsonl sanitised
                         ensureWriter ()
                         match writer with
                         | null -> ()

--- a/src/Terminal.Core/SessionSanitiser.fs
+++ b/src/Terminal.Core/SessionSanitiser.fs
@@ -1,0 +1,209 @@
+namespace Terminal.Core
+
+open System
+open System.Collections.Generic
+open System.Text
+open Microsoft.Extensions.Logging
+
+/// Cycle 24d-2 — env-var VALUE-based sanitiser for SessionTuple
+/// persistence. Captures the values of deny-listed env vars at
+/// startup, then redacts those values wherever they appear in
+/// persisted tuple text fields.
+///
+/// **Threat model**: a shell expands an env var into output. For
+/// example, `echo $GITHUB_TOKEN` causes the shell to substitute
+/// the literal token value `ghp_abc123...` into stdout. The
+/// terminal sees the expanded value (NOT the variable name); the
+/// SessionLogWriter would then persist that expanded value to
+/// `session-<id>.jsonl`. This sanitiser substitutes the value
+/// with the marker `<REDACTED:GITHUB_TOKEN>` before write, so
+/// the on-disk artefact never contains the secret.
+///
+/// **NOT a NAME-based sanitiser**. Stage 7's env-scrub at the
+/// child-process boundary (`src/Terminal.Pty/Native.fs:449-465`)
+/// works at process-creation time — it strips deny-listed names
+/// from the spawned shell's environment block so the shell can't
+/// expand them in the first place. This sanitiser is the
+/// complement: it handles the case where the env var WAS in the
+/// parent's env (so pty-speak inherited it) and the user's
+/// command echoed the value into the persisted output.
+///
+/// **Deny-list pattern**: lifted verbatim from
+/// `Terminal.Pty.Native.isDenied`. Suffix match on uppercase
+/// names: `*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`. Single
+/// exemption: `ANTHROPIC_API_KEY` (Claude Code's primary
+/// credential).
+///
+/// **Min-length threshold**: 16 chars. A short env-var value
+/// like `BANK_API_KEY=admin` (5 chars) would NOT register;
+/// otherwise we'd redact every occurrence of "admin" in any
+/// command output, which is absurd.
+///
+/// **Redaction marker format**: `<REDACTED:UPPERCASE_NAME>`.
+/// Decades-stable; angle brackets are unambiguous in shell
+/// output (rare); colon-delimited for regex parseability by
+/// future replay tools.
+///
+/// **Substring-overlap safety**: registered values are sorted
+/// by length DESCENDING so that if one secret value is a
+/// substring of another, the longer one is redacted first.
+///
+/// **Where applied**: `SessionLogWriter.writeOne` calls
+/// `sanitiseTuple` on every tuple before formatTupleAsJsonl.
+/// The substrate's in-memory History keeps unsanitised text
+/// (the user can recover their own commands via Ctrl+Shift+Y);
+/// only the persistence layer redacts. This is the layered
+/// design — substrate stays honest, persistence boundary
+/// applies the privacy policy.
+///
+/// **Threading**: `register`, `sanitise`, and `sanitiseTuple`
+/// guard the registered list with a lock. Registration
+/// typically happens once at startup but the lock makes the
+/// API safe to call from anywhere. `clear` is intended for
+/// test isolation only.
+[<RequireQualifiedAccess>]
+module SessionSanitiser =
+
+    /// Minimum value length for registration. Values shorter
+    /// than this are silently dropped to avoid spamming
+    /// redactions on common short values. 16 chars is short
+    /// enough to capture realistic credentials (most modern
+    /// API keys are 32+ chars; even legacy ones tend to be
+    /// 20-40 chars) while filtering out things like
+    /// `BANK_API_KEY=admin` that would otherwise trigger
+    /// hilarious false-positive redactions on the literal
+    /// word "admin".
+    [<Literal>]
+    let MinValueLength : int = 16
+
+    /// Suffix-match deny-list. Mirrors
+    /// `Terminal.Pty.Native.isDenied` exactly (Stage 7 PO-5).
+    /// Single exemption: `ANTHROPIC_API_KEY` (Claude Code's
+    /// primary credential workload). Internal so tests can
+    /// reach it.
+    let internal isDenied (name: string) : bool =
+        let n = name.ToUpperInvariant()
+        if n = "ANTHROPIC_API_KEY" then false
+        else
+            n.EndsWith("_TOKEN", StringComparison.Ordinal)
+            || n.EndsWith("_SECRET", StringComparison.Ordinal)
+            || n.EndsWith("_KEY", StringComparison.Ordinal)
+            || n.EndsWith("_PASSWORD", StringComparison.Ordinal)
+
+    /// Build the redaction marker for a registered env-var
+    /// name. Stable across versions per the
+    /// SESSION-MODEL.md "On-disk wire format" section.
+    let internal markerFor (name: string) : string =
+        sprintf "<REDACTED:%s>" (name.ToUpperInvariant())
+
+    // Internal mutable state. Tuples are (value, marker). We
+    // sort by value-length DESC so that if one secret is a
+    // substring of another, the longer one is matched first.
+    // Lock guards mutation + iteration.
+    let private gate = obj ()
+    let mutable private registered : (string * string) list = []
+
+    /// Register one (value, name) pair. Silently skips when
+    /// the value is shorter than `MinValueLength`, empty, or
+    /// whitespace. Idempotent on duplicates (re-registering
+    /// the same value just updates the marker).
+    let register (value: string) (name: string) : unit =
+        if String.IsNullOrWhiteSpace(value) then ()
+        elif value.Length < MinValueLength then ()
+        else
+            lock gate (fun () ->
+                let marker = markerFor name
+                let withoutDup =
+                    registered |> List.filter (fun (v, _) -> v <> value)
+                let appended = (value, marker) :: withoutDup
+                registered <-
+                    appended
+                    |> List.sortByDescending (fun (v, _) -> v.Length))
+
+    /// Enumerate the process environment, register every
+    /// matching deny-listed env var's value, return the count
+    /// of successful registrations. Per LOGGING.md ("log
+    /// counts, never names or values"), the count is logged
+    /// at Information level by the caller.
+    ///
+    /// Idempotent: subsequent calls re-scan the env and
+    /// register any new matches; existing registrations stay.
+    /// Use `clear` for test isolation between runs.
+    let registerFromEnvironment (logger: ILogger) : int =
+        let envVars = Environment.GetEnvironmentVariables()
+        let mutable count = 0
+        let enumerator = envVars.GetEnumerator()
+        try
+            while enumerator.MoveNext() do
+                let entry = enumerator.Entry
+                match entry.Key, entry.Value with
+                | (:? string as name), (:? string as value) ->
+                    if isDenied name then
+                        let lengthBefore =
+                            lock gate (fun () -> registered.Length)
+                        register value name
+                        let lengthAfter =
+                            lock gate (fun () -> registered.Length)
+                        if lengthAfter > lengthBefore then
+                            count <- count + 1
+                | _ -> ()
+        finally
+            match enumerator with
+            | :? IDisposable as d -> d.Dispose()
+            | _ -> ()
+        logger.LogInformation(
+            "SessionSanitiser: registered {Count} env-var-value redaction patterns from process environment.",
+            count)
+        count
+
+    /// Apply all registered redactions to `text`. Pure;
+    /// returns the input unchanged if no registered values
+    /// occur. Replacement is case-sensitive ordinal
+    /// substring match (env-var values are typically
+    /// case-sensitive credentials).
+    let sanitise (text: string) : string =
+        if String.IsNullOrEmpty(text) then text
+        else
+            let snapshot =
+                lock gate (fun () -> registered)
+            if List.isEmpty snapshot then text
+            else
+                let sb = StringBuilder(text)
+                for (value, marker) in snapshot do
+                    sb.Replace(value, marker) |> ignore
+                sb.ToString()
+
+    /// Apply redactions to all text-bearing fields of a
+    /// SessionTuple. Returns a new tuple with `CommandText`,
+    /// `OutputText`, `PromptText`, and every `ExtraParams`
+    /// value sanitised. Conservative: anything that could
+    /// carry expanded env-var values gets the treatment.
+    /// `Id`, timestamps, `ShellId`, `CommandId`, `ExitCode`,
+    /// and `Sources` are passed through unchanged (they
+    /// can't carry user-controlled content).
+    let sanitiseTuple
+            (tuple: SessionModel.SessionTuple)
+            : SessionModel.SessionTuple
+            =
+        { tuple with
+            PromptText = sanitise tuple.PromptText
+            CommandText = sanitise tuple.CommandText
+            OutputText = sanitise tuple.OutputText
+            ExtraParams =
+                tuple.ExtraParams
+                |> Map.map (fun _ v -> sanitise v) }
+
+    /// Reset the registered list. Test-only — production code
+    /// never calls this. Used by `SessionSanitiserTests.fs`
+    /// to isolate per-test state given the module-level
+    /// mutable.
+    let clear () : unit =
+        lock gate (fun () ->
+            registered <- [])
+
+    /// Internal — peek at the current registered count for
+    /// tests that need to assert "exactly N values are
+    /// registered" without inspecting the values themselves
+    /// (which would defeat the privacy contract).
+    let internal registeredCount () : int =
+        lock gate (fun () -> registered.Length)

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="CanonicalState.fs" />
     <Compile Include="SessionModel.fs" />
     <Compile Include="SessionPersistence.fs" />
+    <Compile Include="SessionSanitiser.fs" />
     <Compile Include="SessionLogWriter.fs" />
     <Compile Include="HeuristicPromptDetector.fs" />
     <Compile Include="DisplayPathway.fs" />

--- a/tests/Tests.Unit/SessionSanitiserTests.fs
+++ b/tests/Tests.Unit/SessionSanitiserTests.fs
@@ -1,0 +1,367 @@
+module PtySpeak.Tests.Unit.SessionSanitiserTests
+
+open System
+open Xunit
+open Microsoft.Extensions.Logging.Abstractions
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 24d-2 — SessionSanitiser behavioural pinning
+// ---------------------------------------------------------------------
+//
+// SessionSanitiser holds module-level mutable state (the
+// registered list). Each test calls `clear ()` first to isolate
+// from sibling tests + any startup `registerFromEnvironment`
+// (the test process inherits the env from the runner, which on
+// CI may include real credentials matching the deny-list — we
+// don't want those leaking through).
+//
+// Tests pin:
+//   * MinValueLength threshold.
+//   * Empty/whitespace value handling.
+//   * Deny-list pattern parity with Stage 7's Native.fs.
+//   * Single-value redaction.
+//   * Multiple-value redaction.
+//   * Substring-overlap safety (longer value wins).
+//   * Per-tuple field application (CommandText, OutputText,
+//     PromptText, ExtraParams values).
+//   * registerFromEnvironment populates from process env.
+//   * clear empties the registered list.
+//   * Marker format `<REDACTED:UPPERCASE_NAME>`.
+
+// ---------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------
+
+let private fixedTuple () : SessionModel.SessionTuple =
+    { Id = Guid.Parse("11111111-2222-3333-4444-555555555555")
+      CommandId = None
+      ShellId = "powershell"
+      PromptStartedAt = DateTime(2026, 5, 9, 12, 0, 0, DateTimeKind.Utc)
+      CommandStartedAt = None
+      OutputStartedAt = None
+      CommandFinishedAt =
+        Some (DateTime(2026, 5, 9, 12, 0, 1, DateTimeKind.Utc))
+      PromptText = "PS>"
+      CommandText = ""
+      OutputText = ""
+      ExitCode = Some 0
+      Sources = Map.empty
+      ExtraParams = Map.empty }
+
+let private resetSanitiser () : unit =
+    SessionSanitiser.clear ()
+
+// ---------------------------------------------------------------------
+// MinValueLength threshold
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``MinValueLength constant equals 16`` () =
+    // Pinned: future changes to the threshold must update this
+    // test deliberately.
+    Assert.Equal(16, SessionSanitiser.MinValueLength)
+
+[<Fact>]
+let ``register skips values shorter than MinValueLength`` () =
+    resetSanitiser ()
+    SessionSanitiser.register "short" "BANK_API_KEY"
+    let text = "the password is short"
+    Assert.Equal(text, SessionSanitiser.sanitise text)
+
+[<Fact>]
+let ``register accepts values exactly at MinValueLength`` () =
+    resetSanitiser ()
+    let value = "abcdefghijklmnop"   // exactly 16 chars
+    Assert.Equal(16, value.Length)
+    SessionSanitiser.register value "MY_TOKEN"
+    let text = sprintf "echo %s" value
+    Assert.Equal(
+        "echo <REDACTED:MY_TOKEN>",
+        SessionSanitiser.sanitise text)
+
+[<Fact>]
+let ``register skips empty / whitespace values`` () =
+    resetSanitiser ()
+    SessionSanitiser.register "" "EMPTY_KEY"
+    SessionSanitiser.register "   " "WHITESPACE_KEY"
+    SessionSanitiser.register "\t\n" "TAB_KEY"
+    Assert.Equal(0, SessionSanitiser.registeredCount ())
+
+// ---------------------------------------------------------------------
+// Marker format
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``marker uses uppercase name and angle-bracket format`` () =
+    resetSanitiser ()
+    SessionSanitiser.register
+        "github_pat_aaaaaaaaaaaaaaaaaaaa" "github_token"
+    let result =
+        SessionSanitiser.sanitise
+            "token=github_pat_aaaaaaaaaaaaaaaaaaaa rest"
+    Assert.Equal("token=<REDACTED:GITHUB_TOKEN> rest", result)
+
+// ---------------------------------------------------------------------
+// Single-value redaction + leaves unrelated text alone
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``sanitise replaces a registered value with the marker`` () =
+    resetSanitiser ()
+    let secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    SessionSanitiser.register secret "GITHUB_TOKEN"
+    Assert.Equal(
+        sprintf "echo <REDACTED:GITHUB_TOKEN>",
+        SessionSanitiser.sanitise (sprintf "echo %s" secret))
+
+[<Fact>]
+let ``sanitise leaves text without registered values unchanged`` () =
+    resetSanitiser ()
+    SessionSanitiser.register
+        "ghp_abcdefghijklmnopqrstuvwxyz" "GITHUB_TOKEN"
+    let text = "ls -la /usr/local/bin"
+    Assert.Equal(text, SessionSanitiser.sanitise text)
+
+[<Fact>]
+let ``sanitise is a no-op on an empty registered list`` () =
+    resetSanitiser ()
+    let text = "anything goes here"
+    Assert.Equal(text, SessionSanitiser.sanitise text)
+
+// ---------------------------------------------------------------------
+// Multiple-value redaction
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``sanitise handles multiple distinct registered values in one string`` () =
+    resetSanitiser ()
+    let token = "ghp_abcdefghijklmnopqrstuvwxyz"
+    let key = "AKIAIOSFODNN7EXAMPLE_aaaa"
+    SessionSanitiser.register token "GITHUB_TOKEN"
+    SessionSanitiser.register key "AWS_ACCESS_KEY"
+    let text = sprintf "%s and %s leaked" token key
+    Assert.Equal(
+        "<REDACTED:GITHUB_TOKEN> and <REDACTED:AWS_ACCESS_KEY> leaked",
+        SessionSanitiser.sanitise text)
+
+[<Fact>]
+let ``sanitise handles the same value appearing multiple times`` () =
+    resetSanitiser ()
+    let secret = "secret_value_that_is_long_enough_to_register"
+    SessionSanitiser.register secret "MY_TOKEN"
+    let text = sprintf "%s and %s and %s" secret secret secret
+    Assert.Equal(
+        "<REDACTED:MY_TOKEN> and <REDACTED:MY_TOKEN> and <REDACTED:MY_TOKEN>",
+        SessionSanitiser.sanitise text)
+
+// ---------------------------------------------------------------------
+// Substring-overlap safety
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``sanitise replaces longer values before shorter (substring safety)`` () =
+    resetSanitiser ()
+    let shorter = "abcdefghijklmnop"   // 16 chars
+    let longer = "abcdefghijklmnopqrstuvwx"   // 24 chars (extends shorter)
+    SessionSanitiser.register shorter "SHORT_KEY"
+    SessionSanitiser.register longer "LONG_KEY"
+    // Text containing only the longer string MUST redact as
+    // <REDACTED:LONG_KEY>, not <REDACTED:SHORT_KEY>qrstuvwx.
+    let text = sprintf "value: %s" longer
+    Assert.Equal(
+        "value: <REDACTED:LONG_KEY>",
+        SessionSanitiser.sanitise text)
+
+// ---------------------------------------------------------------------
+// Stage 7 deny-list parity (isDenied)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``isDenied matches *_TOKEN`` () =
+    Assert.True(SessionSanitiser.isDenied "GITHUB_TOKEN")
+    Assert.True(SessionSanitiser.isDenied "github_token")
+    Assert.True(SessionSanitiser.isDenied "MyApp_Token")
+
+[<Fact>]
+let ``isDenied matches *_SECRET`` () =
+    Assert.True(SessionSanitiser.isDenied "OAUTH_SECRET")
+    Assert.True(SessionSanitiser.isDenied "client_secret")
+
+[<Fact>]
+let ``isDenied matches *_KEY`` () =
+    Assert.True(SessionSanitiser.isDenied "AWS_ACCESS_KEY")
+    Assert.True(SessionSanitiser.isDenied "api_key")
+
+[<Fact>]
+let ``isDenied matches *_PASSWORD`` () =
+    Assert.True(SessionSanitiser.isDenied "DB_PASSWORD")
+    Assert.True(SessionSanitiser.isDenied "ssh_password")
+
+[<Fact>]
+let ``isDenied does NOT match unrelated names`` () =
+    Assert.False(SessionSanitiser.isDenied "PATH")
+    Assert.False(SessionSanitiser.isDenied "HOME")
+    Assert.False(SessionSanitiser.isDenied "USER")
+    // Confirm the suffix-match is anchored: `KEYBOARD_LAYOUT`
+    // does NOT match `*_KEY` (no leading underscore before
+    // KEY), per Stage 7's design.
+    Assert.False(SessionSanitiser.isDenied "KEYBOARD_LAYOUT")
+    Assert.False(SessionSanitiser.isDenied "KEYS_TO_THE_KINGDOM")
+
+[<Fact>]
+let ``isDenied exempts ANTHROPIC_API_KEY (Claude Code primary credential)`` () =
+    Assert.False(SessionSanitiser.isDenied "ANTHROPIC_API_KEY")
+    Assert.False(SessionSanitiser.isDenied "anthropic_api_key")
+
+// ---------------------------------------------------------------------
+// sanitiseTuple
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``sanitiseTuple sanitises CommandText and OutputText`` () =
+    resetSanitiser ()
+    let secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    SessionSanitiser.register secret "GITHUB_TOKEN"
+    let tuple =
+        { fixedTuple () with
+            CommandText = sprintf "echo %s" secret
+            OutputText = sprintf "echoed: %s" secret }
+    let sanitised = SessionSanitiser.sanitiseTuple tuple
+    Assert.Equal("echo <REDACTED:GITHUB_TOKEN>", sanitised.CommandText)
+    Assert.Equal("echoed: <REDACTED:GITHUB_TOKEN>", sanitised.OutputText)
+
+[<Fact>]
+let ``sanitiseTuple sanitises PromptText and ExtraParams values`` () =
+    resetSanitiser ()
+    let secret = "secret_value_long_enough_to_register"
+    SessionSanitiser.register secret "PROMPT_TOKEN"
+    let tuple =
+        { fixedTuple () with
+            PromptText = sprintf "[%s] $" secret
+            ExtraParams =
+                Map.ofList [ "k", sprintf "param=%s" secret ] }
+    let sanitised = SessionSanitiser.sanitiseTuple tuple
+    Assert.Equal("[<REDACTED:PROMPT_TOKEN>] $", sanitised.PromptText)
+    Assert.Equal(
+        "param=<REDACTED:PROMPT_TOKEN>",
+        Map.find "k" sanitised.ExtraParams)
+
+[<Fact>]
+let ``sanitiseTuple leaves non-text fields unchanged`` () =
+    resetSanitiser ()
+    SessionSanitiser.register
+        "ghp_abcdefghijklmnopqrstuvwxyz" "GITHUB_TOKEN"
+    let original = fixedTuple ()
+    let sanitised = SessionSanitiser.sanitiseTuple original
+    // No secrets in original's text fields → text unchanged
+    // AND non-text fields unchanged.
+    Assert.Equal(original.Id, sanitised.Id)
+    Assert.Equal(original.ShellId, sanitised.ShellId)
+    Assert.Equal(original.PromptStartedAt, sanitised.PromptStartedAt)
+    Assert.Equal(original.CommandFinishedAt, sanitised.CommandFinishedAt)
+    Assert.Equal(original.ExitCode, sanitised.ExitCode)
+
+[<Fact>]
+let ``sanitiseTuple ExtraParams keys pass through unchanged (only values are sanitised)`` () =
+    resetSanitiser ()
+    let secret = "secret_value_long_enough_to_register"
+    SessionSanitiser.register secret "API_KEY"
+    let tuple =
+        { fixedTuple () with
+            ExtraParams =
+                Map.ofList
+                    [ "key1", "innocent value"
+                      "key2", sprintf "with %s inside" secret ] }
+    let sanitised = SessionSanitiser.sanitiseTuple tuple
+    Assert.True(Map.containsKey "key1" sanitised.ExtraParams)
+    Assert.True(Map.containsKey "key2" sanitised.ExtraParams)
+    Assert.Equal(
+        "innocent value",
+        Map.find "key1" sanitised.ExtraParams)
+    Assert.Equal(
+        "with <REDACTED:API_KEY> inside",
+        Map.find "key2" sanitised.ExtraParams)
+
+// ---------------------------------------------------------------------
+// clear
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``clear empties the registered list`` () =
+    resetSanitiser ()
+    let secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    SessionSanitiser.register secret "GITHUB_TOKEN"
+    Assert.True(SessionSanitiser.registeredCount () > 0)
+    let textBefore = sprintf "echo %s" secret
+    Assert.NotEqual<string>(
+        textBefore, SessionSanitiser.sanitise textBefore)
+    SessionSanitiser.clear ()
+    Assert.Equal(0, SessionSanitiser.registeredCount ())
+    Assert.Equal(textBefore, SessionSanitiser.sanitise textBefore)
+
+// ---------------------------------------------------------------------
+// registerFromEnvironment
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``registerFromEnvironment registers values for matching env-var names`` () =
+    resetSanitiser ()
+    // Capture and restore: matches the FileLoggerTests env-var
+    // isolation pattern. Avoids passing a literal `null` to
+    // SetEnvironmentVariable (F# 9 nullness friendly).
+    let varName = "PTYSPEAK_TEST_TOKEN"
+    let original = Environment.GetEnvironmentVariable(varName)
+    let testValue = "test_secret_value_aaaaaaaaaaaaaaaaaaaaaaaaa"
+    Environment.SetEnvironmentVariable(varName, testValue)
+    try
+        let count =
+            SessionSanitiser.registerFromEnvironment
+                NullLogger.Instance
+        // At least our test value should register; CI runners
+        // may have other matching env vars too.
+        Assert.True(count >= 1)
+        // The value should now redact.
+        Assert.Equal(
+            "echo <REDACTED:PTYSPEAK_TEST_TOKEN>",
+            SessionSanitiser.sanitise (sprintf "echo %s" testValue))
+    finally
+        Environment.SetEnvironmentVariable(varName, original)
+        resetSanitiser ()
+
+[<Fact>]
+let ``registerFromEnvironment skips non-deny-listed names`` () =
+    resetSanitiser ()
+    let varName = "PTYSPEAK_TEST_NORMAL_VAR"
+    let original = Environment.GetEnvironmentVariable(varName)
+    let testValue = "ordinary_long_value_aaaaaaaaaaaaaaaaa"
+    Environment.SetEnvironmentVariable(varName, testValue)
+    try
+        SessionSanitiser.registerFromEnvironment
+            NullLogger.Instance
+        |> ignore
+        // The non-deny-listed value should pass through.
+        Assert.Equal(
+            sprintf "echo %s" testValue,
+            SessionSanitiser.sanitise (sprintf "echo %s" testValue))
+    finally
+        Environment.SetEnvironmentVariable(varName, original)
+        resetSanitiser ()
+
+[<Fact>]
+let ``registerFromEnvironment skips short values`` () =
+    resetSanitiser ()
+    let varName = "PTYSPEAK_TEST_SHORT_KEY"
+    let original = Environment.GetEnvironmentVariable(varName)
+    Environment.SetEnvironmentVariable(varName, "abc")
+    try
+        SessionSanitiser.registerFromEnvironment
+            NullLogger.Instance
+        |> ignore
+        // Short value not registered; "abc" passes through.
+        Assert.Equal(
+            "echo abc",
+            SessionSanitiser.sanitise "echo abc")
+    finally
+        Environment.SetEnvironmentVariable(varName, original)
+        resetSanitiser ()

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="CanonicalStateTests.fs" />
     <Compile Include="SessionModelTests.fs" />
     <Compile Include="SessionPersistenceTests.fs" />
+    <Compile Include="SessionSanitiserTests.fs" />
     <Compile Include="SessionModelJsonlTests.fs" />
     <Compile Include="SessionLogWriterTests.fs" />
     <Compile Include="HeuristicPromptDetectorTests.fs" />


### PR DESCRIPTION
## Summary

Closes the **Cycle 24d** sub-cycle. Adds VALUE-based redaction of env-var-derived secrets in persisted SessionTuple text fields, complementing Stage 7's NAME-only env-scrub at the child-process spawn boundary.

**Threat model**: a shell expands an env var into output — e.g. `echo $GITHUB_TOKEN` substitutes the literal token value `ghp_abc123...` into stdout. The terminal sees the expanded value (NOT the variable name); without sanitisation the SessionLogWriter would persist that value to the on-disk JSONL. NAME-only matching can't catch this case; once the shell has expanded, the literal name is gone.

## What ships

- **NEW** `src/Terminal.Core/SessionSanitiser.fs` — module with public surface: `register`, `registerFromEnvironment`, `sanitise`, `sanitiseTuple`, `clear` (test-only), `MinValueLength`, `isDenied` (internal, Stage 7 deny-list parity).
- **MODIFIED** `src/Terminal.Core/SessionLogWriter.fs` — `writeOne` calls `SessionSanitiser.sanitiseTuple` before `SessionModel.formatTupleAsJsonl`. The substrate's in-memory History keeps unsanitised text (user can recover their own commands via `Ctrl+Shift+Y`); only the persistence layer redacts.
- **MODIFIED** `src/Terminal.App/Program.fs` — composition root calls `SessionSanitiser.registerFromEnvironment` at startup unconditionally (cheap; the registered values are only consulted by the sink's `writeOne`, which never runs when no sink exists). Per `LOGGING.md`, the registration count is logged at Information level — never the names or values.
- **NEW** `tests/Tests.Unit/SessionSanitiserTests.fs` — 21 xUnit `[<Fact>]` tests.
- **MODIFIED** `docs/SESSION-MODEL.md` — adds "Env-var-value sanitisation (Cycle 24d-2)" sub-section.

## Locked design

- **Deny-list pattern**: lifted verbatim from `Terminal.Pty.Native.isDenied` (Stage 7 PO-5). Suffix match on uppercase names: `*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`. `ANTHROPIC_API_KEY` exempted (Claude Code's primary credential, same precedent).
- **Min-length threshold**: 16 chars. Avoids false positives on short common values (`BANK_API_KEY=admin` would NOT register).
- **Redaction marker**: `<REDACTED:UPPERCASE_NAME>`. Decades-stable; angle brackets unambiguous in shell output; colon-delimited for regex parseability by future replay tools.
- **Substring-overlap safety**: registered values sorted by length DESC so the longer value matches first if one is a substring of another.
- **Sanitised fields**: `CommandText`, `OutputText`, `PromptText`, every `ExtraParams` value. Conservative.
- **Threading**: lock-guarded module-level state; safe from any thread.

## Test plan

- [ ] CI green on Windows-latest (build + 21 new + ~588 existing xUnit tests).
- [ ] Manual maintainer smoke (after merge):
  - Set `BANK_API_KEY=test_secret_value_aaaaaaaaaaaaa` (≥ 16 chars) before launching pty-speak.
  - Launch with `mode = "session_log"` or `"always"`.
  - Run `echo $BANK_API_KEY` (or `Get-Content env:BANK_API_KEY` in PowerShell).
  - Inspect `%LOCALAPPDATA%\PtySpeak\sessions\session-<id>.jsonl`: the value should NOT appear; the marker `<REDACTED:BANK_API_KEY>` should.
  - The Ctrl+Shift+Y clipboard dump (in-memory History) should still show the unsanitised value (substrate stays honest; only the persistence layer redacts).
- [ ] NVDA matrix unchanged (no user-facing behaviour beyond the redaction in persisted files).

## Limitations (documented)

- Env vars set after launch are NOT retroactively scrubbed. Restart-to-update is the documented cost.
- Pattern-based detection (e.g. AWS-key regex `^AKIA[0-9A-Z]{16}$`) is out of scope; future cycles can add this if demand surfaces.

## Cycle 24 progress

24a (PR #203) ✅ → 24b (PR #206) ✅ → 24c (PR #208) ✅ → 24d-1 (PR #209) ✅ → **24d-2 (this PR)**. Cycle 24e (NVDA matrix + diagnostic helper) is the closing sub-cycle.

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_