### PR TITLE
feat(channels): Cycle 31a — IOutputSink boundary interface + portability CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,41 @@ jobs:
           path: releases/
           retention-days: 7
 
+  portability-lint:
+    name: Portability lint (substrate / channel boundary)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Cycle 31a (2026-05-09): enforces ADR 0001 substrate / channel
+    # dichotomy at CI gate. Substrate code in `Terminal.Core` and
+    # `Terminal.Audio` MUST NOT import host-specific types
+    # (`System.Windows.*`, `PresentationCore`, `WindowsBase`,
+    # `Microsoft.Win32`) — those belong on the channel side
+    # (`Terminal.Accessibility` and the host process).
+    #
+    # The grep is anchored on `^[[:space:]]*open[[:space:]]+`
+    # so doc-comment mentions of these namespaces (e.g.,
+    # `KeyEncoding.fs:11` "Why a private DU instead of WPF's
+    # `System.Windows.Input.Key`?") do NOT trigger the lint —
+    # only actual `open` declarations on Core code do.
+    #
+    # Verified against current `main`: returns zero matches
+    # (the substrate is currently clean per Phase 1 audit
+    # 2026-05-09).
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Substrate must not import host-specific types
+        run: |
+          set -e
+          violations=$(grep -rEn '^[[:space:]]*open[[:space:]]+(System\.Windows|PresentationCore|WindowsBase|Microsoft\.Win32)' src/Terminal.Core src/Terminal.Audio --include='*.fs' || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Portability invariant violated. Substrate code (Terminal.Core / Terminal.Audio) must not import host-specific types per ADR 0001."
+            echo "$violations"
+            exit 1
+          fi
+          echo "Portability invariant held: no host-specific imports in substrate."
+
   workflow-lint:
     name: Workflow lint (actionlint)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,61 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 31a): `IOutputSink` boundary interface + portability CI lint
+
+First code cycle of the substrate / channel boundary work locked
+in Cycle 30. Promotes the existing `Channel` record (a record-of-
+functions used by the dispatcher) to satisfy a formally-typed
+`IOutputSink` interface. Adds a CI gate that fails the build if
+substrate code (`Terminal.Core` / `Terminal.Audio`) ever imports
+host-specific types per ADR 0001. **No user-visible behaviour
+change** — all three shipped channels (NvdaChannel, EarconChannel,
+FileLoggerChannel) continue to work identically; their factory
+signatures are unchanged; the composition root (`Program.fs:891-916`)
+is untouched.
+
+- **`src/Terminal.Core/OutputEventTypes.fs`** — declares the
+  `IOutputSink` interface (`Id: ChannelId`, `Send: OutputEvent →
+  RenderInstruction → unit`) just before the existing `Channel`
+  record. The `Channel` record gains an `interface IOutputSink
+  with` implementation that forwards both members to the
+  record's own fields. The interface lives in the same file
+  (rather than a separate `Channels/IOutputSink.fs`) for F#
+  compile-order reasons — `IOutputSink` references types defined
+  earlier in `OutputEventTypes.fs`, and the `Channel` record
+  must reference `IOutputSink` to implement it.
+- **`src/Terminal.Core/OutputDispatcher.fs:106-114`** —
+  `routePair` upcasts the resolved channel to `IOutputSink`
+  before invoking `Send`. Functionally identical for `Channel`-
+  record sinks (which trivially satisfy the interface);
+  establishes the contract for future producers (linear-text
+  substrate consumers in Cycle 34, future cross-platform
+  channel adapters) that implement `IOutputSink` directly
+  without being `Channel` records.
+- **`tests/Tests.Unit/IOutputSinkTests.fs`** (new) — 6 facts
+  pinning the interface contract: each shipped channel's
+  factory output coerces to `IOutputSink`; the coerced
+  interface preserves the empty-payload skip (Nvda) + non-
+  Earcon skip (Earcon) + structured-log emit (FileLogger);
+  the `Channel` record's interface impl forwards `Id` and
+  `Send` reflexively to the record's own fields.
+- **`.github/workflows/ci.yml`** — new `portability-lint` job
+  (ubuntu-latest, 5-minute timeout) that fails the build if
+  `grep -rEn '^[[:space:]]*open[[:space:]]+(System\.Windows|
+  PresentationCore|WindowsBase|Microsoft\.Win32)' src/Terminal.Core
+  src/Terminal.Audio --include='*.fs'` returns matches. Anchored
+  on `^[[:space:]]*open[[:space:]]+` so doc-comment mentions of
+  these namespaces (e.g., `KeyEncoding.fs:11`'s comment
+  explaining "Why a private DU instead of WPF's
+  `System.Windows.Input.Key`?") do NOT trigger the lint.
+  Verified clean on current `main`.
+
+Cycle 31b (next) lands the sibling boundary interfaces:
+`IClipboardProvider`, `IHotkeyTranslator`, `IDisplayBuffer` —
+all pure interface declarations with no consumer cutovers.
+First cutover (`IDisplayBuffer` at `TerminalView.cs:1002`) lands
+in Cycle 32b alongside the selection TOML loader.
+
 ### Docs (Cycle 30): substrate / channel boundary doc + ADR 0001 + PANE-MODEL refinement
 
 Doc-only foundation cycle landing the architectural framing

--- a/src/Terminal.Core/OutputDispatcher.fs
+++ b/src/Terminal.Core/OutputDispatcher.fs
@@ -103,10 +103,21 @@ module OutputDispatcher =
     /// notification-processing decisions, and the Render for
     /// the actual emission. Decisions referencing an
     /// unregistered channel are silently dropped.
+    ///
+    /// Cycle 31a (2026-05-09): the channel is upcast to
+    /// `IOutputSink` at the call site so the dispatcher
+    /// consumes the formal boundary surface rather than the
+    /// record's stored field. Functionally identical for the
+    /// `Channel` record (which trivially satisfies the
+    /// interface); establishes the contract for future
+    /// producers that implement `IOutputSink` directly without
+    /// being `Channel` records.
     let private routePair (effectiveEvent: OutputEvent) (decisions: ChannelDecision[]) : unit =
         for decision in decisions do
             match ChannelRegistry.lookup decision.Channel with
-            | Some channel -> channel.Send effectiveEvent decision.Render
+            | Some channel ->
+                let sink = channel :> IOutputSink
+                sink.Send effectiveEvent decision.Render
             | None -> ()
 
     /// Event-tap registry — a list of `OutputEvent -> unit`

--- a/src/Terminal.Core/OutputEventTypes.fs
+++ b/src/Terminal.Core/OutputEventTypes.fs
@@ -330,15 +330,72 @@ module SelectionExtensions =
     [<Literal>]
     let Source = "selection.source"
 
+/// First-class boundary surface for output channels — the
+/// "channel" side of the substrate / channel dichotomy per
+/// `docs/CORE-ABSTRACTION-BOUNDARY.md` §3 + ADR 0001.
+///
+/// Cycle 31a (2026-05-09) promotes the existing `Channel`
+/// record-of-functions to a formally-typed interface. The
+/// `Channel` record below trivially satisfies this interface;
+/// future producers (linear-text-stream consumers in Cycle 34;
+/// future cross-platform channel adapters) can implement
+/// `IOutputSink` directly without going through the `Channel`
+/// record shape.
+///
+/// **Threading contract:** implementations are called
+/// synchronously from `OutputDispatcher.routePair`. Any host-
+/// thread marshalling (e.g., WPF `Dispatcher.Invoke` for NVDA)
+/// is the implementation's responsibility, embedded in its
+/// `Send` closure or interface body.
+///
+/// **Portability:** this interface lives in `Terminal.Core` —
+/// the substrate side of the boundary. Implementations may
+/// live in OS-specific assemblies (`Terminal.Accessibility`
+/// for UIA, `Terminal.Audio` for WASAPI, future
+/// `Terminal.Channels.AT-SPI` for Linux). The substrate-side
+/// portability invariant (`Terminal.Core` MUST NOT import
+/// host-specific types) is enforced by the
+/// `portability-lint` CI step added in this cycle.
+///
+/// **Co-location with `Channel` record (file placement note):**
+/// the original Cycle 31 plan sketched a separate
+/// `src/Terminal.Core/Channels/IOutputSink.fs` file. F# compile-
+/// order constraints make that placement awkward — `IOutputSink`
+/// references `OutputEvent`, `RenderInstruction`, and
+/// `ChannelId`, all of which are defined earlier in this file,
+/// and the `Channel` record below must reference `IOutputSink`
+/// to implement it. Co-locating in the same file resolves both
+/// constraints without introducing a precursor file split. The
+/// architectural intent is preserved: `IOutputSink` IS the
+/// boundary interface; `Channel` IS one implementation.
+type IOutputSink =
+    /// Stable identifier for dispatcher routing (e.g., `"nvda"`,
+    /// `"earcon"`, `"filelogger"`).
+    abstract Id: ChannelId
+
+    /// Render a `ChannelDecision` against this sink.
+    /// Synchronous; implementations that need async work
+    /// (audio playback, IPC) MUST queue and return immediately.
+    abstract Send: OutputEvent -> RenderInstruction -> unit
+
 /// A channel is an `OutputEvent` consumer. The `Send` callback
 /// is invoked by the dispatcher per `ChannelDecision`; it is
 /// responsible for any threading marshalling (e.g., the
 /// NvdaChannel's WPF dispatcher hop). Channels do NOT block
 /// the dispatcher — backpressure is handled internally per
 /// spec B.5.3.
+///
+/// Implements `IOutputSink` (Cycle 31a) — the dispatcher consumes
+/// channels through the interface; the record shape is preserved
+/// so factories (`NvdaChannel.create`, `EarconChannel.create`,
+/// `FileLoggerChannel.create`) and the composition root
+/// (`Program.fs:891-916`) continue unchanged.
 type Channel =
     { Id: ChannelId
       Send: OutputEvent -> RenderInstruction -> unit }
+    interface IOutputSink with
+        member this.Id = this.Id
+        member this.Send event render = this.Send event render
 
 /// A profile is a pure function with per-instance state. `Apply`
 /// is the per-event entry point; `Tick` is the time-driven flush

--- a/tests/Tests.Unit/IOutputSinkTests.fs
+++ b/tests/Tests.Unit/IOutputSinkTests.fs
@@ -1,5 +1,7 @@
 module PtySpeak.Tests.Unit.IOutputSinkTests
 
+open System
+open Microsoft.Extensions.Logging
 open Xunit
 open Terminal.Core
 
@@ -79,26 +81,43 @@ let ``EarconChannel via IOutputSink preserves non-Earcon skip`` () =
 // ---- FileLoggerChannel coerces to IOutputSink ------------------
 
 /// Tiny ILogger fake — captures `LogInformation` calls without
-/// pulling in the full RecordingLogger from FileLoggerChannelTests.
+/// pulling in the `private` RecordingLogger from
+/// FileLoggerChannelTests.fs. Uses the same F# 9 + .NET 9
+/// nullness-correct signatures (per CONTRIBUTING.md "F# 9
+/// nullness annotations bite at .NET-API boundaries"):
+///
+/// - `BeginScope<'TState when 'TState : not null>` — F# requires
+///   the constraint to match the C# `where TState : notnull`.
+/// - `Log<'TState>` does NOT carry the constraint (F#'s reading
+///   of the metadata).
+/// - `ex: exn | null` — the C# parameter is `Exception?`; F# 9
+///   requires the `| null` annotation to compile under
+///   `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`.
+/// - `formatter: System.Func<'TState, exn | null, string>` —
+///   same nullness requirement on the formatter delegate.
+type private NoopScope() =
+    interface System.IDisposable with
+        member _.Dispose() = ()
+
 type private CapturingLogger() =
     let entries = ResizeArray<string>()
     member _.Entries = entries
-    interface Microsoft.Extensions.Logging.ILogger with
-        member _.BeginScope<'TState>(_state: 'TState) : System.IDisposable =
-            { new System.IDisposable with member _.Dispose() = () }
-        member _.IsEnabled(_logLevel) = true
-        member _.Log<'TState>(
-                _logLevel,
-                _eventId,
-                state: 'TState,
-                _exn: exn,
-                formatter: System.Func<'TState, exn, string>) =
-            entries.Add(formatter.Invoke(state, _exn))
+    interface ILogger with
+        member _.BeginScope<'TState when 'TState : not null>(_state: 'TState) : System.IDisposable =
+            (new NoopScope()) :> System.IDisposable
+        member _.IsEnabled(_: LogLevel) : bool = true
+        member _.Log<'TState>
+                (_level: LogLevel,
+                 _eventId: EventId,
+                 state: 'TState,
+                 ex: exn | null,
+                 formatter: System.Func<'TState, exn | null, string>) : unit =
+            entries.Add(formatter.Invoke(state, ex))
 
 [<Fact>]
 let ``FileLoggerChannel record coerces to IOutputSink and emits a structured log entry`` () =
     let logger = CapturingLogger()
-    let channel = FileLoggerChannel.create (logger :> Microsoft.Extensions.Logging.ILogger)
+    let channel = FileLoggerChannel.create (logger :> ILogger)
     let sink = channel :> IOutputSink
     Assert.Equal(FileLoggerChannel.id, sink.Id)
     let event = buildEvent SemanticCategory.StreamChunk "diag-payload"

--- a/tests/Tests.Unit/IOutputSinkTests.fs
+++ b/tests/Tests.Unit/IOutputSinkTests.fs
@@ -1,0 +1,126 @@
+module PtySpeak.Tests.Unit.IOutputSinkTests
+
+open Xunit
+open Terminal.Core
+
+/// Cycle 31a — pins the IOutputSink interface contract:
+///
+/// 1. The `Channel` record (`OutputEventTypes.fs:339-360`)
+///    trivially satisfies `IOutputSink` via the interface
+///    implementation added in Cycle 31a.
+/// 2. All three shipped channel factories (`NvdaChannel.create`,
+///    `EarconChannel.create`, `FileLoggerChannel.create`) return
+///    `Channel` records that coerce cleanly to `IOutputSink` and
+///    round-trip representative `RenderInstruction`s.
+/// 3. The dispatcher's call-site upcast in
+///    `OutputDispatcher.routePair:106-114` is functionally
+///    identical to the pre-Cycle-31a direct `channel.Send` call.
+///
+/// These tests are an architectural pin: future cycles that
+/// introduce non-`Channel` `IOutputSink` implementations
+/// (linear-text producers in Cycle 34, future cross-platform
+/// channels) MUST keep these passing — the Channel-record path
+/// is the canonical "satisfies the contract" reference shape.
+
+let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEvent =
+    OutputEvent.create semantic Priority.Polite "test" payload
+
+// ---- NvdaChannel coerces to IOutputSink ------------------------
+
+[<Fact>]
+let ``NvdaChannel record coerces to IOutputSink and round-trips RenderText`` () =
+    let calls = ResizeArray<string * string>()
+    let recorder (msg, activityId) = calls.Add((msg, activityId))
+    let channel = NvdaChannel.create recorder
+    let sink = channel :> IOutputSink
+    Assert.Equal(NvdaChannel.id, sink.Id)
+    let event = buildEvent SemanticCategory.StreamChunk "hello"
+    sink.Send event (RenderText "hello")
+    Assert.Equal(1, calls.Count)
+    let (msg, _activityId) = calls.[0]
+    Assert.Equal("hello", msg)
+
+[<Fact>]
+let ``NvdaChannel via IOutputSink preserves empty-payload skip`` () =
+    let calls = ResizeArray<string * string>()
+    let recorder (msg, activityId) = calls.Add((msg, activityId))
+    let channel = NvdaChannel.create recorder
+    let sink = channel :> IOutputSink
+    let event = buildEvent SemanticCategory.StreamChunk ""
+    sink.Send event (RenderText "")
+    Assert.Empty(calls)
+
+// ---- EarconChannel coerces to IOutputSink ----------------------
+
+[<Fact>]
+let ``EarconChannel record coerces to IOutputSink and round-trips RenderEarcon`` () =
+    EarconChannel.clearForTests ()
+    let calls = ResizeArray<string>()
+    let recorder = calls.Add
+    let channel = EarconChannel.create recorder
+    let sink = channel :> IOutputSink
+    Assert.Equal(EarconChannel.id, sink.Id)
+    let event = buildEvent SemanticCategory.ErrorLine "boom"
+    sink.Send event (RenderEarcon "error-tone")
+    Assert.Equal(1, calls.Count)
+    Assert.Equal("error-tone", calls.[0])
+
+[<Fact>]
+let ``EarconChannel via IOutputSink preserves non-Earcon skip`` () =
+    EarconChannel.clearForTests ()
+    let calls = ResizeArray<string>()
+    let recorder = calls.Add
+    let channel = EarconChannel.create recorder
+    let sink = channel :> IOutputSink
+    let event = buildEvent SemanticCategory.StreamChunk "text"
+    sink.Send event (RenderText "text")
+    Assert.Empty(calls)
+
+// ---- FileLoggerChannel coerces to IOutputSink ------------------
+
+/// Tiny ILogger fake — captures `LogInformation` calls without
+/// pulling in the full RecordingLogger from FileLoggerChannelTests.
+type private CapturingLogger() =
+    let entries = ResizeArray<string>()
+    member _.Entries = entries
+    interface Microsoft.Extensions.Logging.ILogger with
+        member _.BeginScope<'TState>(_state: 'TState) : System.IDisposable =
+            { new System.IDisposable with member _.Dispose() = () }
+        member _.IsEnabled(_logLevel) = true
+        member _.Log<'TState>(
+                _logLevel,
+                _eventId,
+                state: 'TState,
+                _exn: exn,
+                formatter: System.Func<'TState, exn, string>) =
+            entries.Add(formatter.Invoke(state, _exn))
+
+[<Fact>]
+let ``FileLoggerChannel record coerces to IOutputSink and emits a structured log entry`` () =
+    let logger = CapturingLogger()
+    let channel = FileLoggerChannel.create (logger :> Microsoft.Extensions.Logging.ILogger)
+    let sink = channel :> IOutputSink
+    Assert.Equal(FileLoggerChannel.id, sink.Id)
+    let event = buildEvent SemanticCategory.StreamChunk "diag-payload"
+    sink.Send event (RenderText "diag-payload")
+    Assert.Equal(1, logger.Entries.Count)
+
+// ---- Channel record's IOutputSink impl is reflexive ------------
+
+[<Fact>]
+let ``Channel record IOutputSink impl forwards Id and Send to the record's own fields`` () =
+    let calls = ResizeArray<OutputEvent * RenderInstruction>()
+    let channel : Channel =
+        { Id = "test-sink"
+          Send = fun event render -> calls.Add((event, render)) }
+    let sink = channel :> IOutputSink
+    Assert.Equal("test-sink", sink.Id)
+    let event = buildEvent SemanticCategory.StreamChunk "x"
+    let render = RenderText "x"
+    sink.Send event render
+    Assert.Equal(1, calls.Count)
+    let (capturedEvent, capturedRender) = calls.[0]
+    Assert.Equal("x", capturedEvent.Payload)
+    match capturedRender with
+    | RenderText s -> Assert.Equal("x", s)
+    | other -> Assert.Fail(sprintf "expected RenderText \"x\"; got %A" other)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="NvdaChannelTests.fs" />
     <Compile Include="FileLoggerChannelTests.fs" />
     <Compile Include="EarconChannelTests.fs" />
+    <Compile Include="IOutputSinkTests.fs" />
     <Compile Include="EarconProfileTests.fs" />
     <Compile Include="SelectionProfileTests.fs" />
     <Compile Include="OutputDispatcherTests.fs" />


### PR DESCRIPTION
## Summary

First code cycle of the substrate / channel boundary work locked in Cycle 30 (PR #234 / commit `dd299e3`). Promotes the existing `Channel` record-of-functions to satisfy a formally-typed `IOutputSink` interface. Adds a CI gate that fails the build if substrate code (`Terminal.Core` / `Terminal.Audio`) ever imports host-specific types per ADR 0001.

**No user-visible behaviour change** — all three shipped channels (NvdaChannel, EarconChannel, FileLoggerChannel) continue to work identically; their factory signatures are unchanged; the composition root (`Program.fs:891-916`) is untouched. All existing channel-side tests continue to pass without modification.

## What changed

- **`src/Terminal.Core/OutputEventTypes.fs`** — declares the `IOutputSink` interface (`Id: ChannelId`, `Send: OutputEvent → RenderInstruction → unit`) just before the existing `Channel` record. The `Channel` record gains an `interface IOutputSink with` implementation that forwards both members to the record's own fields. The interface lives in the same file (rather than a separate `Channels/IOutputSink.fs` as the plan originally sketched) for F# compile-order reasons — `IOutputSink` references types defined earlier in `OutputEventTypes.fs`, and the `Channel` record must reference `IOutputSink` to implement it.
- **`src/Terminal.Core/OutputDispatcher.fs:106-114`** — `routePair` upcasts the resolved channel to `IOutputSink` before invoking `Send`. Functionally identical for `Channel`-record sinks (which trivially satisfy the interface); establishes the contract for future producers (linear-text substrate consumers in Cycle 34, future cross-platform channel adapters) that implement `IOutputSink` directly without being `Channel` records.
- **`tests/Tests.Unit/IOutputSinkTests.fs`** (new) — 6 facts pinning the interface contract: each shipped channel's factory output coerces to `IOutputSink`; the coerced interface preserves the empty-payload skip (Nvda) + non-Earcon skip (Earcon) + structured-log emit (FileLogger); the `Channel` record's interface impl forwards `Id` and `Send` reflexively to the record's own fields.
- **`.github/workflows/ci.yml`** — new `portability-lint` job (ubuntu-latest, 5-minute timeout) that fails the build if `grep -rEn '^[[:space:]]*open[[:space:]]+(System\.Windows|PresentationCore|WindowsBase|Microsoft\.Win32)' src/Terminal.Core src/Terminal.Audio --include='*.fs'` returns matches. Anchored on `^[[:space:]]*open[[:space:]]+` so doc-comment mentions of these namespaces (e.g., `KeyEncoding.fs:11`'s comment "Why a private DU instead of WPF's `System.Windows.Input.Key`?") do **not** trigger the lint. Verified clean on current `main`.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## What this PR deliberately omits

- **Sibling boundary interfaces** (`IClipboardProvider`, `IHotkeyTranslator`, `IDisplayBuffer`) — that's Cycle 31b. Those are pure interface declarations with no consumer cutovers.
- **First IDisplayBuffer consumer cutover** (`TerminalView.cs:1002` → `_displayBuffer.Snapshot(...)`) — that's Cycle 32b alongside the selection TOML loader.
- **Composition-root change** — `Program.fs:891-916` is untouched. Channels are still registered as `Channel` records via `ChannelRegistry.register`. Future cycles may migrate the registry to hold `IOutputSink` directly; that's a separate concern.
- **EarconChannel internal refactor** — module-level `mutable muted` + `muteLock` pattern at `EarconChannel.fs:40-41` is preserved verbatim. Future cycles may migrate to per-instance state; this cycle does not.

## Test plan

- [x] All three existing channel test files (`NvdaChannelTests.fs`, `EarconChannelTests.fs`, `FileLoggerChannelTests.fs`) continue to pass without modification.
- [x] `IOutputSinkTests.fs` (new, 6 facts) passes.
- [x] `portability-lint` CI job runs and passes on this PR (substrate is clean — no new violations introduced).
- [x] Standard CI (Build + test on windows-latest, Workflow lint, Markdown link check) passes.
- [ ] Optional follow-up: a temporary fixup commit adding `open System.Windows` to a Core file to demonstrate the lint actually fires; then revert. (Per Cycle 31a stopping-gate spec; can be done as a post-merge sanity check on the next PR if not done here.)

## Configurability note

No new candidate user settings introduced. Per CONTRIBUTING.md "Consider configurability when iterating": `IOutputSink` has no thresholds, timeouts, or tunable values; the portability lint is project policy, not user-tunable.

## ADR reference

ADR 0001 (`docs/adr/0001-substrate-channel-dichotomy.md`, merged in Cycle 30 PR #234) is the architectural authority for this work. The interface promotion + portability lint together formalize the boundary that ADR 0001 declared as non-negotiable.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_