### PR TITLE
feat(terminal-app): Cycle 25b-1a — bundle gains session-log section + Ctrl+Shift+L removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 25b-1a): bundle gains session-log section + Ctrl+Shift+L removed
+
+Follow-up to 25b-1 (PR #221) after the maintainer validated the
+bundle format on a real Ctrl+Shift+D press:
+
+- **New `--- SESSION LOG ---` section** in the bundle, between
+  `CONFIG.TOML` and `ENVIRONMENT`. Carries the same
+  `Session log mode <mode>; path <full-path>.` line that
+  `Ctrl+Shift+S` announces, surfaced as a first-class
+  triage line so the maintainer doesn't have to grep the
+  FileLogger log slice for the active session-log path.
+  Single source of truth: `Program.fs.buildSessionLogSummary`
+  is consumed by both the S handler and D's
+  `resolveSessionLogSummary` closure.
+
+- **`Ctrl+Shift+L` (CopyLatestLog) removed entirely**. The D
+  bundle's `--- FILELOGGER ACTIVE LOG ---` section subsumes
+  L's payload — having a dedicated copy-just-the-log hotkey
+  was redundant given the bundle's coverage. Removed:
+  `HotkeyRegistry.AppCommand.CopyLatestLog` DU case + `nameOf`
+  arm + `builtIns` row + `allCommands` entry; the
+  `runCopyLatestLog` handler in `Program.fs` (~135 lines
+  including the dispatcher-deadlock-fix Task wrapper); the
+  `bindHotkey` line; the `SetCopyLogToClipboardHandler`
+  defense-in-depth wiring; the C# `_copyActiveLogToClipboard`
+  field, `SetCopyLogToClipboardHandler` setter, the
+  `Key.OemSemicolon` direct handler in `OnPreviewKeyDown`,
+  and the `(Key.L, ...)` row in `AppReservedHotkeys`. Tests
+  and `CLAUDE.md` / `ACCESSIBILITY-TESTING.md` updated to
+  point at D for log-paste flows. Per the maintainer's
+  hotkey-count-pressure feedback (working-memory ceiling).
+
 ### Changed (Cycle 25b-1): Ctrl+Shift+D bundles diagnostic dump + Ctrl+Shift+T placeholder removed
 
 `Ctrl+Shift+D` (autonomous diagnostic battery) now writes a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,10 +321,6 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   to clipboard, so a paste-back to triage chat carries the full
   triage context in one block)
 - `Ctrl+Shift+R` — draft-a-new-release form launcher
-- `Ctrl+Shift+L` — copy active session log to clipboard
-  (Cycle 25a moved from `Ctrl+Shift+;` for the L-as-Log
-  mnemonic; the old "open logs folder" binding is replaced
-  by `Ctrl+Shift+P` below)
 - `Ctrl+Shift+P` — open the pty-speak data folder
   (`%LOCALAPPDATA%\PtySpeak\`, parent of `\logs`,
   `\sessions`, and `config.toml`) (Cycle 25a; replaces the
@@ -351,7 +347,9 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   <full-path>.` for `session_log` / `always`;
   `Session log mode memory_only; no file.` for `memory_only`.
   Companion to `Ctrl+Shift+P` (open the data-folder root)
-  and `Ctrl+Shift+L` (copy active log to clipboard).
+  and `Ctrl+Shift+D` (which folds the same summary into the
+  bundle's `--- SESSION LOG ---` section so a paste-back
+  carries it without a separate keystroke).
 
 Reserved (not yet bound):
 
@@ -442,9 +440,11 @@ The 5s background heartbeat
 (`runHeartbeat` in `Program.fs`) writes a line per tick to the
 active log including `Pid={Pid} Alive={Alive}`. When triaging
 "why did NVDA stop reading?" post-hoc, ask for the log slice
-covering that time window (`Ctrl+Shift+L` copies the active log)
-and grep `Heartbeat` to find the moment `Alive=False` first
-appears. That's the precise wedge timestamp.
+covering that time window (`Ctrl+Shift+D` bundles the active
+FileLogger log into clipboard + a dated snapshot file) and
+grep `Heartbeat` in the bundle's `--- FILELOGGER ACTIVE LOG ---`
+section to find the moment `Alive=False` first appears. That's
+the precise wedge timestamp.
 
 **Process tree diagnostic:**
 

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -387,7 +387,7 @@ surface, not solve.**
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| **Default-shell launch (PR-B)**     | Launch pty-speak with `PTYSPEAK_SHELL` unset    | cmd.exe spawns; NVDA reads the cmd prompt; log line "Startup shell: Command Prompt (command line: cmd.exe)" appears in the active session log (press `Ctrl+Shift+L` to copy the log to clipboard, or `Ctrl+Shift+P` to open the data folder and navigate into `\logs`) |
+| **Default-shell launch (PR-B)**     | Launch pty-speak with `PTYSPEAK_SHELL` unset    | cmd.exe spawns; NVDA reads the cmd prompt; log line "Startup shell: Command Prompt (command line: cmd.exe)" appears in the active session log (press `Ctrl+Shift+D` to bundle the log into clipboard + a dated snapshot file, or `Ctrl+Shift+P` to open the data folder and navigate into `\logs`) |
 | **Env-scrub empirical check (PR-A)** | At the cmd prompt, type `set` and press Enter | Output enumerates the child's env block. Confirm sensitive vars from the deny-list are ABSENT: `GITHUB_TOKEN`, `OPENAI_API_KEY` (any `*_TOKEN`/`*_SECRET`/`*_PASSWORD`/non-Anthropic `*_KEY`). Confirm allow-list vars are PRESENT: `PATH`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `HOME`, `TERM=xterm-256color`, `COLORTERM=truecolor`. Active session log includes "Env-scrub: stripped {N} variables before child spawn." (count only; never names or values) |
 | **Claude-shell launch (PR-B)**      | Quit pty-speak; relaunch with `PTYSPEAK_SHELL=claude` (or with claude.exe on PATH and PR-C's hotkey approach below) | claude.exe spawns; NVDA reads the welcome screen; log line "Startup shell: Claude Code (command line: <resolved path>)" |
 | **Welcome screen (Claude)**         | After Claude spawns, listen                     | NVDA reads the welcome screen                                    |
@@ -464,7 +464,7 @@ verify each layer's user-facing contract.
 
 | Test                              | Procedure                                       | Expected behaviour                                               |
 |-----------------------------------|-------------------------------------------------|------------------------------------------------------------------|
-| Mode change at startup            | Press `Ctrl+Shift+E` to open `config.toml` (auto-creates with defaults if missing); set `[session_model.persistence] mode = "session_log"`; save; relaunch (or press `Ctrl+Shift+1` to reload persistence config without restart per Cycle 25a's reload-on-switch) | App starts cleanly; active session log (press `Ctrl+Shift+L` to copy to clipboard) contains `Config: [session_model.persistence] section parsed; mode=session_log, ...` immediately followed by `SessionModel persistence mode: session_log (output_dir=..., format=jsonl, max_session_size_mb=...)`; no Warning about "not yet implemented" |
+| Mode change at startup            | Press `Ctrl+Shift+E` to open `config.toml` (auto-creates with defaults if missing); set `[session_model.persistence] mode = "session_log"`; save; relaunch (or press `Ctrl+Shift+1` to reload persistence config without restart per Cycle 25a's reload-on-switch) | App starts cleanly; active session log (press `Ctrl+Shift+D` and inspect the bundle's `--- FILELOGGER ACTIVE LOG ---` section in clipboard) contains `Config: [session_model.persistence] section parsed; mode=session_log, ...` immediately followed by `SessionModel persistence mode: session_log (output_dir=..., format=jsonl, max_session_size_mb=...)`; no Warning about "not yet implemented" |
 | Open-config auto-create (Cycle 25a) | Delete `%LOCALAPPDATA%\PtySpeak\config.toml` if present; press `Ctrl+Shift+E` | NVDA announces "Created config file with defaults; opening." Default text editor opens to a fresh `config.toml` containing all four documented sections (`[session_model.persistence]`, `[startup]`, `[logging]`, plus `schema_version = 1`) with inline comments describing each value. Re-pressing `Ctrl+Shift+E` re-opens the existing file with the announcement "Opening config file." (no overwrite) |
 | Open-data-folder hotkey (Cycle 25a) | Press `Ctrl+Shift+P` | Explorer opens at `%LOCALAPPDATA%\PtySpeak\` showing `\logs`, `\sessions`, and `config.toml` — single jumping-off point for any of them. NVDA announces "Opening data folder." beforehand |
 | File creation in `session_log` mode | With mode set as above, run `echo hello`        | File `%LOCALAPPDATA%\PtySpeak\sessions\session-<UUID>.jsonl` exists; first line is one valid JSON object containing `"commandText":"echo hello"` and `"schemaVersion":1` |
@@ -476,7 +476,8 @@ verify each layer's user-facing contract.
 **Diagnostic decoder for Cycle 24:**
 
 - **Mode change ignored at startup** → grep the FileLogger
-  log (press `Ctrl+Shift+L` to copy to clipboard) for
+  log (press `Ctrl+Shift+D` and inspect the bundle's
+  `--- FILELOGGER ACTIVE LOG ---` section in clipboard) for
   `Config: ` lines. Cycle
   24f added explicit per-branch diagnostic logging:
   - `Config: no [session_model] section in TOML; using

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -863,6 +863,7 @@ module Diagnostics =
             (batteryLogContent: string)
             (fileLoggerLogPath: string option)
             (configPath: string)
+            (sessionLogSummary: string)
             : string =
         let sb = StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
@@ -900,6 +901,10 @@ module Diagnostics =
         appendLine "--- CONFIG.TOML ---"
         appendLine (sprintf "(source: %s)" configPath)
         appendLine (readFileSafe configPath)
+        appendLine ""
+
+        appendLine "--- SESSION LOG ---"
+        appendLine sessionLogSummary
         appendLine ""
 
         appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"
@@ -957,6 +962,7 @@ module Diagnostics =
             (resolveSeq: unit -> int64)
             (resolveSessionSnapshot: unit -> SessionModelSnapshot)
             (resolveFileLoggerLogPath: unit -> string option)
+            (resolveSessionLogSummary: unit -> string)
             : unit =
         let log = Logger.get "Terminal.App.Diagnostics.runFullBattery"
         let _ =
@@ -1112,6 +1118,7 @@ module Diagnostics =
                     // triage chat carries everything in one block.
                     let configPath = Config.defaultConfigFilePath ()
                     let fileLoggerLogPath = resolveFileLoggerLogPath ()
+                    let sessionLogSummary = resolveSessionLogSummary ()
                     let snapshotPath = resolveSnapshotPath now
                     let bundle =
                         formatDiagnosticBundle
@@ -1120,6 +1127,7 @@ module Diagnostics =
                             content
                             fileLoggerLogPath
                             configPath
+                            sessionLogSummary
                     let writtenPath = writeSnapshotFile log snapshotPath bundle
                     let savedFragment =
                         match writtenPath with

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -523,171 +523,16 @@ module Program =
             }
         ()
 
-    /// Copy the active session's log file content to the
-    /// system clipboard so the maintainer can paste it into a
-    /// bug report without navigating File Explorer. Triggered
-    /// by `Ctrl+Shift+;` (the semicolon / colon key, immediately
-    /// to the right of `L` on a US-layout keyboard). Pairs by
-    /// physical proximity with the `Ctrl+Shift+L` open-folder
-    /// primary: same hand position, two adjacent keys, "open
-    /// the folder | copy the active file". Reads the file
-    /// pointed to by `FileLoggerSink.ActiveLogPath`, copies the
-    /// entire content as a single string, and announces the
-    /// byte count via NVDA on success.
-    ///
-    /// Hotkey-choice history. The original binding was
-    /// `Ctrl+Alt+L` (paired with `Ctrl+Shift+L` open-folder).
-    /// Two production issues forced the move:
-    ///
-    /// 1. `Ctrl+Alt+L` is the Windows Magnifier "zoom-in"
-    ///    shortcut on some default Magnifier configurations,
-    ///    so the OS swallowed the gesture before it reached
-    ///    pty-speak.
-    /// 2. The `Alt`-modifier path through WPF's input pipeline
-    ///    delivers `e.Key = Key.System` + `e.SystemKey = Key.L`,
-    ///    which required a SystemKey-aware filter throughout
-    ///    `OnPreviewKeyDown` — and that filter then intercepted
-    ///    `Alt+F4`, breaking the OS window-close gesture.
-    ///
-    /// `Ctrl+Shift+C` was considered but reserved for a future
-    /// copy-latest-command-output feature (the cross-terminal
-    /// convention for that gesture). Layout caveat: on non-US
-    /// keyboards the `OemSemicolon` virtual-key sits in a
-    /// different physical position; remap when configurable
-    /// keybindings ship in Phase 2.
-    let private runCopyLatestLog (window: MainWindow) : unit =
-        let log = Logger.get "Terminal.App.Program.runCopyLatestLog"
-        log.LogInformation("Ctrl+Shift+; pressed — copying active log to clipboard.")
-        match loggerSink with
-        | None ->
-            window.TerminalSurface.Announce(
-                "Logging is not initialised yet; nothing to copy.",
-                ActivityIds.error)
-        | Some sink ->
-            // Stage 7-followup PR-G — fix dispatcher deadlock that
-            // wedged the WPF window when this hotkey ran while NVDA
-            // had a long readout queued.
-            //
-            // The previous implementation called
-            // `sink.FlushPending(500).Result` on the dispatcher.
-            // `FlushPending` is `task { ... let! winner =
-            // Task.WhenAny(...) ... }`; the `let!` captures the
-            // WPF dispatcher's `SynchronizationContext`. When the
-            // dispatcher thread calls `.Result`, it blocks waiting
-            // for the task. The task's continuation needs to
-            // resume on the captured context — which is the
-            // dispatcher itself. Permanent deadlock; the 500ms
-            // timeout never fires because the timeout's
-            // continuation can't run on the wedged dispatcher.
-            // Empirical confirmation: 2026-05-03 NVDA pass log
-            // showed `Ctrl+Shift+;` entry-log fired at 19:13:51.861
-            // followed by zero subsequent dispatcher events for
-            // 2.5+ minutes (heartbeats kept firing on the
-            // background timer, confirming the runtime was alive
-            // but the WPF dispatcher was stuck).
-            //
-            // Additional concern: `Clipboard.SetText` requires the
-            // STA apartment AND can hang on contention with NVDA's
-            // clipboard hooks / antivirus / clipboard managers.
-            // Both issues are fixed by running the whole copy
-            // operation off the dispatcher in a Task: FlushPending
-            // is awaited normally (no `.Result`), the clipboard
-            // SetText runs on a dedicated STA thread with a 3s
-            // timeout, and the announcement dispatches back to the
-            // WPF thread on completion. The hotkey handler returns
-            // immediately; the dispatcher never blocks.
-            let _ =
-                task {
-                    try
-                        let! drained = sink.FlushPending(500)
-                        if not drained then
-                            log.LogInformation(
-                                "FlushPending timed out after 500ms; clipboard may be missing entries enqueued in the last few hundred ms.")
-                        let path = sink.ActiveLogPath
-                        if not (System.IO.File.Exists path) then
-                            let action () =
-                                window.TerminalSurface.Announce(
-                                    "Active log file does not exist yet; press a key or wait for an event first.",
-                                    ActivityIds.error)
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
-                        else
-                            // FileShare.ReadWrite matches the
-                            // FileLogger writer's open mode (the
-                            // writer holds the file with FileAccess.Write
-                            // + FileShare.ReadWrite, so a reader
-                            // with FileShare.ReadWrite is granted
-                            // by the OS).
-                            let content =
-                                use stream =
-                                    new System.IO.FileStream(
-                                        path,
-                                        System.IO.FileMode.Open,
-                                        System.IO.FileAccess.Read,
-                                        System.IO.FileShare.ReadWrite)
-                                use reader =
-                                    new System.IO.StreamReader(
-                                        stream, System.Text.Encoding.UTF8)
-                                reader.ReadToEnd()
-                            // System.Windows.Clipboard.SetText
-                            // requires STA apartment. Thread-pool
-                            // threads are MTA, so we spin up a
-                            // dedicated STA thread for this single
-                            // operation. Bounded by a 3s timeout
-                            // so clipboard contention can't hang
-                            // the workflow indefinitely.
-                            let setOk = TaskCompletionSource<bool>()
-                            let staBody = ThreadStart(fun () ->
-                                try
-                                    System.Windows.Clipboard.SetText(content)
-                                    setOk.TrySetResult(true) |> ignore
-                                with ex ->
-                                    log.LogWarning(
-                                        ex,
-                                        "Clipboard.SetText threw: {Message}",
-                                        ex.Message)
-                                    setOk.TrySetResult(false) |> ignore)
-                            let staThread = new Thread(staBody)
-                            staThread.SetApartmentState(ApartmentState.STA)
-                            staThread.IsBackground <- true
-                            staThread.Start()
-                            let! winner =
-                                Task.WhenAny(
-                                    setOk.Task :> Task,
-                                    Task.Delay(3000))
-                            let succeeded =
-                                obj.ReferenceEquals(winner, setOk.Task)
-                                && setOk.Task.Result
-                            let bytes =
-                                System.Text.Encoding.UTF8.GetByteCount(content)
-                            let msg, activityId =
-                                if succeeded then
-                                    log.LogInformation(
-                                        "Copied active log to clipboard. Path={Path} Bytes={Bytes}",
-                                        path, bytes)
-                                    sprintf
-                                        "Log copied to clipboard. %d bytes; ready to paste."
-                                        bytes,
-                                    ActivityIds.diagnostic
-                                else
-                                    log.LogWarning(
-                                        "Clipboard.SetText timed out or failed after 3s; clipboard may not contain log content.")
-                                    "Clipboard copy timed out. Try again, or open the logs folder via Ctrl+Shift+L.",
-                                    ActivityIds.error
-                            let action () =
-                                window.TerminalSurface.Announce(msg, activityId)
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
-                    with ex ->
-                        let safe = AnnounceSanitiser.sanitise ex.Message
-                        log.LogError(ex, "Failed to copy active log to clipboard.")
-                        let action () =
-                            window.TerminalSurface.Announce(
-                                sprintf "Could not copy log: %s" safe,
-                                ActivityIds.error)
-                        try
-                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
-                        with _ -> ()
-                }
-            ()
+    // Cycle 25b-1a — `runCopyLatestLog` (Ctrl+Shift+L) removed.
+    // The Ctrl+Shift+D diagnostic battery now bundles the active
+    // FileLogger log into its dump-and-clipboard payload (alongside
+    // the battery log, config.toml, session-log summary, and
+    // redacted env), so a separate "copy just the log" hotkey is
+    // redundant and contributed to working-memory hotkey-count
+    // pressure. The defense-in-depth `OemSemicolon` direct handler
+    // in `TerminalView.OnPreviewKeyDown` and the
+    // `SetCopyLogToClipboardHandler` plumbing are deleted in the
+    // same change.
 
     /// Stage 7-followup PR-E — toggle the active `FileLoggerSink`'s
     /// min-level between Information (default) and Debug, and
@@ -798,21 +643,13 @@ module Program =
         bindHotkey window HotkeyRegistry.DraftNewRelease (fun () -> runOpenNewRelease window)
         bindHotkey window HotkeyRegistry.OpenDataFolder (fun () -> runOpenDataFolder window)
         bindHotkey window HotkeyRegistry.OpenConfig (fun () -> runOpenConfig window)
-        bindHotkey window HotkeyRegistry.CopyLatestLog (fun () -> runCopyLatestLog window)
         bindHotkey window HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
         bindHotkey window HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
 
-        // Direct dispatch via TerminalView.OnPreviewKeyDown is
-        // kept as a defence-in-depth path because Window-level
-        // KeyBinding routing for custom FrameworkElements has
-        // been observed to flake (the Ctrl+V family of bugs).
-        // Both paths are wired; whichever fires first wins.
-        // Ctrl+Shift+; is a plain Ctrl+Shift gesture so no
-        // SystemKey unwrap is needed in the filter chain — the
-        // PR #108 SystemKey filter was removed in this PR
-        // because it intercepted Alt+F4.
-        window.TerminalSurface.SetCopyLogToClipboardHandler(
-            Action(fun () -> runCopyLatestLog window))
+        // Cycle 25b-1a — `SetCopyLogToClipboardHandler` defense-in-
+        // depth wiring removed alongside the Ctrl+Shift+L hotkey
+        // itself. The Ctrl+Shift+D bundle is now the single
+        // paste-the-log path.
 
         // Phase A — display-pathway pipeline:
         //
@@ -1900,6 +1737,27 @@ module Program =
                     sprintf "Health check failed: %s" safe,
                     ActivityIds.error)
 
+        // Cycle 25b-1a — single source of truth for the
+        // session-log mode/path triage line. Both Ctrl+Shift+S
+        // (verbal announce, via runAnnounceSessionLogPath below)
+        // and Ctrl+Shift+D's bundle (via the resolveSessionLogSummary
+        // closure passed into runFullBattery) read this. Defined
+        // before runDiagnostic so the closure can capture it.
+        let buildSessionLogSummary () : string =
+            let modeStr =
+                SessionPersistence.modeToString
+                    persistenceConfig.Mode
+            match sessionLogWriter with
+            | None ->
+                sprintf
+                    "Session log mode %s; no file."
+                    modeStr
+            | Some sink ->
+                sprintf
+                    "Session log mode %s; path %s."
+                    modeStr
+                    sink.ActiveLogPath
+
         // PR #165 — Ctrl+Shift+D (extended diagnostic battery).
         // The closure is defined here (not at module top) because
         // it reads `hostHandle`, `currentShell`, and the live
@@ -1939,6 +1797,13 @@ module Program =
                 // closure is captured.
                 (fun () ->
                     loggerSink |> Option.map (fun s -> s.ActiveLogPath))
+                // Cycle 25b-1a — session-log summary line for the
+                // bundle's `--- SESSION LOG ---` section. Same
+                // string Ctrl+Shift+S announces. Closure captures
+                // `buildSessionLogSummary` (defined above) so the
+                // mode/path are resolved at press-time and reflect
+                // any reload-on-shell-switch that happened since.
+                buildSessionLogSummary
 
         // Cycle 22b — Ctrl+Shift+Y. Closure captures
         // `currentSession` from compose-local scope. Resolves
@@ -2048,20 +1913,7 @@ module Program =
         // module-load time.
         let runAnnounceSessionLogPath () : unit =
             try
-                let modeStr =
-                    SessionPersistence.modeToString
-                        persistenceConfig.Mode
-                let summary =
-                    match sessionLogWriter with
-                    | None ->
-                        sprintf
-                            "Session log mode %s; no file."
-                            modeStr
-                    | Some sink ->
-                        sprintf
-                            "Session log mode %s; path %s."
-                            modeStr
-                            sink.ActiveLogPath
+                let summary = buildSessionLogSummary ()
                 log.LogInformation(
                     "Session log path requested. {Summary}",
                     summary)

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -82,11 +82,6 @@ module HotkeyRegistry =
         // Cycle 25a — auto-create config.toml with defaults if
         // missing, then open in default app.
         | OpenConfig
-        // Logging-restructure PR (#111) — copy active log to clipboard.
-        // Cycle 25a — moved from `Ctrl+Shift+;` to `Ctrl+Shift+L`
-        // (mnemonic: L for Log; the old `Ctrl+Shift+L` opened the
-        // logs folder, which was deleted in favor of OpenDataFolder).
-        | CopyLatestLog
         // Stage 7-followup PR-E — toggle FileLogger min-level.
         | ToggleDebugLog
         // Stage 7-followup PR-F + PR-J liveness probe — health check.
@@ -118,7 +113,6 @@ module HotkeyRegistry =
         | DraftNewRelease -> "DraftNewRelease"
         | OpenDataFolder -> "OpenDataFolder"
         | OpenConfig -> "OpenConfig"
-        | CopyLatestLog -> "CopyLatestLog"
         | ToggleDebugLog -> "ToggleDebugLog"
         | HealthCheck -> "HealthCheck"
         | IncidentMarker -> "IncidentMarker"
@@ -170,10 +164,6 @@ module HotkeyRegistry =
             Key = Letter 'E'
             Modifiers = ctrlShift
             Description = "Edit config.toml (Cycle 25a; auto-creates with defaults if missing)" }
-          { Command = CopyLatestLog
-            Key = Letter 'L'
-            Modifiers = ctrlShift
-            Description = "Copy active session log to clipboard (Cycle 25a moved from Ctrl+Shift+;)" }
           { Command = ToggleDebugLog
             Key = Letter 'G'
             Modifiers = ctrlShift
@@ -247,7 +237,6 @@ module HotkeyRegistry =
           DraftNewRelease
           OpenDataFolder
           OpenConfig
-          CopyLatestLog
           ToggleDebugLog
           HealthCheck
           IncidentMarker

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -61,34 +61,11 @@ public class TerminalView : FrameworkElement
     /// </summary>
     private Action<int, int>? _resize;
 
-    /// <summary>
-    /// Direct callback for the `Ctrl+Shift+;` "copy active log
-    /// to clipboard" hotkey. Wired by
-    /// <see cref="SetCopyLogToClipboardHandler"/> from
-    /// <c>Program.fs compose ()</c>. Defence-in-depth path
-    /// alongside the Window-level `KeyBinding`, which has been
-    /// observed to flake for custom <see cref="FrameworkElement"/>s
-    /// (see the Ctrl+V family of bugs). Direct handling at the
-    /// top of <see cref="OnPreviewKeyDown"/> guarantees the
-    /// gesture reaches <c>runCopyLatestLog</c> regardless of
-    /// any quirks in WPF's CommandManager class routing.
-    ///
-    /// Hotkey-choice history: `Ctrl+Alt+L` was the original
-    /// binding but collided with the Windows Magnifier zoom-in
-    /// shortcut on some default Magnifier configs, AND required
-    /// a SystemKey-aware filter in this method that in turn
-    /// intercepted `Alt+F4`. `Ctrl+Shift+;` (the semicolon /
-    /// colon key, <see cref="Key.OemSemicolon"/>) was chosen for
-    /// proximity recall — physically adjacent to `L` (the
-    /// `Ctrl+Shift+L` open-folder primary) on a US-layout
-    /// keyboard. Reserves `Ctrl+Shift+C` for a future
-    /// copy-latest-command-output feature, which is the cross-
-    /// terminal convention for that gesture. Layout caveat: on
-    /// non-US layouts the `OemSemicolon` virtual-key may sit in
-    /// a different physical position; remap when configurable
-    /// keybindings ship in Phase 2.
-    /// </summary>
-    private Action? _copyActiveLogToClipboard;
+    // Cycle 25b-1a — `_copyActiveLogToClipboard` field +
+    // `SetCopyLogToClipboardHandler` setter + the OemSemicolon
+    // direct-handler in OnPreviewKeyDown were removed alongside
+    // the Ctrl+Shift+L hotkey itself. Ctrl+Shift+D's bundle is
+    // now the single paste-the-log path.
 
     /// <summary>
     /// Stage 6 PR-B — 200ms trailing-edge debounce for
@@ -198,18 +175,8 @@ public class TerminalView : FrameworkElement
         _resize = resize ?? throw new ArgumentNullException(nameof(resize));
     }
 
-    /// <summary>
-    /// Wire the Ctrl+Shift+; handler. Called from
-    /// <c>Program.fs compose ()</c> with a closure that invokes
-    /// <c>runCopyLatestLog</c>. The handler must run on the WPF
-    /// dispatcher thread (it touches the clipboard); our caller
-    /// in OnPreviewKeyDown already runs on the dispatcher so no
-    /// marshalling needed.
-    /// </summary>
-    public void SetCopyLogToClipboardHandler(Action handler)
-    {
-        _copyActiveLogToClipboard = handler ?? throw new ArgumentNullException(nameof(handler));
-    }
+    // Cycle 25b-1a — `SetCopyLogToClipboardHandler` deleted with
+    // the Ctrl+Shift+L hotkey itself.
 
     /// <summary>
     /// Attach a screen to render. Call once at startup; subsequent
@@ -395,8 +362,6 @@ public class TerminalView : FrameworkElement
 
             // Cycle 25a — reorganized to put the most-used hotkeys
             // on letter keys and free Ctrl+Shift+; entirely:
-            //   Ctrl+Shift+L: copy active session log to clipboard
-            //                 (mnemonic: L for Log; was opens-folder).
             //   Ctrl+Shift+P: open the pty-speak data folder
             //                 (parent of logs / sessions / config;
             //                 navigable to any of them in one
@@ -410,7 +375,10 @@ public class TerminalView : FrameworkElement
             // snapshot file + clipboard); the interactive
             // process-cleanup test moves to a future app menu
             // rather than a hotkey.
-            (Key.L, ModifierKeys.Control | ModifierKeys.Shift, "Copy active log to clipboard"),
+            // Cycle 25b-1a: removed Ctrl+Shift+L (CopyLatestLog).
+            // Ctrl+Shift+D's bundle is now the only paste-the-log
+            // path; the dedicated copy-just-the-log hotkey was
+            // redundant given the bundle's coverage.
             (Key.P, ModifierKeys.Control | ModifierKeys.Shift, "Open pty-speak data folder"),
             (Key.E, ModifierKeys.Control | ModifierKeys.Shift, "Edit config.toml"),
 
@@ -758,19 +726,9 @@ public class TerminalView : FrameworkElement
     /// </summary>
     private bool HandleAppLevelShortcut(Key key, ModifierKeys modifiers)
     {
-        // Ctrl+Shift+; → copy active log to clipboard. Handled
-        // FIRST and independent of _writeBytes because this
-        // gesture is meaningful even when no PTY host is attached
-        // (e.g. early in app lifecycle if compose() hasn't
-        // finished wiring SetPtyHost). Window-level KeyBinding
-        // routing has been observed to flake on custom
-        // FrameworkElements; direct handling here is the reliable
-        // path.
-        if (key == Key.OemSemicolon && modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
-        {
-            _copyActiveLogToClipboard?.Invoke();
-            return true;
-        }
+        // Cycle 25b-1a — `Ctrl+Shift+;` direct handler removed
+        // with the Ctrl+Shift+L hotkey itself. The semicolon
+        // gesture passes through to the shell as plain text.
 
         if (_writeBytes is null) return false;
 

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -64,7 +64,8 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // and OpenConfig take its slot.
               HotkeyRegistry.OpenDataFolder
               HotkeyRegistry.OpenConfig
-              HotkeyRegistry.CopyLatestLog
+              // Cycle 25b-1a — CopyLatestLog removed (D's bundle
+              // subsumes it).
               HotkeyRegistry.ToggleDebugLog
               HotkeyRegistry.HealthCheck
               HotkeyRegistry.IncidentMarker
@@ -181,12 +182,15 @@ let ``CheckForUpdates is bound to Ctrl+Shift+U`` () =
         hk.Modifiers)
 
 [<Fact>]
-let ``CopyLatestLog is bound to Ctrl+Shift+L (Cycle 25a moved from Ctrl+Shift+;)`` () =
-    let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.CopyLatestLog
-    Assert.Equal(HotkeyRegistry.Letter 'L', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
-        hk.Modifiers)
+let ``Ctrl+Shift+L is unbound (Cycle 25b-1a removed CopyLatestLog)`` () =
+    // Cycle 25b-1a — CopyLatestLog removed entirely. The
+    // Ctrl+Shift+D diagnostic battery's bundle now includes the
+    // active FileLogger log slice, making a dedicated "copy just
+    // the log" hotkey redundant. The L gesture must now flow
+    // through to the shell as plain text.
+    let modifiers = Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]
+    let result = HotkeyRegistry.tryFind (HotkeyRegistry.Letter 'L') modifiers
+    Assert.Equal(None, result)
 
 [<Fact>]
 let ``OpenDataFolder is bound to Ctrl+Shift+P (Cycle 25a)`` () =


### PR DESCRIPTION
## Summary

Two follow-ups to PR #221 after the maintainer validated the bundle format on a real `Ctrl+Shift+D` press:

1. **New `--- SESSION LOG ---` section in the bundle**, between `CONFIG.TOML` and `ENVIRONMENT`. Carries the same `Session log mode <mode>; path <full-path>.` line that `Ctrl+Shift+S` announces, surfaced as a first-class triage line so the active session-log path doesn't have to be grepped out of the FileLogger log slice. Single source of truth via `Program.fs.buildSessionLogSummary` consumed by both the S handler and D's `resolveSessionLogSummary` closure.

2. **`Ctrl+Shift+L` (CopyLatestLog) removed entirely**. The D bundle's `--- FILELOGGER ACTIVE LOG ---` section subsumes L's payload, so a dedicated copy-just-the-log hotkey is redundant. Removed: `HotkeyRegistry.AppCommand.CopyLatestLog` DU case + `nameOf` arm + `builtIns` row + `allCommands` entry; the `runCopyLatestLog` handler in `Program.fs` (~135 lines including the dispatcher-deadlock-fix Task wrapper); the `bindHotkey` line; the `SetCopyLogToClipboardHandler` defense-in-depth wiring; the C# `_copyActiveLogToClipboard` field, `SetCopyLogToClipboardHandler` setter, the `Key.OemSemicolon` direct handler in `OnPreviewKeyDown`, and the `(Key.L, ...)` row in `AppReservedHotkeys`. HotkeyRegistry tests + `CLAUDE.md` / `ACCESSIBILITY-TESTING.md` updated to point at D for log-paste flows. Per your hotkey-count-pressure feedback.

Net: -156 lines.

## Test plan

- [ ] CI green (Tests.Unit: -1 CopyLatestLog pin test, +1 L-unbound pin test; net no count change).
- [ ] Press `Ctrl+Shift+D` after release: bundle now includes `--- SESSION LOG ---` section between CONFIG.TOML and ENVIRONMENT.
- [ ] Press `Ctrl+Shift+S`: announces the same line that's in the bundle's session-log section.
- [ ] Press `Ctrl+Shift+L`: flows through to the shell as plain text (no announcement, no handler).
- [ ] Press `Ctrl+Shift+;`: also flows through (the C# defense-in-depth direct handler is gone too).

https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7ZFZDHxGHQT8ikyEeFAjV)_