### PR TITLE
feat(config): Cycle 32a — [profile.selection] TOML loader closes Stage 8e-A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,68 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 32a): `[profile.selection]` TOML loader — closes Stage 8e-A scope
+
+The four `SelectionDetector` tunable thresholds (`HighlightDetectionThresholdMs`,
+`DismissalGraceMs`, `KeystrokeCorrelationWindowMs`, `MinConfidence`)
+are now overridable via a new `[profile.selection]` TOML section.
+The detector itself (`SelectionDetector.fs:128-148` `Parameters`
+record + `defaultParameters`, both shipped in Cycle 29a) is
+**unchanged** — Cycle 32a is pure Config-side plumbing. With
+this PR, **Stage 8e-A is fully shipped** (Cycle 29a substrate +
+Cycle 29b consumer-side wiring + Cycle 32a config plumbing);
+Stage 8e-B (UIA listbox peer) remains open as a separate plan-
+mode pass.
+
+- **`src/Terminal.Core/Config.fs`** — adds
+  `SelectionParameterOverrides` record (four `option`-typed
+  fields mirroring the detector's `Parameters` shape); appends
+  the field to the top-level `Config` record + `defaultConfig`;
+  adds `parseProfileSelectionOverrides` (mirrors
+  `parseLoggingOverrides` template) and `resolveSelectionParameters`
+  (mirrors `resolveStreamParameters` template) helpers; wires
+  the parser into `tryLoad`.
+- **`src/Terminal.App/Program.fs:1186`** — composition cutover:
+  `SelectionDetector.create SelectionDetector.defaultParameters`
+  becomes
+  `SelectionDetector.create (Config.resolveSelectionParameters config)`.
+  Three-line change.
+- **`tests/Tests.Unit/ConfigTests.fs`** — adds 6 new facts in a
+  new "Cycle 32a — `[profile.selection]` TOML loader" section
+  covering: section absent → `SelectionDetector.defaultParameters`;
+  all four keys present override; single key overrides + others
+  default; unrecognised `min_confidence` string logs Warning +
+  defaults; non-integer threshold logs Warning + defaults; non-
+  positive (zero / negative) threshold logs Warning + defaults.
+- **`docs/USER-SETTINGS.md`** — new "Selection prompt thresholds
+  and confidence modes (Cycle 32a)" subsection documenting the
+  four keys, their defaults, the snake_case TOML format
+  (`heuristic_sgr` / `heuristic_sgr_with_keystroke` for the enum
+  values), tuning use cases, and the no-hot-reload caveat.
+- **`docs/STAGE-7-ISSUES.md`** — `[output-selection]` "Status"
+  line flipped from "Cycle 29c finalises the substrate" to
+  "Stage 8e-A is fully shipped (Cycle 29a + 29b + 32a)".
+
+**No behaviour change** for users who do not add a
+`[profile.selection]` section to `config.toml` — `defaultConfig`'s
+`SelectionOverrides` field is `None` everywhere, so
+`resolveSelectionParameters` returns
+`SelectionDetector.defaultParameters` byte-equivalent.
+
+**No hot-reload.** `[profile.selection]` is loaded once at
+startup; mid-session `config.toml` edits require a restart.
+Matches every existing TOML section except
+`[session_model.persistence]` (which gets reloaded on shell-
+switch via `Program.fs:2488-2500`). Adding hot-reload would
+be a future micro-cycle.
+
+**Validation per `docs/STAGE-7-ISSUES.md` `[output-selection]`:**
+manual NVDA testing requires a Claude tool-use prompt that
+forces user confirmation — write a file in an untrusted
+directory to defeat Claude's auto-trust mode. The Cycle 29b
+NVDA matrix (in `docs/ACCESSIBILITY-TESTING.md`) is the
+authoritative test surface; Cycle 32a does not add a new row.
+
 ### Added (Cycle 31b): sibling boundary interface declarations — `IClipboardProvider`, `IHotkeyTranslator<'TGesture>`, `IDisplayBuffer`
 
 Three pure interface declarations completing the boundary set

--- a/docs/STAGE-7-ISSUES.md
+++ b/docs/STAGE-7-ISSUES.md
@@ -386,15 +386,21 @@ the Output framework cycle's Selection profile.
 [`spec/tech-plan.md`](../spec/tech-plan.md) §7.4 known issue
 #2 → Stage 8). Empirical confirmation pending.
 
-**Status (2026-05-09).** Code-complete via Cycles 29a + 29b
-(Stage 8e-A parts 1+2 of 3): NVDA reads selection prompts
-as text ("selection prompt: Edit, Yes, Always, No (selected:
-Yes)" + "selected: Yes, 2 of 4" on highlight movement +
-"selection dismissed" on dismissal). UIA listbox semantics —
+**Status (post-Cycle 32a).** Stage 8e-A is fully shipped
+(Cycle 29a substrate + Cycle 29b consumer-side wiring +
+**Cycle 32a `[profile.selection]` TOML loader**). NVDA reads
+selection prompts as text ("selection prompt: Edit, Yes,
+Always, No (selected: Yes)" + "selected: Yes, 2 of 4" on
+highlight movement + "selection dismissed" on dismissal); the
+four detector thresholds (`HighlightDetectionThresholdMs`,
+`DismissalGraceMs`, `KeystrokeCorrelationWindowMs`,
+`MinConfidence`) are now overridable via `[profile.selection]`
+in `config.toml` (per
+[`docs/USER-SETTINGS.md`](USER-SETTINGS.md) "Selection prompt
+thresholds and confidence modes"). UIA listbox semantics —
 the full fix that gives NVDA `1 of 4` navigation + ListItem
 control type — arrives in Stage 8e-B (separate plan-mode
-pass). Cycle 29c finalises the substrate with
-`[profile.selection]` TOML loader.
+pass).
 
 **Validation gotcha — Claude auto-trust mode skips the
 prompt UI** (discovered during Cycle 29b NVDA test

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -856,6 +856,68 @@ is. Other power-user knobs:
   Stream profile during Part 3 Stage A; nothing in the
   pipeline (parser, screen, drain, peer) needs to move.
 
+### Selection prompt thresholds and confidence modes (Cycle 32a)
+
+#### Current state
+
+The `SelectionDetector` (Cycle 29a substrate; `src/Terminal.Core/SelectionDetector.fs`) watches the screen substrate for SGR-styled rows that look like interactive-list selection prompts (e.g., Claude tool-use confirmations, cmd `choice`, fzf in non-alt-screen mode). It emits `SelectionShown` / `SelectionItem` / `SelectionDismissed` semantic events that the `SelectionProfile` (Cycle 29b) translates into NVDA announcements.
+
+Four tunable parameters live in the detector's `Parameters` record (`SelectionDetector.fs:128-148`):
+
+- `HighlightDetectionThresholdMs` — milliseconds a row must remain visually styled before counting as a stable selection candidate. Default **100**.
+- `DismissalGraceMs` — milliseconds the candidate must remain absent before emitting `SelectionDismissed`. Default **150**.
+- `KeystrokeCorrelationWindowMs` — milliseconds after a user keystroke (arrow key) inside which an SGR change counts as keystroke-correlated. Default **250**.
+- `MinConfidence` — minimum confidence tier required for emission. Either `HeuristicSGR` (signals 1+2 only — more permissive; surfaces gaps quickly) or `HeuristicSGRWithKeystroke` (signals 1+2+3 — strict; requires arrow-key correlation observed within the keystroke window). Default `HeuristicSGR`.
+
+Cycle 32a externalises all four via TOML.
+
+#### Why hardcoded before Cycle 32a
+
+The defaults are spec-derived (`spec/tech-plan.md` §8.1; `spec/event-and-output-framework.md` §B.3.3). Cycle 29b NVDA validation 2026-05-09 surfaced acute regressions elsewhere (spinner storms, red-tone misfires) but did not surface a need to tune the selection thresholds — the gotcha that surfaced was that Claude's auto-trust mode skipped the confirmation prompt entirely (per `docs/STAGE-7-ISSUES.md` `[output-selection]` section), not that the thresholds were wrong.
+
+Cycle 32a externalises the knobs without changing defaults. Power users (or future per-shell tuning) can override.
+
+#### What configurability looks like
+
+```toml
+schema_version = 1
+
+[profile.selection]
+# Milliseconds a row's SGR-styled run must remain stable before
+# the detector treats it as a selection candidate. Defaults to 100.
+highlight_detection_threshold_ms = 100
+
+# Milliseconds the candidate must remain absent before emitting
+# SelectionDismissed. Defaults to 150.
+dismissal_grace_ms = 150
+
+# Milliseconds after a user keystroke (arrow key) inside which an
+# SGR change counts as keystroke-correlated. Defaults to 250.
+keystroke_correlation_window_ms = 250
+
+# Minimum confidence required to emit SelectionShown. Either
+# "heuristic_sgr" (signals 1+2 only) or
+# "heuristic_sgr_with_keystroke" (signals 1+2+3 — arrow-key
+# correlation observed within the keystroke window).
+# Default: "heuristic_sgr".
+min_confidence = "heuristic_sgr_with_keystroke"
+```
+
+All four keys are optional; absent keys fall back to detector defaults. Unknown keys log a Warning and are dropped. Non-positive integer values log a Warning and fall back to default. Unrecognised `min_confidence` strings log a Warning and fall back to `"heuristic_sgr"`.
+
+Tuning use cases:
+
+- **Slow synthesiser / slow user** — raise `highlight_detection_threshold_ms` to 200-300ms so transient SGR repaints don't trigger spurious "selection prompt" announcements.
+- **Strict mode (Claude tool-use only)** — set `min_confidence = "heuristic_sgr_with_keystroke"` to suppress non-keystroke-correlated selections (e.g., a `git status` line that happens to be SGR-styled but isn't a real prompt).
+- **Faster dismissal** — lower `dismissal_grace_ms` to 50ms if the maintainer wants `SelectionDismissed` to fire immediately when a prompt clears.
+
+#### Implementation notes
+
+- Cycle 32a-only scope: `src/Terminal.Core/Config.fs` adds `SelectionParameterOverrides` record + `parseProfileSelectionOverrides` parser + `resolveSelectionParameters` helper. `src/Terminal.App/Program.fs:1186` composition cutover (3-line change). `tests/Tests.Unit/ConfigTests.fs` adds 6 facts covering: section absent → defaults; all four keys present override; single key present overrides + others default; unrecognised `min_confidence` logs Warning + defaults; non-integer threshold logs Warning + defaults; non-positive threshold logs Warning + defaults.
+- **No hot-reload** — the detector is constructed once at startup with the resolved parameters; mid-session config changes require a restart. This matches every other section except `[session_model.persistence]` (which gets reloaded on shell-switch via `Program.fs:2488-2500`). Hot-reload could be added in a future cycle by plumbing into the existing shell-switch reload handler.
+- **No detector internal changes** — the `Parameters` record + `defaultParameters` value already exist (Cycle 29a shipped them); Cycle 32a only adds Config-side overrides + composition-root wiring.
+- **Validation** — per `docs/STAGE-7-ISSUES.md` `[output-selection]`, manual NVDA testing requires a Claude tool-use prompt that requires user confirmation (force a prompt by writing a file in an untrusted directory; Claude auto-trust mode skips the prompt for trusted workspaces). The Cycle 29b NVDA matrix is the authoritative test surface; Cycle 32a does not add a new row.
+
 ### Stopgap: announce-length cap (Stage 7-followup PR-H)
 
 `src/Terminal.App/Program.fs`'s drain task currently caps every

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1178,12 +1178,15 @@ module Program =
         // Cycle 29b — selection-prompt detector. Same actor-
         // model contract as `promptDetector`: mutated on the
         // PathwayPump worker thread, captured by closures that
-        // stay in this scope. Defaults loaded inline (Cycle 29c
-        // will load from `[profile.selection]` TOML). Reset on
-        // shell-switch + alt-screen entry alongside
-        // `promptDetector`.
+        // stay in this scope. Cycle 32a wires
+        // `[profile.selection]` TOML overrides via
+        // `Config.resolveSelectionParameters`; absent or
+        // empty section → `SelectionDetector.defaultParameters`
+        // verbatim. Reset on shell-switch + alt-screen entry
+        // alongside `promptDetector`.
         let mutable selectionDetector : SelectionDetector.T =
-            SelectionDetector.create SelectionDetector.defaultParameters
+            SelectionDetector.create
+                (Config.resolveSelectionParameters config)
 
         // PathwayPump — Phase A replacement for TranslatorPump.
         // Reads raw ScreenNotifications and routes by case:

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -154,6 +154,21 @@ module Config =
           /// `sink.SetMinLevel` IF the env var was not set.
           MinLevel: LogLevel option }
 
+    /// Cycle 32a — `[profile.selection]` table overrides for
+    /// `SelectionDetector.Parameters` (defined at
+    /// `SelectionDetector.fs:128-148`). `None` fields fall back
+    /// to `SelectionDetector.defaultParameters` at the resolver
+    /// (`resolveSelectionParameters` below). The detector is
+    /// constructed once at startup with the resolved parameters
+    /// (`Program.fs` composition root); no hot-reload — matches
+    /// every other section except `[session_model.persistence]`,
+    /// which gets reloaded on shell-switch.
+    type SelectionParameterOverrides =
+        { HighlightDetectionThresholdMs: int option
+          DismissalGraceMs: int option
+          KeystrokeCorrelationWindowMs: int option
+          MinConfidence: SelectionDetector.SelectionSource option }
+
     /// The top-level config record. `ShellOverrides` is keyed
     /// by lowercase shell-id strings (`"cmd"`, `"claude"`,
     /// `"powershell"` — mirrors `ShellRegistry.parseEnvVar`'s
@@ -172,7 +187,12 @@ module Config =
           /// composition-root time; the FileLogger sink's
           /// `SetMinLevel` is called post-Config-load when this
           /// is `Some` AND `PTYSPEAK_LOG_LEVEL` is unset.
-          LoggingOverrides: LoggingOverrides }
+          LoggingOverrides: LoggingOverrides
+          /// Cycle 32a — `[profile.selection]` table.
+          /// Resolved via `resolveSelectionParameters`;
+          /// composition root passes the result to
+          /// `SelectionDetector.create` at startup.
+          SelectionOverrides: SelectionParameterOverrides }
 
     /// The all-defaults Config — equivalent to "no config file
     /// present". `defaultConfig` is the authoritative source
@@ -198,7 +218,12 @@ module Config =
           StartupOverrides =
             { DefaultShell = None }
           SessionPersistence = SessionPersistence.defaultConfig
-          LoggingOverrides = { MinLevel = None } }
+          LoggingOverrides = { MinLevel = None }
+          SelectionOverrides =
+            { HighlightDetectionThresholdMs = None
+              DismissalGraceMs = None
+              KeystrokeCorrelationWindowMs = None
+              MinConfidence = None } }
 
     /// The default config file path —
     /// `%LOCALAPPDATA%\PtySpeak\config.toml`. Mirrors the
@@ -693,6 +718,81 @@ module Config =
                         None
             { MinLevel = minLevel }
 
+    /// Cycle 32a — parse `[profile.selection]` table for the
+    /// SelectionDetector tunable parameters. Recognised keys:
+    /// `highlight_detection_threshold_ms`, `dismissal_grace_ms`,
+    /// `keystroke_correlation_window_ms` (all positive integers,
+    /// milliseconds), and `min_confidence`
+    /// (`"heuristic_sgr"` | `"heuristic_sgr_with_keystroke"`,
+    /// case-insensitive). Unknown keys log + drop; non-positive
+    /// values log + fall back to defaults; unrecognised
+    /// `min_confidence` values log + fall back to default.
+    let private parseProfileSelectionOverrides
+            (logger: ILogger)
+            (root: TomlTable)
+            : SelectionParameterOverrides
+            =
+        match tryGetTable root "profile" with
+        | None -> defaultConfig.SelectionOverrides
+        | Some profileTable ->
+            match tryGetTable profileTable "selection" with
+            | None -> defaultConfig.SelectionOverrides
+            | Some selectionTable ->
+                let knownKeys =
+                    Set.ofList
+                        [ "highlight_detection_threshold_ms"
+                          "dismissal_grace_ms"
+                          "keystroke_correlation_window_ms"
+                          "min_confidence" ]
+                for key in selectionTable.Keys do
+                    if not (knownKeys.Contains(key)) then
+                        logger.LogWarning(
+                            "Config: [profile.selection] unknown key '{Key}'; ignored.",
+                            key)
+
+                let parsePositiveMs (key: string) : int option =
+                    match tryGetInt selectionTable key with
+                    | None ->
+                        if selectionTable.ContainsKey(key) then
+                            logger.LogWarning(
+                                "Config: [profile.selection] {Key} is non-integer; using default.",
+                                key)
+                        None
+                    | Some raw ->
+                        // Reuses the existing positive-int validator
+                        // (Config.fs:506) which logs "non-positive;
+                        // clamping to default" for raw <= 0 and
+                        // "exceeds Int32.MaxValue; clamping to default"
+                        // for overflow.
+                        parsePositiveInt logger "[profile.selection]" key raw
+
+                let parseMinConfidence () : SelectionDetector.SelectionSource option =
+                    match tryGetString selectionTable "min_confidence" with
+                    | None ->
+                        if selectionTable.ContainsKey("min_confidence") then
+                            logger.LogWarning(
+                                "Config: [profile.selection] min_confidence is non-string; using default.")
+                        None
+                    | Some raw ->
+                        match raw.Trim().ToLowerInvariant() with
+                        | "heuristic_sgr" ->
+                            Some SelectionDetector.HeuristicSGR
+                        | "heuristic_sgr_with_keystroke" ->
+                            Some SelectionDetector.HeuristicSGRWithKeystroke
+                        | _ ->
+                            logger.LogWarning(
+                                "Config: [profile.selection] min_confidence = '{Value}' is not 'heuristic_sgr' or 'heuristic_sgr_with_keystroke'; using default.",
+                                raw)
+                            None
+
+                { HighlightDetectionThresholdMs =
+                    parsePositiveMs "highlight_detection_threshold_ms"
+                  DismissalGraceMs =
+                    parsePositiveMs "dismissal_grace_ms"
+                  KeystrokeCorrelationWindowMs =
+                    parsePositiveMs "keystroke_correlation_window_ms"
+                  MinConfidence = parseMinConfidence () }
+
     /// Cycle 19 — resolve the startup-shell preference. Returns
     /// `Some shellKey` when `[startup] default_shell` was set
     /// to a recognised shell id; `None` otherwise (composition
@@ -819,13 +919,16 @@ module Config =
                             SessionPersistence.parseFromTable logger model
                         let loggingOverrides =
                             parseLoggingOverrides logger model
+                        let selectionOverrides =
+                            parseProfileSelectionOverrides logger model
                         let result =
                             { SchemaVersion = version
                               ShellOverrides = shellOverrides
                               StreamOverrides = streamOverrides
                               StartupOverrides = startupOverrides
                               SessionPersistence = sessionPersistence
-                              LoggingOverrides = loggingOverrides }
+                              LoggingOverrides = loggingOverrides
+                              SelectionOverrides = selectionOverrides }
                         // One Information line summarising the
                         // resolved config so post-hoc diagnosis
                         // via Ctrl+Shift+; is trivial. The
@@ -889,3 +992,27 @@ module Config =
             Option.defaultValue defaults.BackspacePolicy ov.BackspacePolicy
           ModeBarrierFlushPolicy =
             Option.defaultValue defaults.ModeBarrierFlushPolicy ov.ModeBarrierFlushPolicy }
+
+    /// Cycle 32a — resolve the SelectionDetector parameters from
+    /// a Config. Each field that's `None` in `SelectionOverrides`
+    /// falls back to `SelectionDetector.defaultParameters`'s
+    /// value. The composition root passes the result to
+    /// `SelectionDetector.create` once at startup; no hot-reload.
+    let resolveSelectionParameters
+            (config: Config)
+            : SelectionDetector.Parameters
+            =
+        let defaults = SelectionDetector.defaultParameters
+        let ov = config.SelectionOverrides
+        { HighlightDetectionThresholdMs =
+            Option.defaultValue
+                defaults.HighlightDetectionThresholdMs
+                ov.HighlightDetectionThresholdMs
+          DismissalGraceMs =
+            Option.defaultValue defaults.DismissalGraceMs ov.DismissalGraceMs
+          KeystrokeCorrelationWindowMs =
+            Option.defaultValue
+                defaults.KeystrokeCorrelationWindowMs
+                ov.KeystrokeCorrelationWindowMs
+          MinConfidence =
+            Option.defaultValue defaults.MinConfidence ov.MinConfidence }

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -690,3 +690,121 @@ let ``writeDefaults creates parent directory tree if missing`` () =
     let wrote = Config.writeDefaults nestedPath
     Assert.True(wrote)
     Assert.True(File.Exists(nestedPath))
+
+// ---------------------------------------------------------------------
+// Cycle 32a — `[profile.selection]` TOML loader
+// ---------------------------------------------------------------------
+//
+// Pins the SelectionParameterOverrides parser + resolver added in
+// Cycle 32a. The detector itself (`SelectionDetector.Parameters` +
+// `defaultParameters` shipped in Cycle 29a) is unchanged; tests
+// here only exercise the Config-side plumbing.
+
+[<Fact>]
+let ``[profile.selection] absent — resolveSelectionParameters returns SelectionDetector.defaultParameters`` () =
+    let toml = "schema_version = 1\n"
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    Assert.Equal(SelectionDetector.defaultParameters, resolved)
+
+[<Fact>]
+let ``[profile.selection] all four keys present override all defaults`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              "[profile.selection]"
+              "highlight_detection_threshold_ms = 200"
+              "dismissal_grace_ms = 300"
+              "keystroke_correlation_window_ms = 500"
+              "min_confidence = \"heuristic_sgr_with_keystroke\""
+              "" ]
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    Assert.Equal(200, resolved.HighlightDetectionThresholdMs)
+    Assert.Equal(300, resolved.DismissalGraceMs)
+    Assert.Equal(500, resolved.KeystrokeCorrelationWindowMs)
+    Assert.Equal(
+        SelectionDetector.HeuristicSGRWithKeystroke,
+        resolved.MinConfidence)
+
+[<Fact>]
+let ``[profile.selection] single key overrides; others fall back to defaults`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              "[profile.selection]"
+              "keystroke_correlation_window_ms = 400"
+              "" ]
+    let config, _ = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    let defaults = SelectionDetector.defaultParameters
+    Assert.Equal(
+        defaults.HighlightDetectionThresholdMs,
+        resolved.HighlightDetectionThresholdMs)
+    Assert.Equal(defaults.DismissalGraceMs, resolved.DismissalGraceMs)
+    Assert.Equal(400, resolved.KeystrokeCorrelationWindowMs)
+    Assert.Equal(defaults.MinConfidence, resolved.MinConfidence)
+
+[<Fact>]
+let ``[profile.selection] unrecognised min_confidence string logs Warning and defaults`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              "[profile.selection]"
+              "min_confidence = \"fictional_tier\""
+              "" ]
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    Assert.Equal(SelectionDetector.HeuristicSGR, resolved.MinConfidence)
+    Assert.True(
+        logger.MessagesAtLevel(LogLevel.Warning)
+        |> Seq.exists (fun msg ->
+            msg.Contains("min_confidence") && msg.Contains("fictional_tier")),
+        sprintf
+            "expected a Warning mentioning min_confidence + fictional_tier; got: %A"
+            (logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList))
+
+[<Fact>]
+let ``[profile.selection] non-integer threshold logs Warning and defaults`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              "[profile.selection]"
+              "highlight_detection_threshold_ms = \"not_a_number\""
+              "" ]
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    Assert.Equal(
+        SelectionDetector.defaultParameters.HighlightDetectionThresholdMs,
+        resolved.HighlightDetectionThresholdMs)
+    Assert.True(
+        logger.MessagesAtLevel(LogLevel.Warning)
+        |> Seq.exists (fun msg ->
+            msg.Contains("highlight_detection_threshold_ms")),
+        "expected a Warning mentioning highlight_detection_threshold_ms")
+
+[<Fact>]
+let ``[profile.selection] non-positive threshold logs Warning and defaults`` () =
+    let toml =
+        String.concat "\n"
+            [ "schema_version = 1"
+              "[profile.selection]"
+              "dismissal_grace_ms = 0"
+              "keystroke_correlation_window_ms = -50"
+              "" ]
+    let config, logger = loadFromText toml
+    let resolved = Config.resolveSelectionParameters config
+    let defaults = SelectionDetector.defaultParameters
+    Assert.Equal(defaults.DismissalGraceMs, resolved.DismissalGraceMs)
+    Assert.Equal(
+        defaults.KeystrokeCorrelationWindowMs,
+        resolved.KeystrokeCorrelationWindowMs)
+    // parsePositiveInt logs "non-positive; clamping to default"
+    // for both 0 and negative values; both keys triggered it.
+    let warningCount =
+        logger.MessagesAtLevel(LogLevel.Warning)
+        |> Seq.filter (fun msg ->
+            msg.Contains("[profile.selection]")
+            && msg.Contains("non-positive"))
+        |> Seq.length
+    Assert.Equal(2, warningCount)


### PR DESCRIPTION
## Summary

The four `SelectionDetector` tunable thresholds (`HighlightDetectionThresholdMs`, `DismissalGraceMs`, `KeystrokeCorrelationWindowMs`, `MinConfidence`) are now overridable via a new `[profile.selection]` TOML section. The detector itself (`SelectionDetector.fs:128-148` `Parameters` record + `defaultParameters`, both shipped in Cycle 29a) is **unchanged** — Cycle 32a is pure Config-side plumbing.

**With this PR, Stage 8e-A is fully shipped** (Cycle 29a substrate + Cycle 29b consumer wiring + Cycle 32a config plumbing). Stage 8e-B (UIA listbox peer) remains open as a separate plan-mode pass.

## What changed

- **`src/Terminal.Core/Config.fs`** — adds `SelectionParameterOverrides` record (four `option`-typed fields mirroring the detector's `Parameters` shape); appends the field to the top-level `Config` record + `defaultConfig`; adds `parseProfileSelectionOverrides` (mirrors `parseLoggingOverrides` template; reuses existing `parsePositiveInt` validator at line 506) and `resolveSelectionParameters` helpers; wires the parser into `tryLoad`.
- **`src/Terminal.App/Program.fs:1186`** — composition cutover: `SelectionDetector.create SelectionDetector.defaultParameters` becomes `SelectionDetector.create (Config.resolveSelectionParameters config)`. Three-line change.
- **`tests/Tests.Unit/ConfigTests.fs`** — adds 6 new facts in a new "Cycle 32a — `[profile.selection]` TOML loader" section covering: section absent → defaults; all four keys present override; single key overrides + others default; unrecognised `min_confidence` string logs Warning + defaults; non-integer threshold logs Warning + defaults; non-positive threshold logs "non-positive; clamping to default" Warning + defaults (twice — once for 0, once for negative).
- **`docs/USER-SETTINGS.md`** — new "Selection prompt thresholds and confidence modes (Cycle 32a)" subsection documenting the four keys, defaults, snake_case TOML format, tuning use cases, and the no-hot-reload caveat.
- **`docs/STAGE-7-ISSUES.md`** — `[output-selection]` "Status" line flipped from "Cycle 29c finalises the substrate" to "Stage 8e-A is fully shipped (Cycle 29a + 29b + 32a)".
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## TOML format (user-facing)

```toml
schema_version = 1

[profile.selection]
highlight_detection_threshold_ms = 100
dismissal_grace_ms = 150
keystroke_correlation_window_ms = 250
min_confidence = "heuristic_sgr_with_keystroke"
```

All four keys are optional; absent keys fall back to detector defaults. Unknown keys log Warning + drop. Non-positive integer values log Warning + fall back to default. Unrecognised `min_confidence` strings log Warning + fall back to `"heuristic_sgr"`.

## What this PR deliberately omits

- **No detector internal changes.** The `Parameters` record + `defaultParameters` value already exist (Cycle 29a shipped them); Cycle 32a only adds Config-side overrides + composition-root wiring. `SelectionDetector.fs` and `SelectionProfile.fs` are untouched.
- **No existing test changes.** `SelectionDetectorTests.fs` and `SelectionProfileTests.fs` continue to use `defaultParameters` and stay green.
- **No hot-reload.** `[profile.selection]` is loaded once at startup; mid-session `config.toml` edits require a restart. Matches every existing TOML section except `[session_model.persistence]` (which gets reloaded on shell-switch via `Program.fs:2488-2500`). Adding hot-reload would be a future micro-cycle.
- **No new ACCESSIBILITY-TESTING.md row.** Pure config plumbing reuses the existing Cycle 29b matrix.
- **No per-shell selection overrides.** A future cycle could add `[shell.<id>.profile.selection]` for per-shell tuning; Cycle 32a's `[profile.selection]` is global across all shells.

## Test plan

- [x] `ConfigTests.fs` — 6 new facts pass.
- [x] Existing `ConfigTests.fs` (~36 facts), `SelectionDetectorTests.fs`, `SelectionProfileTests.fs` continue to pass without modification.
- [x] Standard CI (Build + test on windows-latest, Workflow lint, Markdown link check, Portability lint) passes.
- [ ] **Optional manual NVDA validation (maintainer):** edit `config.toml` to add `[profile.selection]` with `min_confidence = "heuristic_sgr_with_keystroke"`, restart pty-speak, run a Claude tool-use prompt that requires user confirmation (force a prompt by writing a file in an untrusted directory per the Cycle 29b auto-trust caveat in `docs/STAGE-7-ISSUES.md`). Confirm NVDA does NOT announce the selection until the user presses an arrow key.

## Configurability note

This PR introduces four candidate user settings; all four are documented in `docs/USER-SETTINGS.md` ("Selection prompt thresholds and confidence modes" subsection) per CONTRIBUTING.md "Consider configurability when iterating".

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_