### PR TITLE
docs: history sub-pane navigation contract via CommandOutputTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Docs (post-Cycle-31a): history sub-pane navigation contract via CommandOutputTuple
+
+Doc-only refinement folding the `docs/research/Output-paradigms.md`
+CommandOutputTuple primitive (Section 1.6) into the history sub-
+pane's navigation contract. The framing aligns the CHI '21
+Pradhan et al. CLI-accessibility finding (command-as-anchor
+navigation as the single most-requested CLI feature) with our
+existing three-sub-pane decomposition. No behaviour change; no
+new exemplar canonical displays added — the three exemplars
+(raw text / interactive list / form with text input) stand.
+
+- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §6 — history sub-pane
+  paragraph rewritten to name CommandOutputTuple as the unit of
+  history navigation, with concrete quick-nav primitives (`h` /
+  `Shift+h` for command boundaries, `o` / `Shift+o` for output
+  blocks, `Alt+Up` / `Alt+Down` for tuple boundaries) replacing
+  the prior "paragraph navigation" hand-waving. Cross-references
+  the research doc; defers full UIA pattern provider mapping to
+  Cycle 33 RFC.
+- **`docs/PANE-MODEL.md`** — same refinement applied to the
+  "Shell pane internal structure" subsection's history sub-pane
+  bullet. Adds a substrate-of-truth pointer to
+  `SESSION-MODEL.md` §4.
+
+The two emission/output research docs landed independently on
+main between Cycle 30 and 31a (`docs/research/Output-paradigms.md`
++ `docs/research/emission-paradigms.md`); this PR is the first
+to cite them. Further integration (seam-hierarchy commit,
+cadence parameters, tail-mask vocabulary) lands in Cycle 33's
+linear-text-substrate RFC.
+
 ### Added (Cycle 31a): `IOutputSink` boundary interface + portability CI lint
 
 First code cycle of the substrate / channel boundary work locked

--- a/docs/CORE-ABSTRACTION-BOUNDARY.md
+++ b/docs/CORE-ABSTRACTION-BOUNDARY.md
@@ -409,15 +409,35 @@ substrate slice:
    parser's classification decisions become user-perceivable
    form.
 
-3. **History sub-pane** — sealed past `SessionTuple`s, semantic-
-   navigable. Quick-nav primitives (paragraph-within-output;
-   prev/next command boundary; jump-to-most-recent-output)
-   make keyboard navigation fast for a screen-reader user
-   who needs to jump back to a prior result without scrolling
-   linearly. Substrate: SessionModel + the linear-text
-   producer's high-water-mark commits (post-Cycle 34, replaces
-   `extractCommandAndOutput`). Each tuple is a navigable text
-   region with prev/next-paragraph + prev/next-tuple gestures.
+3. **History sub-pane** — sealed past `SessionTuple`s exposed
+   as **CommandOutputTuple** canonical-display primitives
+   (the unit of history navigation per
+   [`docs/research/Output-paradigms.md` §1.6](research/Output-paradigms.md)).
+   Each tuple wraps the submitted command, the output stream,
+   and the exit code as a single semantically-navigable region.
+   Concrete quick-nav contract:
+   - **`h` / `Shift+h`** — next / previous command boundary
+     (each command line is exposed as a level-2 heading via
+     UIA `Document` + TextPattern attributes).
+   - **`o` / `Shift+o`** — next / previous output block (the
+     output region of the current tuple; embedded-object
+     navigation in NVDA browse mode).
+   - **`Alt+Up` / `Alt+Down`** — previous / next tuple boundary
+     (parallel to VS Code's `editor.action.marker.next`).
+   - **Jump-to-most-recent-output** — reserved hotkey TBD;
+     resets focus to the most recent CommandOutputTuple's
+     output region.
+
+   Substrate: SessionModel + the linear-text producer's high-
+   water-mark commits (post-Cycle 34, replaces
+   `extractCommandAndOutput`'s screen-row reconstruction).
+   The CommandOutputTuple primitive (UIA `ControlType.Group`
+   wrapping a read-only `ControlType.Edit` for the command,
+   a `ControlType.Document` for the output, and a
+   `ControlType.Text` for the exit code with `ItemStatus`)
+   is one of the canonical-display extension points named in
+   §5; the catalog's full interaction contract for this
+   primitive lands in Cycle 33 RFC.
 
 ### Why this decomposition
 

--- a/docs/PANE-MODEL.md
+++ b/docs/PANE-MODEL.md
@@ -550,16 +550,35 @@ The three sub-panes:
    (interactive list / form). The current-output sub-pane is
    the place where the parser's classification decisions become
    user-perceivable form.
-3. **History sub-pane** — sealed past `SessionTuple`s,
-   semantic-navigable. Quick-nav primitives (paragraph-within-
-   output; prev/next command boundary; jump-to-most-recent-
-   output) make keyboard navigation fast for a screen-reader
-   user who needs to jump back to a prior result without
-   scrolling linearly. Substrate: SessionModel + the linear-
-   text producer's high-water-mark commits (post-Cycle 34,
-   replaces `extractCommandAndOutput`'s screen-row
-   reconstruction). Each tuple is a navigable text region with
-   prev/next-paragraph + prev/next-tuple gestures.
+3. **History sub-pane** — sealed past `SessionTuple`s exposed
+   as **CommandOutputTuple** canonical-display primitives (the
+   unit of history navigation per
+   [`research/Output-paradigms.md` §1.6](research/Output-paradigms.md)).
+   Each tuple wraps the submitted command, the output stream,
+   and the exit code as a single semantically-navigable region.
+   Concrete quick-nav contract:
+   - **`h` / `Shift+h`** — next / previous command boundary
+     (each command line exposed as a level-2 heading via UIA
+     `Document` + TextPattern attributes).
+   - **`o` / `Shift+o`** — next / previous output block
+     (embedded-object navigation in NVDA browse mode).
+   - **`Alt+Up` / `Alt+Down`** — previous / next tuple
+     boundary (parallel to VS Code's
+     `editor.action.marker.next`).
+   - **Jump-to-most-recent-output** — reserved hotkey TBD;
+     resets focus to the most recent tuple's output region.
+
+   Substrate: SessionModel + the linear-text producer's high-
+   water-mark commits (post-Cycle 34, replaces
+   `extractCommandAndOutput`'s screen-row reconstruction). The
+   CommandOutputTuple primitive (UIA `ControlType.Group`
+   wrapping a read-only `ControlType.Edit` for the command,
+   a `ControlType.Document` for the output, and a
+   `ControlType.Text` for the exit code with `ItemStatus`)
+   gets its full interaction contract in Cycle 33 RFC; today's
+   substrate (the SessionTuple in
+   [`SESSION-MODEL.md` §4](SESSION-MODEL.md)) is its
+   substrate-of-truth.
 
 **Why this decomposition matters for the pane catalog**: the
 three sub-panes crystallize a fixed interaction paradigm — the


### PR DESCRIPTION
## Summary

Doc-only refinement (~70 LOC across 3 markdown files) folding the `docs/research/Output-paradigms.md` CommandOutputTuple primitive (§1.6) into the history sub-pane's navigation contract. The two emission/output research docs landed on main independently between Cycle 30 and Cycle 31a; this PR is the first to cite them.

**No behaviour change.** No new exemplar canonical displays added — the three exemplars (raw text / interactive list / form with text input) stand unchanged. This PR sharpens the *navigation contract* of one of the three sub-panes, replacing prior "paragraph navigation" hand-waving with concrete quick-nav primitives derived from the research's interaction contract.

## What changed

- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §6 — history sub-pane paragraph rewritten:
  - Names CommandOutputTuple as the unit of history navigation.
  - Adds concrete quick-nav primitives: `h` / `Shift+h` (command boundaries via UIA `Document` + TextPattern level-2 headings), `o` / `Shift+o` (output blocks via embedded-object navigation in NVDA browse mode), `Alt+Up` / `Alt+Down` (tuple boundaries, parallel to VS Code's `editor.action.marker.next`).
  - Notes the UIA `ControlType.Group` wrapping pattern (read-only `Edit` for command, `Document` for output, `Text` for exit code with `ItemStatus`) as a Cycle 33 RFC scoping point.
- **`docs/PANE-MODEL.md`** — same refinement applied to the "Shell pane internal structure" subsection's history-sub-pane bullet. Adds a substrate-of-truth pointer to `SESSION-MODEL.md` §4 so future implementation cycles can find the SessionTuple shape.
- **`CHANGELOG.md`** — `[Unreleased]` entry for the doc tweak.

## Why now

The maintainer-skim of `docs/research/Output-paradigms.md` (2026-05-09 post-Cycle-31a) surfaced that our existing three-sub-pane history bullet was hand-waving "paragraph navigation" while the research doc had a concrete interaction contract pre-written. Aligning the language now (before Cycle 31b's sibling boundary interfaces) keeps the docs internally consistent.

## What this PR deliberately omits

- **No fourth exemplar.** ConfirmationPrompt (research's hybrid alert+selection from §1.2), DiffView, CodeBlockWithSyntaxStructure, etc. remain catalog extension points; they don't get exemplar status.
- **No code changes.** The CommandOutputTuple's UIA pattern provider implementation lands in a future cycle (Cycle 37+ or a dedicated history-navigation cycle).
- **No seam-hierarchy / cadence / tail-mask vocabulary integration.** Those land in Cycle 33's `docs/rfc/0001-linear-text-substrate.md`.
- **No `[Jump-to-most-recent-output]` hotkey assignment.** Reserved as TBD; AppReservedHotkeys allocation is a future cycle.

## Test plan

- [x] Markdown link check passes (the two new internal references — `research/Output-paradigms.md`, `SESSION-MODEL.md` — both resolve; the research doc landed on main independently and is at the path cited).
- [x] Strictly docs-only — only `.md` files modified; no `.fs` / `.csproj` / workflow / TOML / YAML files touched.
- [x] All cross-references between the doc set still resolve.

Per CLAUDE.md "Docs-only PRs may merge after only the markdown link check passes — skip the slow Windows build/test." Will merge once link check is green.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_