### PR TITLE
feat(views): Cycle 26a — app menu skeleton + UIA plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 26a): app menu skeleton + UIA plumbing
+
+First PR of Cycle 26 (the multi-PR app-menu mini-cycle planned in
+[`docs/PROJECT-PLAN-2026-05-09.md`](docs/PROJECT-PLAN-2026-05-09.md)).
+Goal of the cycle: surface every `AppCommand` (14 reserved hotkeys
+today) as a discoverable menu item with its keyboard shortcut shown
+via `MenuItem.InputGestureText`, plus add a new menu-only
+`RunProcessCleanupScript` command — relieving the maintainer's
+hotkey-count working-memory ceiling and creating a natural surface
+for future diagnostic scripts to plug in without burning hotkey slots.
+
+This first PR lands the **structural skeleton** only; no command
+wiring, no behaviour change beyond proving the menu renders + UIA
+routes correctly.
+
+- **`src/Views/MainWindow.xaml`**: wrap the existing `<Grid>` in a
+  `<DockPanel>`. Add a top-docked `<Menu>` with
+  `AutomationProperties.Name="Application menu"` and
+  `AutomationProperties.AutomationId="pty-speak.AppMenu"` (mirrors
+  the `pty-speak.<surface>` AutomationId convention used on
+  `MainWindow` itself, future-proofing for FlaUI E2E per the
+  parked Cycle 25b-2 design). The terminal view stays as the
+  `LastChildFill` child so it expands to fill the remaining space.
+- **Single throwaway menu item**: `_Help → E_xit` wired to a
+  `Click` handler in `MainWindow.xaml.cs` that calls `Close()`.
+  Its only purpose is to prove that menu Click events route
+  end-to-end before Cycle 26b lands the populated-from-`HotkeyRegistry`
+  structure. Cycle 26b deletes both the item and the handler.
+- **`src/Views/MainWindow.xaml.cs`**: add the `Exit_Click` handler
+  (deleted in Cycle 26b). Add an addendum to the existing focus-routing
+  comment block (lines 44-62) explicitly noting that the Cycle 26a
+  Menu does NOT compete for focus on `Loaded` — WPF Menu only claims
+  focus on Alt press or explicit `Focus()`, and the `DockPanel`
+  layout keeps `TerminalSurface.Focus()` routing to the document-role
+  peer as before. The Cycle 26a NVDA matrix row pins this.
+- **No code changes outside `src/Views/`**. F# code, hotkey registry,
+  `OnPreviewKeyDown` filter, and the C# `AppReservedHotkeys` mirror
+  are all untouched.
+- **NVDA validation gate** (lands in Cycle 26d's matrix-row PR):
+  Launch reads "pty-speak terminal {version}, document"; press Alt
+  to summon the menu bar; arrow keys announce menu names; Esc
+  returns focus and NVDA re-announces "document".
+
 ### Added (Cycle 25d): `PROJECT-PLAN-2026-05-09.md` dated successor + cross-reference sweep
 
 Spawns the dated successor strategic plan

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -8,7 +8,24 @@
         Background="Black"
         AutomationProperties.Name="pty-speak terminal"
         AutomationProperties.AutomationId="pty-speak.MainWindow">
-    <Grid>
+    <DockPanel>
+        <!-- Cycle 26a: top-of-window app menu skeleton. Always-visible
+             (NVDA-user has no real-estate cost; discoverability is the
+             point — see PROJECT-PLAN-2026-05-09.md "Cycle 26 — app menu").
+             AutomationProperties.AutomationId mirrors the
+             `pty-speak.<surface>` convention used on MainWindow itself
+             so a future FlaUI E2E suite (Cycle 25b-2, parked) can
+             find it deterministically. The single _Help → E_xit item
+             is a smoke-test placeholder; Cycle 26b replaces this with
+             the full menu structure populated from HotkeyRegistry. -->
+        <Menu DockPanel.Dock="Top"
+              AutomationProperties.Name="Application menu"
+              AutomationProperties.AutomationId="pty-speak.AppMenu">
+            <MenuItem Header="_Help">
+                <MenuItem Header="E_xit"
+                          Click="Exit_Click" />
+            </MenuItem>
+        </Menu>
         <views:TerminalView x:Name="TerminalSurface" x:FieldModifier="public" />
-    </Grid>
+    </DockPanel>
 </Window>

--- a/src/Views/MainWindow.xaml.cs
+++ b/src/Views/MainWindow.xaml.cs
@@ -60,6 +60,15 @@ public partial class MainWindow : Window
         // Terminal.App's `Program.fs` already handles screen
         // attachment in `Window.Loaded`; this fits naturally
         // alongside.
+        //
+        // Cycle 26a addendum: the Menu added in MainWindow.xaml
+        // does NOT compete for focus on Loaded. WPF Menu only
+        // claims focus on Alt press or explicit Focus() call,
+        // and the layout (DockPanel.Dock="Top" Menu, then
+        // TerminalView) keeps TerminalSurface's Focus() call
+        // routing to the document-role peer as before. Pinned
+        // by the Cycle 26a NVDA matrix row in
+        // docs/ACCESSIBILITY-TESTING.md.
         Loaded += (_, _) => TerminalSurface.Focus();
 
         // Audit-cycle PR-C deleted the SourceInitialized +
@@ -75,4 +84,11 @@ public partial class MainWindow : Window
         // is reached via `TerminalView.OnCreateAutomationPeer`
         // — no native-interop window subclass involved.
     }
+
+    // Cycle 26a: throwaway Help → Exit menu item handler.
+    // Smoke-test wiring to prove the Menu surface routes click
+    // events end-to-end. Cycle 26b replaces the entire Help
+    // menu structure with the populated-from-HotkeyRegistry
+    // version, and this handler is deleted with it.
+    private void Exit_Click(object sender, RoutedEventArgs e) => Close();
 }


### PR DESCRIPTION
## Summary

First PR of **Cycle 26** (the multi-PR app-menu mini-cycle planned in [`docs/PROJECT-PLAN-2026-05-09.md`](docs/PROJECT-PLAN-2026-05-09.md)). Goal of the cycle: surface every `AppCommand` (14 reserved hotkeys today) as a discoverable menu item with its keyboard shortcut shown via `MenuItem.InputGestureText`, plus add a new menu-only `RunProcessCleanupScript` command — relieving the maintainer's hotkey-count working-memory ceiling.

This first PR lands the **structural skeleton only**:

- **`src/Views/MainWindow.xaml`**: wrap the existing `<Grid>` in a `<DockPanel>`. Add a top-docked `<Menu>` with `AutomationProperties.Name="Application menu"` and `AutomationProperties.AutomationId="pty-speak.AppMenu"`.
- **Single throwaway `_Help → E_xit` `MenuItem`** wired to a `Click` handler in code-behind that calls `Close()`. Smoke-test only; deleted in Cycle 26b.
- **`MainWindow.xaml.cs`**: addendum to the existing focus-routing comment block explicitly noting the Cycle 26a Menu does NOT compete for focus on `Loaded` (WPF Menu only claims focus on Alt or explicit `Focus()`).
- **No code changes outside `src/Views/`**. F# code, hotkey registry, `OnPreviewKeyDown` filter, C# `AppReservedHotkeys` mirror all untouched.

## Test plan

- [x] `git diff --stat` matches predicted scope (3 files, ~78 insertions).
- [x] No code changes outside `src/Views/` (verified via diff).
- [ ] CI Windows build + tests pass (build is the structural validator).
- [ ] CI markdown link check passes.
- [ ] CI workflow lint passes.
- [ ] (Manual NVDA gate, lands in Cycle 26d) Launch reads "document"; Alt opens menu; Esc returns to "document"; existing 14 hotkeys still fire correctly.

## Cycle 26 sequencing (per the strategic plan)

- **26a (this PR)** — Menu skeleton + UIA plumbing.
- 26b — Wire 14 existing AppCommands into menu items via shared `RoutedCommand` instances; option-typing the `Hotkey` record; new `AppReservedHotkeysMirrorTests.fs` for F#/C# parity invariant.
- 26c — Add `RunProcessCleanupScript` menu-only AppCommand + handler.
- 26d — NVDA matrix rows + documentation refresh.

https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x

---
_Generated by [Claude Code](https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x)_