### PR TITLE
feat(terminal-app): Cycle 25b-1 — Ctrl+Shift+D bundles diagnostic dump + Ctrl+Shift+T placeholder removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,53 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 25b-1): Ctrl+Shift+D bundles diagnostic dump + Ctrl+Shift+T placeholder removed
+
+`Ctrl+Shift+D` (autonomous diagnostic battery) now writes a
+combined diagnostic-dump bundle into a dated snapshot file at
+`%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<yyyy-MM-dd-HH-mm-ss-fff>.txt`
+**and** copies the bundle to clipboard (instead of just the
+diagnostic-battery log). The bundle includes:
+
+- The diagnostic-battery log (existing per-shell command results,
+  earcon replay outcome, T0 process snapshot, SessionModel
+  substrate state).
+- The active FileLogger log slice (carries Cycle 24f / 24g
+  `Config:` parse messages, the runtime heartbeat trail, and
+  any error-path log lines).
+- The literal `config.toml` content (or "(file not present)").
+- The current process environment with deny-list redaction
+  (`*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`, `*_PASSWD` —
+  values redacted to `<redacted by suite>`; `ANTHROPIC_API_KEY`
+  exempted; names always shown verbatim).
+- A header with capture timestamp, pty-speak version, OS, .NET
+  runtime, process ID.
+
+Format is plain text with `--- SECTION ---` markers between
+sections so future replay tools can index content by section.
+Designed for one-keystroke paste-back to triage chat: the bundle
+carries everything the maintainer needs to triage a Cycle 24
+matrix-row failure or a runtime regression in one block.
+
+`Ctrl+Shift+T` (the `RunTestMatrix` placeholder shipped in 25a)
+is removed entirely — the `AppCommand` DU case, the `nameOf` arm,
+the `builtIns` row, the C#-side `AppReservedHotkeys` row, the
+`runTestMatrix` `ActivityId`, and the `runRunTestMatrix`
+placeholder handler in `Program.fs`. The diagnostic suite folds
+into `Ctrl+Shift+D` rather than splitting across two hotkeys per
+the maintainer's "everything that can be automated goes into D"
+directive. The interactive `test-process-cleanup.ps1` (which
+requires the maintainer to physically close pty-speak via Alt+F4
+/ X-button) stays in the repo but is invoked manually from
+PowerShell rather than hotkey-launched; a future cycle's app
+menu will surface it.
+
+The Cycle 25b plan originally bundled this with a UIA-driven
+FlaUI test runner; the dump-bundle half ships first (this PR)
+and the FlaUI runner lands as a separate PR (25b-2) so the
+maintainer can validate the bundle format before committing to
+the larger E2E test infrastructure.
+
 ### Added (Cycle 25a): hotkey reorg + open-config + reload-on-shell-switch + [logging] TOML
 
 Operational ergonomics bundle landed in response to the friction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,8 +313,13 @@ is load-bearing and pinned by xUnit + behavioural tests.
 Currently shipped (orientation reference; spec section 6 is canonical):
 
 - `Ctrl+Shift+U` — Velopack auto-update (Stage 11)
-- `Ctrl+Shift+D` — process-cleanup diagnostic launcher with
-  inline shell-process snapshot announce (PR-J)
+- `Ctrl+Shift+D` — full automated diagnostic battery (Cycle 25b
+  bundles its diagnostic-battery log + active FileLogger log +
+  config.toml + redacted environment into a single dated
+  snapshot file at `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\
+  snapshot-<yyyy-MM-dd-HH-mm-ss-fff>.txt` and copies the bundle
+  to clipboard, so a paste-back to triage chat carries the full
+  triage context in one block)
 - `Ctrl+Shift+R` — draft-a-new-release form launcher
 - `Ctrl+Shift+L` — copy active session log to clipboard
   (Cycle 25a moved from `Ctrl+Shift+;` for the L-as-Log
@@ -326,8 +331,6 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   old `Ctrl+Shift+L`)
 - `Ctrl+Shift+E` — edit `config.toml` in the default app;
   auto-creates with sensible defaults if missing (Cycle 25a)
-- `Ctrl+Shift+T` — run automated NVDA-matrix test runner
-  (Cycle 25b; placeholder handler in 25a)
 - `Ctrl+Shift+1` / `+2` / `+3` — hot-switch the spawned shell
   (`+1`=cmd / `+2`=PowerShell / `+3`=Claude; PR-J reordered to
   put PowerShell next to cmd as the diagnostic control shell)
@@ -340,8 +343,9 @@ Currently shipped (orientation reference; spec section 6 is canonical):
 - `Ctrl+Shift+Y` — copy SessionModel history to clipboard (Cycle 22b);
   paste-friendly structured plain-text dump of all completed
   tuples + any in-flight active tuple. Companion to
-  `Ctrl+Shift+D` (which announces a substrate summary);
-  `Ctrl+Shift+Y` dumps the full content for analysis.
+  `Ctrl+Shift+D` (which copies the broader diagnostic snapshot
+  bundle); `Ctrl+Shift+Y` is the SessionModel-only narrow dump
+  for substrate-specific analysis.
 - `Ctrl+Shift+S` — announce the active session-log file path
   (Cycle 24e); verbose format `Session log mode <mode>; path
   <full-path>.` for `session_log` / `always`;
@@ -400,11 +404,12 @@ recipes Ctrl+Shift+D uses internally.
 
 **Inline child-process check (the everyday triage tool):**
 
-The user can press `Ctrl+Shift+D` in pty-speak and NVDA reads back
-"Diagnostic snapshot: 1 cmd, 0 powershell, 0 pwsh, 1 claude, 1
-Terminal.App. Launching cleanup test." in one announcement —
-that's the inline enumeration the F# `enumerateShellProcesses`
-helper produces (`src/Terminal.App/Program.fs`). For Claude
+`Ctrl+Shift+D` runs the autonomous diagnostic battery (which
+internally calls F# `enumerateShellProcesses` —
+`src/Terminal.App/Diagnostics.fs`) and writes the per-process
+counts into both the diagnostic-battery log file AND the
+combined snapshot bundle that lands in clipboard +
+`%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\`. For Claude
 sessions reasoning about what the user might be seeing, the
 equivalent CLI commands are:
 
@@ -443,14 +448,17 @@ appears. That's the precise wedge timestamp.
 
 **Process tree diagnostic:**
 
-`Ctrl+Shift+D` launches `scripts/test-process-cleanup.ps1` in a
-new PowerShell window for the close-and-recheck flow. That
-script enumerates Terminal.App.exe + its parent-PID children +
-sibling shell counts (`Get-ShellProcessSnapshot`), then asks the
-user to close pty-speak via Alt+F4 / X-button and reports
-whether anything was orphaned. Use this when diagnosing Job
-Object cascade-kill regressions, NOT for "is the child alive
-right now?" — that's the inline check above.
+`scripts/test-process-cleanup.ps1` is the interactive complement
+to `Ctrl+Shift+D`'s autonomous battery (Cycle 25b decoupled it
+from the hotkey because it requires the maintainer to physically
+close pty-speak via Alt+F4 / X-button). The script enumerates
+Terminal.App.exe + its parent-PID children + sibling shell counts
+(`Get-ShellProcessSnapshot`), prompts the maintainer to close
+pty-speak, and reports whether anything was orphaned. Run it
+directly from PowerShell when diagnosing Job Object cascade-kill
+regressions, NOT for "is the child alive right now?" — that's the
+inline check above. A future cycle's app menu will surface this
+script as a menu item.
 
 ## Current sequencing (May 2026)
 

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -398,7 +398,7 @@ surface, not solve.**
 | **Hot-switch cmd → claude (PR-C)**  | At the cmd prompt, press `Ctrl+Shift+2`         | NVDA announces "Switching to Claude Code." → ~700ms pause → "Switched to Claude Code." → claude welcome reads. Active session log includes "Shell-switch: spawning Claude Code. CommandLine=<path>" |
 | **Hot-switch claude → cmd (PR-C)**  | After claude is running, press `Ctrl+Shift+1`   | NVDA announces "Switching to Command Prompt." → ~700ms pause → "Switched to Command Prompt." → cmd prompt reads. Brief alt-screen residue is acceptable for v1 — log severity to `STAGE-7-ISSUES.md` with `[output-tui]` tag if it confuses the read |
 | **Hot-switch resolve failure (PR-C)** | On a machine WITHOUT claude.exe on PATH, press `Ctrl+Shift+2` | NVDA announces "Cannot switch to Claude Code: not found on PATH." (sanitised). The existing cmd shell continues to work; the user is NOT dropped into a dead window |
-| **Process-cleanup after switch (PR-C)** | After at least one Ctrl+Shift+1 / Ctrl+Shift+2 cycle, press `Ctrl+Shift+D` (process-cleanup diagnostic) | Diagnostic confirms no orphan `claude.exe` / cmd.exe / Terminal.App processes from the previous host. (Job Object's `KILL_ON_JOB_CLOSE` is the kernel-enforced cleanup.) |
+| **Process-cleanup after switch (PR-C)** | After at least one Ctrl+Shift+1 / Ctrl+Shift+2 cycle, press `Ctrl+Shift+D` (autonomous diagnostic battery) | The battery's snapshot section in the bundled dump (clipboard + dated snapshot file) confirms no orphan `claude.exe` / cmd.exe / Terminal.App processes from the previous host. (Job Object's `KILL_ON_JOB_CLOSE` is the kernel-enforced cleanup.) Cycle 25b — Ctrl+Shift+D no longer auto-launches `test-process-cleanup.ps1`; that interactive close-and-recheck flow is now invoked manually from PowerShell when reproducing Job-cascade-kill regressions. |
 | **Quitting cleanly**                | `/exit` (Claude), `exit` (cmd), or Ctrl+D       | Process exits; NVDA announces it; terminal returns to host shell or window closes |
 | **PTYSPEAK_SHELL unrecognised value** | Launch pty-speak with `PTYSPEAK_SHELL=garbage` | cmd.exe still spawns (fallback); active session log includes "PTYSPEAK_SHELL=\"garbage\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude." NVDA-bound behaviour is identical to default-shell launch |
 
@@ -646,8 +646,8 @@ the app-reserved-hotkey contract in `spec/tech-plan.md` §6.
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| Diagnostic launcher               | From running pty-speak, press `Ctrl+Shift+D`    | NVDA reads "Diagnostic launched in a separate PowerShell window. Switch to that window to follow the test."; PowerShell window opens; bundled `test-process-cleanup.ps1` runs; on Alt+Tab to that window NVDA reads its plain-text progress |
-| Diagnostic two-pass               | After the launcher: follow the script's prompts | Pass 1 (Alt+F4 close) and Pass 2 (X-button close, with `Alt+Space`/`Enter` keyboard-equivalent) both report PASS; final summary line `OVERALL: PASS` |
+| Diagnostic battery (Cycle 25b)    | From running pty-speak, press `Ctrl+Shift+D`    | NVDA reads "Starting diagnostic on <Shell>..." → ~10s autonomous battery → "Diagnostic complete. K of N passed. SessionModel: ... Diagnostic snapshot bundle copied to clipboard. Snapshot saved to %LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<stamp>.txt." Bundle includes: per-shell command battery results + SessionModel substrate state + active FileLogger log slice + config.toml + redacted environment. Paste back from clipboard for triage. |
+| Process-cleanup interactive test  | From a PowerShell prompt (not pty-speak's hotkey since Cycle 25b), run `& "$env:LOCALAPPDATA\pty-speak\current\test-process-cleanup.ps1"` | Pass 1 (Alt+F4 close) and Pass 2 (X-button close, with `Alt+Space`/`Enter` keyboard-equivalent) both report PASS; final summary line `OVERALL: PASS`. A future cycle's app menu will surface this script as a menu item. |
 | Release-notes launcher            | From running pty-speak, press `Ctrl+Shift+R`    | NVDA reads "Opened release notes in default browser: <url>"; default browser opens to the GitHub Releases page |
 | Release-notes URL is correct      | Inspect the browser's address bar               | URL is `https://github.com/KyleKeane/pty-speak/releases` (or whatever fork's `UpdateRepoUrl` was configured to) |
 
@@ -665,16 +665,22 @@ input) ship; see SESSION-HANDOFF item 6 for options.
 
 **Diagnostic decoder for the launcher hotkeys:**
 
-- **`Ctrl+Shift+D` silent, no PowerShell window** → Either the
-  `setupDiagnosticKeybinding` wiring regressed in `Program.fs`, OR
-  the bundled `test-process-cleanup.ps1` is missing from the
-  install. Check `%LocalAppData%\pty-speak\current\` for the
-  script file; if missing, the `Content` include in
-  `Terminal.App.fsproj` regressed (which Velopack pack picks up).
-- **`Ctrl+Shift+D` opens PowerShell but the script bails immediately
-  with "pty-speak already running, abort"** → PR #82's fix
-  regressed; the script's `Run-Pass` should detect-and-reuse, not
-  abort.
+- **`Ctrl+Shift+D` silent, no announcement** → The
+  `bindHotkey window HotkeyRegistry.RunDiagnostic runDiagnostic`
+  wiring regressed, OR `runFullBattery`'s outer `try`-`with`
+  swallowed an exception (check the active FileLogger log for an
+  ERR line tagged `Terminal.App.Diagnostics.runFullBattery`).
+  Cycle 25b: D no longer launches a PowerShell window; the
+  battery runs in-process. If you expected a PS window, you're
+  probably thinking of `test-process-cleanup.ps1` which is now
+  invoked manually.
+- **`Ctrl+Shift+D` runs the battery but the snapshot file is
+  missing** → `writeSnapshotFile` failed (e.g. the user lacks
+  write access to `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\`).
+  The clipboard payload still contains the bundle; the announce
+  notes "Snapshot file write failed; clipboard still has the
+  bundle." Investigate via the FileLogger log's
+  `Diagnostic snapshot file write failed` warning line.
 - **`Ctrl+Shift+R` silent, no browser** → Either the
   `setupReleasesKeybinding` wiring regressed, OR the user has no
   default browser handler registered for `https:` URLs (rare on

--- a/scripts/test-process-cleanup.ps1
+++ b/scripts/test-process-cleanup.ps1
@@ -1,5 +1,16 @@
 # Process-cleanup baseline test for pty-speak.
 #
+# As of Cycle 25b this script is invoked manually rather than
+# from a hotkey. Ctrl+Shift+D now runs the autonomous diagnostic
+# battery + bundles the dump (FileLogger log + config + env)
+# into a dated snapshot file under `%LOCALAPPDATA%\PtySpeak\
+# diagnostic-snapshots\` plus the clipboard. This script
+# (which requires the maintainer to physically close pty-speak
+# via Alt+F4 / X-button) is the interactive complement: run it
+# manually when triaging Job Object cascade-kill regressions.
+# A future cycle's app menu will surface it; until then, run
+# directly from PowerShell as documented below.
+#
 # Run from PowerShell. The script:
 #   1. Locates the installed pty-speak under %LocalAppData%\pty-speak\.
 #   2. For each close method (Alt+F4 then X button):

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -919,9 +919,16 @@ module Diagnostics =
             (content: string)
             : string option =
         try
-            let dir = Path.GetDirectoryName(path)
-            if not (String.IsNullOrEmpty dir) then
-                Directory.CreateDirectory(dir) |> ignore
+            // F# 9 nullness: Path.GetDirectoryName returns
+            // `string | null` (the F# 9 annotation marks every
+            // System.IO API that can legitimately return null).
+            // Narrow via pattern match so the non-null arm
+            // type-checks against Directory.CreateDirectory's
+            // non-nullable signature.
+            match Path.GetDirectoryName(path) with
+            | null -> ()
+            | "" -> ()
+            | dir -> Directory.CreateDirectory(dir) |> ignore
             File.WriteAllText(path, content, Encoding.UTF8)
             Some path
         with ex ->

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -751,14 +751,185 @@ module Diagnostics =
     /// Same parent folder as regular `pty-speak-*.log` files so
     /// `Ctrl+Shift+L` opens the right area; the
     /// `diagnostic-` prefix is what distinguishes them.
-    let private resolveDiagnosticLogPath () : string =
-        let now = DateTimeOffset.UtcNow.UtcDateTime
+    /// Cycle 25b: takes `now` so the diagnostic-log file and the
+    /// snapshot bundle file share an identical stamp for
+    /// cross-referencing.
+    let private resolveDiagnosticLogPath (now: DateTime) : string =
         let root =
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
         let dayFolder = now.ToString("yyyy-MM-dd")
         let stamp = now.ToString("yyyy-MM-dd-HH-mm-ss-fff")
         let dir = Path.Combine(root, "PtySpeak", "logs", dayFolder)
         Path.Combine(dir, sprintf "diagnostic-%s.log" stamp)
+
+    /// Cycle 25b — paired snapshot-bundle path. Lives under
+    /// `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\` (a flat
+    /// folder; one file per Ctrl+Shift+D press, named with the
+    /// same stamp as the diagnostic-log file from that run so
+    /// future cross-referencing is mechanical). Plain `.txt` so
+    /// the maintainer can paste the contents back into a triage
+    /// chat or open in any text viewer.
+    let private resolveSnapshotPath (now: DateTime) : string =
+        let root =
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        let stamp = now.ToString("yyyy-MM-dd-HH-mm-ss-fff")
+        let dir = Path.Combine(root, "PtySpeak", "diagnostic-snapshots")
+        Path.Combine(dir, sprintf "snapshot-%s.txt" stamp)
+
+    // ---------------------------------------------------------------
+    // Cycle 25b — diagnostic-dump bundle
+    // ---------------------------------------------------------------
+
+    /// Read a file's content with FileShare.ReadWrite. Used for
+    /// the active FileLogger log (which the running app is still
+    /// writing to) and for config.toml. Returns a parenthesised
+    /// note when the file is missing or unreadable rather than
+    /// throwing — the bundle should always include something for
+    /// each section so the maintainer can see "config not
+    /// present" vs "config read failed".
+    let private readFileSafe (path: string) : string =
+        try
+            if not (File.Exists path) then
+                sprintf "(file not present: %s)" path
+            else
+                use stream =
+                    new FileStream(
+                        path, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite)
+                use reader = new StreamReader(stream, Encoding.UTF8)
+                reader.ReadToEnd()
+        with ex ->
+            sprintf "(read failed: %s)" ex.Message
+
+    /// Env-var deny-list mirroring `SessionSanitiser`'s pattern
+    /// for value-redaction in session logs (`*_TOKEN`, `*_SECRET`,
+    /// `*_KEY`, `*_PASSWORD`, `*_PASSWD`). `ANTHROPIC_API_KEY` is
+    /// exempted: the maintainer's Claude-shell triage flow needs
+    /// to confirm it's actually set in the spawned-app environment
+    /// when debugging "claude.exe spawned but immediately
+    /// errored", and the maintainer routinely shares the dump
+    /// content back to triage conversations where the value is
+    /// expected to be visible. Names always appear verbatim — the
+    /// SET of configured variables is itself useful diagnostic
+    /// info (e.g. spotting a missing `PATH` entry that broke a
+    /// shell launch).
+    let private isSensitiveEnvName (name: string) : bool =
+        if String.IsNullOrEmpty name then false
+        elif String.Equals(name, "ANTHROPIC_API_KEY", StringComparison.OrdinalIgnoreCase) then false
+        else
+            let upper = name.ToUpperInvariant()
+            upper.EndsWith("_TOKEN")
+            || upper.EndsWith("_SECRET")
+            || upper.EndsWith("_KEY")
+            || upper.EndsWith("_PASSWORD")
+            || upper.EndsWith("_PASSWD")
+
+    /// Snapshot the current process environment, sorted by name,
+    /// with sensitive values redacted. Format: one `NAME=value`
+    /// line per variable.
+    let private formatEnvironmentRedacted () : string =
+        let table = Environment.GetEnvironmentVariables()
+        let names = ResizeArray<string>()
+        for entry in table do
+            let de = entry :?> System.Collections.DictionaryEntry
+            match de.Key with
+            | :? string as k -> names.Add(k)
+            | _ -> ()
+        names.Sort()
+        let sb = StringBuilder()
+        for name in names do
+            let value =
+                match table.[name] with
+                | :? string as s -> s
+                | null -> ""
+                | other -> string other
+            let displayValue =
+                if isSensitiveEnvName name then "<redacted by suite>"
+                else value
+            sb.AppendLine(sprintf "%s=%s" name displayValue) |> ignore
+        sb.ToString()
+
+    /// Assemble the combined diagnostic dump bundle. Plain text
+    /// with `--- SECTION ---` markers between sections; format
+    /// is intentionally stable so future replay tools can index
+    /// content by section header. The diagnostic-battery log
+    /// (already gathered by `runFullBattery`) plus the active
+    /// FileLogger log slice (which carries Cycle 24f / 24g
+    /// `Config:` parse messages and the runtime heartbeat trail)
+    /// plus the literal config.toml plus a redacted env snapshot.
+    let private formatDiagnosticBundle
+            (now: DateTime)
+            (batteryLogPath: string)
+            (batteryLogContent: string)
+            (fileLoggerLogPath: string option)
+            (configPath: string)
+            : string =
+        let sb = StringBuilder()
+        let appendLine (s: string) = sb.AppendLine(s) |> ignore
+        let separator = "========================================================="
+        appendLine separator
+        appendLine "pty-speak diagnostic snapshot (Cycle 25b)"
+        appendLine (sprintf "Captured: %s UTC" (now.ToString("yyyy-MM-dd HH:mm:ss")))
+        let version =
+            try
+                let asm = System.Reflection.Assembly.GetExecutingAssembly()
+                let v = asm.GetName().Version
+                if isNull v then "unknown" else string v
+            with _ -> "unknown"
+        appendLine (sprintf "Version: %s" version)
+        appendLine (sprintf "OS: %s" (Environment.OSVersion.VersionString))
+        appendLine (sprintf ".NET: %s" (Environment.Version.ToString()))
+        appendLine (sprintf "Process ID: %d" (System.Diagnostics.Process.GetCurrentProcess().Id))
+        appendLine separator
+        appendLine ""
+
+        appendLine "--- DIAGNOSTIC BATTERY LOG ---"
+        appendLine (sprintf "(source: %s)" batteryLogPath)
+        appendLine batteryLogContent
+        appendLine ""
+
+        appendLine "--- FILELOGGER ACTIVE LOG ---"
+        match fileLoggerLogPath with
+        | Some path ->
+            appendLine (sprintf "(source: %s)" path)
+            appendLine (readFileSafe path)
+        | None ->
+            appendLine "(FileLogger not configured)"
+        appendLine ""
+
+        appendLine "--- CONFIG.TOML ---"
+        appendLine (sprintf "(source: %s)" configPath)
+        appendLine (readFileSafe configPath)
+        appendLine ""
+
+        appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"
+        appendLine (formatEnvironmentRedacted ())
+        appendLine ""
+
+        appendLine "--- END OF SNAPSHOT ---"
+        sb.ToString()
+
+    /// Write the bundle text to disk. Creates the parent dir if
+    /// missing. Returns the path written, or `None` on failure
+    /// (the caller still has the bundle in memory for clipboard
+    /// fallback). Never throws.
+    let private writeSnapshotFile
+            (log: ILogger)
+            (path: string)
+            (content: string)
+            : string option =
+        try
+            let dir = Path.GetDirectoryName(path)
+            if not (String.IsNullOrEmpty dir) then
+                Directory.CreateDirectory(dir) |> ignore
+            File.WriteAllText(path, content, Encoding.UTF8)
+            Some path
+        with ex ->
+            log.LogWarning(
+                ex,
+                "Diagnostic snapshot file write failed at {Path}: {Message}",
+                path, ex.Message)
+            None
 
     // ---------------------------------------------------------------
     // Main entry — runFullBattery
@@ -778,12 +949,18 @@ module Diagnostics =
             (resolveShell: unit -> ShellRegistry.Shell)
             (resolveSeq: unit -> int64)
             (resolveSessionSnapshot: unit -> SessionModelSnapshot)
+            (resolveFileLoggerLogPath: unit -> string option)
             : unit =
         let log = Logger.get "Terminal.App.Diagnostics.runFullBattery"
         let _ =
             task {
                 try
-                    let logPath = resolveDiagnosticLogPath ()
+                    // Cycle 25b — single timestamp drives the
+                    // diagnostic-battery log filename AND the
+                    // paired snapshot bundle filename so the two
+                    // are mechanically cross-referenceable.
+                    let now = DateTimeOffset.UtcNow.UtcDateTime
+                    let logPath = resolveDiagnosticLogPath now
                     use writer = new DiagnosticLogWriter(logPath)
                     let cat = "Diagnostic.Init"
                     let shell = resolveShell ()
@@ -919,21 +1096,50 @@ module Diagnostics =
                                 "Diagnostic complete. %d of %d passed.%s"
                                 pass total
                                 substrateFragment
-                    if String.IsNullOrEmpty content then
-                        let msg = sprintf "%s Could not read diagnostic log." summaryLine
+                    // Cycle 25b — assemble the combined dump
+                    // bundle: diagnostic-battery log + FileLogger
+                    // active log + config.toml + redacted env.
+                    // Write to the dated snapshot folder; clipboard
+                    // payload is the BUNDLE (not just the
+                    // diagnostic-battery log) so a paste-back to
+                    // triage chat carries everything in one block.
+                    let configPath = Config.defaultConfigFilePath ()
+                    let fileLoggerLogPath = resolveFileLoggerLogPath ()
+                    let snapshotPath = resolveSnapshotPath now
+                    let bundle =
+                        formatDiagnosticBundle
+                            now
+                            logPath
+                            content
+                            fileLoggerLogPath
+                            configPath
+                    let writtenPath = writeSnapshotFile log snapshotPath bundle
+                    let savedFragment =
+                        match writtenPath with
+                        | Some p -> sprintf " Snapshot saved to %s." p
+                        | None -> " Snapshot file write failed; clipboard still has the bundle."
+                    let! copied = copyToClipboardSta log bundle
+                    if copied then
+                        let msg =
+                            sprintf
+                                "%s Diagnostic snapshot bundle copied to clipboard.%s"
+                                summaryLine
+                                savedFragment
                         do! announce msg
                     else
-                        let! copied = copyToClipboardSta log content
-                        if copied then
-                            let msg = sprintf "%s Diagnostic log copied to clipboard." summaryLine
-                            do! announce msg
-                        else
-                            let msg =
+                        let msg =
+                            match writtenPath with
+                            | Some p ->
                                 sprintf
-                                    "%s Clipboard copy failed; diagnostic log at %s."
+                                    "%s Clipboard copy failed; snapshot saved to %s."
+                                    summaryLine
+                                    p
+                            | None ->
+                                sprintf
+                                    "%s Clipboard copy and snapshot write both failed; diagnostic log at %s."
                                     summaryLine
                                     logPath
-                            do! announce msg
+                        do! announce msg
                 with ex ->
                     log.LogError(
                         ex,

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -523,22 +523,6 @@ module Program =
             }
         ()
 
-    /// Cycle 25a — placeholder for the test-runner hotkey.
-    /// PR 25b replaces this with the FlaUI-driver launcher.
-    /// Until then, pressing `Ctrl+Shift+T` announces that the
-    /// runner isn't yet implemented (rather than silently
-    /// no-op-ing, which would be confusing — the binding is
-    /// reachable via the routed-command surface and the user
-    /// has every reason to think pressing it should do
-    /// something).
-    let private runRunTestMatrix (window: MainWindow) : unit =
-        let log = Logger.get "Terminal.App.Program.runRunTestMatrix"
-        log.LogInformation(
-            "Ctrl+Shift+T pressed — test-matrix runner not yet implemented (Cycle 25b).")
-        window.TerminalSurface.Announce(
-            "Test matrix runner not yet implemented; ships in Cycle 25b.",
-            ActivityIds.runTestMatrix)
-
     /// Copy the active session's log file content to the
     /// system clipboard so the maintainer can paste it into a
     /// bug report without navigating File Explorer. Triggered
@@ -817,7 +801,6 @@ module Program =
         bindHotkey window HotkeyRegistry.CopyLatestLog (fun () -> runCopyLatestLog window)
         bindHotkey window HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
         bindHotkey window HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
-        bindHotkey window HotkeyRegistry.RunTestMatrix (fun () -> runRunTestMatrix window)
 
         // Direct dispatch via TerminalView.OnPreviewKeyDown is
         // kept as a defence-in-depth path because Window-level
@@ -1944,6 +1927,18 @@ module Program =
                         currentSession
                         promptDetector
                         activePathway.Id)
+                // Cycle 25b — snapshot-bundle path resolver. The
+                // diagnostic battery now includes the FileLogger
+                // active log slice in its dump-and-clipboard
+                // bundle so a paste-back to triage chat carries
+                // Cycle 24f / 24g `Config:` parse messages, the
+                // heartbeat trail, and any error-path log lines
+                // alongside the battery's own output. Resolves at
+                // press-time because `loggerSink` is a module-
+                // level mutable that compose () sets after this
+                // closure is captured.
+                (fun () ->
+                    loggerSink |> Option.map (fun s -> s.ActiveLogPath))
 
         // Cycle 22b — Ctrl+Shift+Y. Closure captures
         // `currentSession` from compose-local scope. Resolves

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -105,8 +105,6 @@ module HotkeyRegistry =
         | CopyHistoryToClipboard
         // Cycle 24e — announce active session-log file path.
         | AnnounceSessionLogPath
-        // Cycle 25b — run automated NVDA-matrix test runner.
-        | RunTestMatrix
 
     /// Stable string name for a command, used as the
     /// `RoutedCommand` name passed to WPF and as a TOML key
@@ -130,7 +128,6 @@ module HotkeyRegistry =
         | MuteEarcons -> "MuteEarcons"
         | CopyHistoryToClipboard -> "CopyHistoryToClipboard"
         | AnnounceSessionLogPath -> "AnnounceSessionLogPath"
-        | RunTestMatrix -> "RunTestMatrix"
 
     /// Default key binding for a command. Mirrors the
     /// `AppReservedHotkeys` table in
@@ -160,7 +157,7 @@ module HotkeyRegistry =
           { Command = RunDiagnostic
             Key = Letter 'D'
             Modifiers = ctrlShift
-            Description = "Process-cleanup diagnostic launcher (PR-J adds inline shell-process snapshot)" }
+            Description = "Run full automated diagnostic suite (Cycle 25b — bundles dump to clipboard + dated snapshot file)" }
           { Command = DraftNewRelease
             Key = Letter 'R'
             Modifiers = ctrlShift
@@ -212,11 +209,7 @@ module HotkeyRegistry =
           { Command = AnnounceSessionLogPath
             Key = Letter 'S'
             Modifiers = ctrlShift
-            Description = "Announce the active session-log file path (Cycle 24e)" }
-          { Command = RunTestMatrix
-            Key = Letter 'T'
-            Modifiers = ctrlShift
-            Description = "Run automated NVDA-matrix test runner (Cycle 25b)" } ]
+            Description = "Announce the active session-log file path (Cycle 24e)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —
@@ -263,5 +256,4 @@ module HotkeyRegistry =
           SwitchToClaude
           MuteEarcons
           CopyHistoryToClipboard
-          AnnounceSessionLogPath
-          RunTestMatrix ]
+          AnnounceSessionLogPath ]

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -492,7 +492,3 @@ module ActivityIds =
     /// freshly written) before the default-app launch grabs
     /// focus.
     let openConfig = "pty-speak.open-config"
-
-    /// Run-test-matrix announcements (Cycle 25b
-    /// `Ctrl+Shift+T`). Emits launch + completion summary.
-    let runTestMatrix = "pty-speak.run-test-matrix"

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -403,13 +403,16 @@ public class TerminalView : FrameworkElement
             //                 arrow-key step).
             //   Ctrl+Shift+E: edit config.toml (auto-creates
             //                 with defaults if missing).
-            //   Ctrl+Shift+T: placeholder for the Cycle 25b
-            //                 test-matrix runner.
             //   Ctrl+Shift+; vacated entirely (no alias).
+            // Cycle 25b: removed Ctrl+Shift+T placeholder. The
+            // diagnostic suite folded into Ctrl+Shift+D (Cycle 25b
+            // bundles FileLogger log + config + env into a dated
+            // snapshot file + clipboard); the interactive
+            // process-cleanup test moves to a future app menu
+            // rather than a hotkey.
             (Key.L, ModifierKeys.Control | ModifierKeys.Shift, "Copy active log to clipboard"),
             (Key.P, ModifierKeys.Control | ModifierKeys.Shift, "Open pty-speak data folder"),
             (Key.E, ModifierKeys.Control | ModifierKeys.Shift, "Edit config.toml"),
-            (Key.T, ModifierKeys.Control | ModifierKeys.Shift, "Run NVDA-matrix test runner"),
 
             // Stage 7 PR-C — hot-switch the spawned shell mid-session.
             // PR-J (2026-05-03) reordered the slots and added

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -76,10 +76,7 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // Cycle 22b — copy SessionModel history to clipboard.
               HotkeyRegistry.CopyHistoryToClipboard
               // Cycle 24e — announce session-log file path.
-              HotkeyRegistry.AnnounceSessionLogPath
-              // Cycle 25b — automated test runner (placeholder
-              // handler in 25a; full implementation in 25b).
-              HotkeyRegistry.RunTestMatrix ]
+              HotkeyRegistry.AnnounceSessionLogPath ]
     let actual = Set.ofList HotkeyRegistry.allCommands
     Assert.Equal<Set<HotkeyRegistry.AppCommand>>(expected, actual)
 
@@ -208,12 +205,14 @@ let ``OpenConfig is bound to Ctrl+Shift+E (Cycle 25a)`` () =
         hk.Modifiers)
 
 [<Fact>]
-let ``RunTestMatrix is bound to Ctrl+Shift+T (Cycle 25b)`` () =
-    let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.RunTestMatrix
-    Assert.Equal(HotkeyRegistry.Letter 'T', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
-        hk.Modifiers)
+let ``Ctrl+Shift+T is unbound (Cycle 25b removed RunTestMatrix placeholder)`` () =
+    // Cycle 25b — the RunTestMatrix placeholder shipped in 25a is
+    // removed. The diagnostic suite folds into Ctrl+Shift+D rather
+    // than splitting across two hotkeys; the interactive cleanup
+    // test (which required user input) moves to a future app menu.
+    let modifiers = Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]
+    let result = HotkeyRegistry.tryFind (HotkeyRegistry.Letter 'T') modifiers
+    Assert.Equal(None, result)
 
 [<Fact>]
 let ``Ctrl+Shift+; is unbound (Cycle 25a vacated)`` () =


### PR DESCRIPTION
## Summary

`Ctrl+Shift+D`'s autonomous diagnostic battery now writes a **combined diagnostic-dump bundle** into a dated snapshot file at `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<yyyy-MM-dd-HH-mm-ss-fff>.txt` **and** copies the bundle to clipboard (instead of just the diagnostic-battery log). Designed for one-keystroke paste-back to triage chat: the bundle carries everything the maintainer needs to triage a Cycle 24 matrix-row failure or runtime regression in one block.

`Ctrl+Shift+T` (the `RunTestMatrix` placeholder shipped in 25a) is removed entirely. The diagnostic suite folds into D rather than splitting across two hotkeys per the maintainer's "everything that can be automated goes into D" directive. The interactive `test-process-cleanup.ps1` (which requires physically closing pty-speak via Alt+F4 / X-button) stays in the repo but is invoked manually; a future cycle's app menu will surface it.

## What's in the dump bundle

Plain-text, sectioned with `--- SECTION ---` markers for grep-ability and future replay-tool indexing:

- **Header**: capture timestamp (UTC), pty-speak version, OS, .NET runtime, process ID.
- **DIAGNOSTIC BATTERY LOG**: existing per-shell command battery results, earcon replay outcome, T0 process snapshot, SessionModel substrate state. Source path noted.
- **FILELOGGER ACTIVE LOG**: the in-flight `pty-speak-*.log` slice — carries Cycle 24f/24g `Config:` parse messages, the runtime heartbeat trail, and any error-path log lines.
- **CONFIG.TOML**: the literal config content (or `(file not present)`).
- **ENVIRONMENT (deny-listed values redacted)**: full env, sorted alphabetically by name. Names always shown verbatim (the SET of configured vars is itself useful diagnostic info — e.g. spotting a missing `PATH` entry that broke a shell launch). Values redacted to `<redacted by suite>` for `*_TOKEN` / `*_SECRET` / `*_KEY` / `*_PASSWORD` / `*_PASSWD`. `ANTHROPIC_API_KEY` exempted — the maintainer's Claude-shell triage flow needs to confirm it's set in the spawned-app environment.

## Removed (Ctrl+Shift+T cleanup)

- `HotkeyRegistry.AppCommand.RunTestMatrix` DU case + `nameOf` arm + `builtIns` row + `allCommands` entry.
- `ActivityIds.runTestMatrix`.
- `Program.fs` `runRunTestMatrix` placeholder handler + its `bindHotkey` line.
- `TerminalView.AppReservedHotkeys` `(Key.T, ...)` row.
- `HotkeyRegistryTests` references; replaced with a `Ctrl+Shift+T is unbound` pin test.

## Out of scope (deferred to Cycle 25b-2)

The Cycle 25b plan originally bundled this with a UIA-driven FlaUI test runner. The dump-bundle half ships first (this PR) and the FlaUI runner lands as a separate PR (25b-2) so the maintainer can validate the bundle format before committing to the larger E2E test infrastructure (FlaUI flakiness, CI integration concerns — UIA needs an interactive desktop session that GitHub-hosted Windows runners don't have).

## Test plan

- [ ] CI green (Tests.Unit reduced by 1 RunTestMatrix-pin test, gained 1 T-unbound pin test; net no count change).
- [ ] Maintainer cuts release with this commit; updates via `Ctrl+Shift+U`.
- [ ] Press `Ctrl+Shift+D`:
  - NVDA reads "Starting diagnostic on <Shell>..." → ~10s autonomous battery → "Diagnostic complete. K of N passed. SessionModel: ... Diagnostic snapshot bundle copied to clipboard. Snapshot saved to %LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<stamp>.txt."
  - Verify the snapshot file exists at the announced path.
  - Verify the snapshot file contains all five sections (header, battery log, FileLogger log, config.toml, environment).
  - Paste clipboard into a triage chat reply; verify the bundle arrives whole.
- [ ] Press `Ctrl+Shift+T` — flows through to the shell as plain text (no announcement, no handler).

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_