### PR TITLE
test(file-logger): explicit FlushPending in day-folder test (CI flake fix)

### DIFF
--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -213,6 +213,14 @@ let ``logger creates the day-folder if it does not exist`` () =
     let provider = new FileLoggerProvider(sink) :> ILoggerProvider
     let logger = provider.CreateLogger("Test")
     logger.LogInformation("should create the parent dir + day folder")
+    // FlushPending blocks until the drain has processed pending
+    // entries — opening the log file creates the parent directory
+    // tree as a side effect. Pre-fix, the test relied on
+    // `Dispose`'s 2-second drain-wait, which became flaky under
+    // CI load after ~40 concurrent-filesystem-I/O tests landed in
+    // Cycles 24c-24f. `FlushPending` is the explicit sync API
+    // (same one `Ctrl+Shift+;` uses to read the file safely).
+    sink.FlushPending(5000).Wait() |> ignore
     (provider :> IDisposable).Dispose()
     Assert.True(Directory.Exists(nestedDir),
         "Expected sink to create the log root")


### PR DESCRIPTION
## Summary

The release CI for `v0.0.1-preview.74` failed with the test `logger creates the day-folder if it does not exist` raising `Expected sink to create the log root`. The same code passed when PR #212 merged moments earlier — this is a flaky test, not a regression in #212.

**Root cause:** the test relied implicitly on `FileLoggerSink.Dispose`'s 2-second `drainTask.Wait(2000)` to finish flushing the pending log entry. Cycles 24c-24f added ~40 new tests, several doing concurrent filesystem I/O (`SessionLogWriterTests`, `SessionSanitiserTests`, `SessionPersistenceTests`). Under the heavier CI load the drain task occasionally doesn't finish its final-pass within the 2s window, the directory isn't created yet when `Dispose` returns, and the assertion fires.

**Fix:** call the existing `sink.FlushPending(5000)` API before `Dispose`. `FlushPending` is the documented synchronization barrier — it's what `Ctrl+Shift+;` clipboard copy uses for the same "must be flushed to disk" guarantee. It blocks until the drain has processed pending entries, which means the log file has been opened, which creates the parent directory tree as a side effect. The assertion now has a deterministic happens-before relationship with the directory-creation side effect instead of relying on a heuristic timeout.

Production behavior unchanged.

## Test plan

- [ ] CI green on Windows-latest.
- [ ] Maintainer cuts a fresh release tag (e.g. `v0.0.1-preview.75`) at the post-merge commit; release pipeline now runs to completion.

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_