### PR TITLE
feat(terminal-core): TOML model snapshot logged at startup (Cycle 24g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,42 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 24g): TOML model snapshot logged at startup
+
+Diagnostic surface to pin the difference between "config section
+absent from the parsed Tomlyn model" and "config section present
+but keyed differently than my reader expected" — the case Cycle
+24f's per-branch logging surfaced but couldn't disambiguate
+without further investigation.
+
+`Config.tryLoad` now logs the **full parsed TOML model** as a
+JSON-shaped hierarchical dump immediately after `Toml.ToModel()`
+returns, BEFORE any per-section reader runs. A maintainer can:
+
+- See exactly which top-level keys Tomlyn produced — pinning
+  encoding (BOM), dotted-key, and typo issues that are
+  otherwise invisible (the file parses cleanly, the section
+  just isn't where the per-section reader looks).
+- Compare the dump's structure against the source TOML to spot
+  invisible characters or unexpected representations.
+- Forward the log slice (via `Ctrl+Shift+;`) for triage without
+  having to manually transcribe the file content.
+
+JSON-shaped (not TOML re-emit) so subtleties like `[a.b.c]`
+dotted-header → nested-table representation are explicit. Keys
+quoted; embedded quotes/control chars escaped per JSON rules.
+Unrecognised value types render as `"<<TypeName: value>>"` so
+future Tomlyn types don't crash the dump.
+
+The on-demand variant (hotkey-driven snapshot copy-to-clipboard
+plus unknown-keys flagging) is planned for the upcoming Cycle
+25 PR; this 24g surface is the no-new-hotkey unblocker that
+captures the model on every launch.
+
+10 new xUnit `[<Fact>]` tests in `ConfigTests.fs` covering empty
+table, scalar types, nested dotted-headers, escaping, indent
+shape, comma separation, empty sub-tables, and inline arrays.
+
 ### Fixed (Cycle 24f): SessionModel persistence config diagnostic + matrix section-name typo
 
 Two paired fixes surfaced during the first manual NVDA-matrix

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -2,6 +2,7 @@ namespace Terminal.Core
 
 open System
 open System.IO
+open System.Text
 open Microsoft.Extensions.Logging
 open Tomlyn
 open Tomlyn.Model
@@ -238,6 +239,112 @@ module Config =
               "bulk_change_threshold"
               "backspace_policy"
               "mode_barrier_flush_policy" ]
+
+    /// Cycle 24g — emit a JSON-shaped hierarchical dump of a
+    /// parsed `TomlTable` so a maintainer can compare what
+    /// Tomlyn actually understood against what they wrote in
+    /// `config.toml`. Pins the difference between "section
+    /// absent from the parsed model" and "section present but
+    /// keyed differently than my reader expected" without
+    /// requiring per-key trace logging on every parse path.
+    ///
+    /// Format choices:
+    ///
+    /// - JSON-shaped (not literal TOML re-emit) so subtleties
+    ///   like dotted-key vs. nested-table representation are
+    ///   visible. A maintainer reading the dump sees the
+    ///   logical structure the parser landed on, NOT the
+    ///   surface syntax it originated from.
+    /// - Two-space indent per level. Keys quoted; embedded
+    ///   quotes / control chars escaped per JSON rules. Arrays
+    ///   inline. Sub-tables nested.
+    /// - Unrecognised value types render as
+    ///   `"<<TypeName: value>>"` so future Tomlyn types don't
+    ///   crash the dump and any oddity is greppable.
+    /// - Non-deterministic key order: Tomlyn's `TomlTable`
+    ///   preserves insertion order from the parsed source, so
+    ///   the dump's ordering matches the user's file ordering.
+    let internal snapshotAsJson (root: TomlTable) : string =
+        let sb = StringBuilder()
+        let escape (s: string) : string =
+            let inner = StringBuilder(s.Length + 2)
+            for c in s do
+                match c with
+                | '"' -> inner.Append("\\\"") |> ignore
+                | '\\' -> inner.Append("\\\\") |> ignore
+                | '\n' -> inner.Append("\\n") |> ignore
+                | '\r' -> inner.Append("\\r") |> ignore
+                | '\t' -> inner.Append("\\t") |> ignore
+                | c when c < ' ' ->
+                    inner.AppendFormat(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        "\\u{0:x4}",
+                        int c)
+                    |> ignore
+                | c -> inner.Append(c) |> ignore
+            inner.ToString()
+        let rec writeValue (indent: int) (value: obj | null) : unit =
+            match value with
+            | null ->
+                sb.Append("null") |> ignore
+            | :? TomlTable as t ->
+                writeTable indent t
+            | :? TomlArray as arr ->
+                sb.Append('[') |> ignore
+                let mutable first = true
+                for item in arr do
+                    if not first then sb.Append(", ") |> ignore
+                    first <- false
+                    writeValue (indent + 1) item
+                sb.Append(']') |> ignore
+            | :? TomlTableArray as arr ->
+                sb.Append('[') |> ignore
+                let mutable first = true
+                for item in arr do
+                    if not first then sb.Append(", ") |> ignore
+                    first <- false
+                    writeTable (indent + 1) item
+                sb.Append(']') |> ignore
+            | :? string as s ->
+                sb.Append('"').Append(escape s).Append('"') |> ignore
+            | :? bool as b ->
+                sb.Append(if b then "true" else "false") |> ignore
+            | :? int64 as i ->
+                sb.Append(string i) |> ignore
+            | :? double as d ->
+                sb.Append(
+                    d.ToString(
+                        System.Globalization.CultureInfo.InvariantCulture))
+                |> ignore
+            | other ->
+                sb.AppendFormat(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    "\"<<{0}: {1}>>\"",
+                    other.GetType().Name,
+                    escape (string other))
+                |> ignore
+        and writeTable (indent: int) (t: TomlTable) : unit =
+            let entries = t |> Seq.toList
+            if List.isEmpty entries then
+                sb.Append("{}") |> ignore
+            else
+                sb.AppendLine("{") |> ignore
+                let prefix = String(' ', (indent + 1) * 2)
+                entries
+                |> List.iteri (fun i kvp ->
+                    sb.Append(prefix)
+                        .Append('"')
+                        .Append(escape kvp.Key)
+                        .Append("\": ")
+                    |> ignore
+                    writeValue (indent + 1) kvp.Value
+                    if i < entries.Length - 1 then
+                        sb.AppendLine(",") |> ignore
+                    else
+                        sb.AppendLine() |> ignore)
+                sb.Append(String(' ', indent * 2)).Append('}') |> ignore
+        writeTable 0 root
+        sb.ToString()
 
     /// Internal — known shell-id keys for `[shell.<id>]`.
     /// Mirrors `ShellRegistry.parseEnvVar`'s lowercase
@@ -523,6 +630,18 @@ module Config =
                     defaultConfig
                 else
                     let model = doc.ToModel()
+                    // Cycle 24g — log the raw parsed TOML model
+                    // BEFORE any per-section reader runs. Lets a
+                    // maintainer compare Tomlyn's interpretation
+                    // against their `config.toml` content, which
+                    // pins encoding / dotted-key / typo issues
+                    // that are otherwise invisible (the TOML
+                    // parses cleanly, the section just isn't
+                    // where the per-section reader looks).
+                    logger.LogInformation(
+                        "Config: parsed TOML model snapshot from {Path}:\n{Snapshot}",
+                        filePath,
+                        snapshotAsJson model)
                     let version = parseSchemaVersion logger model
                     if version > CurrentSchemaVersion then
                         logger.LogError(

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -469,3 +469,90 @@ let ``[startup] unknown key logs Warning but does not corrupt parse`` () =
     Assert.Equal(Some "cmd", Config.resolveDefaultShell config)
     Assert.True(logger.HasLevel(LogLevel.Warning))
 
+
+// ---------------------------------------------------------------------
+// Cycle 24g — snapshotAsJson: TOML model dump
+// ---------------------------------------------------------------------
+//
+// Pinned for the diagnostic surface that lets a maintainer compare
+// what Tomlyn understood against what they wrote in config.toml.
+// The dump is JSON-shaped so subtleties like dotted-key vs. nested-
+// table representation are visible.
+
+let private parseToTable (toml: string) : Tomlyn.Model.TomlTable =
+    let doc = Tomlyn.Toml.Parse(toml)
+    Assert.False(doc.HasErrors, "Test TOML must parse cleanly")
+    doc.ToModel()
+
+[<Fact>]
+let ``snapshotAsJson on empty TOML returns "{}"`` () =
+    let model = parseToTable ""
+    Assert.Equal("{}", Config.snapshotAsJson model)
+
+[<Fact>]
+let ``snapshotAsJson emits string values quoted`` () =
+    let model = parseToTable "name = \"hello\"\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"name\": \"hello\"", json)
+
+[<Fact>]
+let ``snapshotAsJson emits int64 values as bare numbers`` () =
+    let model = parseToTable "n = 42\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"n\": 42", json)
+
+[<Fact>]
+let ``snapshotAsJson emits bool values as lowercase literals`` () =
+    let model = parseToTable "flag = true\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"flag\": true", json)
+
+[<Fact>]
+let ``snapshotAsJson nests dotted-key headers as sub-tables`` () =
+    // The bug we're chasing: Tomlyn's representation of
+    // `[a.b]`-headers. snapshotAsJson should show the model
+    // exactly as the rest of the parser sees it. With a clean
+    // Tomlyn install + UTF-8 input, this should produce nested
+    // tables.
+    let model = parseToTable "[session_model.persistence]\nmode = \"session_log\"\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"session_model\":", json)
+    Assert.Contains("\"persistence\":", json)
+    Assert.Contains("\"mode\": \"session_log\"", json)
+
+[<Fact>]
+let ``snapshotAsJson escapes embedded quotes and backslashes`` () =
+    let model = parseToTable "path = \"C:\\\\Users\\\\test\"\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"path\": \"C:\\\\Users\\\\test\"", json)
+
+[<Fact>]
+let ``snapshotAsJson emits nested table with two-space indent`` () =
+    let model = parseToTable "[outer]\n[outer.inner]\nkey = \"value\"\n"
+    let json = Config.snapshotAsJson model
+    // Outer level: top "{" + 2-space indent for "outer" key
+    Assert.StartsWith("{", json)
+    Assert.Contains("  \"outer\":", json)
+    // Inner level: 4-space indent for "inner.key"
+    Assert.Contains("    \"inner\":", json)
+    Assert.Contains("      \"key\": \"value\"", json)
+
+[<Fact>]
+let ``snapshotAsJson preserves multiple sibling keys as comma-separated entries`` () =
+    let model = parseToTable "a = 1\nb = 2\nc = 3\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"a\": 1,", json)
+    Assert.Contains("\"b\": 2,", json)
+    Assert.Contains("\"c\": 3", json)
+
+[<Fact>]
+let ``snapshotAsJson emits empty sub-table inline as {}`` () =
+    let model = parseToTable "[empty]\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"empty\": {}", json)
+
+[<Fact>]
+let ``snapshotAsJson handles arrays as bracketed inline lists`` () =
+    let model = parseToTable "items = [1, 2, 3]\n"
+    let json = Config.snapshotAsJson model
+    Assert.Contains("\"items\": [1, 2, 3]", json)

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -4,6 +4,7 @@ open System
 open System.IO
 open Xunit
 open Microsoft.Extensions.Logging
+open Tomlyn
 open Terminal.Core
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Diagnostic surface to pin the difference between "config section absent from the parsed Tomlyn model" and "config section present but keyed differently than my reader expected" — the case Cycle 24f's per-branch logging surfaced but couldn't disambiguate.

The maintainer reports their `config.toml` contains literally `[session_model.persistence]\nmode = "session_log"\n` (verified character-by-character via `type` at the cmd prompt), the file is UTF-8 no-BOM, and yet 24f's diagnostic logs `Config: no [session_model] section in TOML`. My existing tests with that exact same content pass — so something invisible about the maintainer's specific file (encoding, line endings, whitespace, Tomlyn version quirk) is in play, and we need to see what Tomlyn actually parsed.

## What ships

`Config.tryLoad` now logs the **full parsed TOML model** as a JSON-shaped hierarchical dump immediately after `Toml.ToModel()` returns, BEFORE any per-section reader runs:

```
Config: parsed TOML model snapshot from C:\Users\...\config.toml:
{
  "session_model": {
    "persistence": {
      "mode": "session_log"
    }
  }
}
```

A maintainer can:
- See exactly which top-level keys Tomlyn produced.
- Compare the dump's structure against the source TOML to spot invisible characters or unexpected representations.
- Forward the log slice via `Ctrl+Shift+;` for triage without having to manually transcribe the file content.

**Format choices:**
- JSON-shaped (not TOML re-emit) so subtleties like `[a.b.c]` dotted-header → nested-table representation are explicit.
- Two-space indent per level. Keys quoted; embedded quotes/control chars escaped per JSON rules. Arrays inline. Sub-tables nested.
- Unrecognised value types render as `"<<TypeName: value>>"` so future Tomlyn types don't crash the dump.
- Insertion order preserved (matches user's file ordering).

## Tests

10 new xUnit `[<Fact>]` in `ConfigTests.fs`:
- Empty table → `{}`.
- String / int64 / bool scalar formatting.
- **Nested dotted-headers** (the case we're chasing — verifies that with clean Tomlyn input, `[session_model.persistence]` produces nested sub-tables in the dump).
- Embedded-quote and backslash escaping.
- Two-space-per-level indent shape.
- Comma separation between sibling keys.
- Empty sub-table inline as `{}`.
- Inline arrays as `[1, 2, 3]`.

## Test plan

- [ ] CI green on Windows-latest (build + 10 new + ~810 existing xUnit tests).
- [ ] Maintainer cuts a release that includes this commit, `Ctrl+Shift+U` updates the running app, presses `Ctrl+Shift+;`, and pastes the new `Config: parsed TOML model snapshot from ...` block. The dump will pin whether their file's `session_model` actually exists in the parsed model or whether something invisible has shifted it elsewhere.

## Out of scope (Cycle 25)

- Hotkey-driven on-demand snapshot copy-to-clipboard (operating on current process state).
- Unknown-keys flagging against per-section schemas (typo detection).

This 24g surface is the no-new-hotkey unblocker for the immediate `memory_only` debug. The richer hotkey-driven version goes into the bigger Cycle 25 cycle alongside open-config + reload-on-shell-switch + automated test runner.

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_