### PR TITLE
refactor(views): Cycle 32b — first IDisplayBuffer consumer (TerminalView render path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,58 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 32b): first `IDisplayBuffer` consumer — TerminalView render path
+
+`TerminalView`'s UI render path (`OnRender`) now consumes the
+`IDisplayBuffer` boundary interface (Cycle 31b) instead of
+calling `Screen.SnapshotRows` directly. The composition root
+constructs an inline F# object expression wrapping the existing
+`Screen` instance; the C# render loop receives an injected
+`IDisplayBuffer` via a new `SetDisplayBuffer` method that mirrors
+the existing `SetScreen` / `SetPtyHost` post-construction-injection
+pattern. **Pure refactor — visual rendering identical;** the
+`System.Tuple<long, Tuple<int, int>, Cell[][]>` shape returned by
+`Snapshot` is byte-identical to the prior `SnapshotRows`, so
+`.Item3` access in C# is unchanged.
+
+This is the **first consumer cutover** for the four boundary
+interfaces declared in Cycle 31. The other six `Screen.SnapshotRows`
+call sites (`Program.fs:1258/1345/1375/1480/1534/2574`,
+`TerminalAutomationPeer.fs:742`) remain on direct `Screen`
+access — future cycles can migrate as concrete value motivation
+surfaces.
+
+- **`src/Views/TerminalView.cs`** — adds `using Terminal.Core.Channels;`,
+  a new `private IDisplayBuffer? _displayBuffer;` field after the
+  existing `_screen` field, a new `SetDisplayBuffer(IDisplayBuffer)`
+  setter mirroring `SetScreen`, and a 1-line cutover at the render
+  call site (now line 1011 post-edits): `_screen.SnapshotRows(0, _screen.Rows)`
+  becomes `_displayBuffer.Snapshot(0, _screen.Rows)`. The
+  `_screen.Cols` access on the next line stays direct — `IDisplayBuffer`
+  is a snapshot-only contract; grid sizing is host-surface metadata
+  that future renderers will read from their own surface
+  dimensions.
+- **`src/Terminal.App/Program.fs`** — adds `open Terminal.Core.Channels`
+  at the top; immediately after the existing
+  `window.TerminalSurface.SetScreen(screen)` at line 731, adds
+  an inline `IDisplayBuffer` object expression wrapping the
+  same `screen` instance plus a `SetDisplayBuffer(displayBuffer)`
+  call. ~10 LOC. No new file (YAGNI principle — extract to a
+  named `DefaultDisplayBuffer` class when a second consumer
+  surfaces).
+
+**No tests changed.** No `TerminalView*Tests` exist (per
+CONTRIBUTING.md "Tests" §"NVDA: manual for each release", the
+render path is NVDA-validated manually). The Cycle 31a / 31b /
+32a unit-test surface stays green by construction (no public
+API changed; `IDisplayBuffer` was declared in Cycle 31b with
+no consumers, and Cycle 32b wires the first one).
+
+**Validation:** maintainer launches pty-speak via `dotnet run` (or
+the installed Velopack build) and verifies the terminal renders
+normally on a real PTY session. The cutover is a pure refactor —
+if rendering looks correct, the abstraction layer is sound.
+
 ### Added (Cycle 32a): `[profile.selection]` TOML loader — closes Stage 8e-A scope
 
 The four `SelectionDetector` tunable thresholds (`HighlightDetectionThresholdMs`,

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -11,6 +11,7 @@ open Microsoft.Extensions.Logging
 open Velopack
 open Velopack.Sources
 open Terminal.Core
+open Terminal.Core.Channels
 open Terminal.Audio
 open Terminal.Parser
 open Terminal.Pty
@@ -729,6 +730,19 @@ module Program =
         let screen = Screen(rows = ScreenRows, cols = ScreenCols)
         let parser = Parser.create ()
         window.TerminalSurface.SetScreen(screen)
+
+        // Cycle 32b — first consumer of the IDisplayBuffer boundary
+        // interface (Cycle 31b declaration). Inline F# object
+        // expression wrapping the `screen` instance just constructed
+        // above; YAGNI principle over a separate named adapter
+        // class until a second implementation surfaces. Future
+        // renderers (Avalonia, GTK, AppKit) inject their own
+        // IDisplayBuffer instead of going through Screen directly.
+        let displayBuffer =
+            { new IDisplayBuffer with
+                member _.Snapshot(startRow, count) =
+                    screen.SnapshotRows(startRow, count) }
+        window.TerminalSurface.SetDisplayBuffer(displayBuffer)
 
         // Pre-framework-cycle PR-O — wire each app-reserved
         // hotkey through the unified `bindHotkey` helper which

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -1008,7 +1008,14 @@ public class TerminalView : FrameworkElement
         // dark surface even when no screen is attached yet.
         drawingContext.DrawRectangle(_background, null, new Rect(RenderSize));
 
-        if (_screen is null)
+        // Cycle 32b — both fields must be set by the composition root
+        // before the first render frame. SetScreen + SetDisplayBuffer
+        // are called sequentially at Program.fs:731-...; in practice
+        // both are always non-null here. The null-check is defense
+        // in depth + satisfies C# nullable-reference-types analysis
+        // (otherwise CS8602 fires on `_displayBuffer.Snapshot(...)`
+        // below).
+        if (_screen is null || _displayBuffer is null)
         {
             return;
         }

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using Terminal.Accessibility;
 using Terminal.Core;
+using Terminal.Core.Channels;
 
 namespace PtySpeak.Views;
 
@@ -43,6 +44,17 @@ public class TerminalView : FrameworkElement
     private double _cellHeight;
 
     private Screen? _screen;
+
+    /// <summary>
+    /// Cycle 32b — first consumer of the <see cref="IDisplayBuffer"/>
+    /// boundary interface declared in Cycle 31b. Composition root
+    /// constructs an adapter wrapping the same <see cref="Screen"/>
+    /// passed to <see cref="SetScreen"/>, then calls
+    /// <see cref="SetDisplayBuffer"/>. Future renderers (Avalonia,
+    /// GTK, AppKit) inject a different <c>IDisplayBuffer</c>
+    /// implementation; the C# render loop is unchanged.
+    /// </summary>
+    private IDisplayBuffer? _displayBuffer;
 
     /// <summary>
     /// Stage 6 PR-B — sink for keyboard / paste / focus bytes. Set
@@ -187,6 +199,20 @@ public class TerminalView : FrameworkElement
         _screen = screen ?? throw new ArgumentNullException(nameof(screen));
         InvalidateMeasure();
         InvalidateVisual();
+    }
+
+    /// <summary>
+    /// Cycle 32b — wires the <see cref="IDisplayBuffer"/> snapshot
+    /// surface for the UI render path. Composition root calls this
+    /// immediately after <see cref="SetScreen"/> with an adapter
+    /// that wraps the same <see cref="Screen"/> instance. Mirrors
+    /// the existing <see cref="SetScreen"/> / <see cref="SetPtyHost"/>
+    /// post-construction-injection pattern.
+    /// </summary>
+    public void SetDisplayBuffer(IDisplayBuffer displayBuffer)
+    {
+        _displayBuffer = displayBuffer
+            ?? throw new ArgumentNullException(nameof(displayBuffer));
     }
 
     /// <summary>
@@ -999,7 +1025,15 @@ public class TerminalView : FrameworkElement
         // F# 3-tuple becomes `Tuple<long, Tuple<int, int>, Cell[][]>`
         // — the Cell[][] moves from `.Item2` to `.Item3`. UI rendering
         // doesn't need cursor position, so `.Item2` is discarded.
-        var snap = _screen.SnapshotRows(0, _screen.Rows);
+        //
+        // Cycle 32b: snapshot now flows through the IDisplayBuffer
+        // boundary (Cycle 31b interface) instead of direct Screen
+        // access. Identical tuple shape — `.Item3` access unchanged.
+        // `_screen.Cols` stays direct (IDisplayBuffer is a
+        // snapshot-only contract; grid sizing is host-surface
+        // metadata that future renderers will read from their own
+        // surface dimensions).
+        var snap = _displayBuffer.Snapshot(0, _screen.Rows);
         var rows = snap.Item3;
         var cols = _screen.Cols;
 


### PR DESCRIPTION
## Summary

`TerminalView`'s UI render path (`OnRender`) now consumes the `IDisplayBuffer` boundary interface (Cycle 31b declaration) instead of calling `Screen.SnapshotRows` directly. **Pure refactor** — visual rendering identical; the `System.Tuple<long, Tuple<int, int>, Cell[][]>` shape returned by `Snapshot` is byte-identical to the prior `SnapshotRows`, so `.Item3` access in C# is unchanged.

This is the **first consumer cutover** for the four boundary interfaces declared in Cycle 31. The other six `Screen.SnapshotRows` call sites (`Program.fs:1258/1345/1375/1480/1534/2574`, `TerminalAutomationPeer.fs:742`) remain on direct `Screen` access — future cycles can migrate as concrete value motivation surfaces.

## What changed

- **`src/Views/TerminalView.cs`** — adds `using Terminal.Core.Channels;`, a new `private IDisplayBuffer? _displayBuffer;` field after the existing `_screen` field, a new `SetDisplayBuffer(IDisplayBuffer)` setter mirroring the existing `SetScreen` / `SetPtyHost` post-construction-injection pattern, and a 1-line cutover at the render call site: `_screen.SnapshotRows(0, _screen.Rows)` becomes `_displayBuffer.Snapshot(0, _screen.Rows)`. The `_screen.Cols` access on the next line **stays direct** — `IDisplayBuffer` is a snapshot-only contract; grid sizing is host-surface metadata that future renderers will read from their own surface dimensions.
- **`src/Terminal.App/Program.fs`** — adds `open Terminal.Core.Channels` at the top; immediately after the existing `window.TerminalSurface.SetScreen(screen)` at line 731, adds an inline F# `IDisplayBuffer` object expression wrapping the same `screen` instance plus a `SetDisplayBuffer(displayBuffer)` call. ~10 LOC. **No new file** (YAGNI principle — extract to a named `DefaultDisplayBuffer` class when a second consumer surfaces).
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## What this PR deliberately omits

- **Does NOT migrate the 6 other `Screen.SnapshotRows` call sites.** `Program.fs:1258/1345/1375/1480/1534/2574` and `TerminalAutomationPeer.fs:742` stay direct. Future cycles handle as motivation surfaces.
- **Does NOT extract a named `DefaultDisplayBuffer` class.** Inline F# object expression in `Program.fs` is the right scope for a single-method, single-consumer adapter.
- **Does NOT add `Cols` / `Rows` accessors to `IDisplayBuffer`.** Grid dimensions stay surface-specific (the WPF `TerminalView` reads them from `_screen.Cols`).
- **Does NOT remove the `_screen` field from `TerminalView`.** The field stays for `_screen.Cols` (UI sizing), `_screen.Modes` (BracketedPaste / FocusReporting reads in `OnPreviewKeyDown`), and `MeasureOverride` reads. A future cycle could split these out into a separate interface (`IScreenMetadata`?) but that's scope creep.
- **Does NOT add tests.** No `TerminalView*Tests` exist (per CONTRIBUTING.md "Tests" §"NVDA: manual for each release", the render path is NVDA-validated manually).

## Test plan

- [x] Standard CI (Build + test on windows-latest, Workflow lint, Markdown link check, Portability lint) passes — F# and C# both compile; existing test surface (Cycle 31a IOutputSinkTests, Cycle 32a ConfigTests, etc.) stays green.
- [x] Portability lint continues to pass — no host-specific imports introduced into substrate code.
- [x] F# / C# tuple shape verified pre-commit (per CONTRIBUTING.md "F#/C# tuple-shape boundary"): `IDisplayBuffer.Snapshot` returns identical `int64 * (int * int) * Cell[][]` shape as `Screen.SnapshotRows`; C# `.Item3` access unchanged.
- [ ] **Maintainer manual smoke test (post-merge):** launch pty-speak via `dotnet run` (or installed Velopack build) and verify the terminal renders normally on a real PTY session. Pure refactor — if rendering looks correct, the abstraction layer is sound.

## Configurability note

No new candidate user settings introduced. Per CONTRIBUTING.md "Consider configurability when iterating": this is an internal refactor exposing an existing abstraction surface to its first consumer; nothing user-tunable.

## Architectural note

With Cycle 32b, the `IDisplayBuffer` boundary interface has its first consumer — completing the architectural arc that started with Cycle 30 (boundary doc + ADR 0001), continued through Cycle 31a (IOutputSink + portability CI lint), Cycle 31b (sibling interface declarations), and Cycle 32a (selection TOML loader). The substrate / channel dichotomy is now **structurally enforced + first-consumer-validated**.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_