### PR TITLE
docs: Cycle 30 — substrate / channel boundary doc + ADR 0001 + PANE-MODEL refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,66 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Docs (Cycle 30): substrate / channel boundary doc + ADR 0001 + PANE-MODEL refinement
+
+Doc-only foundation cycle landing the architectural framing
+locked in PROJECT-PLAN-2026-05-09 §A. No behaviour change. The
+boundary is a non-negotiable design constraint going forward;
+all subsequent linear-text-substrate work (Cycles 33-35) builds
+against it.
+
+- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** (new) — canonical
+  statement of the substrate / channel dichotomy. §1 records
+  the maintainer-blessed four-part assertion verbatim. §2-§3
+  define what substrate code (`Terminal.Core`) and channel code
+  (`Terminal.Accessibility`) may and may not do. §4 names the
+  NLP-style parser pipeline layering. §5 catalogs the **three
+  exemplar canonical displays** (raw text / interactive list /
+  form with text input) that seed the canonical-display
+  vocabulary; severity alert / progress / status / tabular /
+  tree are named extension points but not specified. §6
+  formalises the **three-sub-pane interaction paradigm**
+  (command-input / current-output / history) for the shell
+  pane plus three reserved peer panes (notification queue /
+  contextual keyword info / input assistant). §7 specifies the
+  streaming-incomplete protocol. §8 codifies the portability
+  invariant.
+- **`docs/adr/0001-substrate-channel-dichotomy.md`** (new) —
+  ADR recording the four-part assertion as accepted. Documents
+  context (today's screen-grid substrate breaks down on linear
+  workloads — confirmed Cycle 29b spinner storms, red-tone
+  misfires, `extractCommandAndOutput` fragility), decision (the
+  boundary is non-negotiable), and consequences (positive +
+  costs, including the multi-cycle inversion and parallel-
+  substrate transition window).
+- **`docs/PANE-MODEL.md`** (updated) — bumped snapshot to
+  2026-05-09. Catalog table extended with the three new
+  reserved peer panes (notification queue / contextual keyword
+  info / input assistant). Inserted "Shell pane internal
+  structure" subsection that points at
+  CORE-ABSTRACTION-BOUNDARY.md §6 for the three-sub-pane
+  decomposition. Three new pane sections appended after AI
+  assistance — each one paragraph with content source, user
+  interaction sketch, cross-pane coordination, UIA mapping,
+  reserved decisions. CORE-ABSTRACTION-BOUNDARY.md is now the
+  canonical source for all four refinements.
+- **`CLAUDE.md`** (updated) — reading order at session start
+  expanded to insert CORE-ABSTRACTION-BOUNDARY.md as item 5
+  (between strategic plan and spec/tech-plan). Read before
+  working on substrate or channel code.
+- **`CONTRIBUTING.md`** (updated) — "Honor the spec" rule
+  extended to add the boundary doc + ADR 0001 as a third
+  non-negotiable: substrate code (`Terminal.Core`) may not
+  import channel concerns (`Terminal.Accessibility`); channels
+  may not produce new semantic events.
+
+The Claude-research handoffs originally drafted (canonical-
+display taxonomy survey + streaming partial-emit prior-art
+survey) are deferred per the maintainer's 2026-05-09
+redirect; the three exemplar canonical displays establish
+the abstraction without requiring full taxonomy scoping.
+Research can be commissioned later if extension demand arises.
+
 ### Docs (Cycle 29b NVDA-test follow-up): captured three lessons from 2026-05-09 validation pass
 
 Doc-only follow-up to Cycle 29b's NVDA validation. Three

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,20 @@ before deviating.
    revision, preserved verbatim) and the original
    `PROJECT-PLAN-2026-05.md` per Track E E5 dated-snapshot
    discipline.
-5. **[`spec/tech-plan.md`](spec/tech-plan.md)** §N for the canonical
+5. **[`docs/CORE-ABSTRACTION-BOUNDARY.md`](docs/CORE-ABSTRACTION-BOUNDARY.md)**
+   — architectural framing that locks the substrate / channel
+   dichotomy; recorded as
+   [`docs/adr/0001-substrate-channel-dichotomy.md`](docs/adr/0001-substrate-channel-dichotomy.md).
+   **Non-negotiable design constraint going forward.** Names the
+   three exemplar canonical displays (raw text / interactive
+   list / form with text input), the three-sub-pane interaction
+   paradigm (input / current-output / history), and the three
+   reserved peer panes (notification queue, contextual keyword
+   info, input assistant). Read before working on substrate or
+   channel code.
+6. **[`spec/tech-plan.md`](spec/tech-plan.md)** §N for the canonical
    spec of whatever stage you're working on.
-6. **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — canonical PR shape,
+7. **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — canonical PR shape,
    branch naming, F# / .NET 9 gotchas, accessibility
    non-negotiables, P/Invoke conventions, test conventions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,16 @@ to not relearn.
    [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md).
 2. **Honor the spec.** [`spec/overview.md`](spec/overview.md) is the
    architectural rationale; [`spec/tech-plan.md`](spec/tech-plan.md) is
-   the stage-by-stage implementation plan. Changes that contradict
-   either need an issue and discussion first.
+   the stage-by-stage implementation plan;
+   [`docs/CORE-ABSTRACTION-BOUNDARY.md`](docs/CORE-ABSTRACTION-BOUNDARY.md)
+   (recorded as
+   [`docs/adr/0001-substrate-channel-dichotomy.md`](docs/adr/0001-substrate-channel-dichotomy.md))
+   is the **non-negotiable substrate / channel boundary** every
+   downstream stage builds against — substrate code (`Terminal.Core`)
+   may not import channel concerns (`Terminal.Accessibility`) and
+   vice versa, and channels may not produce new semantic events.
+   Changes that contradict any of the three need an issue and
+   discussion first.
 3. **Walking-skeleton discipline.** We add Stage N only when Stage N-1
    ships and is validated end-to-end. Don't merge Stage 5 streaming
    notifications before Stage 4 text exposure works in Inspect.exe.

--- a/docs/CORE-ABSTRACTION-BOUNDARY.md
+++ b/docs/CORE-ABSTRACTION-BOUNDARY.md
@@ -1,0 +1,571 @@
+# Core abstraction boundary
+
+> **Snapshot**: 2026-05-09
+> **Status**: architectural framing — locks the substrate /
+> channel dichotomy that all downstream stages build against.
+> **Authoring item**: PROJECT-PLAN-2026-05-09 §A (architectural
+> assertion).
+> **ADR**: [`adr/0001-substrate-channel-dichotomy.md`](adr/0001-substrate-channel-dichotomy.md)
+> records the dichotomy as a non-negotiable design constraint.
+> **Companion docs**:
+> - [`PIPELINE-NARRATIVE.md`](PIPELINE-NARRATIVE.md) — operational
+>   mechanics of today's 12-stage pipeline; this doc names which
+>   of those stages live below the boundary (substrate) vs. above
+>   (channels).
+> - [`CHANNEL-ARCHITECTURE.md`](CHANNEL-ARCHITECTURE.md) — channel-
+>   based-communication principle; this doc renames the boundary
+>   side as "substrate" and clarifies the inversion required to
+>   support trickle-feed inputs.
+> - [`INTERACTION-MODEL.md`](INTERACTION-MODEL.md) — Shell
+>   Interaction Manager + three-component model; this doc
+>   re-frames the components as sub-panes (§6).
+> - [`SESSION-MODEL.md`](SESSION-MODEL.md) — history substrate;
+>   the linear-text producer (§5) is the canonical replacement
+>   for `extractCommandAndOutput`'s screen-row reconstruction.
+> - [`PANE-MODEL.md`](PANE-MODEL.md) — workspace + multi-pane
+>   framework; consumes §6's three-sub-pane decomposition + three
+>   reserved peer panes.
+> - [`PROJECT-PLAN-2026-05-09.md`](PROJECT-PLAN-2026-05-09.md) —
+>   Section 1 (architectural assertion) is the source text this
+>   doc lifts verbatim.
+
+## What this document is
+
+The **architectural boundary** that separates pty-speak's
+**substrate** (the byte → semantic-event substrate produced by
+the parser pipeline) from its **channels** (the canonical-display
+primitives that consume substrate output and render it for the
+user via NVDA / earcons / FileLogger / future surfaces).
+
+The boundary is a **non-negotiable design constraint** going
+forward. Every stage from the linear-text substrate inversion
+(2026-05-09 plan Cycle 34) onward is designed against this
+boundary: substrate code may not import channel concerns;
+channel code may not depend on substrate-internal modules.
+
+This doc is the canonical statement of what the boundary is, why
+it exists, what each side may do, and how the two sides
+communicate. It supersedes prior framings in
+[`CHANNEL-ARCHITECTURE.md`](CHANNEL-ARCHITECTURE.md) and
+[`PIPELINE-NARRATIVE.md`](PIPELINE-NARRATIVE.md) where those
+framings are silent on the boundary.
+
+## Why this exists
+
+Through Stages 1-7, pty-speak grew a screen-grid substrate
+(`Terminal.Core.Screen`) that accumulates parsed VT events into
+a visual cell grid. Channels (NvdaChannel, FileLoggerChannel,
+EarconChannel) consume `OutputEvent`s emitted by `StreamPathway`,
+which derives those events by **diffing the screen grid row-by-
+row between flushes** (`StreamPathway.fs:45-200`,
+`Coalescer.fs:35-150`).
+
+The screen-grid substrate is the right answer for **TUI**
+workloads that draw alt-screen interfaces (vim, htop, less),
+because alt-screen apps are inherently 2D — they paint cells at
+arbitrary `(row, col)` positions and rely on the screen grid as
+truth. But the screen-grid substrate is the **wrong** answer for
+**linear / streaming text** workloads, which include:
+
+- Plain-cmd / plain-PowerShell output (`dir`, `git status`).
+- `claude --dangerously-skip-permissions` text and tool-use
+  output (the dominant maintainer workload).
+- Build / compile output (`dotnet build`, `npm install`).
+- Any output that doesn't enter alt-screen.
+
+For linear workloads, the screen grid forces the substrate to
+**reconstruct** the natural byte sequence by walking cells and
+joining rows — an inversion of cause and effect. The byte
+sequence existed first; the screen grid was derived from it; but
+the channels read the derived form back as if it were primary.
+This shows up as bugs:
+
+- **Spinner storms** (Cycle 29b confirmed: ~80 announces per
+  Claude turn). Each spinner glyph rotation is a row-diff event
+  fired through StreamPathway; identical-hash dedup catches
+  repeats but Claude's incrementing token-counter defeats it.
+- **Red-tone misfires** (Cycle 29b confirmed: ~30 error-tones
+  per Claude turn). Spinner glyphs are red-coloured; the row-
+  diff path can't tell "spinner frame" from "actual error line"
+  because both arrive as `RowChanged` events.
+- **`extractCommandAndOutput` fragility** (`SessionModel.fs:316-
+  427`). The session-history substrate reconstructs (command,
+  output) tuples by walking rows of the screen grid and
+  splitting at prompt boundaries — duplicating the parsing work
+  the screen grid already did and reintroducing all the row-
+  wrap / line-continuation edge cases.
+
+The fix requires **inverting the substrate**: the linear text
+stream becomes the source of truth; the screen grid becomes one
+of several derived projections (used only for alt-screen
+content). This doc names the boundary that makes the inversion
+sound.
+
+## §1 — The four-part architectural assertion
+
+This is the maintainer-blessed canonical assertion (PROJECT-PLAN-
+2026-05-09 §1, lifted verbatim and recorded in ADR 0001):
+
+> 1. **The natural language structure of the way that we think
+>    of text in the terminal is to model the way the bytes
+>    flow.** A terminal is a stream of bytes. Linear text is the
+>    natural shape of those bytes. The screen grid is one
+>    derived projection of the byte stream, suitable for alt-
+>    screen TUIs; it is not the canonical substrate.
+> 2. **As the bytes are flowing through the terminal, we want
+>    to apply NLP-style methodologies to dissect aspects from
+>    that stream of bytes.** The byte → semantic-event pipeline
+>    is structurally analogous to a tokenize → parse → classify
+>    → enrich NLP pipeline. Each stage adds a derived layer of
+>    structure without erasing the prior stages.
+> 3. **Various canonical formats of display will be deployed in
+>    a way that we currently call channels.** A canonical
+>    display is a presentation primitive with a fixed UIA control
+>    type, an ARIA role analog, a reading pattern under each
+>    screen reader, and an interaction contract. Channels deliver
+>    canonical-display payloads; the substrate produces them.
+> 4. **It's important that we structure the application in a way
+>    that the methods of dissection can be ported to other
+>    operating systems.** Substrate is OS-portable; channels are
+>    OS-specific (UIA on Windows, AT-SPI on Linux, NSAccessibility
+>    on macOS). The boundary between them is the portability
+>    seam.
+
+The four parts together yield: a portable, layered substrate
+that produces canonical-display payloads, consumed by OS-specific
+channel adapters.
+
+## §2 — The substrate side
+
+The substrate is everything **below the boundary** — the byte →
+semantic-event flow.
+
+### Substrate composition
+
+- **Layer 0 (raw bytes)** — `ConPtyHost` reads PTY stdout into
+  the Coalescer's input queue. No interpretation.
+- **Layer 1 (parser)** — `Terminal.Core.VtParser` tokenizes
+  bytes into VT events (Print, CSI, OSC, DCS, ESC, control).
+  This is the **lexer** in NLP terms.
+- **Layer 2 (linear-text producer + screen producer)** —
+  Two parallel substrate projections:
+  - `LinearTextStream` (Cycle 34, planned) — appends every
+    Coalescer-batched byte (less alt-screen content) to a
+    linear in-memory buffer with a live-region pointer for
+    overwrite-in-place sequences. **This is the canonical
+    substrate for linear workloads.**
+  - `Terminal.Core.Screen` (shipping today) — the cell grid.
+    **Demoted** to "alt-screen substrate only" once §6 inversion
+    completes; remains the canonical substrate for vim / htop /
+    less / any alt-screen TUI.
+- **Layer 3 (detectors)** — derived semantic-event producers
+  consume substrate output:
+  - `HeuristicPromptDetector` (shipping) — prompt-boundary
+    finalize.
+  - `SelectionDetector` (Cycle 29a-c, shipping) — interactive-
+    list candidate detection.
+  - Future: `ErrorLineDetector`, `KeywordDetector`,
+    `FormPromptDetector`, `ProgressDetector`.
+- **Layer 4 (semantic-event store)** — `OutputEvent` /
+  `SemanticEvent` records flowing through the pipeline. These
+  are the **tokens with attached semantic categories** in NLP
+  terms. **Profiles** (StreamProfile, SelectionProfile,
+  EarconProfile, future FormProfile) consume these to make
+  channel decisions.
+
+### What substrate code may NOT do
+
+- **No imports from the `Terminal.Accessibility` assembly.**
+  Substrate code may not reference `TerminalAutomationPeer`,
+  any UIA pattern provider, or the `System.Windows.Automation`
+  / `System.Windows.Automation.Peers` namespaces.
+- **No P/Invoke into Win32 UIA.**
+  `UiaRaiseNotificationEvent` calls live in the channel layer.
+- **No imports from `Terminal.App` (composition root).**
+  Substrate is consumed by the app, never the reverse.
+- **No WPF dependencies in the linear-text producer or
+  detectors.** They operate on byte / event streams; rendering
+  is the channel layer's job.
+
+### What substrate code MAY do
+
+- Produce `OutputEvent` / `SemanticEvent` records with
+  structured payloads.
+- Maintain in-memory data structures (linear-text buffer,
+  screen grid, session history).
+- Run on background threads (`Coalescer` already does;
+  `LinearTextStream` will).
+- Emit diagnostics through the `IDiagnosticSink` boundary.
+
+### Today's substrate gaps
+
+- The linear-text producer doesn't exist yet (Cycle 34 ships
+  it).
+- `extractCommandAndOutput` is screen-grid-derived and
+  duplicates parser work; replaced by the linear-text producer's
+  high-water-mark commit semantics.
+- The screen-grid substrate is currently the canonical substrate
+  for both alt-screen AND linear workloads; the inversion
+  reduces it to alt-screen-only.
+
+## §3 — The channel side
+
+The channel layer is everything **above the boundary** — the
+semantic-event → user-perceivable output flow.
+
+### Channel composition
+
+- **Profiles** (StreamProfile, SelectionProfile, EarconProfile,
+  future FormProfile, future ErrorProfile) — pattern-match on
+  `SemanticEvent.Category` + `Extensions`; emit `ChannelDecision`
+  records targeted at specific channels.
+- **Channels** (NvdaChannel, FileLoggerChannel, EarconChannel,
+  future SapiChannel for cross-platform) — execute
+  `ChannelDecision` payloads. NvdaChannel raises UIA
+  notifications; FileLoggerChannel writes structured log lines;
+  EarconChannel plays WASAPI audio.
+- **OS adapters** — channels are OS-specific. The Windows
+  build's NvdaChannel uses UIA; a future Linux build's
+  AtspiChannel would use AT-SPI (the same profile output drives
+  both).
+
+### Canonical displays (the channel-layer vocabulary)
+
+A **canonical display** is a presentation primitive with:
+
+- A **UIA control type** (`Document`, `List`, `Group`, etc.).
+- An **ARIA role analog** (`role="log"`, `role="listbox"`,
+  `role="form"`).
+- A **reading pattern** under each major screen reader (NVDA,
+  JAWS, Narrator).
+- A fixed **interaction contract** (read-only, arrow-navigable,
+  Tab-between-fields, etc.).
+
+Three exemplar canonical displays (§5 below) seed the catalog;
+extension points (severity alert, indeterminate progress, status
+indicator, tabular output, hierarchical tree) are named but not
+specified in this cycle.
+
+### What channel code may NOT do
+
+- **No imports from substrate-internal modules.** Channel code
+  consumes `OutputEvent` / `SemanticEvent` / `ChannelDecision` —
+  the published types — but does not reach into
+  `LinearTextStream` internals, `VtParser`'s state machine, or
+  the screen grid's cell array.
+- **No producing new semantic events.** Channels render; they
+  do not classify. If a channel needs richer information than
+  the substrate provides, the right fix is a new detector in
+  the substrate, not a channel-side reclassification.
+- **No mutable cross-channel state.** Two channels rendering
+  the same `ChannelDecision` must produce the same output
+  regardless of order.
+
+### What channel code MAY do
+
+- Call OS-specific accessibility APIs (UIA, AT-SPI,
+  NSAccessibility).
+- Render to WPF / Avalonia / GTK surfaces.
+- Maintain channel-local state (NvdaChannel's per-ActivityId
+  notification dedup is a current example).
+- Coordinate with WPF dispatcher / UI thread.
+
+## §4 — The NLP-style parser pipeline
+
+The substrate is structured as an NLP-style layered analysis:
+
+| NLP stage | Substrate stage | Today |
+|---|---|---|
+| Lexer (bytes → tokens) | `VtParser` (bytes → VT events) | ✅ shipping |
+| Parser (tokens → trees) | `LinearTextStream` (events → linear text + live region) | 📋 Cycle 34 |
+| | `Screen` (events → cell grid) | ✅ shipping (demoted to alt-screen only post-Cycle 35) |
+| Tagger / classifier (trees → semantic categories) | `HeuristicPromptDetector`, `SelectionDetector`, future `ErrorLineDetector` / `FormPromptDetector` / `KeywordDetector` | partially shipping |
+| Enricher (categories → structured records) | Profiles (StreamProfile, SelectionProfile, EarconProfile, future FormProfile) | partially shipping |
+
+Each layer adds a derived view; **no layer erases prior layers**.
+The bytes remain available; the linear text remains available;
+the events remain available. Detectors that disagree (e.g.
+`SelectionDetector` says "this is an interactive list" but a
+hypothetical `FormPromptDetector` says "this is a form field")
+both emit, and profile precedence (TOML-configurable per
+[USER-SETTINGS.md](USER-SETTINGS.md) when that lands) decides
+which channel decision wins.
+
+This layering is what makes the substrate **portable**: a
+Linux build re-uses the parser, the linear-text producer, the
+detectors, and the profile decisions; only the channel layer
+swaps OS adapters.
+
+## §5 — Three exemplar canonical displays
+
+The 2026-05-09 plan ships **three simple representative
+canonical-display exemplars** that establish the abstraction
+without over-specifying. The catalog can be extended later
+(severity alert, indeterminate progress, status indicator,
+tabular output, hierarchical tree) without rework once these
+three are in place. Full interaction contracts + UIA mappings
+are scoped in `CANONICAL-DISPLAY-CATALOG.md` (Cycle 33,
+forthcoming).
+
+### Exemplar 1 — Raw text
+
+The bulk of cmd / PowerShell / Claude text output.
+
+- **Substrate**: linear-text (the Stream pathway, post-Cycle
+  35).
+- **UIA**: `ControlType.Document` + `TextPattern` (already
+  shipped at the screen substrate; rewires to linear substrate
+  in Cycle 35).
+- **ARIA analog**: `role="log"` aria-live=polite for streaming
+  output; `role="document"` for sealed history tuples.
+- **NVDA**: review-cursor navigable; live announces via
+  `UiaRaiseNotificationEvent`; quick-nav `o`/`O` for next/prev
+  output block (future history-sub-pane work).
+- **Interaction**: read-only.
+- **Ships in**: Cycle 35 (Stream profile rebuild).
+
+### Exemplar 2 — Interactive list
+
+Selection prompts: Claude tool-use, cmd `choice`, fzf-non-alt-
+screen.
+
+- **Substrate**: derived semantic-event store
+  (SelectionDetector output → SelectionProfile decisions).
+- **UIA**: `ControlType.List` + `ControlType.ListItem` with
+  `ISelectionProvider` + `ISelectionItemProvider`. Already
+  partially shipped via Cycles 29a/29b as text-only; promoted
+  to full UIA listbox semantics in Cycle 37.
+- **ARIA analog**: `role="listbox"` with `aria-activedescendant`.
+- **NVDA**: announces "list with N items, item M of N"; arrow-
+  key navigable; Enter invokes.
+- **Interaction**: arrow keys move selection; Enter invokes;
+  Esc dismisses.
+- **Ships in**: Cycle 37 (Stage 8e-B UIA listbox peer).
+
+### Exemplar 3 — Form with text input
+
+Multi-field prompts: `Read-Host` chains, credentials prompt,
+multi-step interactive command builders.
+
+- **Substrate**: linear-text (Stream pathway) +
+  `InputPathway` for keystroke routing.
+- **UIA**: `ControlType.Group` containing one or more
+  `ControlType.Edit` with `IValueProvider`.
+- **ARIA analog**: `role="form"` with descendant
+  `role="textbox"` fields and `aria-label`.
+- **NVDA**: focus-mode automatically (forms-mode); arrow / Tab
+  between fields; Enter submits.
+- **Interaction**: Tab between fields; type to fill; Enter
+  submits.
+- **Ships in**: Cycle 38 (input framework foundation +
+  FormProfile; Form is the most input-heavy canonical display
+  and naturally pairs with the InputPathway substrate).
+
+### Catalog extension points (named, not specified)
+
+Future canonical displays the catalog may grow:
+
+- **Severity alert** — error / warning lines. Likely UIA
+  `Notification` event + earcon channel, ARIA `role="alert"`
+  (assertive).
+- **Status indicator** — health, mode, shell. Likely UIA
+  `StatusBar`, ARIA `role="status"`.
+- **Indeterminate progress** — spinners, "Thinking…". Live-
+  region overwrite at substrate layer; suppressed at channel
+  layer (no per-frame announces). ARIA `role="progressbar"`
+  aria-valuenow=undefined.
+- **Tabular output** — `dir /columns`, `Get-Process`
+  output. UIA `Table` + `TableItem`; ARIA `role="table"`.
+- **Hierarchical tree** — `tree /F` output. UIA `Tree` +
+  `TreeItem`; ARIA `role="tree"`.
+
+These extension points are mentioned to establish that the
+catalog is not closed; the three exemplars are the working
+seed, not the full vocabulary.
+
+## §6 — Three-sub-pane interaction paradigm
+
+The shell pane (today's `TerminalView`, owned by the Shell
+Interaction Manager per [INTERACTION-MODEL §4](INTERACTION-MODEL.md))
+is internally three **sub-panes**, each consuming a different
+substrate slice:
+
+### The three sub-panes
+
+1. **Command-input sub-pane** — where the user types commands
+   that get sent to the PTY child. Today: typing into the
+   single `TerminalView` surface; future: a dedicated text-
+   input region. Substrate: future `InputPathway` (Cycle 38)
+   + `EchoCorrelator`. Visible representation of "what I am
+   about to send".
+
+2. **Current-output sub-pane** — where the active in-flight
+   output is rendered using whatever canonical display the
+   parser determines (raw text for plain output, interactive
+   list for selection prompts, form for input fields, future
+   primitives for additional cases). Substrate: linear-text
+   producer (raw text) + detector output (interactive list /
+   form). The current-output sub-pane is the place where the
+   parser's classification decisions become user-perceivable
+   form.
+
+3. **History sub-pane** — sealed past `SessionTuple`s, semantic-
+   navigable. Quick-nav primitives (paragraph-within-output;
+   prev/next command boundary; jump-to-most-recent-output)
+   make keyboard navigation fast for a screen-reader user
+   who needs to jump back to a prior result without scrolling
+   linearly. Substrate: SessionModel + the linear-text
+   producer's high-water-mark commits (post-Cycle 34, replaces
+   `extractCommandAndOutput`). Each tuple is a navigable text
+   region with prev/next-paragraph + prev/next-tuple gestures.
+
+### Why this decomposition
+
+The three sub-panes crystallize a fixed interaction paradigm:
+the user is always in one of three modes — **inputting** a
+command, **interacting with** the current output, or
+**exploring** history. The framework names that paradigm so
+implementation cycles can build against it.
+
+Today's `TerminalView` plays all three roles in a single
+surface. The decomposition is **conceptual first** — the three
+sub-panes have distinct substrates and accessibility surfaces
+even though they share rendering today. A future Phase 2 layout
+PR may surface them as distinct WPF regions; the conceptual
+decomposition does not require it.
+
+### Three additional reserved peer panes
+
+Beyond the three sub-panes that decompose the shell pane, the
+2026-05-09 redirect added **three new reserved peer panes** to
+the workspace catalog. These are siblings to the shell pane,
+captured in [`PANE-MODEL.md`](PANE-MODEL.md) as 📋 reserved
+(documentation only; no design / spec / implementation in this
+plan):
+
+- **Notification queue pane** — ephemeral toast-style
+  notifications surfaced from stream input (e.g., spinner-burst
+  summary, build-completed, test-failure-detected). Clears on
+  read or timeout. UIA `role="log"` aria-live=assertive analog.
+- **Contextual keyword info pane** — displays contextual
+  information about particular keywords surfaced in output
+  (e.g., when output mentions a file path, error code, package
+  name, or symbol, this pane offers documentation / definition /
+  link). Driven by a future detector layer (`KeywordDetector`).
+- **Input assistant pane** — gives contextual information
+  about commands being typed in the command-input sub-pane
+  (e.g., man-page snippet for `git push`, autocomplete
+  suggestions, parameter help). Coordinated with the command-
+  input sub-pane via the input framework substrate (Cycle 38).
+
+These additions do not change the architectural boundary; they
+extend the workspace with new channel-layer consumers of the
+same substrate.
+
+## §7 — Streaming-incomplete protocol
+
+The linear-text substrate is **incomplete at every tick**. A
+byte that arrived 5ms ago might be the start of a longer
+sequence whose final shape is still in flight. The protocol
+that lets profiles emit usefully against an incomplete stream:
+
+- **Idle quanta as commit points.** Coalescer's debounce-window
+  fire = high-water-mark commit; profiles emit suffix-since-
+  last-commit.
+- **Prompt boundary as finalize.** `HeuristicPromptDetector`
+  fire = `SessionTuple.OutputText` sealed; immutable in History.
+- **Mid-stream events carry `Sealed: bool` extension.** Unsealed
+  events are advisory (profiles may show provisional state but
+  must not commit irreversibly); sealed events are authoritative.
+- **Live region.** A `(start, length)` pointer into the
+  substrate tail. Bytes overwriting the live region (`\r`-
+  without-`\n`, cursor-up-then-back, ESC[K) replace tail; do
+  not append. Spinners + progress bars + `--More--` paginator
+  prompts live here. Detection mechanism finalized in Cycle 33
+  RFC.
+
+This protocol is the contract that makes the linear-text
+substrate usable by channels without erasing the streaming
+nature of the underlying byte flow. Channels see a sequence of
+sealed + unsealed events; they decide what to do with each.
+
+## §8 — The portability invariant
+
+The boundary doubles as the **portability seam**. A future
+non-Windows build of pty-speak (Linux + AT-SPI; macOS +
+NSAccessibility) re-uses everything below the boundary
+unchanged:
+
+- VtParser
+- LinearTextStream (post-Cycle 34)
+- Screen (for alt-screen)
+- All detectors (PromptDetector, SelectionDetector, future
+  ErrorLineDetector / FormPromptDetector / KeywordDetector)
+- All profiles (StreamProfile, SelectionProfile, EarconProfile,
+  future FormProfile)
+- SessionModel + the linear-text high-water-mark replacement
+  for `extractCommandAndOutput`
+
+Only the channel-side OS adapters change:
+
+- NvdaChannel → AtspiChannel / NSAccessibilityChannel
+- WPF rendering → GTK / AppKit rendering
+- WASAPI EarconChannel → ALSA / CoreAudio EarconChannel
+
+The portability invariant is enforced **structurally**: substrate
+projects (`Terminal.Core`) do not reference channel projects
+(`Terminal.Accessibility`, the future `Terminal.Channels.AT-SPI`).
+A code review that surfaces a substrate → channel reference is
+a boundary violation; reviewers block.
+
+## §9 — What this doc is NOT
+
+- **Not a spec.** Concrete F# / C# types, module shapes,
+  pattern provider implementations live in
+  [spec/tech-plan.md](../spec/tech-plan.md) and the forthcoming
+  [`CANONICAL-DISPLAY-CATALOG.md`](CANONICAL-DISPLAY-CATALOG.md)
+  (Cycle 33).
+- **Not an implementation plan.** Cycle-by-cycle rollout lives
+  in [`PROJECT-PLAN-2026-05-09.md`](PROJECT-PLAN-2026-05-09.md).
+- **Not a research deliverable.** The two Claude-research
+  handoffs originally drafted (canonical-display taxonomy
+  survey + streaming partial-emit prior-art survey) are
+  deferred; the three exemplar canonical displays in §5
+  establish the abstraction without requiring full taxonomy
+  scoping. Research can be commissioned later if extension
+  demand arises (per PROJECT-PLAN-2026-05-09 §6).
+
+## §10 — Cross-references
+
+- **ADR**: [`adr/0001-substrate-channel-dichotomy.md`](adr/0001-substrate-channel-dichotomy.md)
+- **Strategic plan**: [`PROJECT-PLAN-2026-05-09.md`](PROJECT-PLAN-2026-05-09.md)
+- **Channel principle (older framing)**:
+  [`CHANNEL-ARCHITECTURE.md`](CHANNEL-ARCHITECTURE.md)
+- **Pipeline mechanics**: [`PIPELINE-NARRATIVE.md`](PIPELINE-NARRATIVE.md)
+- **Interaction model**: [`INTERACTION-MODEL.md`](INTERACTION-MODEL.md)
+- **Session history**: [`SESSION-MODEL.md`](SESSION-MODEL.md)
+- **Pane catalog + sub-pane decomposition**:
+  [`PANE-MODEL.md`](PANE-MODEL.md)
+- **Spec authority**: [`spec/tech-plan.md`](../spec/tech-plan.md)
+
+## Versioning + maintenance
+
+Follows the snapshot model established by the other research-
+stage docs. Top-of-doc front matter carries
+`Snapshot: YYYY-MM-DD`. Trigger conditions for re-snapshot:
+
+- Cycle 33 RFC ships the `CANONICAL-DISPLAY-CATALOG.md` —
+  cross-reference here.
+- Cycle 34 ships `LinearTextStream` — substrate description
+  in §2 transitions from "📋" to "✅".
+- Cycle 35 demotes the screen-grid substrate to alt-screen-
+  only — §2 wording shifts.
+- Cycle 38 ships FormProfile + InputPathway — §5 Exemplar 3
+  status transitions.
+- A new exemplar is promoted from "extension point" to
+  "shipping" — §5 grows.
+
+The boundary itself (§1's four-part assertion) is intended to be
+**stable across implementation cycles**. If the boundary changes,
+that's an ADR-level event (a new ADR superseding 0001), not a
+re-snapshot.

--- a/docs/PANE-MODEL.md
+++ b/docs/PANE-MODEL.md
@@ -1,9 +1,10 @@
 # Pane Model
 
-> **Snapshot**: 2026-05-07
+> **Snapshot**: 2026-05-09
 > **Status**: design / forward-looking — sketch only; not a full spec; not yet implemented
 > **Authoring item**: backlog item 30 (research stage)
 > **Companion docs**:
+> - [`CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) — substrate / channel boundary. Defines the three-sub-pane decomposition of the shell pane (§6) and the three reserved peer panes (notification queue, contextual keyword info, input assistant) added in 2026-05-09 redirect. Canonical source for both refinements; this doc lifts the framing into the workspace catalog.
 > - [`INTERACTION-MODEL.md`](INTERACTION-MODEL.md) — architectural framing (Shell Interaction Manager + three-component model). The shell pane is owned by the SIM; this doc extends into multi-pane composition.
 > - [`PIPELINE-NARRATIVE.md`](PIPELINE-NARRATIVE.md) — operational mechanics (12-stage byte-to-announcement flow). Each pane runs its own pipeline.
 > - [`SESSION-MODEL.md`](SESSION-MODEL.md) — history substrate. The cherry-picked I/O pairs pane consumes SessionModel queries.
@@ -486,11 +487,14 @@ panes. Concrete UI / data shapes deferred.
 
 | Pane | Producer | Content source | Status |
 |---|---|---|---|
-| **Shell pane** | SIM | PTY child process; cell grid | ✅ shipping |
+| **Shell pane** (decomposes into three sub-panes — see "Shell pane internal structure" below) | SIM | PTY child process; linear-text producer + screen grid | ✅ shipping |
 | **File tree pane** | Filesystem Producer (future) | Directory enumeration; OS file events | 📋 reserved |
 | **Cherry-picked I/O pairs pane** | Pinned-Tuple Producer (future) | SessionModel query (selected tuples) | 📋 reserved |
 | **Language documentation pane** | Doc Producer (future) | Local docset / web docs / LSP-sourced | 📋 reserved |
 | **AI assistance pane** | LLM Producer (future) | Anthropic Claude API; SessionModel-grounded | 📋 reserved |
+| **Notification queue pane** | Stream-derived notification producer (future) | StreamProfile + future notification taxonomy | 📋 reserved (added 2026-05-09) |
+| **Contextual keyword info pane** | KeywordDetector + reference resolver (future) | Output substrate; user keyword highlights | 📋 reserved (added 2026-05-09) |
+| **Input assistant pane** | InputPathway + completion / help producer (future) | Command-input sub-pane substrate | 📋 reserved (added 2026-05-09) |
 
 ### Shell pane (✅ shipping)
 
@@ -513,6 +517,68 @@ Surface, Active Output, Historical Document — per
 [INTERACTION-MODEL §5](INTERACTION-MODEL.md)) is internal
 to the shell pane; the workspace doesn't see those
 components, just the pane as a whole.
+
+### Shell pane internal structure — three sub-panes
+
+> **Canonical source**:
+> [`CORE-ABSTRACTION-BOUNDARY.md` §6](CORE-ABSTRACTION-BOUNDARY.md).
+> This subsection summarises that framing for the pane-catalog
+> reader; the boundary doc carries the substrate-level detail.
+
+The shell pane internally decomposes into **three sub-panes**,
+each consuming a different substrate slice. Today's
+`TerminalView` plays all three roles in a single WPF surface;
+the decomposition is **conceptual first** (substrate +
+accessibility surfaces are distinct even though rendering is
+shared today). A future Phase 2 layout PR may surface them as
+distinct WPF regions; the conceptual decomposition does not
+require it.
+
+The three sub-panes:
+
+1. **Command-input sub-pane** — where the user types commands
+   that get sent to the PTY child. Substrate: future
+   `InputPathway` (Cycle 38) + `EchoCorrelator`. Visible
+   representation of "what I am about to send".
+2. **Current-output sub-pane** — where the active in-flight
+   output is rendered using whatever canonical display the
+   parser determines (raw text / interactive list / form with
+   text input — the three exemplar canonical displays of
+   [`CORE-ABSTRACTION-BOUNDARY.md` §5](CORE-ABSTRACTION-BOUNDARY.md);
+   future primitives extend the catalog without re-architecting).
+   Substrate: linear-text producer (raw text) + detector output
+   (interactive list / form). The current-output sub-pane is
+   the place where the parser's classification decisions become
+   user-perceivable form.
+3. **History sub-pane** — sealed past `SessionTuple`s,
+   semantic-navigable. Quick-nav primitives (paragraph-within-
+   output; prev/next command boundary; jump-to-most-recent-
+   output) make keyboard navigation fast for a screen-reader
+   user who needs to jump back to a prior result without
+   scrolling linearly. Substrate: SessionModel + the linear-
+   text producer's high-water-mark commits (post-Cycle 34,
+   replaces `extractCommandAndOutput`'s screen-row
+   reconstruction). Each tuple is a navigable text region with
+   prev/next-paragraph + prev/next-tuple gestures.
+
+**Why this decomposition matters for the pane catalog**: the
+three sub-panes crystallize a fixed interaction paradigm — the
+user is always in one of three modes — **inputting** a command,
+**interacting with** the current output, or **exploring**
+history. The framework names that paradigm so workspace-level
+focus routing (the Pane Coordinator's responsibility) and pane-
+switch announcements know what they're switching among. A future
+"focus the input sub-pane" gesture is meaningfully distinct from
+"focus the shell pane" — the former targets a specific sub-pane
+within the shell pane.
+
+The three-sub-pane decomposition supersedes any prior framing in
+this doc that treated the shell pane as monolithic. The doc's
+previous catalog row above is preserved, but the "internal
+structure" pointer is what governs implementation: when adding
+shell-pane-internal substrate or accessibility infrastructure,
+treat the three sub-panes as the unit, not the shell pane as a
+whole.
 
 ### File tree pane (📋 reserved)
 
@@ -654,6 +720,156 @@ Reserved decisions: API client implementation (Anthropic
 SDK); auth token storage (TOML / OS keyring); cost +
 rate-limit handling; offline degradation (what happens
 without network).
+
+### Notification queue pane (📋 reserved — added 2026-05-09)
+
+> **Source**:
+> [`CORE-ABSTRACTION-BOUNDARY.md` §6](CORE-ABSTRACTION-BOUNDARY.md)
+> "Three additional reserved peer panes". Captured here as a
+> documentation reservation; no design / spec / implementation
+> in the 2026-05-09 plan.
+
+An ephemeral toast-style queue for notifications surfaced from
+the stream substrate. Produces:
+
+- A scrolling list of recent notification entries (e.g.
+  spinner-burst summary "Claude finished thinking after 12s",
+  build-completed, test-failure-detected, long-running-
+  command-progress milestones).
+- Entries time out or clear on user read.
+- The pane sits as a peer to the shell pane in the workspace;
+  the user can focus it by hotkey to re-read recent
+  notifications.
+
+User interaction:
+
+- Arrow keys navigate the queue.
+- Enter on an entry: re-read the notification verbosely (NVDA
+  expansion).
+- Delete on an entry: dismiss / clear.
+- A "clear all" hotkey.
+
+Cross-pane coordination:
+
+- Shell pane → notification queue: stream-derived notifications
+  flow as the shell pane's substrate produces them. (The
+  channel-layer producer for these notifications is future
+  work; the substrate hooks already exist via the
+  StreamPathway / EarconPathway emit points.)
+- Notification queue → shell pane: optional "jump to the output
+  that produced this notification" gesture (requires
+  SessionModel substrate cross-link).
+
+UIA: `role="log"` aria-live=assertive analog;
+`ControlType.List` with `ControlType.ListItem` children.
+
+Reserved decisions: notification taxonomy (which substrate
+events qualify); persistence (in-memory only vs. on-disk);
+deduplication policy; per-shell vs. unified queue.
+
+### Contextual keyword info pane (📋 reserved — added 2026-05-09)
+
+> **Source**:
+> [`CORE-ABSTRACTION-BOUNDARY.md` §6](CORE-ABSTRACTION-BOUNDARY.md)
+> "Three additional reserved peer panes". Captured here as a
+> documentation reservation; no design / spec / implementation
+> in the 2026-05-09 plan.
+
+A pane that displays contextual information about particular
+keywords surfaced in shell output. Produces:
+
+- Definitions / documentation / reference snippets for keywords
+  the user (or the substrate) highlights — file paths, error
+  codes, package names, language symbols, command names.
+- Updates on shell pane keyword surface events (driven by a
+  future `KeywordDetector` in the parser pipeline).
+- Updates on user-explicit "look up X in shell context"
+  gestures.
+
+User interaction:
+
+- Arrow keys / Page Up / Down navigate the displayed reference
+  text.
+- Hyperlinks within the reference: Enter follows; UIA invoke.
+- "Pin this reference" gesture: persist into the cherry-picked
+  I/O pane (or a notes substrate; out of scope for this
+  reservation).
+
+Cross-pane coordination:
+
+- Shell pane → contextual keyword info: detector-fired keyword
+  events open the pane to the relevant reference.
+- Cherry-picked I/O pane → contextual keyword info: re-look-up
+  on a pinned tuple's keyword.
+
+Distinguishing from the language documentation pane: language
+docs is a passive viewer the user navigates explicitly; the
+contextual keyword info pane is **substrate-driven** —
+keywords surfaced in output trigger lookups automatically (or
+on a single confirmation gesture). The two panes may share a
+backend reference resolver but differ in UX flow.
+
+UIA: `ControlType.Document` + `ITextProvider` + hyperlink
+invoke; ARIA `role="region"` aria-live=polite analog (so the
+user is informed when new context arrives but not interrupted).
+
+Reserved decisions: keyword detection mechanism (heuristic
+regex vs. LSP-grounded); reference source registry overlap with
+docs pane; on-demand vs. always-resolve cadence; per-shell
+keyword-allowlist scoping.
+
+### Input assistant pane (📋 reserved — added 2026-05-09)
+
+> **Source**:
+> [`CORE-ABSTRACTION-BOUNDARY.md` §6](CORE-ABSTRACTION-BOUNDARY.md)
+> "Three additional reserved peer panes". Captured here as a
+> documentation reservation; no design / spec / implementation
+> in the 2026-05-09 plan.
+
+A pane that gives contextual information about commands being
+typed in the shell pane's command-input sub-pane. Produces:
+
+- Man-page snippets / command help / parameter documentation
+  for the command currently being composed.
+- Autocomplete / completion suggestions sourced from shell
+  history, filesystem, or per-command completion specs.
+- Inline warnings / safety checks for risky commands (rm -rf,
+  force-push patterns, etc.).
+
+Updates flow from the InputPathway substrate (Cycle 38) — every
+keystroke into the command-input sub-pane is mirrored to the
+input assistant's content producer, which re-resolves help /
+completions in real time (with debounce).
+
+User interaction:
+
+- Arrow keys navigate completion suggestions.
+- Tab from the command-input sub-pane: accept the highlighted
+  completion (subject to the command-input sub-pane's existing
+  Tab semantics — the maintainer's keyboard contract decides
+  who wins on conflict).
+- Enter on a help section: read it verbosely.
+- Esc: dismiss the assistant for this command.
+
+Cross-pane coordination:
+
+- Command-input sub-pane → input assistant: every keystroke
+  drives content refresh.
+- Input assistant → command-input sub-pane: completion
+  acceptance writes the suggested text back into the input
+  buffer.
+- AI assistance pane ↔ input assistant: optional integration
+  where the AI pane surfaces completions sourced from prior
+  conversation context (deferred coordination).
+
+UIA: two regions — completion list (`ControlType.List`) +
+help text (`ControlType.Document`); ARIA `role="form"`
+container with `role="listbox"` + `role="region"` children.
+
+Reserved decisions: completion source registry (shell-native
+completion specs vs. custom); debounce cadence; integration
+shape with the maintainer's preferred shell completion stack;
+risky-command warning policy.
 
 ## Coordination protocols
 

--- a/docs/adr/0001-substrate-channel-dichotomy.md
+++ b/docs/adr/0001-substrate-channel-dichotomy.md
@@ -1,0 +1,203 @@
+# ADR 0001 — Substrate / channel dichotomy as a non-negotiable architectural constraint
+
+- **Status**: Accepted
+- **Date**: 2026-05-09
+- **Deciders**: maintainer (KyleKeane)
+- **Authoring item**: PROJECT-PLAN-2026-05-09 §A (architectural
+  assertion); Cycle 30 doc-only PR.
+- **Companion docs**:
+  - [`../CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md)
+    — full architectural framing.
+  - [`../PROJECT-PLAN-2026-05-09.md`](../PROJECT-PLAN-2026-05-09.md)
+    — strategic plan that depends on this ADR.
+
+## Context
+
+Through Stages 1-7, pty-speak's substrate has been the
+**screen grid** — a 2D `(row, col)` cell array maintained by
+`Terminal.Core.Screen` and updated by VT events emitted from
+`VtParser`. Channels (NvdaChannel, FileLoggerChannel,
+EarconChannel) consume `OutputEvent`s emitted by
+`StreamPathway`, which derives those events by **diffing the
+screen grid row-by-row between flushes**.
+
+This works for TUI workloads (vim, htop, less, anything that
+draws an alt-screen interface) because alt-screen apps are
+inherently 2D. But for **linear / streaming text** workloads —
+plain-cmd / plain-PowerShell output, `claude --dangerously-skip-
+permissions` text and tool-use output, build / compile output —
+the screen grid is the **wrong** primary substrate. The byte
+stream existed first; the screen grid was derived from it; but
+under today's architecture the channels read the derived form
+back as if it were primary.
+
+Concrete failure modes confirmed in production (Cycle 29b NVDA
+validation 2026-05-09):
+
+- **Spinner storms** — Claude's thinking-state spinners produce
+  ~80 NVDA announces per Claude turn. Identical-hash dedup
+  catches repeats but the incrementing token-counter on each
+  spinner frame defeats it.
+- **Red-tone misfires** — Claude's spinner glyphs are red-
+  coloured, so the row-diff path fires `ErrorLine` events for
+  every spinner frame; ~30 `error-tone` earcons per Claude
+  turn.
+- **`extractCommandAndOutput` fragility** — `SessionModel.fs:316-
+  427` reconstructs (command, output) tuples by walking screen-
+  grid rows, duplicating the parsing work and reintroducing
+  edge cases.
+
+The fix requires **inverting the substrate**: linear text
+becomes the source of truth for linear workloads; the screen
+grid becomes one of several derived projections (used only for
+alt-screen content). The inversion is a multi-cycle effort
+(planned across Cycles 33-35); it requires a stable
+architectural commitment to be sound.
+
+## Decision
+
+The maintainer-blessed canonical assertion (lifted verbatim
+from PROJECT-PLAN-2026-05-09 §1) becomes a **non-negotiable
+architectural constraint**:
+
+> 1. **The natural language structure of the way that we think
+>    of text in the terminal is to model the way the bytes
+>    flow.** A terminal is a stream of bytes. Linear text is the
+>    natural shape of those bytes. The screen grid is one
+>    derived projection of the byte stream, suitable for alt-
+>    screen TUIs; it is not the canonical substrate.
+> 2. **As the bytes are flowing through the terminal, we want
+>    to apply NLP-style methodologies to dissect aspects from
+>    that stream of bytes.** The byte → semantic-event pipeline
+>    is structurally analogous to a tokenize → parse → classify
+>    → enrich NLP pipeline. Each stage adds a derived layer of
+>    structure without erasing the prior stages.
+> 3. **Various canonical formats of display will be deployed in
+>    a way that we currently call channels.** A canonical
+>    display is a presentation primitive with a fixed UIA control
+>    type, an ARIA role analog, a reading pattern under each
+>    screen reader, and an interaction contract. Channels deliver
+>    canonical-display payloads; the substrate produces them.
+> 4. **It's important that we structure the application in a way
+>    that the methods of dissection can be ported to other
+>    operating systems.** Substrate is OS-portable; channels are
+>    OS-specific (UIA on Windows, AT-SPI on Linux,
+>    NSAccessibility on macOS). The boundary between them is the
+>    portability seam.
+
+The four parts together yield: **a portable, layered substrate
+that produces canonical-display payloads, consumed by OS-
+specific channel adapters.**
+
+## Consequences
+
+### Positive
+
+- **Linear workloads (Claude, plain cmd / pwsh, build output)
+  get a substrate that fits their natural shape.** Spinner
+  storms, red-tone misfires, and `extractCommandAndOutput`
+  fragility all become tractable once the linear-text producer
+  ships (Cycle 34) and the Stream profile rebuilds against it
+  (Cycle 35).
+- **The channel layer becomes purely presentational.** Profiles
+  pattern-match on semantic events; channels render
+  `ChannelDecision` payloads. No channel-side reclassification
+  logic; no substrate-state-leakage into UIA peers.
+- **Cross-platform is a structural property, not a future
+  retrofit.** The substrate / channel boundary doubles as the
+  Windows / Linux / macOS portability seam. A future
+  `Terminal.Channels.AT-SPI` Linux adapter consumes the same
+  `ChannelDecision` records as `Terminal.Accessibility`'s
+  Windows UIA channel.
+- **Multi-pane consumes the same substrate.** The three-sub-
+  pane decomposition (command-input / current-output / history)
+  + three reserved peer panes (notification queue, contextual
+  keyword info, input assistant) are channel-layer consumers.
+  Adding a new pane does not require new substrate plumbing.
+
+### Negative / costs
+
+- **A multi-cycle inversion (Cycles 33-35).** The shipping
+  Stream profile must rebuild against the linear substrate
+  without regressing the existing NVDA matrix. Cycle 36 is a
+  dedicated validation gate for this.
+- **Two parallel substrates exist during the transition.** The
+  screen grid stays the primary substrate until Cycle 35; the
+  linear-text producer runs in parallel from Cycle 34. The
+  two-substrate window is a complexity tax accepted as the
+  price of a safe inversion.
+- **Existing tests keyed to screen-row-diff semantics need
+  updating.** Per CONTRIBUTING.md "Tests with semantic-laden
+  assertions need updating when semantics change", every test
+  that asserts on `OutputEvent.Payload` content under the
+  current row-diff semantics needs to be reviewed against the
+  new suffix-since-last-commit semantics in Cycle 35.
+- **`extractCommandAndOutput` is preserved but demoted.** The
+  fallback path remains for session-restore-from-disk
+  scenarios (where the linear stream wasn't captured at runtime);
+  the runtime path uses the linear-text producer's high-water-
+  mark. Two code paths instead of one — accepted for backwards
+  compatibility with on-disk session files.
+
+### Boundary enforcement
+
+The boundary is enforced **structurally**, not just by
+convention:
+
+- **Substrate code (in `Terminal.Core`) may NOT import
+  `Terminal.Accessibility`** or any UIA / WPF / OS-specific
+  module. Code review blocks a substrate → channel reference.
+- **Channel code may NOT import substrate-internal modules.**
+  Channels consume the published `OutputEvent` /
+  `SemanticEvent` / `ChannelDecision` types but do not reach
+  into `LinearTextStream` internals, `VtParser` state, or the
+  screen grid's cell array.
+- **Channels may not produce new semantic events.** If a
+  channel needs richer information than the substrate provides,
+  the right fix is a new detector in the substrate, not a
+  channel-side reclassification.
+
+These rules are surfaced in CORE-ABSTRACTION-BOUNDARY.md §2-§3
+and become standard review checks once the boundary doc lands.
+
+## Alternatives considered
+
+### Alternative A: Keep the screen grid as the primary substrate; fix bugs incrementally
+
+**Why rejected**: Each fix would be a one-off heuristic patch
+(spinner-glyph denylist, red-character-count threshold, prompt-
+boundary heuristic refinement). The architectural mismatch
+between linear bytes and 2D grid would persist; future
+workloads (REPL inputs, form prompts, LLM tool-use) would
+each hit fresh variants of the same class of bug. The
+maintenance cost compounds.
+
+### Alternative B: Maintain only the linear substrate; drop the screen grid entirely
+
+**Why rejected**: Alt-screen TUIs (vim, htop, less) are real
+workloads that need a 2D substrate. Dropping the screen grid
+breaks them. The boundary doc's framing — "screen grid demoted
+to alt-screen-only" — preserves the screen grid for the
+workloads it was correct for, while letting linear workloads
+use a substrate that fits their shape.
+
+### Alternative C: Build the canonical-display catalog from a research deliverable before committing to the boundary
+
+**Why rejected**: The maintainer's 2026-05-09 redirect was to
+defer research and ship three exemplar canonical displays
+(raw text / interactive list / form with text input) that
+establish the abstraction. The boundary itself does not
+require the full taxonomy — it requires a stable assertion of
+"substrate produces canonical-display payloads, channels render
+them". The three exemplars are sufficient to lock the
+boundary; extension can wait for concrete demand.
+
+## Status notes
+
+- **2026-05-09**: Accepted. CORE-ABSTRACTION-BOUNDARY.md ships
+  in the same Cycle 30 PR as this ADR.
+- **Future supersession**: a new ADR may supersede this one if
+  the four-part assertion's wording changes substantively. Re-
+  snapshot conditions for CORE-ABSTRACTION-BOUNDARY.md (e.g.
+  Cycle 34 ships LinearTextStream) are NOT supersession events;
+  the assertion remains stable across them.


### PR DESCRIPTION
## Summary

Doc-only foundation cycle landing the architectural framing locked in `PROJECT-PLAN-2026-05-09` §A. The substrate / channel boundary becomes a **non-negotiable design constraint** going forward; all subsequent linear-text-substrate work (Cycles 33-35) builds against it. **No behaviour change.**

This is Cycle 30 of the strategic plan — the doc-only foundation that has to land before any code refactor.

## What changed

- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** (new) — canonical statement of the four-part architectural assertion. §1 records the maintainer-blessed assertion verbatim. §2-§3 define what substrate code (`Terminal.Core`) and channel code (`Terminal.Accessibility`) may and may not do. §4 names the NLP-style parser pipeline layering. §5 catalogs the **three exemplar canonical displays** (raw text / interactive list / form with text input) that seed the canonical-display vocabulary; severity alert / progress / status / tabular / tree are named extension points but not specified. §6 formalises the **three-sub-pane interaction paradigm** (command-input / current-output / history) for the shell pane plus three reserved peer panes (notification queue / contextual keyword info / input assistant). §7 specifies the streaming-incomplete protocol. §8 codifies the portability invariant.
- **`docs/adr/0001-substrate-channel-dichotomy.md`** (new) — ADR recording the four-part assertion as accepted. Documents context (today's screen-grid substrate breaks down on linear workloads — confirmed Cycle 29b spinner storms, red-tone misfires, `extractCommandAndOutput` fragility), decision (the boundary is non-negotiable), and consequences (positive + costs).
- **`docs/PANE-MODEL.md`** (updated) — bumped snapshot to 2026-05-09. Catalog table extended with the three new reserved peer panes (notification queue / contextual keyword info / input assistant). Inserted "Shell pane internal structure" subsection that points at `CORE-ABSTRACTION-BOUNDARY.md` §6 for the three-sub-pane decomposition. Three new pane sections appended after AI assistance — each one paragraph with content source, user interaction sketch, cross-pane coordination, UIA mapping, reserved decisions.
- **`CLAUDE.md`** (updated) — reading order at session start expanded to insert `CORE-ABSTRACTION-BOUNDARY.md` as item 5 (between strategic plan and `spec/tech-plan.md`).
- **`CONTRIBUTING.md`** (updated) — "Honor the spec" rule extended to add the boundary doc + ADR 0001 as a third non-negotiable: substrate code may not import channel concerns; channels may not produce new semantic events.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## What this PR deliberately omits

- **Linear-text producer code** — that's Cycle 34. This PR is doc-only foundation.
- **Stream profile rebuild** — that's Cycle 35.
- **Canonical-display catalog spec** — Cycle 33's RFC. This PR scopes only the three exemplars at boundary-doc level; full UIA pattern provider mappings + interaction contracts land in `CANONICAL-DISPLAY-CATALOG.md` later.
- **Research deliverables** — the originally-drafted Claude-research handoffs (canonical-display taxonomy survey + streaming partial-emit prior-art survey) are **deferred** per the maintainer's 2026-05-09 redirect. The three exemplar canonical displays establish the abstraction without requiring full taxonomy scoping. Research can be commissioned later if extension demand arises (per `PROJECT-PLAN-2026-05-09` §6).
- **WPF surface for the three sub-panes** — the three-sub-pane decomposition is **conceptual first** (substrate + accessibility surfaces are distinct even though rendering is shared today). A future Phase 2 layout PR may surface them as distinct WPF regions; this PR does not require it.

## Test plan

- [x] Markdown link check passes (CI's link checker is the gate per CLAUDE.md "Docs-only PRs may merge after only the markdown link check passes").
- [x] All cross-references between the new docs resolve (`CORE-ABSTRACTION-BOUNDARY.md` ↔ `adr/0001-substrate-channel-dichotomy.md` ↔ `PANE-MODEL.md` ↔ `CLAUDE.md` ↔ `CONTRIBUTING.md`).
- [x] No code files modified — strictly markdown / ADR docs.
- [x] `CHANGELOG.md` `[Unreleased]` entry updated.
- [x] Diff scope (~1075 insertions across 6 files) reflects two new substantial docs + three small cross-reference updates; matches expectations for a foundation cycle.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_