### PR TITLE
feat(channels): Cycle 31b — sibling boundary interfaces (IClipboardProvider, IHotkeyTranslator, IDisplayBuffer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,61 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 31b): sibling boundary interface declarations — `IClipboardProvider`, `IHotkeyTranslator<'TGesture>`, `IDisplayBuffer`
+
+Three pure interface declarations completing the boundary set
+named in `docs/CORE-ABSTRACTION-BOUNDARY.md` §1.6 (portability
+invariant). All three live in `Terminal.Core` per the substrate
+side of the boundary; **no consumers are cut over in this PR**.
+First consumer cutover (`IDisplayBuffer` at
+`TerminalView.cs:1002`) lands in Cycle 32b alongside the
+selection TOML loader. Portability CI lint added in Cycle 31a
+continues to gate against host-specific imports leaking into
+substrate code.
+
+- **`src/Terminal.Core/Channels/IClipboardProvider.fs`** (new)
+  — abstract `SetText: string → Async<bool>` codifying the
+  STA-thread + 3-second-timeout contract that
+  `Program.fs:2043` (Ctrl+Shift+Y) and `Diagnostics.fs:726`
+  (Ctrl+Shift+D) currently embed inline; abstract
+  `TryGetText: unit → string option` for read paths
+  (`TerminalView.cs:681,692,742,744`). All five existing call
+  sites continue to use `System.Windows.Clipboard` directly;
+  the interface formalises the seam for future cross-platform
+  builds without forcing a cutover today.
+- **`src/Terminal.Core/Channels/IHotkeyTranslator.fs`** (new) —
+  generic over the host gesture type (`'TGesture`) so
+  Terminal.Core does not import any WPF / GTK / AppKit type.
+  Abstract `Translate: HotkeyKey * Set<Modifier> → 'TGesture`.
+  Today's WPF translation in `Program.fs:274-333`
+  (`translateHotkeyKey` + `translateHotkeyModifiers`) stays as
+  direct helpers; the interface gives a future Avalonia / GTK
+  host a typed seam to plug into.
+- **`src/Terminal.Core/Channels/IDisplayBuffer.fs`** (new) —
+  abstract `Snapshot: int * int → int64 * (int * int) * Cell[][]`
+  matching today's `Screen.SnapshotRows` shape
+  (`Screen.fs:541-553`) including the locking contract
+  (atomic cell + cursor capture). Seven existing
+  `Screen.SnapshotRows` call sites (`TerminalView.cs:1002`,
+  `Program.fs:1258/1345/1375/1480/1534/2574`,
+  `TerminalAutomationPeer.fs:742`) continue direct; Cycle 32b
+  ships a `DefaultDisplayBuffer` adapter and migrates only
+  the UI render call site.
+- **`src/Terminal.Core/Terminal.Core.fsproj`** — three new
+  `<Compile Include>` entries appended after `HotkeyRegistry.fs`
+  (the new files depend on `HotkeyRegistry.HotkeyKey/Modifier`
+  and `Cell` from `Types.fs`, both of which compile earlier).
+- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §10 — cross-references
+  expanded to point at the actual interface files (the prior
+  doc referenced files that didn't yet exist on disk).
+
+The "channel" name in `Channels/` subdirectory is slightly
+imprecise — these three are substrate → host seams, not channel-
+side surfaces (the IOutputSink that channels implement lives
+in `OutputEventTypes.fs` for compile-order reasons). Naming
+preserved for now to match the strategic plan's vocabulary;
+may be revisited if maintenance demand surfaces.
+
 ### Docs (post-Cycle-31a): history sub-pane navigation contract via CommandOutputTuple
 
 Doc-only refinement folding the `docs/research/Output-paradigms.md`

--- a/docs/CORE-ABSTRACTION-BOUNDARY.md
+++ b/docs/CORE-ABSTRACTION-BOUNDARY.md
@@ -557,6 +557,8 @@ a boundary violation; reviewers block.
 
 ## §10 — Cross-references
 
+### Documentation
+
 - **ADR**: [`adr/0001-substrate-channel-dichotomy.md`](adr/0001-substrate-channel-dichotomy.md)
 - **Strategic plan**: [`PROJECT-PLAN-2026-05-09.md`](PROJECT-PLAN-2026-05-09.md)
 - **Channel principle (older framing)**:
@@ -567,6 +569,47 @@ a boundary violation; reviewers block.
 - **Pane catalog + sub-pane decomposition**:
   [`PANE-MODEL.md`](PANE-MODEL.md)
 - **Spec authority**: [`spec/tech-plan.md`](../spec/tech-plan.md)
+
+### Boundary interfaces (the actual code)
+
+The four boundary interfaces named in §1.6 (portability
+invariant) live in `Terminal.Core` per the substrate side of
+the boundary:
+
+- **`IOutputSink`** — declared inline in
+  [`src/Terminal.Core/OutputEventTypes.fs`](../src/Terminal.Core/OutputEventTypes.fs)
+  (just before the `Channel` record at line ~370). Cycle 31a;
+  the `Channel` record satisfies the interface trivially. The
+  dispatcher (`OutputDispatcher.routePair`) consumes via the
+  interface upcast. See §3.
+- **`IClipboardProvider`** —
+  [`src/Terminal.Core/Channels/IClipboardProvider.fs`](../src/Terminal.Core/Channels/IClipboardProvider.fs).
+  Cycle 31b; pure declaration. STA-thread + 3s-timeout
+  contract codified for write paths; read paths are
+  synchronous. No consumers cut over yet — today's `Program.fs:2043`
+  (Ctrl+Shift+Y) and `Diagnostics.fs:726` (Ctrl+Shift+D) keep
+  direct `System.Windows.Clipboard` access.
+- **`IHotkeyTranslator<'TGesture>`** —
+  [`src/Terminal.Core/Channels/IHotkeyTranslator.fs`](../src/Terminal.Core/Channels/IHotkeyTranslator.fs).
+  Cycle 31b; pure declaration. Generic over the host gesture
+  type so Terminal.Core stays free of WPF / GTK / AppKit
+  imports. No consumers cut over yet — today's
+  `Program.fs:274-333` `translateHotkeyKey` /
+  `translateHotkeyModifiers` continue as direct helpers.
+- **`IDisplayBuffer`** —
+  [`src/Terminal.Core/Channels/IDisplayBuffer.fs`](../src/Terminal.Core/Channels/IDisplayBuffer.fs).
+  Cycle 31b; pure declaration. Snapshot-of-grid surface
+  matching `Screen.SnapshotRows` shape (sequence number +
+  cursor + `Cell[][]`). First consumer cutover at
+  `TerminalView.cs:1002` lands in Cycle 32b alongside the
+  selection TOML loader.
+
+The portability invariant is enforced structurally by the
+`portability-lint` CI step (Cycle 31a, in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)) which
+fails the build if any `Terminal.Core` or `Terminal.Audio`
+file imports `System.Windows.*`, `PresentationCore`,
+`WindowsBase`, or `Microsoft.Win32`.
 
 ## Versioning + maintenance
 

--- a/src/Terminal.Core/Channels/IClipboardProvider.fs
+++ b/src/Terminal.Core/Channels/IClipboardProvider.fs
@@ -1,0 +1,58 @@
+namespace Terminal.Core.Channels
+
+/// Host clipboard abstraction for substrate code that needs to
+/// copy or paste through the host's native clipboard surface.
+///
+/// **Why this lives in Terminal.Core:** the clipboard is a host
+/// concern (System.Windows.Clipboard on WPF, Gdk.Clipboard on
+/// GTK, NSPasteboard on AppKit), and substrate code in
+/// Terminal.Core MUST NOT import host-specific types per
+/// `docs/CORE-ABSTRACTION-BOUNDARY.md` §1 + ADR 0001. This
+/// interface is the formal seam: substrate consumers (e.g., a
+/// future "copy SessionTuple" feature originating in
+/// Terminal.Core) accept an `IClipboardProvider` parameter; the
+/// composition root (`Terminal.App/Program.fs`) provides a WPF-
+/// backed implementation.
+///
+/// **Today's call sites (NOT cut over in Cycle 31b):**
+///
+/// - `Terminal.App/Program.fs:2043` — Ctrl+Shift+Y SessionModel
+///   history copy. STA-thread + 3s timeout pattern.
+/// - `Terminal.App/Diagnostics.fs:726` — Ctrl+Shift+D diagnostic
+///   bundle copy. Same STA + 3s timeout pattern.
+/// - `Views/TerminalView.cs:681,692,742,744` — paste-into-PTY
+///   reads (Ctrl+V / Shift+Insert).
+///
+/// All five sites continue calling `System.Windows.Clipboard`
+/// directly through Cycle 31. This interface formalises the
+/// boundary so future cross-platform builds (Linux + GTK,
+/// macOS + AppKit) have a typed seam to plug into.
+///
+/// **STA-thread + timeout contract (write):** WPF clipboard
+/// writes require an STA-apartment thread hop; concurrent
+/// access from non-STA threads throws or hangs. Implementations
+/// on Windows MUST honor the STA contract internally — callers
+/// of this interface should not need to know about apartment
+/// states. The 3-second timeout (matches the existing
+/// `Program.fs:2043` / `Diagnostics.fs:726` pattern) prevents
+/// indefinite blocks when another process holds the clipboard
+/// open.
+///
+/// `SetText` returns `true` on success, `false` on timeout or
+/// other failure so callers can fall back (e.g., log the
+/// content rather than dropping it silently).
+type IClipboardProvider =
+    /// Set clipboard text. Async to allow STA-thread marshalling.
+    /// Returns true on success, false on timeout or other
+    /// failure. Implementations SHOULD apply a 3-second timeout
+    /// per the existing call-site pattern; longer timeouts risk
+    /// blocking the UI thread on a stuck clipboard.
+    abstract SetText: text: string -> Async<bool>
+
+    /// Try to read clipboard text. Returns `None` if the
+    /// clipboard contains no text or if access fails (no
+    /// exception thrown to the caller). Synchronous because
+    /// read paths are query-shaped — see
+    /// `Views/TerminalView.cs:692` `OnPasteCanExecute` which
+    /// short-circuits on an empty clipboard.
+    abstract TryGetText: unit -> string option

--- a/src/Terminal.Core/Channels/IDisplayBuffer.fs
+++ b/src/Terminal.Core/Channels/IDisplayBuffer.fs
@@ -1,0 +1,79 @@
+namespace Terminal.Core.Channels
+
+open Terminal.Core
+
+/// Read-side abstraction for any host renderer that needs a
+/// snapshot of the substrate's screen-grid state.
+///
+/// **Why this lives in Terminal.Core:** the screen grid (today's
+/// `Terminal.Core.Screen`) is substrate-side per
+/// `docs/CORE-ABSTRACTION-BOUNDARY.md` §2. Host renderers
+/// (today's WPF `TerminalView`, future Avalonia /
+/// GTK / AppKit hosts) need a snapshot of cells + cursor
+/// position to draw a frame; this interface is the formal
+/// boundary they consume.
+///
+/// **Substrate dichotomy reminder:** `IDisplayBuffer` is the
+/// snapshot-of-grid surface. Linear-text-stream consumers
+/// (Cycle 34 onwards) get a separate substrate surface (the
+/// `LinearTextStream` producer's high-water-mark commits) —
+/// DO NOT retrofit linear streams into `IDisplayBuffer`. The
+/// substrate dichotomy keeps them separate per the boundary
+/// doc; `IDisplayBuffer` stays focused on the grid (alt-screen
+/// TUIs + the visual rendering surface).
+///
+/// **Today's call sites (NOT cut over in Cycle 31b):** seven
+/// direct `Screen.SnapshotRows` calls remain on the existing
+/// type:
+///
+/// - `Views/TerminalView.cs:1002` — UI render (Cycle 32b
+///   cutover target).
+/// - `Terminal.App/Program.fs:1258` — `handleAltScreenToggled`.
+/// - `Terminal.App/Program.fs:1345` — `handleRowsChanged`.
+/// - `Terminal.App/Program.fs:1375` — `handleTick`.
+/// - `Terminal.App/Program.fs:1480` — `handleSelectionChanged`.
+/// - `Terminal.App/Program.fs:1534` — `reportActivityIfQuiet`.
+/// - `Terminal.App/Program.fs:2574` — `handleNvdaAnnounce`.
+/// - `Terminal.Accessibility/TerminalAutomationPeer.fs:742` —
+///   UIA text-range queries.
+///
+/// Cycle 32b ships a `DefaultDisplayBuffer` adapter (in
+/// Terminal.App composition root) wrapping the existing
+/// `Screen` instance, and migrates `TerminalView.cs:1002` to
+/// consume it. The other call sites stay direct until a future
+/// cycle has concrete value motivation.
+///
+/// **Locking contract:** implementations MUST acquire any
+/// internal state lock during snapshot to prevent torn reads.
+/// The reference implementation (`Screen.SnapshotRows` at
+/// `Screen.fs:541-553`) uses `lock gate` around the cell
+/// `Array.init` + cursor capture; new implementations MUST
+/// preserve atomic cell + cursor capture so consumers don't
+/// see a cursor from frame N+1 paired with cells from frame
+/// N.
+///
+/// **Cell type portability:** the returned `Cell[][]` is fully
+/// OS-portable — composed of `Rune` (UTF-32 scalar),
+/// `ColorSpec` (platform-neutral), and `SgrAttrs` (terminal
+/// attributes). No WPF / GTK / AppKit concerns leak into the
+/// substrate.
+type IDisplayBuffer =
+    /// Snapshot a contiguous row range. Returns:
+    ///
+    /// - `sequenceNumber` (`int64`): monotonic; consumers compare
+    ///   for change detection between snapshots.
+    /// - `cursor` (`int * int`): cursor `(row, col)` position
+    ///   captured atomically with the cell snapshot.
+    /// - `rows` (`Cell[][]`): jagged 2D array where outer length
+    ///   equals `count` and inner length equals the substrate's
+    ///   column count.
+    ///
+    /// `startRow` is 0-indexed from the top of the active buffer;
+    /// `count` MUST be ≤ the buffer's row count. Implementations
+    /// SHOULD validate the range and throw `ArgumentOutOfRangeException`
+    /// on overflow rather than silently truncate (matches the
+    /// existing `Screen.SnapshotRows:541-553` validation).
+    abstract Snapshot:
+        startRow: int *
+        count: int ->
+            int64 * (int * int) * Cell[][]

--- a/src/Terminal.Core/Channels/IHotkeyTranslator.fs
+++ b/src/Terminal.Core/Channels/IHotkeyTranslator.fs
@@ -1,0 +1,58 @@
+namespace Terminal.Core.Channels
+
+open Terminal.Core
+
+/// Translates portable `HotkeyRegistry` shapes into host-
+/// specific gesture types.
+///
+/// **Why this lives in Terminal.Core:** the
+/// `HotkeyRegistry.HotkeyKey` and `HotkeyRegistry.Modifier` DUs
+/// (`HotkeyRegistry.fs`) are deliberately portable F# types so
+/// substrate code can describe hotkey bindings without
+/// importing host-specific input enums. Today's WPF host
+/// translates these to `System.Windows.Input.KeyGesture` at
+/// `Terminal.App/Program.fs:274-333`
+/// (`translateHotkeyKey` + `translateHotkeyModifiers`); a
+/// future Avalonia or GTK host would translate to its own
+/// gesture type. This interface is the formal seam.
+///
+/// **Generic over `'TGesture`** so Terminal.Core does not
+/// import any host-specific type. Callers pass the concrete
+/// gesture type at the binding site:
+///
+/// ```fsharp
+/// // In Terminal.App composition root (WPF-specific):
+/// open System.Windows.Input
+/// let wpfTranslator : IHotkeyTranslator<KeyGesture> =
+///     { new IHotkeyTranslator<KeyGesture> with
+///         member _.Translate(key, modifiers) =
+///             let wpfKey = translateHotkeyKey key
+///             let wpfMods = translateHotkeyModifiers modifiers
+///             KeyGesture(wpfKey, wpfMods) }
+/// ```
+///
+/// **Today's call sites (NOT cut over in Cycle 31b):**
+/// `Terminal.App/Program.fs:274-333` continues to use the
+/// existing `translateHotkeyKey` / `translateHotkeyModifiers`
+/// helpers directly. Future migration (e.g., a
+/// `KeyGestureTranslator.fs` adapter in Terminal.App that
+/// implements this interface) is incremental.
+///
+/// **Why portable HotkeyKey vs WPF Key:** the codebase already
+/// avoided WPF `Key` flowing into Terminal.Core (see the
+/// existing `KeyEncoding.fs:11` doc-comment "Why a private DU
+/// instead of WPF's `System.Windows.Input.Key`?"). This
+/// interface formalises the existing separation; no new
+/// portability work is required.
+type IHotkeyTranslator<'TGesture> =
+    /// Map a portable `HotkeyKey` + `Modifier` set into a host
+    /// gesture descriptor. Implementations on Windows return a
+    /// WPF `KeyGesture`; on Linux, the equivalent AT-SPI / GTK
+    /// gesture descriptor.
+    ///
+    /// The empty `Set<Modifier>` (no modifiers) is valid input
+    /// — implementations MUST handle it without throwing.
+    abstract Translate:
+        key: HotkeyRegistry.HotkeyKey *
+        modifiers: Set<HotkeyRegistry.Modifier> ->
+            'TGesture

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -37,6 +37,9 @@
     <Compile Include="OutputDispatcher.fs" />
     <Compile Include="KeyEncoding.fs" />
     <Compile Include="HotkeyRegistry.fs" />
+    <Compile Include="Channels/IClipboardProvider.fs" />
+    <Compile Include="Channels/IHotkeyTranslator.fs" />
+    <Compile Include="Channels/IDisplayBuffer.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Three pure interface declarations completing the boundary set named in `docs/CORE-ABSTRACTION-BOUNDARY.md` §1.6 (portability invariant). All three live in `Terminal.Core` per the substrate side of the boundary.

**No consumers cut over in this PR.** First consumer cutover (`IDisplayBuffer` at `TerminalView.cs:1002`) lands in Cycle 32b alongside the selection TOML loader. Portability CI lint added in Cycle 31a continues to gate against host-specific imports leaking into substrate code.

## What changed

- **`src/Terminal.Core/Channels/IClipboardProvider.fs`** (new) — `SetText: string → Async<bool>` codifying the STA-thread + 3-second-timeout contract that `Program.fs:2043` (Ctrl+Shift+Y) and `Diagnostics.fs:726` (Ctrl+Shift+D) currently embed inline; `TryGetText: unit → string option` for read paths (`TerminalView.cs:681,692,742,744`). All five existing call sites continue to use `System.Windows.Clipboard` directly; the interface formalises the seam for future cross-platform builds without forcing a cutover today.
- **`src/Terminal.Core/Channels/IHotkeyTranslator.fs`** (new) — generic over the host gesture type (`'TGesture`) so Terminal.Core does not import any WPF / GTK / AppKit type. `Translate: HotkeyKey * Set<Modifier> → 'TGesture`. Today's WPF translation in `Program.fs:274-333` (`translateHotkeyKey` + `translateHotkeyModifiers`) stays as direct helpers; the interface gives a future Avalonia / GTK host a typed seam to plug into.
- **`src/Terminal.Core/Channels/IDisplayBuffer.fs`** (new) — `Snapshot: int * int → int64 * (int * int) * Cell[][]` matching today's `Screen.SnapshotRows` shape (`Screen.fs:541-553`) including the locking contract (atomic cell + cursor capture). Seven existing `Screen.SnapshotRows` call sites (`TerminalView.cs:1002`, `Program.fs:1258/1345/1375/1480/1534/2574`, `TerminalAutomationPeer.fs:742`) continue direct; Cycle 32b ships a `DefaultDisplayBuffer` adapter and migrates only the UI render call site.
- **`src/Terminal.Core/Terminal.Core.fsproj`** — three new `<Compile Include>` entries appended after `HotkeyRegistry.fs` (the new files depend on `HotkeyRegistry.HotkeyKey` / `Modifier` and `Cell` from `Types.fs`, both of which compile earlier).
- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §10 — cross-references expanded to point at the actual interface files (the prior doc referenced files that didn't yet exist on disk).
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## Naming note (`Channels/` directory)

The `Channels/` subdirectory is slightly imprecise — these three interfaces are substrate → host seams, not channel-side surfaces (the `IOutputSink` that channels implement lives in `OutputEventTypes.fs` for compile-order reasons). Naming preserved to match the strategic plan's vocabulary; may be revisited (e.g., `Boundaries/` or `Host/`) if maintenance demand surfaces.

## What this PR deliberately omits

- **No consumer cutovers.** All five clipboard call sites, the WPF hotkey translation, and the seven `Screen.SnapshotRows` call sites continue direct. Cycle 32b cuts over `TerminalView.cs:1002`; later cycles handle the rest as concrete value motivation surfaces.
- **No tests.** Pure interface declarations; nothing to test until consumers exist. (Future cutover PRs will pin contract behavior with implementation-side tests.)
- **No `DefaultDisplayBuffer` / WPF clipboard adapter / WPF hotkey translator implementations.** Those land in cycles that do real cutover work.
- **No `Boundaries/` rename.** Naming may be revisited later.

## Test plan

- [x] Standard CI (Build + test on windows-latest, Workflow lint, Markdown link check, Portability lint) passes.
- [x] Portability lint continues to pass with the three new files (no host-specific imports introduced).
- [x] Existing tests unchanged and continue to pass — interfaces are pure declarations with no consumers.
- [x] F# compile order: new files appended after `HotkeyRegistry.fs` so `HotkeyKey` / `Modifier` / `Cell` types resolve.

## Configurability note

No new candidate user settings introduced. Per CONTRIBUTING.md "Consider configurability when iterating": these are pure architectural interfaces; the existing implicit defaults (3-second clipboard timeout per `Program.fs:2043` / `Diagnostics.fs:726`) become candidate settings if/when consumers cut over.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_