### PR TITLE
feat(views,hotkeys): Cycle 26c — RunProcessCleanupScript menu-only AppCommand + handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,100 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 26c): RunProcessCleanupScript menu-only AppCommand + handler
+
+Third PR of Cycle 26 (the multi-PR app-menu mini-cycle). Lands the
+**first menu-only `AppCommand`** — `RunProcessCleanupScript` —
+proving the option-typed `Hotkey` plumbing introduced in Cycle 26b
+works end-to-end. Surfaces `scripts/test-process-cleanup.ps1` via
+**Diagnostics → Test Process Cleanup**, with no default keyboard
+accelerator (relieving the noted hotkey-count working-memory
+ceiling).
+
+The script needs the maintainer to physically close pty-speak via
+Alt+F4 to verify Job Object cascade-kill cleanup — that's why the
+autonomous in-process diagnostic battery (Ctrl+Shift+D) doesn't
+cover it. PowerShell launches with `-NoExit` so the PASS/FAIL
+output stays visible after the script exits.
+
+**Architectural changes**:
+
+- **`src/Terminal.Core/HotkeyRegistry.fs`** — new
+  `RunProcessCleanupScript` case in the `AppCommand` DU
+  (`nameOf` arm + `builtIns` row with `Key = None; Modifiers =
+  None` + `allCommands` entry). Lines 70-104, 109-125, 146-202,
+  234-249.
+- **`src/Terminal.Core/Types.fs`** — new
+  `ActivityIds.processCleanup = "pty-speak.process-cleanup"`.
+  Distinct ActivityId so consecutive presses dedupe at the
+  NVDA-channel layer.
+- **`src/Terminal.App/Program.fs`** — new
+  `runTestProcessCleanup` handler near `runOpenConfig`. Mirrors
+  the announce-before-focus-grab pattern from
+  `runOpenNewRelease` / `runOpenDataFolder` / `runOpenConfig`:
+  announces "Launching process-cleanup test in a separate
+  PowerShell window.", waits 700ms (so NVDA finishes speaking),
+  then `ProcessStartInfo { FileName = "powershell.exe";
+  Arguments = "-NoExit -ExecutionPolicy Bypass -File
+  \"<path>\""; UseShellExecute = true }`. Script-path resolution
+  via `Path.Combine(AppContext.BaseDirectory,
+  "test-process-cleanup.ps1")`. File-not-found falls through to
+  a sanitised announcement instead of throwing. Wraps in
+  `try/with`; sanitises exception messages via
+  `AnnounceSanitiser.sanitise`. Bind call added alongside the
+  other module-level binds.
+- **`src/Terminal.App/Terminal.App.fsproj`** —
+  `<Content Include>` for the script was already present (PR
+  #81 / Stage 4b precedent); only the inline comment is updated
+  to cite the Cycle 26c menu surface instead of the obsolete
+  `Ctrl+Shift+D` reference.
+- **`src/Views/MainWindow.xaml`** — new
+  `<MenuItem x:Name="MenuItem_RunProcessCleanupScript"
+   x:FieldModifier="public" Header="Test Process _Cleanup" />`
+  under the Diagnostics menu. No `InputGestureText` — compose's
+  reflection-driven wiring assigns it from
+  `HotkeyRegistry.gestureText`, which returns `None` for
+  menu-only commands.
+
+**Three-edit-extension recipe in action**:
+
+This PR exercises the recipe the Cycle 26b CHANGELOG documented
+verbatim:
+
+1. ✅ AppCommand DU case + nameOf arm + allCommands row.
+2. ✅ builtIns row (with `None, None` for menu-only).
+3. ✅ Named `MenuItem` in XAML.
+
+Compose's reflection-driven wiring picks up the new entry
+automatically. No changes to `Program.fs compose()`, no changes
+to `bindHotkey`, no changes to the menu-wiring loop. The handler
+addition + bind call are the only `Program.fs` edits.
+
+**New tests**:
+
+- `tests/Tests.Unit/HotkeyRegistryTests.fs` — extends "allCommands
+  contains exactly the documented commands" set with
+  `RunProcessCleanupScript`. New fixture
+  `RunProcessCleanupScript is menu-only (Cycle 26c)` pins
+  `(None, None)` shape + asserts `gestureText` returns `None`
+  for it (so MenuItem.InputGestureText is left blank in XAML).
+- `tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs` — no change
+  needed; the existing `gesture-bearing` filter
+  (`List.choose (fun h -> match h.Key, h.Modifiers with Some k,
+  Some m -> ...)`) already excludes menu-only commands from the
+  parity check.
+
+**No NVDA validation row in this PR** (the matrix-row PR is Cycle
+26d). Manual NVDA gate to verify in 26d:
+
+- Diagnostics → Test Process _Cleanup → Enter announces
+  "Launching process-cleanup test in a separate PowerShell
+  window."; a new PowerShell window opens with the script
+  running; closing pty-speak via Alt+F4 produces PASS/FAIL
+  output in that window.
+- Menu item is focusable but reads no `InputGestureText` (no
+  shortcut → blank suffix).
+
 ### Added (Cycle 26b): wire 14 existing AppCommands into menu items via shared RoutedCommand
 
 Second PR of Cycle 26 (the multi-PR app-menu mini-cycle). Replaces

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -546,6 +546,66 @@ module Program =
             }
         ()
 
+    /// Launch the interactive process-cleanup test
+    /// (`scripts/test-process-cleanup.ps1`) in a separate
+    /// PowerShell window. Triggered by Diagnostics → Test Process
+    /// Cleanup menu item (Cycle 26c — first menu-only command;
+    /// no keyboard accelerator).
+    ///
+    /// The script needs the user to physically close pty-speak
+    /// (Alt+F4) so it can verify Job Object cascade-kill cleanup
+    /// — autonomous in-process diagnostic batteries can't drive
+    /// that. PowerShell launches with `-NoExit` so the script's
+    /// PASS/FAIL output stays visible after the script exits.
+    /// Script path resolves via `AppContext.BaseDirectory` —
+    /// `Terminal.App.fsproj`'s `<Content Include>` copies the
+    /// script next to `Terminal.App.exe` at build time, and
+    /// Velopack packs it for distribution.
+    ///
+    /// Mirrors `runOpenNewRelease` / `runOpenDataFolder` /
+    /// `runOpenConfig`'s announce-before-focus-grab pattern:
+    /// announce first, 700ms delay so NVDA finishes speaking,
+    /// then launch the new process.
+    let private runTestProcessCleanup (window: MainWindow) : unit =
+        let log = Logger.get "Terminal.App.Program.runTestProcessCleanup"
+        let scriptPath =
+            System.IO.Path.Combine(
+                System.AppContext.BaseDirectory,
+                "test-process-cleanup.ps1")
+        log.LogInformation(
+            "Process-cleanup script launch requested. ScriptPath={Path}",
+            scriptPath)
+        window.TerminalSurface.Announce(
+            "Launching process-cleanup test in a separate PowerShell window.",
+            ActivityIds.processCleanup)
+        let _ =
+            task {
+                do! Task.Delay(700)
+                let action () =
+                    try
+                        if not (System.IO.File.Exists scriptPath) then
+                            window.TerminalSurface.Announce(
+                                "Process-cleanup script not found in install directory.",
+                                ActivityIds.error)
+                        else
+                            let psi = System.Diagnostics.ProcessStartInfo()
+                            psi.FileName <- "powershell.exe"
+                            psi.Arguments <-
+                                sprintf
+                                    "-NoExit -ExecutionPolicy Bypass -File \"%s\""
+                                    scriptPath
+                            psi.UseShellExecute <- true
+                            System.Diagnostics.Process.Start(psi) |> ignore
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        window.TerminalSurface.Announce(
+                            sprintf "Could not launch process-cleanup test: %s" safe,
+                            ActivityIds.error)
+                do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                ()
+            }
+        ()
+
     // Cycle 25b-1a — `runCopyLatestLog` (Ctrl+Shift+L) removed.
     // The Ctrl+Shift+D diagnostic battery now bundles the active
     // FileLogger log into its dump-and-clipboard payload (alongside
@@ -684,6 +744,11 @@ module Program =
         bind HotkeyRegistry.OpenConfig (fun () -> runOpenConfig window)
         bind HotkeyRegistry.ToggleDebugLog (fun () -> runToggleDebugLog window)
         bind HotkeyRegistry.MuteEarcons (fun () -> runMuteEarcons window)
+        // Cycle 26c — first menu-only command. `bindHotkey`
+        // skips the KeyBinding installation (no gesture) but
+        // still creates the CommandBinding so the menu can
+        // dispatch via the captured RoutedCommand.
+        bind HotkeyRegistry.RunProcessCleanupScript (fun () -> runTestProcessCleanup window)
 
         // Cycle 25b-1a — `SetCopyLogToClipboardHandler` defense-in-
         // depth wiring removed alongside the Ctrl+Shift+L hotkey

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -35,11 +35,13 @@
     <!--
       Bundle the process-cleanup diagnostic script next to the
       Terminal.App.exe in the publish output. Velopack pack picks
-      it up automatically. The Ctrl+Shift+D hotkey in Program.fs
-      resolves the script via AppContext.BaseDirectory so the
-      install path doesn't need to be hardcoded. `<Link>` keeps
-      the file flat in the output directory rather than nesting
-      under `..\..\scripts\`.
+      it up automatically. Cycle 26c surfaces the script via the
+      Diagnostics → Test Process Cleanup menu item (no keyboard
+      accelerator); `runTestProcessCleanup` in Program.fs resolves
+      the script via AppContext.BaseDirectory so the install path
+      doesn't need to be hardcoded. `<Link>` keeps the file flat
+      in the output directory rather than nesting under
+      `..\..\scripts\`.
     -->
     <Content Include="..\..\scripts\test-process-cleanup.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -100,6 +100,13 @@ module HotkeyRegistry =
         | CopyHistoryToClipboard
         // Cycle 24e — announce active session-log file path.
         | AnnounceSessionLogPath
+        // Cycle 26c — first menu-only command. Interactive
+        // process-cleanup test (`scripts/test-process-cleanup.ps1`)
+        // surfaced via Diagnostics → Test Process Cleanup. No
+        // default keyboard accelerator; relieves the noted
+        // hotkey-count working-memory ceiling for additional
+        // diagnostic scripts.
+        | RunProcessCleanupScript
 
     /// Stable string name for a command, used as the
     /// `RoutedCommand` name passed to WPF and as a TOML key
@@ -122,6 +129,7 @@ module HotkeyRegistry =
         | MuteEarcons -> "MuteEarcons"
         | CopyHistoryToClipboard -> "CopyHistoryToClipboard"
         | AnnounceSessionLogPath -> "AnnounceSessionLogPath"
+        | RunProcessCleanupScript -> "RunProcessCleanupScript"
 
     /// Default key binding for a command. Mirrors the
     /// `AppReservedHotkeys` table in
@@ -212,7 +220,13 @@ module HotkeyRegistry =
           { Command = AnnounceSessionLogPath
             Key = Some (Letter 'S')
             Modifiers = Some ctrlShift
-            Description = "Announce the active session-log file path (Cycle 24e)" } ]
+            Description = "Announce the active session-log file path (Cycle 24e)" }
+          // Cycle 26c — menu-only; no default keyboard accelerator.
+          // Surfaced as Diagnostics → Test Process Cleanup.
+          { Command = RunProcessCleanupScript
+            Key = None
+            Modifiers = None
+            Description = "Interactive process-cleanup test (test-process-cleanup.ps1; Cycle 26c)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —
@@ -290,4 +304,5 @@ module HotkeyRegistry =
           SwitchToClaude
           MuteEarcons
           CopyHistoryToClipboard
-          AnnounceSessionLogPath ]
+          AnnounceSessionLogPath
+          RunProcessCleanupScript ]

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -492,3 +492,13 @@ module ActivityIds =
     /// freshly written) before the default-app launch grabs
     /// focus.
     let openConfig = "pty-speak.open-config"
+
+    /// Process-cleanup-script launch announcements (Cycle 26c
+    /// Diagnostics → Test Process Cleanup menu item — no
+    /// keyboard accelerator). Emits "Launching process-cleanup
+    /// test in a separate PowerShell window." before
+    /// `powershell.exe` launch grabs focus, then either an OK
+    /// confirmation or a sanitised error path. Distinct
+    /// ActivityId so consecutive presses dedupe at the
+    /// NVDA-channel layer.
+    let processCleanup = "pty-speak.process-cleanup"

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -81,6 +81,13 @@
                 <MenuItem x:Name="MenuItem_RunDiagnostic"
                           x:FieldModifier="public"
                           Header="Run Diagnostic _Battery" />
+                <!-- Cycle 26c — first menu-only command (no
+                     keyboard accelerator). Launches the
+                     interactive process-cleanup test script in
+                     a separate PowerShell window. -->
+                <MenuItem x:Name="MenuItem_RunProcessCleanupScript"
+                          x:FieldModifier="public"
+                          Header="Test Process _Cleanup" />
             </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem x:Name="MenuItem_CheckForUpdates"

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -77,7 +77,11 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // Cycle 22b — copy SessionModel history to clipboard.
               HotkeyRegistry.CopyHistoryToClipboard
               // Cycle 24e — announce session-log file path.
-              HotkeyRegistry.AnnounceSessionLogPath ]
+              HotkeyRegistry.AnnounceSessionLogPath
+              // Cycle 26c — first menu-only command. Surfaced
+              // via Diagnostics → Test Process Cleanup; no
+              // keyboard accelerator.
+              HotkeyRegistry.RunProcessCleanupScript ]
     let actual = Set.ofList HotkeyRegistry.allCommands
     Assert.Equal<Set<HotkeyRegistry.AppCommand>>(expected, actual)
 
@@ -330,6 +334,24 @@ let ``gestureText returns None for menu-only commands`` () =
           Modifiers = None
           Description = "test fixture" }
     Assert.Equal(None, HotkeyRegistry.gestureText menuOnly)
+
+[<Fact>]
+let ``RunProcessCleanupScript is menu-only (Cycle 26c — None Key, None Modifiers)`` () =
+    // Cycle 26c — first menu-only AppCommand. Has no default
+    // keyboard accelerator; surfaced only via the Diagnostics →
+    // Test Process Cleanup menu item. Pin the (None, None)
+    // shape so a future PR doesn't accidentally promote it to
+    // gesture-bearing without an explicit decision.
+    let hk =
+        HotkeyRegistry.hotkeyOf HotkeyRegistry.RunProcessCleanupScript
+    Assert.Equal(None, hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(None, hk.Modifiers)
+    Assert.Equal(
+        "RunProcessCleanupScript",
+        HotkeyRegistry.nameOf HotkeyRegistry.RunProcessCleanupScript)
+    // gestureText must return None for menu-only commands so
+    // MenuItem.InputGestureText is left blank in XAML.
+    Assert.Equal(None, HotkeyRegistry.gestureText hk)
 
 [<Fact>]
 let ``gestureText modifier order is Ctrl+Alt+Shift regardless of Set enumeration`` () =


### PR DESCRIPTION
## Summary

Third PR of **Cycle 26** (the multi-PR app-menu mini-cycle). Lands the **first menu-only `AppCommand`** — `RunProcessCleanupScript` — proving the option-typed `Hotkey` plumbing introduced in Cycle 26b works end-to-end. Surfaces `scripts/test-process-cleanup.ps1` via **Diagnostics → Test Process Cleanup**, with no default keyboard accelerator.

The script needs the maintainer to physically close pty-speak via Alt+F4 to verify Job Object cascade-kill cleanup — that's why the autonomous in-process diagnostic battery (Ctrl+Shift+D) doesn't cover it. PowerShell launches with `-NoExit` so the PASS/FAIL output stays visible after the script exits.

## Architectural changes

- **`HotkeyRegistry.fs`** — new `RunProcessCleanupScript` case in `AppCommand` DU + `nameOf` arm + `builtIns` row with `Key=None, Modifiers=None` + `allCommands` entry.
- **`Types.fs`** — new `ActivityIds.processCleanup` for per-tag NVDA dedupe.
- **`Program.fs`** — new `runTestProcessCleanup` handler near `runOpenConfig`. Mirrors the announce-before-focus-grab pattern: announce, 700ms delay, then `ProcessStartInfo("powershell.exe", "-NoExit -ExecutionPolicy Bypass -File <path>", UseShellExecute=true)`. Script-path via `Path.Combine(AppContext.BaseDirectory, "test-process-cleanup.ps1")`. File-not-found + exception paths sanitised.
- **`Terminal.App.fsproj`** — `<Content Include>` for the script was already present; comment updated to cite Cycle 26c menu surface instead of obsolete Ctrl+Shift+D reference.
- **`MainWindow.xaml`** — new `<MenuItem x:Name="MenuItem_RunProcessCleanupScript" Header="Test Process _Cleanup" />` under Diagnostics. No `InputGestureText` (compose's reflection-driven wiring leaves it blank since `gestureText` returns `None` for menu-only commands).

## Three-edit-extension recipe in action

This PR exercises the recipe documented verbatim in Cycle 26b:

1. ✅ AppCommand DU case + `nameOf` arm + `allCommands` row.
2. ✅ `builtIns` row (with `None, None` for menu-only).
3. ✅ Named `MenuItem` in XAML.

Compose's reflection-driven wiring picks it up automatically. No changes to `bindHotkey`, no changes to the menu-wiring loop. The handler + bind call are the only `Program.fs` edits.

## New tests

- `HotkeyRegistryTests.fs` — extends "allCommands contains exactly the documented commands" set. New fixture `RunProcessCleanupScript is menu-only (Cycle 26c)` pins `(None, None)` shape + asserts `gestureText` returns `None`.
- `AppReservedHotkeysMirrorTests.fs` — no change needed; the existing gesture-bearing filter already excludes menu-only commands from the parity check.

## Test plan

- [x] `git diff --stat` matches predicted scope (7 files, ~223 insertions).
- [x] No changes to `bindHotkey`, the menu-wiring loop in compose, or `OnPreviewKeyDown`.
- [ ] CI Windows build + unit tests pass.
- [ ] CI markdown link check passes.
- [ ] CI workflow lint passes.
- [ ] (Manual NVDA gate, lands in Cycle 26d) Diagnostics → Test Process _Cleanup → Enter announces launch cue; PowerShell window opens; close pty-speak via Alt+F4 to see PASS/FAIL output.

## Cycle 26 sequencing

- ✅ 26a — Menu skeleton + UIA plumbing (PR #225).
- ✅ 26b — Wire 14 AppCommands into menu items (PR #226).
- **26c (this PR)** — RunProcessCleanupScript menu-only AppCommand + handler.
- 26d — NVDA matrix rows + documentation refresh.

https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x

---
_Generated by [Claude Code](https://claude.ai/code/session_0134jAGK4R3nwTU7cbDdWV2x)_