### PR TITLE
fix(terminal-core): SessionPersistence config diagnostic + Cycle 24e matrix typo (Cycle 24f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 24f): SessionModel persistence config diagnostic + matrix section-name typo
+
+Two paired fixes surfaced during the first manual NVDA-matrix
+walkthrough of Cycle 24:
+
+- **`docs/ACCESSIBILITY-TESTING.md` — section-name typo.** The
+  Cycle 24 matrix (PR #211) instructed the maintainer to write
+  `[session_persistence]` in `config.toml`. The actual TOML
+  schema (Cycle 24a, PR #203) uses the **nested** form
+  `[session_model.persistence]`. The maintainer's TOML was
+  effectively invisible and the persistence silently fell
+  through to `memory_only`. Matrix updated to use the canonical
+  section name; the matrix's "Diagnostic decoder" entry now
+  enumerates the new Cycle 24f log lines and the legacy
+  `[session_persistence]` typo as the most-likely culprit.
+- **`SessionPersistence.parseFromTable` — diagnostic gap.** All
+  three parse-branches (no `[session_model]`, `[session_model]`
+  present but no `.persistence` sub-section,
+  `[session_model.persistence]` present and parsed) now emit a
+  distinct **Information** log line so a maintainer can grep
+  `Config:` in the FileLogger log and immediately distinguish
+  "section absent → silent defaults" from "section parsed
+  cleanly to memory_only" from "value rejected → fell back".
+  Pre-24f all three were observationally identical (only the
+  composition root's `SessionModel persistence mode: ...` line
+  was emitted). New messages:
+  - `Config: no [session_model] section in TOML; using
+    session-persistence defaults (mode=memory_only).`
+  - `Config: [session_model] present but no
+    [session_model.persistence] sub-section; using
+    session-persistence defaults (mode=memory_only).`
+  - `Config: [session_model.persistence] section parsed;
+    mode=<X>, output_dir=<Y>, format=jsonl,
+    max_session_size_mb=<N>.`
+
+`SessionPersistenceTests.fs` updated (3 existing tests extended
++ 1 new test) to pin each branch's Information message.
+
 ### Added (Cycle 24e): diagnostic hotkey + NVDA matrix for SessionModel persistence
 
 Closes Cycle 24 with three small operational deliverables on

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -464,7 +464,7 @@ verify each layer's user-facing contract.
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| Mode change at startup            | Edit `%LOCALAPPDATA%\PtySpeak\config.toml` to set `[session_persistence]\nmode = "session_log"`; relaunch | App starts cleanly; active session log (open via `Ctrl+Shift+L` → today's folder) contains the line `SessionModel persistence mode: session_log (output_dir=..., format=jsonl, max_session_size_mb=...)`; no Warning about "not yet implemented" |
+| Mode change at startup            | Edit `%LOCALAPPDATA%\PtySpeak\config.toml` to set `[session_model.persistence]\nmode = "session_log"`; relaunch | App starts cleanly; active session log (open via `Ctrl+Shift+L` → today's folder) contains the line `Config: [session_model.persistence] section parsed; mode=session_log, ...` immediately followed by `SessionModel persistence mode: session_log (output_dir=..., format=jsonl, max_session_size_mb=...)`; no Warning about "not yet implemented" |
 | File creation in `session_log` mode | With mode set as above, run `echo hello`        | File `%LOCALAPPDATA%\PtySpeak\sessions\session-<UUID>.jsonl` exists; first line is one valid JSON object containing `"commandText":"echo hello"` and `"schemaVersion":1` |
 | `Always` mode synchronous flush   | Set `mode = "always"`; relaunch; run `echo one` | The JSONL file contains the `echo one` tuple BEFORE the next prompt is announced (perceptually durable; verify by inspecting the file immediately after the prompt comes back via Notepad → File → Open) |
 | Diagnostic hotkey announces session-log path | Press `Ctrl+Shift+S` in any of the three modes | NVDA announces `Session log mode <mode>; path <full-path>.` for `session_log`/`always`; `Session log mode memory_only; no file.` for `memory_only`. Repeated presses dedupe via the `pty-speak.session-log-path` ActivityId |
@@ -473,13 +473,33 @@ verify each layer's user-facing contract.
 
 **Diagnostic decoder for Cycle 24:**
 
-- **Mode change ignored at startup** → TOML parser fell back
-  to default. Check the active session log for
-  `Failed to parse SessionPersistence config; using defaults`
-  + the inner exception message. Likely culprits: malformed
-  TOML, key typo (`mode` vs `Mode` — case matters),
-  unrecognised value (anything other than the three accepted
-  strings).
+- **Mode change ignored at startup** → grep the FileLogger
+  log (open via `Ctrl+Shift+L`) for `Config: ` lines. Cycle
+  24f added explicit per-branch diagnostic logging:
+  - `Config: no [session_model] section in TOML; using
+    session-persistence defaults.` — the section header was
+    typo'd (the canonical name is **nested**:
+    `[session_model.persistence]`, NOT `[session_persistence]`)
+    or the parent table is missing.
+  - `Config: [session_model] present but no
+    [session_model.persistence] sub-section; using
+    session-persistence defaults.` — you have `[session_model]`
+    on its own but didn't add the `.persistence` sub-table.
+  - `Config: [session_model.persistence] section parsed;
+    mode=<X>, ...` — the section was found and read; if
+    `<X>` isn't what you set, the value itself was rejected
+    (look for an immediately preceding Warning naming the
+    unrecognised value).
+  - `Config: [session_model.persistence] mode = '<value>' is
+    not one of 'memory_only' / 'session_log' / 'always';
+    using default 'memory_only'.` — typo'd value. Note
+    parsing is lower-cased, so `Session_Log` is fine but
+    `sessionlog` (no underscore) is rejected.
+  - If the FileLogger shows `Config: parse error in <path>`
+    instead of any of the above, the TOML file itself has a
+    syntax error (likely an unquoted string value or a
+    duplicate-table conflict). The line with the error is
+    surfaced in the same log entry.
 - **File NOT created in `session_log` mode** → composition
   root never instantiated the sink. Grep the log for
   `SessionLogWriter` lines; absence of any such line means

--- a/src/Terminal.Core/SessionPersistence.fs
+++ b/src/Terminal.Core/SessionPersistence.fs
@@ -110,6 +110,20 @@ module SessionPersistence =
     /// Internal — recognised keys for the
     /// `[session_model.persistence]` table. Used to surface typos
     /// via warn-and-ignore.
+    /// String form of a `PersistenceMode` for log messages and
+    /// diagnostic dumps. Stable identifiers (no localisation) so
+    /// log-grepping is reliable across builds.
+    let modeToString (mode: PersistenceMode) : string =
+        match mode with
+        | MemoryOnly -> "memory_only"
+        | SessionLog -> "session_log"
+        | Always -> "always"
+
+    /// String form of a `PersistenceFormat` for log messages.
+    let formatToString (format: PersistenceFormat) : string =
+        match format with
+        | Jsonl -> "jsonl"
+
     let private knownKeys : Set<string> =
         Set.ofList
             [ "mode"
@@ -227,32 +241,44 @@ module SessionPersistence =
             (root: TomlTable)
             : PersistenceConfig
             =
+        // Cycle 24f — log every branch at Information so a
+        // maintainer can diagnose the difference between
+        // "section absent → silent defaults" and "section
+        // parsed cleanly to memory_only" by reading the
+        // FileLogger log alone. Pre-24f both cases were
+        // observationally identical (the only line emitted
+        // was the composition root's `SessionModel persistence
+        // mode: memory_only ...`).
         match tryGetTable root "session_model" with
-        | None -> defaultConfig
+        | None ->
+            logger.LogInformation(
+                "Config: no [session_model] section in TOML; using session-persistence defaults (mode={Mode}).",
+                modeToString defaultConfig.Mode)
+            defaultConfig
         | Some sessionModelTable ->
             match tryGetTable sessionModelTable "persistence" with
-            | None -> defaultConfig
+            | None ->
+                logger.LogInformation(
+                    "Config: [session_model] present but no [session_model.persistence] sub-section; using session-persistence defaults (mode={Mode}).",
+                    modeToString defaultConfig.Mode)
+                defaultConfig
             | Some persistenceTable ->
                 for key in persistenceTable.Keys do
                     if not (knownKeys.Contains(key)) then
                         logger.LogWarning(
                             "Config: [session_model.persistence] unknown key '{Key}'; ignored.",
                             key)
-                { Mode = parseMode logger persistenceTable
-                  OutputDir = parseOutputDir logger persistenceTable
-                  Format = parseFormat logger persistenceTable
-                  MaxSessionSizeMb = parseMaxSessionSizeMb logger persistenceTable }
-
-    /// String form of a `PersistenceMode` for log messages and
-    /// diagnostic dumps. Stable identifiers (no localisation) so
-    /// log-grepping is reliable across builds.
-    let modeToString (mode: PersistenceMode) : string =
-        match mode with
-        | MemoryOnly -> "memory_only"
-        | SessionLog -> "session_log"
-        | Always -> "always"
-
-    /// String form of a `PersistenceFormat` for log messages.
-    let formatToString (format: PersistenceFormat) : string =
-        match format with
-        | Jsonl -> "jsonl"
+                let parsed =
+                    { Mode = parseMode logger persistenceTable
+                      OutputDir = parseOutputDir logger persistenceTable
+                      Format = parseFormat logger persistenceTable
+                      MaxSessionSizeMb = parseMaxSessionSizeMb logger persistenceTable }
+                logger.LogInformation(
+                    "Config: [session_model.persistence] section parsed; mode={Mode}, output_dir={OutputDir}, format={Format}, max_session_size_mb={MaxSessionSizeMb}.",
+                    modeToString parsed.Mode,
+                    (match parsed.OutputDir with
+                     | Some d -> d
+                     | None -> "<default>"),
+                    formatToString parsed.Format,
+                    parsed.MaxSessionSizeMb)
+                parsed

--- a/tests/Tests.Unit/SessionPersistenceTests.fs
+++ b/tests/Tests.Unit/SessionPersistenceTests.fs
@@ -83,23 +83,56 @@ let ``defaultConfig is MemoryOnly with default size 64MB and Jsonl format`` () =
 // Missing table → defaultConfig
 // ---------------------------------------------------------------------
 
+// Cycle 24f added Information logging on each parse-branch so a
+// maintainer can grep `Config:` and see exactly why the
+// persistence config landed where it did. The three branches
+// (no [session_model], [session_model] without .persistence,
+// [session_model.persistence] present) each log a distinct
+// Information message; tests pin the message text.
+
 [<Fact>]
-let ``empty TOML returns defaultConfig`` () =
+let ``empty TOML returns defaultConfig and logs no [session_model] section`` () =
     let config, logger = parse ""
     Assert.Equal(SessionPersistence.defaultConfig, config)
     Assert.False(logger.HasLevel(LogLevel.Warning))
+    Assert.Contains(
+        logger.MessagesAtLevel(LogLevel.Information),
+        fun m ->
+            m.Contains("no [session_model] section in TOML")
+            && m.Contains("memory_only"))
 
 [<Fact>]
-let ``missing [session_model] table returns defaultConfig`` () =
+let ``missing [session_model] table returns defaultConfig and logs the missing-section diagnostic`` () =
     let config, logger = parse "[unrelated]\nfoo = \"bar\"\n"
     Assert.Equal(SessionPersistence.defaultConfig, config)
     Assert.False(logger.HasLevel(LogLevel.Warning))
+    Assert.Contains(
+        logger.MessagesAtLevel(LogLevel.Information),
+        fun m ->
+            m.Contains("no [session_model] section in TOML"))
 
 [<Fact>]
-let ``[session_model] table without [persistence] sub-table returns defaultConfig`` () =
+let ``[session_model] table without [persistence] sub-table returns defaultConfig and logs the sub-section diagnostic`` () =
     let config, logger = parse "[session_model]\nplaceholder = true\n"
     Assert.Equal(SessionPersistence.defaultConfig, config)
     Assert.False(logger.HasLevel(LogLevel.Warning))
+    Assert.Contains(
+        logger.MessagesAtLevel(LogLevel.Information),
+        fun m ->
+            m.Contains("[session_model] present but no [session_model.persistence]")
+            && m.Contains("memory_only"))
+
+[<Fact>]
+let ``[session_model.persistence] section present logs the parsed-section diagnostic with mode and format`` () =
+    let toml =
+        "[session_model.persistence]\nmode = \"session_log\"\noutput_dir = \"C:\\\\tmp\\\\sessions\"\n"
+    let _, logger = parse toml
+    Assert.Contains(
+        logger.MessagesAtLevel(LogLevel.Information),
+        fun m ->
+            m.Contains("[session_model.persistence] section parsed")
+            && m.Contains("session_log")
+            && m.Contains("jsonl"))
 
 // ---------------------------------------------------------------------
 // mode parsing


### PR DESCRIPTION
## Summary

Two paired fixes surfaced during the first manual NVDA-matrix walkthrough of Cycle 24. Both close the gap between "the maintainer wrote correct-looking TOML and the persistence stayed `memory_only`" and "the FileLogger log explains why".

### 1. `ACCESSIBILITY-TESTING.md` typo (regression from PR #211)

The Cycle 24e matrix told the maintainer to write `[session_persistence]` in `config.toml`. The actual TOML schema from Cycle 24a (PR #203) uses the **nested** form `[session_model.persistence]`. The maintainer's TOML was effectively invisible; persistence silently fell through to `memory_only`.

- Matrix row 1 corrected to canonical section name.
- The "Diagnostic decoder for Cycle 24" entry rewritten to enumerate the new parse-branch log lines and flag the legacy `[session_persistence]` typo as the most-likely culprit.

### 2. `SessionPersistence.parseFromTable` diagnostic gap

Pre-24f, all three parse-branches were observationally identical from the FileLogger log alone — only the composition root's `SessionModel persistence mode: ...` line was emitted. A maintainer could not distinguish "section absent → silent defaults" from "section parsed cleanly to memory_only" from "value rejected → fell back". `parseFromTable` now emits one distinct **Information** log line per branch:

| State | New log line |
|---|---|
| No `[session_model]` in TOML | `Config: no [session_model] section in TOML; using session-persistence defaults (mode=memory_only).` |
| `[session_model]` present but no `.persistence` sub-section | `Config: [session_model] present but no [session_model.persistence] sub-section; using session-persistence defaults (mode=memory_only).` |
| `[session_model.persistence]` parsed | `Config: [session_model.persistence] section parsed; mode=<X>, output_dir=<Y>, format=jsonl, max_session_size_mb=<N>.` |

Existing `parseMode` / `parseFormat` / `parseMaxSessionSizeMb` Warnings on bad values are unchanged; the new Information line composes with them, so a maintainer sees both "section parsed" + the per-field rejection in the same log slice.

`modeToString` / `formatToString` moved up in the source file so `parseFromTable` can reference them (F# requires forward-declaration; they were public utilities defined later in the same module — no public-API change).

## Tests

`SessionPersistenceTests.fs`:
- 3 existing tests extended to assert the new Information messages on the missing-section / sub-section-absent paths (in addition to the existing `Assert.False(HasLevel Warning)` pin).
- 1 new test pins the Information message on the parsed-section path.

## Test plan

- [ ] CI green on Windows-latest (build + 3-extended + 1-new + ~610 existing xUnit tests).
- [ ] After merge: maintainer rebuilds, relaunches with their existing TOML, presses `Ctrl+Shift+;`, pastes the log here. The new `Config: ...` line should immediately reveal which branch the parser took — pinning the actual cause of the "memory_only despite session_log" mystery.

## Out of scope (next planning cycle)

- Open-config hotkey + auto-create with sensible defaults.
- Reload-config-on-shell-switch.
- Automated test-suite runner that snapshots/mutates/restores config without maintainer hand-edits.

These will land as a coordinated cycle once #2's new diagnostic surfaces have served their purpose.

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_