### PR TITLE
feat(views,hotkeys): Cycle 26b — wire 14 existing AppCommands into menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,123 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 26b): wire 14 existing AppCommands into menu items via shared RoutedCommand
+
+Second PR of Cycle 26 (the multi-PR app-menu mini-cycle). Replaces
+the throwaway `_Help → E_xit` placeholder shipped in Cycle 26a with
+the **populated-from-`HotkeyRegistry` structure**: 5 top-level menus
+(Shell, View, Data, Diagnostics, Help) containing 14 named
+`MenuItem`s — one per existing `AppCommand`.
+
+Each menu item binds to the **same `RoutedCommand` instance** that
+`bindHotkey` already creates for the keyboard hotkey. Pressing the
+gesture and clicking the menu item invoke the same handler — single
+source of truth, zero behaviour duplication. NVDA reads the gesture
+text from `MenuItem.InputGestureText` (auto-set from the registry)
+when the menu item is focused.
+
+**Architectural changes**:
+
+- **`src/Terminal.Core/HotkeyRegistry.fs`** — `Hotkey.Key` and
+  `Hotkey.Modifiers` are now `option`-typed (`HotkeyKey option`,
+  `Set<Modifier> option`). All 14 existing `builtIns` entries wrap
+  their gesture with `Some`. Cycle 26c will add the first `None,
+  None` (menu-only) entry. New `gestureText : Hotkey -> string
+  option` helper formats gestures as e.g. `"Ctrl+Shift+U"` /
+  `"Ctrl+Shift+1"` (modifier order Ctrl > Alt > Shift, fixed
+  regardless of `Set` enumeration order). `tryFind` filters to
+  `Some` entries only — menu-only commands are excluded by
+  definition since they have no gesture to look up.
+- **`src/Terminal.App/Program.fs`** — `bindHotkey` signature
+  changed from `unit` return to `RoutedCommand` return so compose
+  can capture each created command. `bindHotkey` now pattern-matches
+  on `(Some k, Some m)` to install the `KeyBinding` (skipping it
+  for menu-only commands) but always registers the `CommandBinding`.
+  A local `bind` wrapper inside compose populates a
+  `Dictionary<AppCommand, RoutedCommand>` as each binding is
+  created. After all 14 binds, a reflection-driven wiring step
+  walks the dictionary and assigns each XAML-named
+  `MenuItem_<nameOf cmd>` element's `Command` and
+  `InputGestureText` properties.
+- **`src/Views/MainWindow.xaml`** — full menu structure with
+  mnemonics: `_Shell` (cmd, PowerShell, Claude), `_View` (debug
+  log toggle, mute earcons), `_Data` (data folder, edit config,
+  copy history, announce session-log path), `Dia_gnostics` (health
+  check, incident marker, run battery), `_Help` (check for updates,
+  draft new release). Each `MenuItem` carries `x:Name` matching
+  `MenuItem_<AppCommandName>` and `x:FieldModifier="public"` so
+  compose's reflection wiring can locate it.
+- **`src/Views/MainWindow.xaml.cs`** — Cycle 26a's throwaway
+  `Exit_Click` handler removed (no longer needed; the populated
+  Help menu replaces the placeholder).
+
+**Extensibility-as-a-design-constraint** (per maintainer directive):
+
+Adding a new menu item is now three single-place edits per PR:
+
+1. Add the `AppCommand` DU case + `nameOf` arm + `allCommands` row
+   in `HotkeyRegistry.fs`.
+2. Add the `builtIns` row (with `Some` for gesture-bearing or
+   `None, None` for menu-only).
+3. Add a `<MenuItem x:Name="MenuItem_<NewCommandName>" ... />` row
+   in `MainWindow.xaml`.
+
+Compose's reflection-driven wiring picks it up automatically. No
+F# composition or test changes required for routine additions.
+
+Adding or removing a default accelerator on an existing command is
+now a one-field edit (`Some` ↔ `None`) rather than a DU-shape
+change. Adding a new top-level menu (Window, Display,
+Preferences/Settings — anticipated by the maintainer in
+[`docs/PROJECT-PLAN-2026-05-09.md`](docs/PROJECT-PLAN-2026-05-09.md))
+is just a new `<MenuItem Header="_NewMenu">` block in XAML; no F#
+changes.
+
+**New invariant test**:
+
+`tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs` (new file).
+Reflectively reads `TerminalView.AppReservedHotkeys` and asserts
+F# / C# parity at test time:
+
+- Every gesture-bearing entry in `HotkeyRegistry.builtIns` has a
+  matching `(Key, ModifierKeys, Description)` row in
+  `AppReservedHotkeys`.
+- Every `AppReservedHotkeys` row has a matching `HotkeyRegistry`
+  entry (no orphans).
+- Counts match (catches "off by one" in the CI log).
+
+This pins the load-bearing `OnPreviewKeyDown` filter contract at
+test time — before Cycle 26b the parity was maintainer convention
+only ("update both surfaces in the same PR"); a missed update would
+silently demote a hotkey to "flows through to the shell as plain
+text instead of firing its handler". The test catches that
+regression immediately.
+
+**Existing tests updated**:
+
+`tests/Tests.Unit/HotkeyRegistryTests.fs` — every direct
+`hk.Key` / `hk.Modifiers` comparison wrapped with `Some (...)` for
+the new option type. `tryFind` round-trip now skips menu-only
+commands (no gesture to round-trip). Collision-detection filters
+to `Some` entries (menu-only `(None, None)` pairs would otherwise
+collide trivially with each other). 4 new fixtures pin the
+option-typing invariant + `gestureText` helper formatting.
+
+**No code changes outside the listed files**. The `OnPreviewKeyDown`
+filter in `TerminalView.cs:530-614` is untouched; the C#
+`AppReservedHotkeys` array at `TerminalView.cs:346-489` is
+untouched. The keyboard pipeline is unaffected.
+
+**NVDA validation gates** (all land in Cycle 26d's matrix-row PR):
+
+- Menu items announce `<name>, <gesture>` when focused
+  (e.g. "Health Check, Ctrl plus Shift plus H").
+- Pressing Enter on a menu item invokes the same handler as the
+  keyboard gesture (verify via Health Check's same one-line
+  summary).
+- All 14 keyboard gestures still fire correctly with the menu in
+  place (kbd pipeline unaffected).
+
 ### Added (Cycle 26a): app menu skeleton + UIA plumbing
 
 First PR of Cycle 26 (the multi-PR app-menu mini-cycle planned in

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4,6 +4,7 @@ open System
 open System.Threading
 open System.Threading.Tasks
 open System.Windows
+open System.Windows.Controls
 open System.Windows.Input
 open System.Windows.Threading
 open Microsoft.Extensions.Logging
@@ -335,23 +336,45 @@ module Program =
     /// Phase 2 user-settings will inject overridden Hotkey
     /// records (different Key / Modifiers per command) before
     /// this call; the dispatch path stays unchanged.
+    /// Cycle 26b — return type changed from `unit` to
+    /// `RoutedCommand` so compose() can capture each created
+    /// command into a dictionary indexed by `AppCommand` and
+    /// then wire `MenuItem.Command` from the corresponding
+    /// XAML-named `MenuItem_<nameOf cmd>` element. Pressing
+    /// the keyboard gesture and selecting the menu item
+    /// invoke the same `RoutedCommand` and therefore the same
+    /// handler — single source of truth, zero behaviour
+    /// duplication.
+    ///
+    /// Cycle 26b — `Hotkey.Key` and `Hotkey.Modifiers` are now
+    /// `option`-typed. Menu-only commands (`Key = None,
+    /// Modifiers = None`) skip the `KeyBinding` registration
+    /// (no keyboard gesture exists) but still register the
+    /// `CommandBinding` so the menu can dispatch via the
+    /// returned `RoutedCommand`.
     let private bindHotkey
             (window: MainWindow)
             (cmd: HotkeyRegistry.AppCommand)
             (handler: unit -> unit)
-            : unit =
+            : RoutedCommand =
         let hk = HotkeyRegistry.hotkeyOf cmd
         let routed = RoutedCommand(HotkeyRegistry.nameOf cmd, typeof<MainWindow>)
-        let gesture =
-            KeyGesture(
-                translateHotkeyKey hk.Key,
-                translateHotkeyModifiers hk.Modifiers)
-        window.InputBindings.Add(KeyBinding(routed, gesture)) |> ignore
+        match hk.Key, hk.Modifiers with
+        | Some k, Some m ->
+            let gesture =
+                KeyGesture(translateHotkeyKey k, translateHotkeyModifiers m)
+            window.InputBindings.Add(KeyBinding(routed, gesture)) |> ignore
+        | _ ->
+            // Menu-only command: no KeyBinding installed.
+            // The CommandBinding below still registers so the
+            // RoutedCommand can be invoked from MenuItem.Command.
+            ()
         window.CommandBindings.Add(
             CommandBinding(
                 routed,
                 ExecutedRoutedEventHandler(fun _ _ -> handler ())))
         |> ignore
+        routed
 
     // Ctrl+Shift+D's body lives in
     // `Terminal.App.Diagnostics.runFullBattery` (PR #165 —
@@ -635,16 +658,32 @@ module Program =
         // Order doesn't matter relative to the ConPTY spawn
         // below; we install before the window is loaded so the
         // keybindings are live for the user's first keypress.
-        bindHotkey window HotkeyRegistry.CheckForUpdates (fun () -> runUpdateFlow window)
+        //
+        // Cycle 26b — capture each `bindHotkey` return value
+        // (the `RoutedCommand` it created) into a dictionary
+        // indexed by `AppCommand` so the menu-wiring step
+        // below this block can assign the same command to the
+        // matching XAML-named `MenuItem_<nameOf cmd>` element.
+        // Pressing the keyboard gesture and selecting the
+        // menu item invoke the same `RoutedCommand` and
+        // therefore the same handler — single source of truth.
+        // The local `bind` wrapper centralises the dictionary
+        // population so individual call sites stay one-liners.
+        let menuCommands =
+            System.Collections.Generic.Dictionary<HotkeyRegistry.AppCommand, RoutedCommand>()
+        let bind cmd handler =
+            let routed = bindHotkey window cmd handler
+            menuCommands.[cmd] <- routed
+        bind HotkeyRegistry.CheckForUpdates (fun () -> runUpdateFlow window)
         // Ctrl+Shift+D's bind is in the closure-bind group below
         // (around line 1537) — its handler captures local
         // mutables (`hostHandle`, `currentShell`, `screen`) that
         // aren't in scope here yet.
-        bindHotkey window HotkeyRegistry.DraftNewRelease (fun () -> runOpenNewRelease window)
-        bindHotkey window HotkeyRegistry.OpenDataFolder (fun () -> runOpenDataFolder window)
-        bindHotkey window HotkeyRegistry.OpenConfig (fun () -> runOpenConfig window)
-        bindHotkey window HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
-        bindHotkey window HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
+        bind HotkeyRegistry.DraftNewRelease (fun () -> runOpenNewRelease window)
+        bind HotkeyRegistry.OpenDataFolder (fun () -> runOpenDataFolder window)
+        bind HotkeyRegistry.OpenConfig (fun () -> runOpenConfig window)
+        bind HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
+        bind HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
 
         // Cycle 25b-1a — `SetCopyLogToClipboardHandler` defense-in-
         // depth wiring removed alongside the Ctrl+Shift+L hotkey
@@ -1937,17 +1976,11 @@ module Program =
         // hostHandle, channels, currentShell) so they're built
         // here rather than as module-level handlers like the
         // Ctrl+Shift+G toggle (which only needs loggerSink).
-        bindHotkey window HotkeyRegistry.HealthCheck runHealthCheck
-        bindHotkey window HotkeyRegistry.IncidentMarker runIncidentMarker
-        bindHotkey window HotkeyRegistry.RunDiagnostic runDiagnostic
-        bindHotkey
-            window
-            HotkeyRegistry.CopyHistoryToClipboard
-            runCopyHistoryToClipboard
-        bindHotkey
-            window
-            HotkeyRegistry.AnnounceSessionLogPath
-            runAnnounceSessionLogPath
+        bind HotkeyRegistry.HealthCheck runHealthCheck
+        bind HotkeyRegistry.IncidentMarker runIncidentMarker
+        bind HotkeyRegistry.RunDiagnostic runDiagnostic
+        bind HotkeyRegistry.CopyHistoryToClipboard runCopyHistoryToClipboard
+        bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
 
         // Stage 7-followup PR-F — background heartbeat. Every 5
         // seconds, log a single Information-level "Heartbeat" line
@@ -2412,9 +2445,42 @@ module Program =
         // The keys are listed in `TerminalView.AppReservedHotkeys`
         // so `OnPreviewKeyDown` doesn't mark them Handled before
         // `InputBindings` can fire.
-        bindHotkey window HotkeyRegistry.SwitchToCmd (fun () -> switchToShell ShellRegistry.Cmd)
-        bindHotkey window HotkeyRegistry.SwitchToPowerShell (fun () -> switchToShell ShellRegistry.PowerShell)
-        bindHotkey window HotkeyRegistry.SwitchToClaude (fun () -> switchToShell ShellRegistry.Claude)
+        bind HotkeyRegistry.SwitchToCmd (fun () -> switchToShell ShellRegistry.Cmd)
+        bind HotkeyRegistry.SwitchToPowerShell (fun () -> switchToShell ShellRegistry.PowerShell)
+        bind HotkeyRegistry.SwitchToClaude (fun () -> switchToShell ShellRegistry.Claude)
+
+        // Cycle 26b — wire the menu items. Walk the
+        // `menuCommands` dictionary populated by the `bind`
+        // wrapper above. For each entry, find the XAML-named
+        // `MenuItem_<nameOf cmd>` element via reflection and
+        // assign its `Command` (so menu click invokes the same
+        // RoutedCommand as the keyboard gesture) and
+        // `InputGestureText` (so NVDA reads the shortcut when
+        // the menu item is focused). Reflection is the cheapest
+        // way to keep the wiring data-driven — adding a new
+        // menu item is just (a) AppCommand DU case, (b) builtIns
+        // row, (c) named MenuItem in XAML; the wiring loop
+        // below picks it up automatically.
+        let windowType = window.GetType()
+        for kv in menuCommands do
+            let fieldName = sprintf "MenuItem_%s" (HotkeyRegistry.nameOf kv.Key)
+            match windowType.GetField(fieldName) with
+            | null ->
+                // No XAML MenuItem with this name. Either the
+                // command isn't surfaced in the menu yet (some
+                // future cycle adds it) or the XAML name diverged
+                // from the registry's nameOf — neither is fatal at
+                // runtime but the missing surface is worth a log
+                // line at a higher level if it ever bites.
+                ()
+            | field ->
+                match field.GetValue(window) with
+                | :? MenuItem as menuItem ->
+                    menuItem.Command <- kv.Value
+                    HotkeyRegistry.gestureText (HotkeyRegistry.hotkeyOf kv.Key)
+                    |> Option.iter (fun text ->
+                        menuItem.InputGestureText <- text)
+                | _ -> ()
 
         app.Exit.Add(fun _ ->
             try log.LogInformation("pty-speak exiting.") with _ -> ()

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -127,10 +127,23 @@ module HotkeyRegistry =
     /// `AppReservedHotkeys` table in
     /// `src/Views/TerminalView.cs`. Phase 2 user-settings will
     /// override per-user.
+    ///
+    /// Cycle 26b — `Key` and `Modifiers` are `option`-typed.
+    /// `Some k, Some m` is a gesture-bearing command (most
+    /// commands today); `None, None` is a menu-only command
+    /// (e.g. `RunProcessCleanupScript` in Cycle 26c) that
+    /// surfaces only via the app menu, no default keyboard
+    /// shortcut. `bindHotkey` skips the `KeyBinding`
+    /// registration in the menu-only case but still registers
+    /// the `CommandBinding` so the `RoutedCommand` can be
+    /// invoked from `MenuItem.Command`. Adding or removing a
+    /// default accelerator on an existing command is now a
+    /// one-field edit (`Some` ↔ `None`) rather than a
+    /// DU-shape change.
     type Hotkey =
         { Command: AppCommand
-          Key: HotkeyKey
-          Modifiers: Set<Modifier>
+          Key: HotkeyKey option
+          Modifiers: Set<Modifier> option
           Description: string }
 
     let private ctrlShift : Set<Modifier> = Set.ofList [ Ctrl; Shift ]
@@ -145,60 +158,60 @@ module HotkeyRegistry =
     /// fixtures pin (a) + (c) + (d).
     let builtIns : Hotkey list =
         [ { Command = CheckForUpdates
-            Key = Letter 'U'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'U')
+            Modifiers = Some ctrlShift
             Description = "Velopack auto-update (Stage 11)" }
           { Command = RunDiagnostic
-            Key = Letter 'D'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'D')
+            Modifiers = Some ctrlShift
             Description = "Run full automated diagnostic suite (Cycle 25b — bundles dump to clipboard + dated snapshot file)" }
           { Command = DraftNewRelease
-            Key = Letter 'R'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'R')
+            Modifiers = Some ctrlShift
             Description = "Draft a new release on GitHub" }
           { Command = OpenDataFolder
-            Key = Letter 'P'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'P')
+            Modifiers = Some ctrlShift
             Description = "Open the pty-speak data folder (Cycle 25a; parent of logs / sessions / config)" }
           { Command = OpenConfig
-            Key = Letter 'E'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'E')
+            Modifiers = Some ctrlShift
             Description = "Edit config.toml (Cycle 25a; auto-creates with defaults if missing)" }
           { Command = ToggleDebugLog
-            Key = Letter 'G'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'G')
+            Modifiers = Some ctrlShift
             Description = "Toggle FileLogger Information ↔ Debug" }
           { Command = HealthCheck
-            Key = Letter 'H'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'H')
+            Modifiers = Some ctrlShift
             Description = "Health-check announce (shell + PID + alive + queue depths)" }
           { Command = IncidentMarker
-            Key = Letter 'B'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'B')
+            Modifiers = Some ctrlShift
             Description = "Incident-marker boundary line in active log" }
           { Command = SwitchToCmd
-            Key = Digit 1
-            Modifiers = ctrlShift
+            Key = Some (Digit 1)
+            Modifiers = Some ctrlShift
             Description = "Switch to cmd shell" }
           { Command = SwitchToPowerShell
-            Key = Digit 2
-            Modifiers = ctrlShift
+            Key = Some (Digit 2)
+            Modifiers = Some ctrlShift
             Description = "Switch to PowerShell shell (PR-J — diagnostic control shell)" }
           { Command = SwitchToClaude
-            Key = Digit 3
-            Modifiers = ctrlShift
+            Key = Some (Digit 3)
+            Modifiers = Some ctrlShift
             Description = "Switch to Claude shell" }
           { Command = MuteEarcons
-            Key = Letter 'M'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'M')
+            Modifiers = Some ctrlShift
             Description = "Mute / unmute WASAPI earcons (Stage 8d.1)" }
           { Command = CopyHistoryToClipboard
-            Key = Letter 'Y'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'Y')
+            Modifiers = Some ctrlShift
             Description = "Copy SessionModel history to clipboard (Cycle 22b)" }
           { Command = AnnounceSessionLogPath
-            Key = Letter 'S'
-            Modifiers = ctrlShift
+            Key = Some (Letter 'S')
+            Modifiers = Some ctrlShift
             Description = "Announce the active session-log file path (Cycle 24e)" } ]
 
     /// Look up the default Hotkey for a command. Throws
@@ -220,10 +233,42 @@ module HotkeyRegistry =
     /// for future user-settings UIs displaying the binding for
     /// a chosen gesture; not used by the dispatch path (which
     /// goes the other way: command → key).
+    ///
+    /// Cycle 26b — menu-only commands (`Hotkey.Key = None`)
+    /// are excluded from `tryFind` results since they have no
+    /// gesture to look up by definition. Only gesture-bearing
+    /// `Some` entries match.
     let tryFind (key: HotkeyKey) (modifiers: Set<Modifier>) : AppCommand option =
         builtIns
-        |> List.tryFind (fun h -> h.Key = key && h.Modifiers = modifiers)
+        |> List.tryFind (fun h ->
+            h.Key = Some key && h.Modifiers = Some modifiers)
         |> Option.map (fun h -> h.Command)
+
+    /// Format a `Hotkey`'s gesture as a human-readable string
+    /// for display in `MenuItem.InputGestureText` (which NVDA
+    /// reads when the menu item is focused). Returns `None`
+    /// for menu-only commands (`Key = None` / `Modifiers = None`)
+    /// so the menu item can omit the shortcut display.
+    ///
+    /// Format mirrors the convention used in CLAUDE.md and
+    /// CHANGELOG entries: `"Ctrl+Shift+U"`, `"Ctrl+Shift+1"`,
+    /// `"Ctrl+Shift+;"`. Modifier order is fixed
+    /// (Ctrl > Alt > Shift) so the rendered text is stable
+    /// regardless of `Set` enumeration order.
+    let gestureText (hk: Hotkey) : string option =
+        match hk.Key, hk.Modifiers with
+        | Some key, Some mods ->
+            let modParts =
+                [ if Set.contains Ctrl mods then yield "Ctrl"
+                  if Set.contains Alt mods then yield "Alt"
+                  if Set.contains Shift mods then yield "Shift" ]
+            let keyText =
+                match key with
+                | Letter c -> string (System.Char.ToUpperInvariant c)
+                | Digit n -> string n
+                | Semicolon -> ";"
+            Some (System.String.Join("+", modParts @ [ keyText ]))
+        | _ -> None
 
     /// All registered AppCommand cases as a list. Manually
     /// maintained; pinned by the

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -9,21 +9,86 @@
         AutomationProperties.Name="pty-speak terminal"
         AutomationProperties.AutomationId="pty-speak.MainWindow">
     <DockPanel>
-        <!-- Cycle 26a: top-of-window app menu skeleton. Always-visible
-             (NVDA-user has no real-estate cost; discoverability is the
-             point — see PROJECT-PLAN-2026-05-09.md "Cycle 26 — app menu").
-             AutomationProperties.AutomationId mirrors the
-             `pty-speak.<surface>` convention used on MainWindow itself
-             so a future FlaUI E2E suite (Cycle 25b-2, parked) can
-             find it deterministically. The single _Help → E_xit item
-             is a smoke-test placeholder; Cycle 26b replaces this with
-             the full menu structure populated from HotkeyRegistry. -->
+        <!-- Cycle 26b: top-of-window app menu populated from
+             HotkeyRegistry. Always-visible (NVDA-user has no
+             real-estate cost; discoverability is the point — see
+             PROJECT-PLAN-2026-05-09.md "Cycle 26 — app menu").
+
+             Each MenuItem has x:Name="MenuItem_<AppCommandName>"
+             matching HotkeyRegistry.nameOf; Program.fs compose()
+             walks the populated `menuCommands` dictionary after
+             all bindHotkey calls and assigns each MenuItem.Command
+             (RoutedCommand shared with the keyboard gesture) +
+             InputGestureText (read by NVDA when focused).
+
+             Adding a new menu item is three edits in one PR:
+             (a) HotkeyRegistry.AppCommand DU case,
+             (b) HotkeyRegistry.builtIns row,
+             (c) <MenuItem x:Name="MenuItem_<NewCmd>" /> here.
+             Compose's reflection-driven wiring auto-picks it up.
+
+             Top-level mnemonics: _Shell, _View, _Data,
+             Dia_gnostics, _Help (all unique; non-conflicting with
+             AppReservedHotkeys's Ctrl+Shift+letter gestures since
+             different modifier sets are different gestures).
+
+             Future menus (Window, Display, Preferences/Settings)
+             will slot in cleanly per the maintainer's
+             extensibility directive (see PROJECT-PLAN-2026-05-09.md). -->
         <Menu DockPanel.Dock="Top"
               AutomationProperties.Name="Application menu"
               AutomationProperties.AutomationId="pty-speak.AppMenu">
+            <MenuItem Header="_Shell">
+                <MenuItem x:Name="MenuItem_SwitchToCmd"
+                          x:FieldModifier="public"
+                          Header="_Cmd" />
+                <MenuItem x:Name="MenuItem_SwitchToPowerShell"
+                          x:FieldModifier="public"
+                          Header="_PowerShell" />
+                <MenuItem x:Name="MenuItem_SwitchToClaude"
+                          x:FieldModifier="public"
+                          Header="C_laude" />
+            </MenuItem>
+            <MenuItem Header="_View">
+                <MenuItem x:Name="MenuItem_ToggleDebugLog"
+                          x:FieldModifier="public"
+                          Header="Toggle _Debug Logging" />
+                <MenuItem x:Name="MenuItem_MuteEarcons"
+                          x:FieldModifier="public"
+                          Header="_Mute Earcons" />
+            </MenuItem>
+            <MenuItem Header="_Data">
+                <MenuItem x:Name="MenuItem_OpenDataFolder"
+                          x:FieldModifier="public"
+                          Header="_Open Data Folder" />
+                <MenuItem x:Name="MenuItem_OpenConfig"
+                          x:FieldModifier="public"
+                          Header="_Edit Config" />
+                <MenuItem x:Name="MenuItem_CopyHistoryToClipboard"
+                          x:FieldModifier="public"
+                          Header="Copy _History to Clipboard" />
+                <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
+                          x:FieldModifier="public"
+                          Header="Announce _Session Log Path" />
+            </MenuItem>
+            <MenuItem Header="Dia_gnostics">
+                <MenuItem x:Name="MenuItem_HealthCheck"
+                          x:FieldModifier="public"
+                          Header="_Health Check" />
+                <MenuItem x:Name="MenuItem_IncidentMarker"
+                          x:FieldModifier="public"
+                          Header="_Incident Marker" />
+                <MenuItem x:Name="MenuItem_RunDiagnostic"
+                          x:FieldModifier="public"
+                          Header="Run Diagnostic _Battery" />
+            </MenuItem>
             <MenuItem Header="_Help">
-                <MenuItem Header="E_xit"
-                          Click="Exit_Click" />
+                <MenuItem x:Name="MenuItem_CheckForUpdates"
+                          x:FieldModifier="public"
+                          Header="Check for _Updates" />
+                <MenuItem x:Name="MenuItem_DraftNewRelease"
+                          x:FieldModifier="public"
+                          Header="Draft New _Release" />
             </MenuItem>
         </Menu>
         <views:TerminalView x:Name="TerminalSurface" x:FieldModifier="public" />

--- a/src/Views/MainWindow.xaml.cs
+++ b/src/Views/MainWindow.xaml.cs
@@ -84,11 +84,4 @@ public partial class MainWindow : Window
         // is reached via `TerminalView.OnCreateAutomationPeer`
         // — no native-interop window subclass involved.
     }
-
-    // Cycle 26a: throwaway Help → Exit menu item handler.
-    // Smoke-test wiring to prove the Menu surface routes click
-    // events end-to-end. Cycle 26b replaces the entire Help
-    // menu structure with the populated-from-HotkeyRegistry
-    // version, and this handler is deleted with it.
-    private void Exit_Click(object sender, RoutedEventArgs e) => Close();
 }

--- a/tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs
+++ b/tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs
@@ -1,0 +1,129 @@
+module PtySpeak.Tests.Unit.AppReservedHotkeysMirrorTests
+
+open Xunit
+open System.Windows.Input
+open Terminal.Core
+open PtySpeak.Views
+
+// ---------------------------------------------------------------------
+// Cycle 26b — F# / C# mirror parity invariant
+// ---------------------------------------------------------------------
+//
+// `HotkeyRegistry.builtIns` (F#, `Terminal.Core/HotkeyRegistry.fs`)
+// is the canonical registry of every app-reserved hotkey.
+// `TerminalView.AppReservedHotkeys` (C#, `src/Views/TerminalView.cs`)
+// is the per-keystroke hot-path mirror consulted by
+// `OnPreviewKeyDown` to decide whether to mark `e.Handled = true`
+// (so the parent Window's `InputBindings` machinery can fire the
+// `RoutedCommand`).
+//
+// The two surfaces are intentionally split — the C# array avoids
+// F#/C# interop cost on every keystroke — but they MUST stay in
+// sync. Before Cycle 26b this was maintained by maintainer
+// convention only ("update both surfaces in the same PR"); a
+// missed update would cause a hotkey to flow through to the
+// shell as plain bytes instead of firing its handler.
+//
+// This fixture pins the invariant at test time. Every
+// gesture-bearing entry in `HotkeyRegistry.builtIns` (i.e. those
+// with `Some Key` and `Some Modifiers`; menu-only commands are
+// excluded by definition since they have no keyboard gesture)
+// must have a corresponding row in `AppReservedHotkeys`. The
+// reverse is also pinned: every C# row corresponds to some F#
+// entry.
+//
+// Both surfaces are accessible to the test:
+//   - `TerminalView` is `public` and `Views.csproj` declares
+//     `<InternalsVisibleTo Include="PtySpeak.Tests.Unit" />`.
+//   - `AppReservedHotkeys` is `public static readonly`.
+//
+// The test inlines its own translation from F# `HotkeyKey` to
+// WPF `Key` and from F# `Modifier` to WPF `ModifierKeys`. The
+// production translation lives in `Program.fs`'s `private`
+// `translateHotkeyKey` / `translateHotkeyModifiers`. The
+// duplication is intentional: a divergence between either
+// translation surfaces immediately as a test failure rather
+// than at NVDA-test time.
+
+let private translateKey (k: HotkeyRegistry.HotkeyKey) : Key =
+    match k with
+    | HotkeyRegistry.Letter c ->
+        match System.Char.ToUpperInvariant(c) with
+        | 'A' -> Key.A | 'B' -> Key.B | 'C' -> Key.C | 'D' -> Key.D
+        | 'E' -> Key.E | 'F' -> Key.F | 'G' -> Key.G | 'H' -> Key.H
+        | 'I' -> Key.I | 'J' -> Key.J | 'K' -> Key.K | 'L' -> Key.L
+        | 'M' -> Key.M | 'N' -> Key.N | 'O' -> Key.O | 'P' -> Key.P
+        | 'Q' -> Key.Q | 'R' -> Key.R | 'S' -> Key.S | 'T' -> Key.T
+        | 'U' -> Key.U | 'V' -> Key.V | 'W' -> Key.W | 'X' -> Key.X
+        | 'Y' -> Key.Y | 'Z' -> Key.Z
+        | other -> failwithf "translateKey: unmapped letter %c" other
+    | HotkeyRegistry.Digit n ->
+        match n with
+        | 1 -> Key.D1 | 2 -> Key.D2 | 3 -> Key.D3
+        | 4 -> Key.D4 | 5 -> Key.D5 | 6 -> Key.D6
+        | 7 -> Key.D7 | 8 -> Key.D8 | 9 -> Key.D9
+        | other -> failwithf "translateKey: unmapped digit %d" other
+    | HotkeyRegistry.Semicolon -> Key.OemSemicolon
+
+let private translateMods (mods: Set<HotkeyRegistry.Modifier>) : ModifierKeys =
+    let mutable result = ModifierKeys.None
+    for m in mods do
+        match m with
+        | HotkeyRegistry.Ctrl -> result <- result ||| ModifierKeys.Control
+        | HotkeyRegistry.Shift -> result <- result ||| ModifierKeys.Shift
+        | HotkeyRegistry.Alt -> result <- result ||| ModifierKeys.Alt
+    result
+
+/// All gesture-bearing F# entries translated to WPF (Key, ModifierKeys).
+let private fSourceGestures () : Set<Key * ModifierKeys> =
+    HotkeyRegistry.builtIns
+    |> List.choose (fun h ->
+        match h.Key, h.Modifiers with
+        | Some k, Some m -> Some (translateKey k, translateMods m)
+        | _ -> None)
+    |> Set.ofList
+
+/// All C# AppReservedHotkeys rows as (Key, ModifierKeys) tuples.
+/// The C# array element type is the value tuple
+/// `(Key Key, ModifierKeys Modifiers, string Description)`,
+/// which the F# pattern `struct (k, m, _)` destructures cleanly.
+let private cMirrorGestures () : Set<Key * ModifierKeys> =
+    TerminalView.AppReservedHotkeys
+    |> Array.map (fun struct (k, m, _) -> (k, m))
+    |> Set.ofArray
+
+[<Fact>]
+let ``every gesture-bearing AppCommand has a matching AppReservedHotkeys row`` () =
+    let fSet = fSourceGestures ()
+    let cSet = cMirrorGestures ()
+    let missing = Set.difference fSet cSet
+    Assert.True(
+        Set.isEmpty missing,
+        sprintf
+            "F# HotkeyRegistry has gestures with no C# AppReservedHotkeys row: %A. \
+             Add the matching (Key, ModifierKeys, Description) tuple to \
+             TerminalView.AppReservedHotkeys."
+            missing)
+
+[<Fact>]
+let ``every AppReservedHotkeys row has a matching gesture-bearing AppCommand`` () =
+    let fSet = fSourceGestures ()
+    let cSet = cMirrorGestures ()
+    let orphan = Set.difference cSet fSet
+    Assert.True(
+        Set.isEmpty orphan,
+        sprintf
+            "C# TerminalView.AppReservedHotkeys has rows with no F# HotkeyRegistry \
+             entry: %A. Either add a matching AppCommand (DU + builtIns row) or \
+             remove the orphan from AppReservedHotkeys."
+            orphan)
+
+[<Fact>]
+let ``F# gesture-bearing count matches C# AppReservedHotkeys count`` () =
+    // Belt-and-suspenders: the two set-difference tests above
+    // catch any asymmetric mismatch, but a same-cardinality
+    // assertion makes the failure mode "off by one" obvious in
+    // a CI log.
+    let fCount = (fSourceGestures ()).Count
+    let cCount = (cMirrorGestures ()).Count
+    Assert.Equal(fCount, cCount)

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -123,9 +123,17 @@ let ``no two hotkeys share the same (key, modifiers) gesture`` () =
     // both, the user's keystroke fires whichever is consulted
     // first (undefined ordering), and the other handler never
     // runs. This fixture catches the collision at test time.
+    //
+    // Cycle 26b — menu-only commands (`Key = None`,
+    // `Modifiers = None`) are excluded from collision detection
+    // by definition: they have no gesture to collide with. Only
+    // gesture-bearing entries participate.
     let gestures =
         HotkeyRegistry.builtIns
-        |> List.map (fun h -> (h.Key, h.Modifiers))
+        |> List.choose (fun h ->
+            match h.Key, h.Modifiers with
+            | Some k, Some m -> Some (k, m)
+            | _ -> None)
     let unique = Set.ofList gestures
     Assert.Equal(gestures.Length, unique.Count)
 
@@ -135,13 +143,19 @@ let ``no two hotkeys share the same (key, modifiers) gesture`` () =
 
 [<Fact>]
 let ``tryFind returns the registered command for each builtIns gesture`` () =
-    // For every entry in `builtIns`, `tryFind` with that entry's
-    // (key, modifiers) should yield the same command back.
-    // Closes the round-trip from the user-settings UI's
-    // perspective: select gesture → recover command.
+    // For every gesture-bearing entry in `builtIns`, `tryFind`
+    // with that entry's (key, modifiers) should yield the same
+    // command back. Closes the round-trip from the user-settings
+    // UI's perspective: select gesture → recover command.
+    //
+    // Cycle 26b — menu-only commands (`Key = None`) are
+    // skipped: they have no gesture to round-trip.
     for hk in HotkeyRegistry.builtIns do
-        let found = HotkeyRegistry.tryFind hk.Key hk.Modifiers
-        Assert.Equal(Some hk.Command, found)
+        match hk.Key, hk.Modifiers with
+        | Some k, Some m ->
+            let found = HotkeyRegistry.tryFind k m
+            Assert.Equal(Some hk.Command, found)
+        | _ -> ()
 
 [<Fact>]
 let ``tryFind returns None for an unregistered gesture`` () =
@@ -176,9 +190,9 @@ let ``tryFind distinguishes modifier sets`` () =
 [<Fact>]
 let ``CheckForUpdates is bound to Ctrl+Shift+U`` () =
     let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.CheckForUpdates
-    Assert.Equal(HotkeyRegistry.Letter 'U', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
+    Assert.Equal(Some (HotkeyRegistry.Letter 'U'), hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(
+        Some (Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]),
         hk.Modifiers)
 
 [<Fact>]
@@ -195,17 +209,17 @@ let ``Ctrl+Shift+L is unbound (Cycle 25b-1a removed CopyLatestLog)`` () =
 [<Fact>]
 let ``OpenDataFolder is bound to Ctrl+Shift+P (Cycle 25a)`` () =
     let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.OpenDataFolder
-    Assert.Equal(HotkeyRegistry.Letter 'P', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
+    Assert.Equal(Some (HotkeyRegistry.Letter 'P'), hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(
+        Some (Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]),
         hk.Modifiers)
 
 [<Fact>]
 let ``OpenConfig is bound to Ctrl+Shift+E (Cycle 25a)`` () =
     let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.OpenConfig
-    Assert.Equal(HotkeyRegistry.Letter 'E', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
+    Assert.Equal(Some (HotkeyRegistry.Letter 'E'), hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(
+        Some (Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]),
         hk.Modifiers)
 
 [<Fact>]
@@ -232,11 +246,11 @@ let ``shell-switch hotkeys are bound to Ctrl+Shift+ digits 1, 2, 3 in PR-J order
     // PR-J reordered: cmd=1, PowerShell=2, Claude=3 (PowerShell
     // sits next to cmd as the diagnostic control shell).
     let cmd = HotkeyRegistry.hotkeyOf HotkeyRegistry.SwitchToCmd
-    Assert.Equal(HotkeyRegistry.Digit 1, cmd.Key)
+    Assert.Equal(Some (HotkeyRegistry.Digit 1), cmd.Key)
     let ps = HotkeyRegistry.hotkeyOf HotkeyRegistry.SwitchToPowerShell
-    Assert.Equal(HotkeyRegistry.Digit 2, ps.Key)
+    Assert.Equal(Some (HotkeyRegistry.Digit 2), ps.Key)
     let claude = HotkeyRegistry.hotkeyOf HotkeyRegistry.SwitchToClaude
-    Assert.Equal(HotkeyRegistry.Digit 3, claude.Key)
+    Assert.Equal(Some (HotkeyRegistry.Digit 3), claude.Key)
 
 [<Fact>]
 let ``AnnounceSessionLogPath is bound to Ctrl+Shift+S (Cycle 24e)`` () =
@@ -244,10 +258,79 @@ let ``AnnounceSessionLogPath is bound to Ctrl+Shift+S (Cycle 24e)`` () =
     // session-log file path. Mnemonic: S for Session log.
     let hk =
         HotkeyRegistry.hotkeyOf HotkeyRegistry.AnnounceSessionLogPath
-    Assert.Equal(HotkeyRegistry.Letter 'S', hk.Key)
-    Assert.Equal<Set<HotkeyRegistry.Modifier>>(
-        Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ],
+    Assert.Equal(Some (HotkeyRegistry.Letter 'S'), hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(
+        Some (Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]),
         hk.Modifiers)
     Assert.Equal(
         "AnnounceSessionLogPath",
         HotkeyRegistry.nameOf HotkeyRegistry.AnnounceSessionLogPath)
+
+// ---------------------------------------------------------------------
+// Cycle 26b — option-typing pinning + gestureText helper
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``every existing AppCommand from Cycle 25b still has Some Key and Some Modifiers`` () =
+    // Cycle 26b option-typed Hotkey.Key + Hotkey.Modifiers to
+    // accommodate menu-only commands. Regression guard: every
+    // command that shipped with a default hotkey before Cycle 26b
+    // must still have one. Silently demoting an existing hotkey
+    // to menu-only would be a UX regression.
+    let priorCommands =
+        [ HotkeyRegistry.CheckForUpdates
+          HotkeyRegistry.RunDiagnostic
+          HotkeyRegistry.DraftNewRelease
+          HotkeyRegistry.OpenDataFolder
+          HotkeyRegistry.OpenConfig
+          HotkeyRegistry.ToggleDebugLog
+          HotkeyRegistry.HealthCheck
+          HotkeyRegistry.IncidentMarker
+          HotkeyRegistry.SwitchToCmd
+          HotkeyRegistry.SwitchToPowerShell
+          HotkeyRegistry.SwitchToClaude
+          HotkeyRegistry.MuteEarcons
+          HotkeyRegistry.CopyHistoryToClipboard
+          HotkeyRegistry.AnnounceSessionLogPath ]
+    for cmd in priorCommands do
+        let hk = HotkeyRegistry.hotkeyOf cmd
+        Assert.True(
+            Option.isSome hk.Key,
+            sprintf "AppCommand %A unexpectedly lost its default Key" cmd)
+        Assert.True(
+            Option.isSome hk.Modifiers,
+            sprintf "AppCommand %A unexpectedly lost its default Modifiers" cmd)
+
+[<Fact>]
+let ``gestureText formats Ctrl+Shift+letter gestures as expected`` () =
+    let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.CheckForUpdates
+    Assert.Equal(Some "Ctrl+Shift+U", HotkeyRegistry.gestureText hk)
+
+[<Fact>]
+let ``gestureText formats Ctrl+Shift+digit gestures as expected`` () =
+    let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.SwitchToCmd
+    Assert.Equal(Some "Ctrl+Shift+1", HotkeyRegistry.gestureText hk)
+
+[<Fact>]
+let ``gestureText returns None for menu-only commands`` () =
+    // Synthesise a menu-only Hotkey shape (no production
+    // command is menu-only as of Cycle 26b; Cycle 26c adds
+    // RunProcessCleanupScript). The format helper must
+    // return None for any (None, None) pair.
+    let menuOnly =
+        { Command = HotkeyRegistry.CheckForUpdates  // command identity is irrelevant here
+          Key = None
+          Modifiers = None
+          Description = "test fixture" }
+    Assert.Equal(None, HotkeyRegistry.gestureText menuOnly)
+
+[<Fact>]
+let ``gestureText modifier order is Ctrl+Alt+Shift regardless of Set enumeration`` () =
+    // Pin the stable rendering order so menu-displayed gestures
+    // and CHANGELOG-cited gestures stay textually identical.
+    let hk =
+        { Command = HotkeyRegistry.CheckForUpdates
+          Key = Some (HotkeyRegistry.Letter 'X')
+          Modifiers = Some (Set.ofList [ HotkeyRegistry.Shift; HotkeyRegistry.Alt; HotkeyRegistry.Ctrl ])
+          Description = "test fixture" }
+    Assert.Equal(Some "Ctrl+Alt+Shift+X", HotkeyRegistry.gestureText hk)

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -317,7 +317,14 @@ let ``gestureText returns None for menu-only commands`` () =
     // command is menu-only as of Cycle 26b; Cycle 26c adds
     // RunProcessCleanupScript). The format helper must
     // return None for any (None, None) pair.
-    let menuOnly =
+    //
+    // Type annotation on the binding is required because
+    // `HotkeyRegistry` is a module inside `Terminal.Core`
+    // (not auto-opened), so a bare record literal can't
+    // infer `Hotkey` from field labels alone — see
+    // CLAUDE.md "Record literal type inference fails when
+    // the record module is not auto-opened" (FS0039 gotcha).
+    let menuOnly : HotkeyRegistry.Hotkey =
         { Command = HotkeyRegistry.CheckForUpdates  // command identity is irrelevant here
           Key = None
           Modifiers = None
@@ -328,7 +335,7 @@ let ``gestureText returns None for menu-only commands`` () =
 let ``gestureText modifier order is Ctrl+Alt+Shift regardless of Set enumeration`` () =
     // Pin the stable rendering order so menu-displayed gestures
     // and CHANGELOG-cited gestures stay textually identical.
-    let hk =
+    let hk : HotkeyRegistry.Hotkey =
         { Command = HotkeyRegistry.CheckForUpdates
           Key = Some (HotkeyRegistry.Letter 'X')
           Modifiers = Some (Set.ofList [ HotkeyRegistry.Shift; HotkeyRegistry.Alt; HotkeyRegistry.Ctrl ])

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="ShellRegistryTests.fs" />
     <Compile Include="ShellSwitchTests.fs" />
     <Compile Include="HotkeyRegistryTests.fs" />
+    <Compile Include="AppReservedHotkeysMirrorTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Second PR of **Cycle 26** (the multi-PR app-menu mini-cycle). Replaces the throwaway `_Help → E_xit` placeholder shipped in Cycle 26a with the **populated-from-`HotkeyRegistry` structure**: 5 top-level menus (Shell, View, Data, Diagnostics, Help) containing 14 named `MenuItem`s — one per existing `AppCommand`.

Each menu item binds to the **same `RoutedCommand` instance** that `bindHotkey` already creates for the keyboard hotkey. Pressing the gesture and clicking the menu item invoke the same handler — single source of truth, zero behaviour duplication.

## Architectural changes

- **`HotkeyRegistry.fs`** — `Hotkey.Key` + `Modifiers` now `option`-typed. All 14 existing `builtIns` wrap with `Some`. New `gestureText` helper formats `"Ctrl+Shift+U"` / `"Ctrl+Shift+1"` (stable modifier order Ctrl > Alt > Shift).
- **`Program.fs`** — `bindHotkey` returns `RoutedCommand` (was `unit`). Pattern-matches on `(Some k, Some m)` for `KeyBinding` (skipping for menu-only). Local `bind` wrapper inside compose populates a `Dictionary<AppCommand, RoutedCommand>`. After all 14 binds, a reflection-driven wiring step assigns each XAML-named `MenuItem_<nameOf cmd>` element's `Command` and `InputGestureText`.
- **`MainWindow.xaml`** — full menu structure with mnemonics. Each `MenuItem` carries `x:Name="MenuItem_<AppCommandName>"` + `x:FieldModifier="public"`.
- **`MainWindow.xaml.cs`** — Cycle 26a's throwaway `Exit_Click` handler removed.

## Extensibility (per maintainer directive)

Adding a new menu item is now **three single-place edits** per PR:
1. `AppCommand` DU case + `nameOf` arm + `allCommands` row in `HotkeyRegistry.fs`.
2. `builtIns` row (`Some` for gesture-bearing or `None,None` for menu-only).
3. `<MenuItem x:Name="MenuItem_<NewCommand>" />` in `MainWindow.xaml`.

Compose's reflection-driven wiring picks it up automatically. No F# composition or test changes required.

Adding/removing a default accelerator on an existing command is now a one-field edit (`Some` ↔ `None`). Adding a new top-level menu (Window / Display / Preferences/Settings, anticipated by the maintainer) is just a new `<MenuItem Header="_NewMenu">` block.

## New invariant test

`tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs` (new file). Pins the load-bearing F# / C# mirror parity at test time — before Cycle 26b this was maintainer convention only ("update both surfaces in the same PR"); a missed update would silently demote a hotkey to "flows through to the shell as plain text". The new fixture catches that regression immediately.

Three tests: gesture-bearing F# entries → matching C# rows; C# rows → matching F# entries (no orphans); same cardinality.

## Test plan

- [x] `git diff --stat` matches predicted scope (8 files, ~596/97 ins/del).
- [x] `OnPreviewKeyDown` filter at `TerminalView.cs:530-614` untouched.
- [x] `AppReservedHotkeys` array at `TerminalView.cs:346-489` untouched.
- [ ] CI Windows build + unit tests pass (4 new + 1 modified test fixtures).
- [ ] CI markdown link check passes.
- [ ] CI workflow lint passes.
- [ ] (Manual NVDA gate, lands in Cycle 26d) Menu items announce `<name>, <gesture>`; menu Enter invokes same handler as keyboard gesture; all 14 keyboard gestures still fire correctly.

## Cycle 26 sequencing

- ✅ 26a — Menu skeleton + UIA plumbing (PR #225, merged).
- **26b (this PR)** — Wire 14 AppCommands into menu items.
- 26c — Add `RunProcessCleanupScript` menu-only AppCommand + handler.
- 26d — NVDA matrix rows + documentation refresh.

https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x

---
_Generated by [Claude Code](https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x)_