### PR TITLE
docs: Cycle 33 — linear-text substrate RFC + canonical-display catalog (pivot gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,102 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Docs (Cycle 33): linear-text substrate RFC + canonical-display catalog (pivot gate)
+
+Doc-only pivot-gate cycle locking the substrate-inversion design
+before any code lands. **No behaviour change.** Two new authoritative
+docs + cross-reference updates in CORE-ABSTRACTION-BOUNDARY.md and
+CLAUDE.md so future cycles read against a stable spec.
+
+This cycle is the architectural lock for the next ~8 cycles
+(34-38) of substrate-inversion work. Cycle 34 implements the
+`LinearTextStream` producer module against the RFC's contract;
+Cycles 35-36 invert the Stream profile against it; Cycles 37-38
+build interactive list + form-with-text-input on the inverted
+substrate. The RFC + catalog supersede the informal streaming-
+incomplete protocol in CORE-ABSTRACTION-BOUNDARY.md §7 for
+normative spec.
+
+- **`docs/rfc/0001-linear-text-substrate.md`** (new, ~610 LOC) —
+  the pivot-gate RFC. 12 sections: Abstract, Motivation, Current
+  Extraction Path (`SessionModel.fs:338-375` `extractContent`),
+  LinearTextStream Producer Design (module shape + buffer +
+  Coalescer hookpoint + 4 MB cap + session-restore-explicitly-
+  out-of-scope), Inversion of Cause and Effect, Streaming-
+  Incomplete Emission Protocol (seam hierarchy + cadence
+  parameters table + ranked live-region detection + sealed/
+  unsealed extension; lifted verbatim from
+  `docs/research/emission-paradigms.md` §3.A-§3.D and §4 closing
+  recommendations), Drain-Checkpoint-Swap Protocol (lifted from
+  emission-paradigms.md §3.E), SessionTuple Finalize Contract,
+  Three Exemplar Canonical Displays (high level; full specs in
+  catalog), Risks + Mitigations (11 items), Acceptance Criteria
+  for Cycle 34 (10 testable invariants), Glossary (8 vocabulary
+  terms adopted), Cross-references.
+- **`docs/CANONICAL-DISPLAY-CATALOG.md`** (new, ~400 LOC) —
+  companion catalog. Full per-primitive specs for the three
+  exemplars: Raw Text (with CommandOutputTuple wrapper for the
+  history sub-pane), Interactive List (with ConfirmationPrompt
+  hybrid for assertive-notification cases), Form with Text Input.
+  Each exemplar covers UIA control type, required pattern
+  providers, ARIA role analog, NVDA reading pattern, JAWS virtual
+  cursor behavior, Narrator behavior, interaction contract,
+  substrate consumption, update cadence, output channel routing,
+  example terminal scenarios. Extension points (SeverityAlert,
+  IndeterminateProgress, CommandOutputTuple, Tier-2 deferred,
+  Tier-3 deferred) listed with one-paragraph descriptions. Output
+  channel routing matrix at the end. Lifted from
+  `docs/research/Output-paradigms.md` §1.1, §1.2, §1.3, §1.6 with
+  attribution; CORE-ABSTRACTION-BOUNDARY.md §5 cited as the
+  three-exemplar framing authority.
+- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §7 — streaming-incomplete
+  protocol summary updated with vocabulary adopted in the RFC
+  (tail mask, drain-checkpoint-swap, seam hierarchy, sealed/
+  unsealed). Cross-references the RFC for normative spec; this
+  section becomes a one-paragraph summary going forward.
+- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §10 — cross-references
+  expanded to include the new RFC + catalog + the two research
+  docs (now in-repo as authoritative sources).
+- **`CLAUDE.md`** "Reading order at session start" — items 6 + 7
+  added for the RFC + catalog. Items 6-7 (spec/tech-plan + 
+  CONTRIBUTING) renumbered to 8-9.
+
+**Vocabulary adopted (project-canonical post-RFC):**
+
+- **Tail mask** (replaces "live region pointer") — per-row state
+  marking content as overwrite-in-place; LATEST semantics.
+- **Drain-checkpoint-swap** (replaces "alt-screen freeze") —
+  three-phase Stream ↔ TUI substrate transition.
+- **Seam hierarchy** (replaces "idle quanta as commit points") —
+  five-priority ordered emission-trigger ranking.
+- **Substrate-of-truth** — formalised; the canonical source from
+  which all derived projections compute.
+- **Literal-language convention** — `select / mark / announce /
+  present / read / focused / current`; sight metaphors
+  `highlight / view / show` eliminated for accessibility-bearing
+  prose.
+- **Sealed / unsealed events** — formalised; `Sealed: bool`
+  extension on every chunk; mirrors RFC 9112 §8.
+- **High-water-mark commit** — the producer's act of finalising
+  a slice of the committed buffer at a seam crossing; replaces
+  `extractContent`'s row-walk (post-Cycle 34).
+
+**Earcon frequency clarification:** the research's Brewster
+guidance (≥125 Hz, ≤5 kHz) conflicts with CONTRIBUTING.md's
+tighter empirical bound (<180 Hz or >1.5 kHz). The RFC defers to
+CONTRIBUTING.md as the production constraint; the research's
+wider lower bound is flagged as a future tuning experiment.
+**No change to CONTRIBUTING.md** in this PR.
+
+**Stopping gate (per the strategic plan §2 Cycle 33):**
+maintainer reads RFC + catalog before Cycle 34 implementation
+begins; signs off on (a) tail-mask vs. brief-drop-to-TuiPathway
+for live-region content, (b) 4 MB per-tuple cap appropriateness,
+(c) freeze-on-alt-screen handles spinner case (spinners do NOT
+enter alt-screen), (d) three exemplar canonical displays
+accepted as the working catalog seed, (e) earcon frequency
+conflict resolved in favor of CONTRIBUTING.md's tighter bounds.
+
 ### Added (Cycle 32b): first `IDisplayBuffer` consumer — TerminalView render path
 
 `TerminalView`'s UI render path (`OnRender`) now consumes the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,27 @@ before deviating.
    reserved peer panes (notification queue, contextual keyword
    info, input assistant). Read before working on substrate or
    channel code.
-6. **[`spec/tech-plan.md`](spec/tech-plan.md)** §N for the canonical
+6. **[`docs/rfc/0001-linear-text-substrate.md`](docs/rfc/0001-linear-text-substrate.md)**
+   — Cycle 33 pivot-gate RFC. Specifies the `LinearTextStream`
+   producer, the streaming-incomplete emission protocol (seam
+   hierarchy + cadence parameters + ranked live-region detection
+   + sealed/unsealed events), and the drain-checkpoint-swap
+   protocol for Stream ↔ TUI substrate transitions. Supersedes
+   CORE-ABSTRACTION-BOUNDARY.md §7's informal protocol for
+   normative spec. Read before working on Cycle 34+ substrate-
+   inversion implementation.
+7. **[`docs/CANONICAL-DISPLAY-CATALOG.md`](docs/CANONICAL-DISPLAY-CATALOG.md)**
+   — Cycle 33 pivot-gate companion. Full per-primitive UIA /
+   ARIA / NVDA / JAWS / Narrator / interaction-contract /
+   channel-routing specs for the three exemplars (raw text +
+   CommandOutputTuple wrapper, interactive list +
+   ConfirmationPrompt hybrid, form with text input) plus named
+   extension points (severity alert, indeterminate progress,
+   Tier-2 deferred, Tier-3 deferred). Read before working on
+   any output-side framework or channel implementation.
+8. **[`spec/tech-plan.md`](spec/tech-plan.md)** §N for the canonical
    spec of whatever stage you're working on.
-7. **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — canonical PR shape,
+9. **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — canonical PR shape,
    branch naming, F# / .NET 9 gotchas, accessibility
    non-negotiables, P/Invoke conventions, test conventions.
 

--- a/docs/CANONICAL-DISPLAY-CATALOG.md
+++ b/docs/CANONICAL-DISPLAY-CATALOG.md
@@ -1,0 +1,400 @@
+# Canonical Display Catalog
+
+**Status:** Cycle 33 working catalog
+**Drafted:** 2026-05-09
+**Snapshot:** 2026-05-09
+**Companion to:** [`docs/rfc/0001-linear-text-substrate.md`](rfc/0001-linear-text-substrate.md)
+**Authority:** [`docs/CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) §5
+
+## Front matter
+
+This catalog specifies the **three exemplar canonical displays** that pty-speak commits to as a working seed taxonomy: raw text, interactive list, form with text input. It also names a set of extension points (severity alert, indeterminate progress, command-output-tuple wrapper, plus Tier-2 and Tier-3 deferred primitives) without locking their specs.
+
+The three-exemplar scope is deliberate. Per the maintainer's 2026-05-09 directive — *"we just need two or three simple canonical examples to get us through the pipeline"* — the catalog avoids premature taxonomy lock-in. Future cycles promote extension points to exemplars when concrete workloads demand them.
+
+### Sources surveyed
+
+- [`docs/research/Output-paradigms.md`](research/Output-paradigms.md) — primary source (849 LOC). Six Tier-1 primitives surveyed in depth; this catalog lifts three with attribution.
+- [`docs/research/emission-paradigms.md`](research/emission-paradigms.md) — secondary source (174 LOC). Cited for live-region detection + cadence parameters that affect each exemplar's update cadence.
+- [`docs/CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) §5 — authoritative for the three-exemplar framing; this catalog provides the full per-primitive treatment.
+- [`docs/PANE-MODEL.md`](PANE-MODEL.md) — pane catalog; the CommandOutputTuple wrapper for raw-text in the history sub-pane (per [PR #236](https://github.com/KyleKeane/pty-speak/pull/236) doc tweak) is referenced from §1.6 here.
+
+### Structure
+
+Each exemplar gets a §X with the following subsections:
+
+- **Content profile** — what concrete workloads land in this primitive.
+- **UIA control type** — Windows accessibility surface (NVDA + JAWS + Narrator's primary integration).
+- **Required UIA pattern providers** — what `IXxxxProvider` interfaces the host must implement.
+- **ARIA role analog** — for parity with the WebView-based docs / help surface.
+- **NVDA reading pattern** — concrete browse-mode / focus-mode behavior + quick-nav letters.
+- **JAWS virtual cursor** — JAWS-specific behavior (forms-mode triggers, keystroke equivalents).
+- **Narrator behavior** — Narrator-specific Scan Mode + landmarks behavior.
+- **Interaction contract** — what keystrokes the user issues; what the primitive does in response.
+- **Substrate consumption** — how the primitive is materialised from the linear-text substrate via detector annotations.
+- **Update cadence** — live polite vs. assertive vs. snapshot; debounce / coalesce contracts.
+- **Output channel routing** — which channels are native fits vs. require translation.
+- **Example terminal scenarios** — three concrete real-world workloads that trigger this primitive.
+
+### Literal-language convention
+
+Throughout this catalog: *select / mark / announce / present / read / focused / current*. Sight metaphors *highlight / view / show* are eliminated, per the Output-paradigms.md Front Matter discipline (and CORE-ABSTRACTION-BOUNDARY.md's adoption of literal-language vocabulary).
+
+-----
+
+## §1 Exemplar 1 — Raw Text
+
+The append-mostly canonical display for assistant prose, command output, and long-running tool stdout. Single highest-traffic primitive in the Claude Code workload.
+
+### 1.1 Content profile
+
+Token-streamed assistant prose with interleaved semantic blocks (thinking, tool-use markers, code fences); shell stdout / stderr bursts; `npm install` log lines; `git push` progress chatter; `cargo build` warnings as they emit. Concrete example: "I'll read the file and then…" arrives as a stream of UTF-8 grapheme clusters, with embedded `<thinking>` and `<tool_use>` regions detected by upstream pipeline stages and re-emitted as named TextPattern annotations.
+
+### 1.2 UIA control type
+
+`ControlType.Document` (control & content view, focusable=true). `LocalizedControlType = "terminal log"`. `LiveSetting = AutomationLiveSetting.Polite`. `ItemType = "stream"`.
+
+### 1.3 Required UIA pattern providers
+
+- **`ITextProvider`** + **`ITextProvider2`** exposing `DocumentRange` and `RangeFromPoint`.
+- **`ITextRangeProvider`** supporting `Move` / `MoveEndpointByUnit` for `TextUnit.Character / Word / Line / Paragraph / Document`.
+- `GetAttributeValue` returns `UIA_FontWeightAttributeId` / `UIA_BackgroundColorAttributeId` / `UIA_ForegroundColorAttributeId` / `UIA_IsHiddenAttributeId` / a custom `pty.SemanticBlock` attribute (`assistant` / `thinking` / `tool-use` / `code` / `diff`). Follow the `microsoft/terminal` `UiaTextRangeBase.GetAttributeValue` / `FindAttribute` precedent (microsoft/terminal PR #10336).
+- **Recommended:** `IValueProvider` (read-only) for legacy MSAA bridging.
+
+### 1.4 ARIA role analog
+
+`role="log"` on the wrapping container with `aria-live="polite"`, `aria-atomic="false"`, `aria-relevant="additions text"`, `aria-busy="true"` while the model is still streaming.
+
+Each interleaved semantic block is wrapped as `role="article"` (assistant turn) or `role="group"` with `aria-roledescription` of `"thinking block"` / `"tool use"` / `"code block"`.
+
+Reference: WAI-ARIA 1.2 `role=log`, MDN log-role doc.
+
+### 1.5 NVDA reading pattern
+
+**Browse mode:** entered automatically on the Document by NVDA's UIA terminal handler; arrow keys read by line; `NVDA+UpArrow` / `NVDA+DownArrow` for say-all from caret. Quick-nav letters (exposed via embedded TextPattern annotations):
+
+- `h` / `Shift+h` — next/previous semantic-block boundary (level-2 headings map to Claude Code turn boundaries; level-3 to thinking / tool-use sub-blocks).
+- `o` / `Shift+o` — next/previous embedded object (tool-use blocks surface as embedded objects).
+- `k` / `Shift+k` — next/previous link (file-paths and URLs detected upstream).
+- `g` / `Shift+g` — next/previous graphic (ASCII art / diff hunk markers when graphic-detector profile is active).
+
+**Focus mode:** entered on `Tab` into the prompt input; while in focus mode all keystrokes pass to the PTY.
+
+`Insert+F7` (Elements List) reveals: Headings (turn boundaries), Links (file paths, URLs), Landmarks (Tier-1 channel regions). NVDA's element-list dialog supports type-ahead filtering.
+
+**Review cursor:** object review treats the Document as one navigator object; document review is scoped to the entire scrollback. `BrailleExtender`'s "automatic review cursor tethering in terminal role" must be honored — emit `terminal` role hint via a custom UIA property so the add-on engages.
+
+### 1.6 CommandOutputTuple wrapper (history sub-pane)
+
+Per the post-Cycle-31a doc tweak ([PR #236](https://github.com/KyleKeane/pty-speak/pull/236)) and [`docs/PANE-MODEL.md`](PANE-MODEL.md) "Shell pane internal structure" §3, the history sub-pane consumes raw-text exemplars wrapped as **CommandOutputTuple** primitives. Each tuple wraps the submitted command, the output stream, and the exit code as a single semantically-navigable region.
+
+- **UIA wrapper:** `ControlType.Group` with `LocalizedControlType = "command/output pair"`, `Name = "<truncated command>"`, `HelpText = "exit code <N>, <duration>"`, `LiveSetting = AutomationLiveSetting.Off` (the inner raw-text exemplar handles live update).
+- **Children:** `ControlType.Edit` (command, read-only after submission via `IValueProvider`), `ControlType.Document` (output; full raw-text exemplar), `ControlType.Text` (exit-code element with `Name = "Exit code 0"` / `"Exit code 127"`, `ItemStatus = "success" | "failure"`).
+- **Quick-nav contract:** `h` / `Shift+h` (command boundaries via level-2 headings), `o` / `Shift+o` (output blocks via embedded-object navigation), `Alt+Up` / `Alt+Down` (tuple boundaries, parallel to VS Code's `editor.action.marker.next`).
+- **Substrate:** the linear-text producer's high-water-mark commits at prompt-boundary fires (per RFC 0001 §7); the wrapper is constructed from the resulting SessionTuple's `CommandText` + `OutputText` + `ExitCode` fields.
+
+### 1.7 JAWS virtual cursor
+
+The `ControlType.Document` with `IsContentElement=true` activates JAWS's virtual buffer (PC Cursor in document-mode) automatically. `INSERT+F6` lists turn-boundary headings; `INSERT+F7` lists detected file-path links; `INSERT+F5` is empty unless a form-input primitive is also present; `INSERT+CTRL+R` lists pty-speak's exposed Landmark regions (input prompt, scrollback, status). Smart Navigation announces the role and content of each element as the virtual cursor crosses it. JAWS Auto Forms Mode triggers when focus enters an embedded `Edit` (the prompt). `NumPad +` / `NumPad -` (Forms Mode toggle) returns control to virtual buffer.
+
+### 1.8 Narrator behavior
+
+Document control type is fully supported. Scan Mode (`Caps+Spacebar` or `Insert+Spacebar`) enables `H/L/K/T/I/B/F` style navigation and arrow-key reading. `Narrator+F6` lists headings, `Narrator+F7` lists links, `Narrator+F5` lists landmarks. Narrator's reading depends heavily on TextPattern (per Chromium docs) — the host's `ITextProvider2.DocumentRange` must be complete and traversable end-to-end without per-character cross-process round-trips (use `GetText(-1)` precedent).
+
+### 1.9 Interaction contract
+
+- **Read keys:** `Up` / `Down` (line), `Left` / `Right` (character; word with `Ctrl`), `Home` / `End` (line bounds), `Ctrl+Home` / `Ctrl+End` (scrollback bounds), `PageUp` / `PageDown` (viewport).
+- **Search:** `Ctrl+F` opens an in-region find-bar (separate primitive — `Find` uses Exemplar 3's form contract).
+- **Type-ahead is NOT consumed in browse mode;** it reaches the PTY only in focus mode.
+- **Activation:** `Enter` on a detected file-path link emits an `Invoke` event consumable by upstream tooling (e.g., open-in-editor pathway).
+
+### 1.10 Substrate consumption
+
+**Linear-text substrate (post-RFC 0001).** The detectors stage tags substrate runs as `assistant-prose | thinking | tool-use | code | diff | command-echo | stdout | stderr` and emits append events; the raw-text exemplar's UIA Document reads from this annotated event store, never from the raw screen-cell substrate. **Substrate inversion:** the screen-cell grid is *secondary* and reconstructed only for the WPF visual channel.
+
+### 1.11 Update cadence
+
+Live, polite. Per-token announcement is **forbidden**. Coalesce appends with the producer's `live_region_debounce_ms` (250 ms default per RFC 0001 §5.2) keyed on word-boundary detection. Emit `UIA_Text_TextChangedEventId` after each coalesced append. Raise an explicit `LiveRegionChanged` event with `AutomationLiveSetting.Polite` only when (a) a complete sentence has been emitted *and* (b) no further bytes have arrived for ≥ 200 ms (lifted from research §1.1; close to the producer's `idle_quantum_ms` of 150 ms). Boundary notifications (block start/end) fire via `UiaRaiseNotificationEvent(NotificationKind.ItemAdded, NotificationProcessing.CurrentThenMostRecent)`.
+
+### 1.12 Output channel routing
+
+- **NVDA UIA:** native fit (Document + TextPattern is the canonical NVDA terminal contract).
+- **Self-voicing TTS:** primary fit; pty-speak's TTS pathway can subscribe to the same coalesced append events with no translation.
+- **Earcon:** semantic-block-boundary earcons (one per kind: assistant, thinking, tool-use, code, diff). Brewster timbre/rhythm guidelines apply, BUT per [`CONTRIBUTING.md`](../CONTRIBUTING.md) line 200's tighter empirical bounds (frequencies must be either below 180 Hz or above 1.5 kHz to stay out of the speech band).
+- **Refreshable braille:** native fit via TextPattern (NVDA's braille subsystem follows the review cursor; `BrailleExtender` adds terminal-mode tethering). LibLouis tables apply.
+- **Spatial audio:** optional — render different `SemanticBlock` kinds at distinct azimuths via Windows `ISpatialAudioClient` with HRTF (e.g., assistant at 0°, thinking at +30° elevation, tool-use at -30° azimuth left). Defer behind a feature flag.
+- **FileLogger:** native fit (annotated events serialize to NDJSON).
+- **WPF visual:** native fit (the screen-cell grid drives the WPF surface; this is the one consumer that legitimately reads from the grid post-substrate-inversion).
+
+### 1.13 Example terminal scenarios
+
+1. Claude Code streaming an assistant turn with embedded `<thinking>` block, then a `tool_use` for `Edit`, then resumed prose.
+2. `npm install` emitting hundreds of `added X packages` lines.
+3. `cargo build --verbose` long-running compiler output with interleaved warnings (stderr) and progress (stdout).
+
+-----
+
+## §2 Exemplar 2 — Interactive List
+
+Vertical or horizontal selection menu, no embedded prose. Distinguished from raw text by **selection semantics** — the user's keystroke commits a choice rather than appending to a stream.
+
+### 2.1 Content profile
+
+`fzf` selection UI; Claude Code `/model` slash-command list; `gh pr list` interactive picker; `git checkout` branch picker; PowerShell `Out-GridView -PassThru`; Ink `SelectInput` components. Also: cmd `choice /C YN` and `apt`'s `Continue? [Y/n]` (these escalate to the ConfirmationPrompt hybrid, see §2.14).
+
+### 2.2 UIA control type
+
+- **Container:** `ControlType.List` implementing `ISelectionProvider`. `IsKeyboardFocusable=true`. `AutomationProperties.Name` set to a derived label (e.g., "Branch picker"). For multi-select pickers (`fzf -m`), `CanSelectMultiple=true`.
+- **Each item:** `ControlType.ListItem` implementing `ISelectionItemProvider`; `IInvokeProvider` is **not** implemented (selection ≠ activation in this exemplar; activation goes through a separate Enter-key dispatch routed by the prompt-substrate detector).
+- `AutomationElementIdentifiers.PositionInSetProperty` and `SizeOfSetProperty` populated from the list cardinality.
+
+### 2.3 Required UIA pattern providers
+
+- **`ISelectionProvider`** on the container (`CanSelectMultiple`, `IsSelectionRequired`, `GetSelection`).
+- **`ISelectionItemProvider`** on each item (`Select`, `AddToSelection`, `RemoveFromSelection`, `IsSelected`, `SelectionContainer`).
+- For ConfirmationPrompt hybrid (§2.14): the items also implement `IInvokeProvider` (single-key activation).
+
+### 2.4 ARIA role analog
+
+`role="listbox"` on the container with `aria-orientation="vertical"` (or `horizontal` per layout), `aria-required="true"`, single-select via `aria-selected`. For multi-select: `aria-multiselectable="true"`. Each `role="option"` carries `aria-keyshortcuts` if a keyboard shortcut exists.
+
+References: WAI-ARIA 1.2 listbox pattern; APG Listbox example.
+
+### 2.5 NVDA reading pattern
+
+Focus mode auto-entered (NVDA's "form field" detection). `Down` / `Up` (or `Right` / `Left` for horizontal) move selection. First-letter type-ahead jumps by `Name`. `Insert+F7` Elements List shows options under "Form fields" / "Lists." Quick-nav `i` (list item) and `l` (list) jump out and back. Quick-nav `b` does **not** apply (these are listitems, not buttons).
+
+### 2.6 JAWS virtual cursor
+
+JAWS auto-forms-mode triggers on focus into the listbox. PC Cursor announces the list role and current item, then "1 of N." `INSERT+F5` (Form Fields List) includes the options.
+
+### 2.7 Narrator behavior
+
+Scan Mode auto-disables when focus enters the listbox (Narrator's "form field" detection). Narrator announces the list role and the focused item, then "1 of N."
+
+### 2.8 Interaction contract
+
+- **Arrow keys** move selection within the listbox.
+- **First-letter type-ahead** (`Y`, `A`, `N`) selects-and-activates immediately when option labels are unambiguous (the Claude Code pattern).
+- **`Enter`** activates the selected option.
+- **`Escape`** dismisses the list (cancels selection); the substrate detector emits `SelectionDismissed`.
+- **`Tab`** is **trapped** within the prompt while it is active for the ConfirmationPrompt hybrid; pure SelectableList lets Tab through to the next element.
+- For the ConfirmationPrompt hybrid: focus is moved into the prompt on appearance and restored on dismissal.
+
+### 2.9 Substrate consumption
+
+**Derived semantic-event store.** The `SelectionDetector` (Cycle 29a substrate; `src/Terminal.Core/SelectionDetector.fs`) consumes the linear-text producer's bytes (post-Cycle 35 inversion) and emits `SelectionShown` / `SelectionItem` / `SelectionDismissed` semantic events. The `SelectionProfile` (Cycle 29b consumer; `src/Terminal.Core/SelectionProfile.fs`) translates these events into NVDA announcements and UIA structure-changed events.
+
+For Claude Code's tool-use confirmations: a `ConfirmationDetector` (future cycle) detects the Ink Select component output pattern. For cmd `choice` / PowerShell `PromptForChoice`: pattern-matched as the prompt seam fires. The exemplar is constructed from the structured detection event, never re-parsed from cells.
+
+### 2.10 Update cadence
+
+**Snapshot-on-render** with selection-follows-focus events on each arrow press.
+
+- One `NotificationKind.Other` + `NotificationProcessing.ImportantAll` event on appearance (see §2.14 for ConfirmationPrompt's stronger `ImportantAll` semantics).
+- One `NotificationKind.ActionCompleted` event on dismissal.
+- `SelectionItemPatternIdentifiers.ElementSelectedEvent` per arrow press.
+- `AutomationElementIdentifiers.StructureChangedEvent` when the underlying list mutates (e.g., fzf type-ahead filtering).
+
+### 2.11 Output channel routing
+
+- **NVDA UIA:** native fit.
+- **Self-voicing TTS:** native fit (the appearance announcement is the trigger).
+- **Earcon:** boundary tick on each selection-shift; **mandatory** "decision required" earcon on appearance for ConfirmationPrompt hybrid + confirming earcon on dismissal. Brewster timbre/rhythm guidelines, but constrained by CONTRIBUTING.md's <180 Hz / >1.5 kHz speech-band rule.
+- **Refreshable braille:** native via UIA TextPattern propagation (the focused option name and selection state).
+- **Spatial audio:** optional — render the prompt earcon at center-front (0°) for spatial salience.
+- **FileLogger:** native — record question, options, default, chosen.
+- **WPF visual:** native.
+
+### 2.12 Example terminal scenarios
+
+1. `fzf` invocation: type-ahead filtering as the user types; arrow keys move within the filtered set; `Enter` commits.
+2. Claude Code `/model` slash-command picker: 4-5 model names; first-letter type-ahead jumps; `Enter` switches model.
+3. `gh pr checkout` interactive PR picker: dynamic list from API; selection commits the checkout.
+
+### 2.13 Selection thresholds (Cycle 32a TOML configurability)
+
+The detector's four tunables are now overridable via `[profile.selection]` in `config.toml` per Cycle 32a (PR #238): `highlight_detection_threshold_ms` (default 100), `dismissal_grace_ms` (default 150), `keystroke_correlation_window_ms` (default 250), `min_confidence` (`heuristic_sgr` | `heuristic_sgr_with_keystroke`, default `heuristic_sgr`). Documented in [`docs/USER-SETTINGS.md`](USER-SETTINGS.md) "Selection prompt thresholds and confidence modes".
+
+### 2.14 ConfirmationPrompt hybrid (related primitive — future)
+
+When the interactive list carries assertive-notification semantics — Claude Code tool-use confirmation, `apt`'s `Continue? [Y/n]`, cmd `choice /C YN` — the catalog notes a hybrid alert+selection pattern that combines this exemplar's selection contract with `role="alertdialog"` modality.
+
+- **UIA:** outer `ControlType.Pane` with `LocalizedControlType = "confirmation"`, `LiveSetting = AutomationLiveSetting.Assertive`. Embedded list per §2.2-§2.3.
+- **ARIA:** outer `role="alertdialog"` with `aria-modal="true"`; inner `role="listbox"` per §2.4.
+- **Notification on appearance:** `UiaRaiseNotificationEvent(NotificationKind.Other, NotificationProcessing.ImportantAll, displayString = "Confirmation required: <prompt>", activityId = "pty-speak.confirmation.<id>")`. **`ImportantAll` (not `ImportantMostRecent`)** because confirmations must not be dropped under burst.
+- **Default option** exposed via `AutomationElementIdentifiers.IsDefaultProperty` (or `aria-current="true"` for ARIA).
+
+Implementation timing: future cycle once both halves of the hybrid (interactive list ✓ shipped via Cycle 29a/29b/32a; assertive-notification UIA peer pending) are stable. Currently Stage 8e-A ships the substrate (Cycle 29a + 29b) + config (Cycle 32a); Stage 8e-B (UIA listbox peer) is the next plan-mode pass.
+
+-----
+
+## §3 Exemplar 3 — Form with Text Input
+
+Field-with-label primitive for shell prompts that require typed input.
+
+### 3.1 Content profile
+
+PowerShell `Read-Host` chains; cmd `set /p var=Prompt: `; password prompts (`sudo`, `ssh`, `git push` over HTTPS); future Claude tool-use approve-with-comment forms (e.g., "approve and tell Claude what to do" option in the §2.14 hybrid). Multi-field forms compose multiple Edit children inside a single Group.
+
+### 3.2 UIA control type
+
+- **Container:** `ControlType.Group` with `LocalizedControlType = "form"`, `Name` set to a derived label (e.g., "Login form"), `LiveSetting = AutomationLiveSetting.Off` (the inner Edit handles live update).
+- **Each field:** `ControlType.Edit` with `IValueProvider` (read-only after submission via `IsReadOnly=true`). For password fields: `ControlType.Edit` with `IsPassword=true` (UIA exposes the field but not its content).
+
+### 3.3 Required UIA pattern providers
+
+- **`IValueProvider`** on each Edit (`Value`, `IsReadOnly`, `SetValue`).
+- Optional: **`ITextProvider`** for multi-line edits with caret navigation (defer to a future cycle if the workload demands).
+
+### 3.4 ARIA role analog
+
+`role="form"` on the container with `aria-label` set to the form description. Each field uses `role="textbox"` with `aria-readonly="true"` once submitted; `aria-required="true"` if mandatory; `aria-describedby` referencing any hint text.
+
+For password fields: `role="textbox" aria-autocomplete="none" aria-roledescription="password"` (the actual input type=password attribute lives in the form-rendering layer; this is for the UIA peer to declare).
+
+### 3.5 NVDA reading pattern
+
+Focus mode auto-entered (NVDA's "edit field" detection). `Tab` between fields; `Shift+Tab` reverse. `Enter` submits. Within an Edit: arrow keys navigate caret; `Home` / `End` for line bounds; `Ctrl+Home` / `Ctrl+End` for field bounds.
+
+`Insert+F5` Form Fields List enumerates the form's edits.
+
+### 3.6 JAWS virtual cursor
+
+JAWS auto-forms-mode on focus into the Edit. PC Cursor announces field role + current value. `INSERT+F5` Form Fields List enumerates fields. `NumPad +` / `NumPad -` toggles forms-mode.
+
+### 3.7 Narrator behavior
+
+Scan Mode auto-disables when focus enters an Edit. Narrator announces field role + value + position (e.g., "Username, edit, 1 of 3").
+
+### 3.8 Interaction contract
+
+- **`Tab` / `Shift+Tab`** between fields.
+- **`Enter`** submits the form.
+- **`Escape`** dismisses (where the underlying shell supports cancellation).
+- **Within an Edit:** standard caret-navigation keys.
+- **For password fields:** content is announced as "password edit, value protected" (literal-language convention; do NOT announce the typed characters).
+
+### 3.9 Substrate consumption
+
+**Linear-text substrate + future `InputPathway`** (Cycle 38). The `FormProfile` detector (Cycle 38a) consumes linear-text bytes and emits `FormPrompt` semantic events when it recognises a `Read-Host` chain or password prompt; the UIA peer (`TerminalFormAutomationPeer`, Cycle 38b) translates the semantic events into the UIA Edit + Group structure.
+
+Until Cycle 38, plain-cmd typed-input echo is handled by Stage 6's typed-echo coalescer (already shipped) — the form exemplar is named in the catalog but its detector + UIA peer arrive in a future cycle.
+
+### 3.10 Update cadence
+
+- **Live polite for typed-echo:** the user's typed bytes arrive via Stage 6's typed-echo coalescer; each character (or coalesced word) raises a `UIA_Text_TextChangedEventId` on the focused Edit.
+- **Snapshot at submit:** on `Enter`, the form's `IsReadOnly` flips to `true`; the submission is announced via `NotificationKind.ActionCompleted`.
+- **Password redaction is mandatory** in all channels except the WPF visual surface (which renders bullets / asterisks per the host's password-field convention).
+
+### 3.11 Output channel routing
+
+- **NVDA UIA:** native fit.
+- **Self-voicing TTS:** native fit (with redaction for password fields).
+- **Earcon:** field tick on `Tab` between fields; submit confirmation earcon on `Enter`.
+- **Refreshable braille:** native via UIA TextPattern (with redaction for password fields — braille displays "•" per cell or similar).
+- **Spatial audio:** not applicable for forms (focus-driven; spatial cues add noise).
+- **FileLogger:** native (with redaction for password fields — log "[password redacted]" not the bytes).
+- **WPF visual:** native (password fields render as bullets per host convention).
+
+### 3.12 Example terminal scenarios
+
+1. `git push origin main` over HTTPS → password prompt → typed bytes redacted in all channels except WPF visual.
+2. PowerShell `Read-Host -Prompt 'Enter your name'` → single-field form → typed-echo polite live region.
+3. Future Claude tool-use approve-with-comment: `[Yes] [No] [Approve and comment...]` → selecting the third option opens a single-field form for the comment text.
+
+### 3.13 Implementation timing
+
+Cycle 38 (input framework cycle). Spec lifted from [`docs/CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) §5 Exemplar 3 + extended here. The exemplar is named in the catalog for completeness; the detector + UIA peer arrive when Cycle 38 ships.
+
+-----
+
+## §4 Extension points (named, not specified)
+
+The catalog names these as future canonical displays without locking the spec. Each is a 1-paragraph description; full per-primitive specs land in future cycles when concrete workloads demand them.
+
+### 4.1 SeverityAlert
+
+Single-shot interruptive announcement of error / warning / fatal. `role="alert"` (implicit `aria-live="assertive"` + `aria-atomic="true"`). Distinguish severity tiers via `aria-roledescription="error"` / `"warning"` / `"fatal"`. Detector consumes ANSI-red + lexical patterns (`error:` / `warning:` / `panic` / `fatal`) + stderr stream origin. Mandatory severity-tier earcons (distinct timbres per tier; rhythmic motif per Brewster, constrained to <180 Hz / >1.5 kHz). Coalescing: collapse identical severity messages within 500 ms into one notification with displayString suffix " (×N)" to avoid flooding (compiler error storms).
+
+Concrete workloads: `tsc` diagnostic with severity, Rust panic, `git push` rejection, `npm ERR!` lines, `cargo build` warnings.
+
+### 4.2 IndeterminateProgress
+
+Spinner-class display: ongoing activity with no completion estimate. Designed deliberately **not** as `role="progressbar"` (which requires `aria-valuenow` and screen-reader percent reporting; per-frame value-change events are catastrophic for screen-reader users).
+
+- **UIA:** `ControlType.Custom` with `LocalizedControlType = "activity indicator"`, `LiveSetting = AutomationLiveSetting.Off` (critical).
+- **ARIA:** `role="status"` with `aria-busy="true"` + `aria-atomic="true"` + descriptive `aria-label`.
+- **No `IRangeValueProvider`. No per-frame UIA events.** The frame animation is purely a WPF-visual concern and must not propagate through the UIA tree.
+- **Lifecycle notifications:** `UiaRaiseNotificationEvent(NotificationKind.ActionCompleted, NotificationProcessing.CurrentThenMostRecent, "Claude is thinking", "<activityId>")` on **start**, with the same `activityId` reused on **end** with `displayString = "Done."`. `CurrentThenMostRecent` so a new "thinking" event supersedes a stale one.
+- **Earcon:** "activity start" + "activity end" earcons; optional looped low-volume background drone while busy (volume below speech threshold; user-disable-able).
+
+Concrete workloads: Claude Code thinking (`⠋ ⠙ ⠹` braille spinner), `npm install` rotating spinner, `git clone` `Receiving objects:` chatter, `cargo build` "Compiling crate-name" status.
+
+The Cycle 29b regression (~80 spinner announcements per Claude turn) motivates getting this right out of the gate when the future cycle ships.
+
+### 4.3 CommandOutputTuple (wrapper for raw-text in history sub-pane)
+
+Already documented in §1.6 as a wrapper primitive. Named here as a discrete extension point because its UIA contract (`ControlType.Group` wrapping `Edit` + `Document` + `Text` for exit code) is distinct from the raw-text exemplar's contract. Its substrate is the linear-text producer's high-water-mark commits; its detector is `HeuristicPromptDetector` (already shipping). The full implementation is the [`PANE-MODEL.md`](PANE-MODEL.md) "Shell pane internal structure" §3 history sub-pane navigation contract.
+
+### 4.4 Tier-2 deferred
+
+These are named in the research doc as Tier-2 primitives (ship within 12 months, post-Cycle 38). Each gets a future canonical-display catalog entry when concrete workloads demand:
+
+- **DiffView** — unified-diff and side-by-side patch displays. Concrete workloads: `git diff`, Claude Code Edit-tool previews, `delta` / `diff-so-fancy` colorised output. UIA: `ControlType.Group` wrapping line-by-line `ControlType.Text` children with `ItemStatus = "added" | "removed" | "context"`; earcon distinct timbres for added vs. removed runs.
+- **CodeBlockWithSyntaxStructure** — syntax-aware code-fence rendering. Concrete workloads: Claude Code's code blocks, `bat`'s syntax-highlighted output, `man` page code samples. UIA: `ControlType.Document` + custom `pty.SyntaxToken` attribute on TextRange; computer-braille tables for braille channel.
+- **DeterminateProgress** — known-completion-percentage activity. Concrete workloads: `wget` / `curl --progress-bar`, `apt install` percentage, `dd` block-count progress. UIA: `ControlType.ProgressBar` + `IRangeValueProvider` (now appropriate because completion is known); rising-sweep earcon at milestones (25%, 50%, 75%, 100%).
+- **FormInputGroup** — specific form variants beyond the generic Exemplar 3. Concrete workloads: multi-field login forms, structured questionnaires, Claude Code's future tool-use approve-with-comment dialog. Builds on Exemplar 3's substrate; adds field-grouping semantics.
+- **TabularDataDisplay** — rows × columns with header semantics. Concrete workloads: PowerShell `Get-Process` formatted output, `kubectl get pods`, SQL query results. UIA: `ControlType.Table` + `ControlType.DataItem` per cell + `ITableProvider`; row-vs-column-tick earcons for navigation.
+
+### 4.5 Tier-3 deferred (research / defer)
+
+Named for future research. No commitment to ship:
+
+- **HierarchicalTreeDisclosure** — multi-level expand / collapse trees. Concrete workloads: `npm ls`, `git log --graph`, `tree`. UIA: `ControlType.Tree` + `IExpandCollapseProvider`; depth-as-pitch earcons.
+- **SpatialAudioStatusField** — continuous low-level status conveyed through HRTF-spatialized ambient tones (concurrent build status, battery, network, model token-rate). UIA: non-focusable `ControlType.Custom` with `LiveSetting=Off`; spatial audio is the primary channel (research-grade; defer to v2).
+- **MultiRegionFocusManager** — composite primitive coordinating multiple concurrent canonical displays in a single terminal viewport (split panes, Claude Code's prompt + assistant + status). Defines the focus-arbitration contract between regions. UIA: each region exposes its own provider tree with `LandmarkType` set; `Ctrl+F6` cycles regions (mirroring the Windows pattern).
+
+-----
+
+## §5 Output Channel Routing Matrix
+
+Legend: ● native fit · ◐ requires translation · ○ not applicable
+
+| Primitive                           | NVDA via UIA | Self-voicing TTS   | Earcon (WASAPI)     | Braille via UIA TextPattern | Spatial audio (HRTF) | FileLogger | WPF visual |
+|-------------------------------------|--------------|--------------------|---------------------|------------------------------|----------------------|------------|------------|
+| **Exemplar 1 — Raw Text**           | ●            | ●                  | ● (block-boundary)  | ●                            | ◐ (block-azimuth)    | ●          | ●          |
+| **Exemplar 1 — CommandOutputTuple** | ●            | ●                  | ● (start / exit-code)| ●                          | ◐ (time-axis)        | ●          | ●          |
+| **Exemplar 2 — Interactive List**   | ●            | ●                  | ● (boundary tick)   | ●                            | ○                    | ●          | ●          |
+| **Exemplar 2 — ConfirmationPrompt** | ●            | ●                  | ● (decision earcon) | ●                            | ◐ (front-center)     | ●          | ●          |
+| **Exemplar 3 — Form with Text Input** | ●          | ● (with redaction) | ● (field tick)      | ●                            | ○                    | ● (redacted) | ●        |
+| **Extension: SeverityAlert**        | ●            | ●                  | ● (severity-tier)   | ●                            | ◐ (severity azimuth) | ●          | ●          |
+| **Extension: IndeterminateProgress**| ●            | ● (start / end only)| ● (start / end + drone) | ◐ (description only)   | ◐ (drone azimuth)    | ●          | ● (frames) |
+
+Self-voicing, refreshable braille, and spatial audio are **first-class peers** — every primitive defines a path through each channel even when a translation step is required. Earcons are mandatory for primitives where a non-speech indication materially reduces dual-task interference (per the Auditory Perception & Cognition 2023 meta-analysis; CONTRIBUTING.md's <180 Hz / >1.5 kHz speech-band exclusion is the production constraint).
+
+-----
+
+## §6 Versioning + maintenance
+
+This catalog uses the snapshot model. Top-of-doc front matter carries `Snapshot: YYYY-MM-DD`. Trigger conditions for re-snapshot:
+
+- An extension point promotes to an exemplar (would happen if a future cycle's NVDA validation surfaces a workload that doesn't fit the three exemplars + named extension points).
+- A new channel is added to the routing matrix (e.g., a future Bluetooth-vibration channel for tactile feedback).
+- The literal-language convention's vocabulary expands (a future cycle adds new approved terms or retires a sight metaphor).
+- A maintainer-authored amendment (per spec-immutability discipline) updates a load-bearing contract — a dated "Amended in Cycle N" note is appended to the affected exemplar.
+
+The three-exemplar scope is **deliberately non-extensible without maintainer authorization**. Future cycles that want to add an exemplar require ADR-style review per the spec-immutability discipline in [`CLAUDE.md`](../CLAUDE.md).
+
+-----
+
+## Cross-references
+
+- [`docs/rfc/0001-linear-text-substrate.md`](rfc/0001-linear-text-substrate.md) — companion RFC; the substrate that feeds this catalog's primitives.
+- [`docs/CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) §5 — three-exemplar framing authority.
+- [`docs/PANE-MODEL.md`](PANE-MODEL.md) — pane catalog; CommandOutputTuple wrapper for raw-text in history sub-pane.
+- [`docs/research/Output-paradigms.md`](research/Output-paradigms.md) — primary source for exemplar UIA / ARIA / NVDA contracts.
+- [`docs/research/emission-paradigms.md`](research/emission-paradigms.md) — secondary source for cadence parameters affecting update cadence.
+- [`docs/USER-SETTINGS.md`](USER-SETTINGS.md) — Cycle 32a `[profile.selection]` thresholds for Exemplar 2's detector.
+- [`docs/STAGE-7-ISSUES.md`](STAGE-7-ISSUES.md) — Stage 7 + 8 issue tracker; closed `[output-selection]` row (Cycle 32a) and open Stage 8e-B (UIA listbox peer for Exemplar 2).
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — earcon frequency constraint (<180 Hz or >1.5 kHz) authoritative over research's wider Brewster guidance.

--- a/docs/CORE-ABSTRACTION-BOUNDARY.md
+++ b/docs/CORE-ABSTRACTION-BOUNDARY.md
@@ -487,22 +487,35 @@ same substrate.
 The linear-text substrate is **incomplete at every tick**. A
 byte that arrived 5ms ago might be the start of a longer
 sequence whose final shape is still in flight. The protocol
-that lets profiles emit usefully against an incomplete stream:
+that lets profiles emit usefully against an incomplete stream
+is specified in full in
+[`docs/rfc/0001-linear-text-substrate.md`](rfc/0001-linear-text-substrate.md)
+§5 (the seam-hierarchy commit model + cadence parameters +
+ranked live-region detection + sealed/unsealed extension).
+This section's framing is preserved as a one-paragraph
+summary; the RFC supersedes for normative spec.
 
-- **Idle quanta as commit points.** Coalescer's debounce-window
-  fire = high-water-mark commit; profiles emit suffix-since-
-  last-commit.
+- **Seam hierarchy.** Five-priority commit triggers (semantic
+  prompt seam > newline > idle quantum > max-bytes > max-time)
+  per RFC §5.1; lifted from
+  [`docs/research/emission-paradigms.md`](research/emission-paradigms.md)
+  §3.A. Each stronger seam pre-empts weaker ones.
 - **Prompt boundary as finalize.** `HeuristicPromptDetector`
-  fire = `SessionTuple.OutputText` sealed; immutable in History.
+  fire = `LinearTextStream.finalizeHighWaterMark` (post-Cycle
+  34) → `SessionTuple.OutputText` sealed; immutable in History.
 - **Mid-stream events carry `Sealed: bool` extension.** Unsealed
   events are advisory (profiles may show provisional state but
   must not commit irreversibly); sealed events are authoritative.
-- **Live region.** A `(start, length)` pointer into the
-  substrate tail. Bytes overwriting the live region (`\r`-
-  without-`\n`, cursor-up-then-back, ESC[K) replace tail; do
-  not append. Spinners + progress bars + `--More--` paginator
-  prompts live here. Detection mechanism finalized in Cycle 33
-  RFC.
+  Mirrors RFC 9112 §8 incomplete-message contract.
+- **Tail mask** (replaces the older "live region pointer"
+  framing per Cycle 33 vocabulary adoption). Per-row state
+  marking content as overwrite-in-place. Bytes overwriting via
+  `\r`-without-`\n`, cursor-up-then-back, ESC[K replace the
+  masked region; do not append. Spinners + progress bars +
+  `--More--` paginator prompts live here with LATEST semantics.
+- **Drain-checkpoint-swap** (replaces "alt-screen freeze"
+  framing). Three-phase Stream ↔ TUI substrate transition per
+  RFC §6.
 
 This protocol is the contract that makes the linear-text
 substrate usable by channels without erasing the streaming
@@ -561,6 +574,16 @@ a boundary violation; reviewers block.
 
 - **ADR**: [`adr/0001-substrate-channel-dichotomy.md`](adr/0001-substrate-channel-dichotomy.md)
 - **Strategic plan**: [`PROJECT-PLAN-2026-05-09.md`](PROJECT-PLAN-2026-05-09.md)
+- **Substrate RFC** (Cycle 33 — pivot gate):
+  [`rfc/0001-linear-text-substrate.md`](rfc/0001-linear-text-substrate.md).
+  Specifies the `LinearTextStream` producer + streaming-
+  incomplete emission protocol + drain-checkpoint-swap;
+  supersedes §7 informal protocol for normative spec.
+- **Canonical-display catalog** (Cycle 33 — pivot gate):
+  [`CANONICAL-DISPLAY-CATALOG.md`](CANONICAL-DISPLAY-CATALOG.md).
+  Full per-primitive UIA / ARIA / NVDA / JAWS / Narrator /
+  channel-routing specs for the three exemplars + named
+  extension points; companion to the substrate RFC.
 - **Channel principle (older framing)**:
   [`CHANNEL-ARCHITECTURE.md`](CHANNEL-ARCHITECTURE.md)
 - **Pipeline mechanics**: [`PIPELINE-NARRATIVE.md`](PIPELINE-NARRATIVE.md)
@@ -568,6 +591,10 @@ a boundary violation; reviewers block.
 - **Session history**: [`SESSION-MODEL.md`](SESSION-MODEL.md)
 - **Pane catalog + sub-pane decomposition**:
   [`PANE-MODEL.md`](PANE-MODEL.md)
+- **Research sources** (now in-repo as authoritative):
+  [`research/emission-paradigms.md`](research/emission-paradigms.md),
+  [`research/Output-paradigms.md`](research/Output-paradigms.md).
+  Primary sources for the Cycle 33 RFC + catalog lifts.
 - **Spec authority**: [`spec/tech-plan.md`](../spec/tech-plan.md)
 
 ### Boundary interfaces (the actual code)

--- a/docs/rfc/0001-linear-text-substrate.md
+++ b/docs/rfc/0001-linear-text-substrate.md
@@ -1,0 +1,608 @@
+# RFC 0001 — LinearTextStream Substrate + Streaming-Incomplete Emission Protocol
+
+**Status:** Draft (Cycle 33; pivot gate before Cycle 34 implementation)
+**Author:** Claude Code via maintainer-directed plan-mode
+**Drafted:** 2026-05-09
+**Snapshot:** 2026-05-09
+**Supersedes:** [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) §7 (informal streaming-incomplete protocol)
+**Implements:** [`docs/adr/0001-substrate-channel-dichotomy.md`](../adr/0001-substrate-channel-dichotomy.md) substrate-side concrete
+
+## Abstract
+
+`LinearTextStream` is the new canonical substrate-of-truth for linear and streaming workloads in pty-speak. It replaces the screen-grid-based extraction path (`SessionModel.fs:338-375` `extractContent`) with an append-only byte-buffered representation of the parser-emitted output, committed at well-defined seams. The screen grid demotes to its rightful role: the substrate-of-truth for alt-screen TUI workloads only, per [ADR 0001](../adr/0001-substrate-channel-dichotomy.md)'s substrate / channel dichotomy.
+
+This RFC specifies:
+
+1. **The producer module** — `src/Terminal.Core/LinearTextStream.fs`, an append-only buffer with **tail mask** semantics for overwrite-class bytes, sized to a 4 MB per-tuple cap with truncation as a safety valve.
+2. **The streaming-incomplete emission protocol** — a five-tier seam hierarchy (semantic prompt seam > newline > idle quantum > max-bytes > max-time), six concrete cadence parameters, a seven-rank live-region detection classifier driven from VT500 parser events, and a sealed/unsealed event extension that mirrors RFC 9112 §8's incomplete-message contract.
+3. **The drain-checkpoint-swap protocol** — a three-phase regime transition for Stream ↔ TUI substrate swaps, anchored at `ESC[?1049h` / `ESC[?1049l` boundaries.
+4. **The three exemplar canonical displays** — high-level UIA / ARIA / NVDA contracts for raw text, interactive list, and form with text input. Full per-primitive specs live in [`docs/CANONICAL-DISPLAY-CATALOG.md`](../CANONICAL-DISPLAY-CATALOG.md); this RFC names them and locates the catalog as authoritative.
+
+This is the **pivot gate** of the substrate-first framework plan ([Strategic plan](../PROJECT-PLAN-2026-05-09.md), strategic codename `we-do-not-need-fluffy-simon`). Cycle 34 implements the producer; Cycles 35–36 invert the Stream profile against it; the rest of the framework follows.
+
+## 1. Motivation
+
+### 1.1 The four-part architectural assertion
+
+Per [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) §1 (locked architectural authority), the maintainer-blessed framing is verbatim:
+
+1. The substrate of truth is the byte stream emitted by the PTY. The screen grid is a derived projection.
+2. Channels are first-class peers. NVDA-via-UIA, self-voicing TTS, earcons, refreshable braille, FileLogger, and the WPF visual surface are each consumers of the substrate-with-detector-annotations; none is privileged.
+3. The detector pipeline (parser → coalescer → profiles → channels) is a deterministic, push-based stream-processing graph. Consumer-specific concerns (UIA peer registration, ANSI-color-as-error-tone, prompt-detection regex) belong at the appropriate stage; the substrate must not absorb them.
+4. The screen-cell grid is the substrate-of-truth for **only one** workload class: alt-screen TUI applications (`vim`, `htop`, `less`, `claude`'s alt-screen mode if it had one). For everything else — shell command output, REPL prose, `dir` listings, `git` chatter, Claude's primary streaming text — the linear byte stream is canonical and the grid is a downstream rendering convenience.
+
+### 1.2 The current extraction path is an inversion
+
+Today's `SessionModel.fs:338-375` `extractContent` function reconstructs linear-text content by walking the screen grid:
+
+> Pure row-walker with two independent branches: (1) **CommandText extraction** renders `snapshot[oldPromptRowIndex]` via `CanonicalState.renderRow`, strips the captured `oldPromptText` prefix, returns the remainder; (2) **OutputText extraction** iterates rows `oldPromptRowIndex + 1` through `newPromptRowIndex - 1`, renders each, filters blank lines, joins with `\n`.
+
+This is *cause-and-effect inverted*. The bytes existed first. The grid was derived from them by the VT500 parser applying ANSI semantics. `extractContent` reads the grid back as if it were primary, then **reconstructs the bytes** by re-rendering rows and stripping prefixes.
+
+The inversion is the source of three concrete failure modes observed during Cycle 29b NVDA validation 2026-05-09:
+
+- **Spinner storms** — Claude's `⠋ ⠙ ⠹ ⠸` thinking spinner mutates a single grid row at 10 Hz. `extractContent`'s row-walk treats every spinner frame as new output. NVDA receives ~80 announcements per Claude turn instead of 1.
+- **Red-tone misfires** — `git status` lines styled with SGR-red trigger `EarconProfile`'s color-as-error detector. The bytes that produced the red glyphs were never errors; the grid's ANSI reverse-projection is mistaken for an error signal.
+- **Unexercised SelectionProfile** — Claude's auto-trust mode skips the confirmation prompt's grid-row-mutation entirely. The substrate-side detector (`SelectionDetector.fs`) couldn't fire because no row was *visually styled* in a selection-prompt-like way. The byte stream contained the prompt regardless; the grid never saw it.
+
+### 1.3 Why a doc-only pivot gate
+
+Cycle 33 is **doc-only by design**. Substrate inversion is the largest architectural decision in the framework plan; locking the design before code lands is non-negotiable per the walking-skeleton discipline ([CONTRIBUTING.md](../../CONTRIBUTING.md) "Walking-skeleton discipline"). This RFC + the companion catalog are the substrate; Cycle 34 ships the producer module against it; Cycle 35 inverts the Stream profile; Cycle 36 validates against the advanced-CMD content matrix.
+
+The two research docs that landed independently between Cycle 30 and Cycle 31a — [`emission-paradigms.md`](../research/emission-paradigms.md) and [`Output-paradigms.md`](../research/Output-paradigms.md) — are RFC-grade prior-art surveys. This RFC lifts ~5 specific items verbatim from emission-paradigms.md and uses Output-paradigms.md as authoritative source for the catalog. Attribution is preserved via inline section references.
+
+## 2. Current Extraction Path: `SessionModel.fs:338-375`
+
+### 2.1 The function being replaced
+
+`extractContent` (private; F#) is the runtime call that produces a SessionTuple's `CommandText` and `OutputText` fields when a prompt boundary fires. Signature:
+
+```fsharp
+let private extractContent
+        (oldPromptText: string)
+        (oldPromptRowIndex: int option)
+        (newPromptRowIndex: int option)
+        (snapshot: Cell[][])
+        : string * string
+```
+
+It is invoked by `applyAndCapture` → `finalizeAndEnqueue` (`SessionModel.fs:406-436`) at every SessionTuple finalization. Two finalization arms reach it:
+
+- **Interrupt path** (`SessionModel.fs:569-574`) — `(Some active, PromptStart)` when a new prompt boundary arrives while a tuple is still active (Ctrl-C scenarios; mid-output prompts).
+- **Normal completion path** (`SessionModel.fs:642-687`) — `(Some active, CommandFinished exitCode)` when the shell signals command completion via OSC 133 `D` or heuristic equivalent.
+
+### 2.2 The algorithm and its brittleness
+
+The CommandText branch (lines 345–359) reads `snapshot[oldPromptRowIndex]`, calls `CanonicalState.renderRow` to convert cells back to a string, strips the prefix that matched the prompt regex, and returns the remainder. Defensive: returns `""` on row-out-of-bounds or prefix-mismatch.
+
+The OutputText branch (lines 360–374) iterates rows `[oldPromptRowIndex + 1 .. newPromptRowIndex - 1]`, renders each via `CanonicalState.renderRow`, filters empty rows, joins with `\n`. Defensive: returns `""` on missing indices or zero-length range.
+
+Five concrete brittleness signals:
+
+1. **Cursor moves invalidate row indices.** A `\r` (carriage return without newline) repositions the cursor; subsequent bytes overwrite the prior row. The row-walk sees only the post-overwrite state; the original bytes are gone.
+2. **Alt-screen entry/exit blanks the grid.** A short-lived TUI invocation (e.g., `git log` with a pager) clears the grid on exit; `extractContent` after an interrupt finds no rows.
+3. **Wrap and scroll lose history.** Output longer than the grid's row count scrolls; rows that scrolled off are unrecoverable from the snapshot.
+4. **SGR styling is fully discarded.** `renderRow` collapses styled cells to plain text; downstream consumers that wanted the styling (`EarconProfile`'s color detection) read the wrong source.
+5. **Dual cost.** Every prompt-boundary fire triggers a full row-range render — O(rows × cols) per emission, even though the bytes were already consumed once on the parser path.
+
+### 2.3 Call sites + invocation frequency
+
+`applyAndCapture` (`SessionModel.fs:498-690`) is invoked per `ScreenNotification.PromptBoundary`. The `PathwayPump.handleRowsChanged` (`Program.fs:~1340`) triggers on every parser-emitted row delta; the prompt detector (`HeuristicPromptDetector.fs:202-335`) gates which deltas reach `applyAndCapture` by enforcing a per-shell stability window (100ms cmd/PowerShell, 200ms Claude). On each fire, `extractContent` walks the snapshot.
+
+In a typical Claude session with 30 tool-use turns, `extractContent` runs at minimum 60 times (PromptStart + CommandFinished per turn), each walking ~30 rows × ~120 cols = 3,600 cells. Total runtime walks: 216,000 cells per session. The proposed substrate replaces this with O(1) high-water-mark commits.
+
+## 3. LinearTextStream Producer Design
+
+### 3.1 Module shape
+
+New module: `src/Terminal.Core/LinearTextStream.fs`. F# module, `internal` to Terminal.Core but with a public `T` opaque type for cross-module reference.
+
+```fsharp
+namespace Terminal.Core
+
+/// Cycle 34 — append-only byte buffer maintaining the canonical
+/// linear substrate per RFC 0001. Hooked into the parser-emit path
+/// (Coalescer input edge); commits at seam-hierarchy boundaries.
+module LinearTextStream =
+
+    /// Opaque producer instance. Holds the appendable buffer + tail
+    /// mask + commit-watermark state.
+    type T
+
+    /// Construction. Wired at composition root post-Cycle 34.
+    val create : parameters: Parameters -> T
+
+    /// Tunable parameters. Shipped as constants in Cycle 34;
+    /// future cycle externalises to TOML `[coalescer]` section.
+    type Parameters =
+        { IdleQuantumMs: int          // 150 ms (default)
+          MaxBytesPerEmit: int         // 4096 bytes
+          MaxTimeWithoutEmitMs: int    // 2000 ms
+          LiveRegionDebounceMs: int    // 250 ms
+          RegimeSwitchDrainMs: int     // 500 ms
+          PerTupleCapBytes: int }      // 4 * 1024 * 1024 (4 MB)
+
+    /// Default parameters (RFC §5.2 lift from emission-paradigms.md §3.C).
+    val defaultParameters : Parameters
+
+    /// Feed bytes from the parser's emit path. Coalescer's input edge
+    /// calls this synchronously per parser tick. The producer
+    /// classifies bytes (printable / overwrite-class / regime-switch),
+    /// appends to the buffer or tail mask, and may emit a commit
+    /// notification if a seam is crossed.
+    val append : T -> byte[] -> CommitNotification list
+
+    /// Force-finalize the current high-water-mark slice into a
+    /// SessionTuple-shaped chunk. Called by SessionModel.applyAndCapture
+    /// on prompt-boundary fire (replaces extractContent's row-walk).
+    val finalizeHighWaterMark : T -> FinalizedChunk
+
+    /// Drain-checkpoint-swap entrypoint (RFC §6). Called by
+    /// PathwayPump on alt-screen toggle.
+    val checkpointAndFreeze : T -> CheckpointResult
+    val resumeFromFreeze : T -> unit
+
+    /// Commit-time notification. Multiple may emerge per append call
+    /// (e.g., a prompt-boundary inside a max-bytes-flushed chunk).
+    type CommitNotification =
+        | EmittedChunk of EmittedChunk
+        | LiveRegionUpdate of LiveRegionUpdate
+        | RegimeSwitch of RegimeSwitch
+
+    /// A finalized chunk produced when the high-water-mark advances.
+    /// Sealed=true means this is the authoritative final state of
+    /// this region; Sealed=false means more bytes may arrive (live-
+    /// region in flight, or max-time emitted while output continues).
+    type EmittedChunk =
+        { Bytes: byte[]
+          Sealed: bool
+          Truncated: bool         // true if 4MB cap forced drop-oldest
+          ProducerWaterMark: int64
+          EmittedAt: DateTime }
+```
+
+The exact F# signatures are sketches; Cycle 34 may adjust the curry/uncurry shape, parameter naming, and visibility modifiers. The architectural shape — append-only buffer + tail mask + seam-driven commits + sealed/unsealed events — is non-negotiable per this RFC.
+
+### 3.2 Buffer structure
+
+Two buffers, one mask:
+
+- **Committed buffer** — the substrate-of-truth. Append-only; entries flow downstream via `EmittedChunk` notifications. Sized to a soft cap of `PerTupleCapBytes` (4 MB default) per command zone. On overflow, drop-oldest semantics apply (head bytes evicted; tail preserved); the next emitted chunk carries `Truncated: true` so consumers can announce "[output truncated]" if appropriate.
+- **Pending buffer** — bytes accumulated since the last seam crossing. Drained at the next seam.
+- **Tail mask** — per-row state marking content as overwrite-in-place. When the producer detects an overwrite-class byte (see §5.3 Live-region detection), the affected row is marked tail-masked; subsequent printable bytes overwrite the masked region rather than appending. On seam crossing, only the most recent state of the tail mask is committed (LATEST semantics from RxJS / Project Reactor).
+
+### 3.3 Hookpoint: Coalescer input edge
+
+The Coalescer (`src/Terminal.Core/Coalescer.fs`) was restructured by PR-N (2026-05-04). The state machine moved to `StreamProfile.fs`; Coalescer.fs now contains only the `CoalescedNotification` DU + 5 pure helpers. The new `LinearTextStream.append` callback hooks at the **input edge** of the Coalescer's debounce — i.e., where the parser's emitted bytes first arrive, before the Coalescer's existing batching kicks in.
+
+Concretely, Cycle 34 wires:
+
+```fsharp
+// Composition root (Program.fs:~1180), post-Coalescer construction.
+let linearStream =
+    LinearTextStream.create LinearTextStream.defaultParameters
+
+// Parser tick callback: split the emit between the existing
+// Coalescer path and the new linear-stream producer.
+let onParserEmit (bytes: byte[]) =
+    let commits = LinearTextStream.append linearStream bytes
+    for commit in commits do
+        match commit with
+        | EmittedChunk chunk -> dispatchToStreamProfile chunk
+        | LiveRegionUpdate upd -> dispatchToStreamProfileLiveRegion upd
+        | RegimeSwitch switch -> dispatchToPathwaySelector switch
+    // Existing Coalescer call retained until Cycle 35 inverts it.
+    coalescer.Apply bytes
+```
+
+Cycle 34 runs the producer **parallel-to-screen** with no consumers — the screen grid path remains authoritative; the producer emits notifications that nothing handles yet. Cycle 35 inverts the Stream profile to consume from the producer; Cycle 36 retires the screen-grid path for non-alt-screen workloads.
+
+### 3.4 Threading
+
+The Coalescer's algorithms run on the **PathwayPump worker thread** (single-threaded notification consumption per `HeuristicPromptDetector.fs:79-82`). The producer's `append` runs on the same thread. No additional synchronization required for the buffer or tail mask; cross-thread reads from the substrate-of-truth happen only at seam-crossing emissions, which marshal through the existing `OutputDispatcher` channel-record path (Cycle 31a `IOutputSink`).
+
+### 3.5 The 4 MB per-tuple cap
+
+The cap is a **safety valve**, not a tuning knob. Pathological inputs — `cat /dev/urandom | python`, malformed shell loops, runaway output from a buggy tool — can produce gigabytes of bytes between prompt boundaries. Without a cap, the producer's committed buffer grows unbounded; the eventual SessionTuple's `OutputText` field would be too large to announce, log, or persist.
+
+The cap operates as **drop-oldest**: when the buffer reaches 4 MB, the oldest 1 MB is evicted to free space, the `Truncated: bool` flag is set on the next emitted chunk and on the eventual SessionTuple. Consumers that care (NvdaChannel announce, FileLoggerChannel log, SessionLogWriter persist) can prefix "[output truncated]" or similar; consumers that don't care (EarconProfile's bell-ring detector) ignore the flag.
+
+The 4 MB number is chosen as ~16 × `MaxBytesPerEmit` (4096 × 1024) — large enough to absorb a long-running `dir /s` traversal of `C:\Windows\System32` (~200K entries × ~80 bytes = ~16 MB) only in the median case; pathological cases will truncate, which is correct. The number is **revisitable in a future cycle** if real workloads surface a misfit.
+
+### 3.6 Session-restore-from-disk: explicitly out of scope
+
+The current JSONL session-persistence path (`SessionPersistence.fs` + `SessionLogWriter.fs`) writes SessionTuples to `%LOCALAPPDATA%\PtySpeak\sessions\session-<SessionId>.jsonl` with a stable schema (`schemaVersion: 1`). The deserialization plumbing exists but is not wired to a restore consumer; restore semantics are explicitly Phase 2 work per Phase 1 exploration findings.
+
+This RFC therefore does **NOT** specify session-restore semantics. The `extractContent` function (`SessionModel.fs:338-375`) is **preserved verbatim post-Cycle 34** in case a future restore implementation re-uses its row-walking logic against a serialized snapshot. The runtime SessionTuple finalize path uses `LinearTextStream.finalizeHighWaterMark`; `extractContent` becomes runtime-unwired but kept for future use.
+
+A future cycle may delete `extractContent` if the restore path is implemented differently (e.g., from a serialized linear-stream slice rather than a re-rendered grid). That decision is out of scope here.
+
+## 4. The Inversion of Cause and Effect
+
+A short conceptual section that crystallizes the architectural shift. May be lifted into [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) §1 as supporting prose.
+
+### 4.1 Three layers of state
+
+The pty-speak pipeline maintains three logical layers:
+
+1. **Bytes** — the parser-emitted stream. Append-only, never lossy. The substrate-of-truth.
+2. **Cells** — the screen grid. A derived projection of bytes via VT500 parser semantics. Lossy at every cursor move and row scroll.
+3. **Annotations** — semantic events overlaid on bytes (PromptBoundary, AltScreenEntered, BellRang, SelectionShown). Produced by detectors that consume bytes (and sometimes cells) and emit boundary-shaped events.
+
+Pre-Cycle-34, downstream consumers (NVDA, FileLogger, EarconProfile) read predominantly from layer 2 (cells) with occasional annotations from layer 3. Reconstructing bytes from cells is therefore the standard operation — and it is structurally lossy.
+
+Post-Cycle-34, consumers read predominantly from layer 1 (bytes) with annotations from layer 3. The grid (layer 2) is computed only when a consumer specifically needs it (alt-screen TUI rendering, the WPF visual surface). Reconstructing bytes from cells becomes unnecessary; the bytes are never lost.
+
+### 4.2 What this enables
+
+Three immediate wins:
+
+- **Spinner storms collapse.** A 10 Hz `\b\r ⠋` sequence is a single tail-masked row in layer 1. The producer commits one chunk per `live_region_debounce_ms` (250 ms default) with the latest spinner glyph. NVDA hears one announcement; not 80.
+- **Color is preserved without re-projection.** SGR escape sequences are bytes in layer 1; downstream `EarconProfile`'s color detector reads them directly. No grid re-rendering, no false positives from styled-but-not-error cells.
+- **Selection prompts surface even without grid mutation.** Claude's auto-trust skip is a layer-3 annotation gap (the prompt detector's regex fires on the byte stream regardless of grid state). The producer is layer-1-faithful; the detector consumes it; the prompt is detected.
+
+### 4.3 What this does NOT change
+
+- **Alt-screen TUI workloads still consume from layer 2.** `vim`, `htop`, `less`, future TUI consumers — these are by definition grid-canonical workloads. The screen grid is their substrate-of-truth. The producer freezes its layer-1 stream during alt-screen and resumes on exit (drain-checkpoint-swap; §6).
+- **WPF visual rendering still consumes from layer 2.** The `IDisplayBuffer` cutover in Cycle 32b is layer-2 to layer-2 (the host renderer reads cells from the grid). No change to that path.
+- **Channel architecture is layer-3-driven.** Channels consume `OutputEvent`s with semantic annotations; the producer's emitted chunks become a new annotation source, but the channel surface is unchanged.
+
+Layer 1 was always there (the parser emitted bytes; the Coalescer consumed them); the change is making layer 1 first-class for downstream consumers rather than reading them back from a lossy projection.
+
+## 5. The Streaming-Incomplete Emission Protocol
+
+This section is largely a verbatim lift from [`docs/research/emission-paradigms.md`](../research/emission-paradigms.md) §3.A–§3.D, with attribution to the prior-art survey and RFC-canonical framing.
+
+### 5.1 Seam hierarchy
+
+Lifted verbatim from [`emission-paradigms.md` §3.A lines 76–83](../research/emission-paradigms.md):
+
+> The primary emission strategy is a **seam-hierarchy commit** evaluated on every parser tick, with the following ordered seams (strongest first):
+>
+> 1. **Semantic prompt seam** (OSC 133 `D` command-finished, or `C` command-output-start when transitioning out of prompt): drain everything in the buffer immediately; mark emission `final=true`. This handles `dir`, plain commands that finish promptly.
+> 2. **Newline boundary** (LF or CRLF arrived since last emit): emit at the last seen newline, retain trailing partial bytes. This handles per-line streaming during `dir /s C:\Windows\System32`.
+> 3. **Idle quantum** (no bytes received for *idle_quantum_ms*): emit accumulated bytes, retain nothing. This handles Claude's text-response streaming at 200–400 chars/sec (gaps between sentences and tool-call boundaries).
+> 4. **Max-bytes ceiling** (buffered bytes ≥ *max_bytes_per_emit*): emit a hard chunk regardless of seam. This is the "tight loop with no newlines" safety valve, modeled on IRC's 512-byte cap and Reactor's 256-element prefetch.
+> 5. **Max-time ceiling** (now − last_emit ≥ *max_time_without_emit*): emit whatever is buffered. This is the "Claude thinking, no output, no spinner suppressed bytes either" liveness guarantee; modeled on SSE's 15 s keep-alive cadence.
+
+Each stronger seam pre-empts weaker ones. A semantic prompt seam at the same parser tick as an idle-quantum trigger drains with `final=true` and marks the chunk `Sealed=true` regardless of the idle quantum's pending state.
+
+The substrate accumulator is **append-only** unless live-region detection (§5.3) marks the current row as overwrite-class, in which case the row's bytes are held in the tail mask, not committed to the substrate. On emission, the tail mask's *latest* state is appended (LATEST semantics from `BufferOverflowStrategy.LATEST`), and the mask is cleared.
+
+### 5.2 Cadence parameters
+
+Lifted verbatim from [`emission-paradigms.md` §3.C lines 108–115](../research/emission-paradigms.md). These values become Cycle 34 constants in `LinearTextStream.fs`; a future micro-cycle (post-Cycle-34) externalises them to a `[coalescer]` TOML section following the Cycle 32a `[profile.selection]` precedent.
+
+| Parameter                | Recommended default | Source / justification                                                                                                                                                                                                                                                                                                                                       |
+|--------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `idle_quantum_ms`        | **150 ms**          | Below the ~200 ms threshold below which sighted users perceive UI as instant; matches HuggingFace TextStreamer's "wait for whitespace, then flush" perception target. NVDA's speech queue can absorb new chunks at ~150 ms intervals without speech jitter (extrapolated from NVDA's own SAPI5 latency observations in nvaccess/nvda#19551). Reasoned default. |
+| `max_bytes_per_emit`     | **4 096 bytes**     | Larger than IRC's 512-byte safety cap (which is too tight for screen-reader chunks of `dir` output) and HTTP chunked-encoding common reads of 4–8 KB. Also approximately one screen-reader announcement-buffer worth at typical TTS rates. Reasoned default.                                                                                                  |
+| `max_time_without_emit`  | **2 000 ms**        | Longer than `tail -f`'s 1 s default poll, shorter than SSE's 3 000 ms reconnect, well within the 15 s SSE keep-alive cadence. Provides a liveness guarantee during silent commands without producing spurious empty chunks. Reasoned default.                                                                                                                |
+| `live_region_debounce_ms`| **250 ms**          | Spinners at 10 Hz produce a frame every 100 ms; debouncing at 250 ms collapses them while preserving one announcement per "real" tail change. Modeled on RxJS `debounceTime` patterns for keystroke-rate sources. Reasoned default.                                                                                                                          |
+| `prompt_seam_priority`   | **highest**         | OSC 133 `C`/`D` always wins over time/byte triggers; matches FinalTerm/iTerm2/VS Code semantic-zone priority. Spec-derived.                                                                                                                                                                                                                                  |
+| `regime_switch_drain_ms` | **500 ms**          | Time the pipeline waits after an alt-screen exit before re-emitting from the Stream pathway, to allow the shell's redrawn prompt to settle. Reasoned default.                                                                                                                                                                                                |
+
+The defaults are starting points, not measured optima. The maintainer should profile NVDA and JAWS announcement latency on representative hardware after Cycle 34 ships; `idle_quantum_ms` in particular may need to rise to 200–300 ms for slower synthesisers or eSpeak-NG with high speech rates.
+
+### 5.3 Live-region detection
+
+Detection is **reactive on a ranked Williams VT500 event set**, not a per-shell heuristic — heuristics break on Windows ConPTY (per VS Code documentation) and on alt-screen apps that share row 0 with prompt output. The producer subscribes to the parser's event stream and applies the following ranked classifier to each row currently being assembled (lifted verbatim from [`emission-paradigms.md` §3.B lines 94–104](../research/emission-paradigms.md)):
+
+> 1. **`ESC[?1049h` / `ESC[?1049l`** — alternate-screen enter/exit. This is not a row-level overwrite; it is a regime switch (§5.4). The substrate is checkpointed and the pipeline switches pathway.
+> 2. **`ESC[2J` (ED 2)** or **`ESC[H ESC[2J`** sequence — full-screen erase. The current substrate is *frozen* and a new substrate begins; alternatively, treat as a regime switch into TUI pathway if it occurs without an alt-screen toggle.
+> 3. **Bare `\r` (CR) without immediately following `\n`** — classic carriage return for in-line overwrite. The current row enters tail-mask state. This catches progress bars (`[####    ] 47%\r`).
+> 4. **`ESC[K` (Erase in Line)** — erases from cursor to end of line. Marks the current row as tail-mask. Catches `--More--` prompts and tab-completion erase-and-redraw.
+> 5. **`ESC[A` (CUU, cursor up)** followed by printable bytes on a previously committed row — retroactive rewrite. Mark the *target row* as tail-mask; if the target row was already emitted, the rewrite is announced as a separate `[updated]` annotation rather than retroactively patching the substrate.
+> 6. **`ESC[<n>D` (CUB, cursor back)** followed by printable text — partial-line overwrite. Same handling as #3.
+> 7. **Reverse Index (`ESC M`)** when at row 0 — indicates scroll, not overwrite, but combined with tail-mask state it should not extend the substrate.
+
+The discriminator runs in the Williams VT500 parser's "Action" hook for ground state and CSI dispatch state; it does not require a separate parsing pass. Output is a per-row enum: `Append | TailMask | Frozen`. Only `Append` rows extend the canonical substrate. Detection is **reactive** (driven by parser events), not **proactive** (no per-shell regex like "if shell == bash and prompt regex matches…"). The single heuristic exception is recognising OSC 133 `A`/`B` markers as "prompt zone" — a row inside a prompt zone is implicitly tail-masked while the user is editing, and frozen on `B`.
+
+### 5.4 Sealed / unsealed event extension
+
+Every chunk emitted by the producer carries a `Sealed: bool` extension on the `OutputEvent`'s extension map. This formalises the informal mention in [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) §7 and mirrors RFC 9112 §8's incomplete-message contract:
+
+- **`Sealed=true`** — the chunk is the authoritative final state of its byte range. Consumers may commit irreversibly (NvdaChannel may announce; FileLoggerChannel may write; SessionLogWriter may persist). Triggered by: semantic prompt seam, max-time ceiling at a logical boundary, alt-screen drain-checkpoint, explicit shell-switch finalize.
+- **`Sealed=false`** — the chunk is a forward progress indicator; more bytes may amend or overwrite this region. Consumers MUST tolerate without crashing; sensible defaults: announce as a polite live-region update (NvdaChannel → `LiveRegionChanged`), buffer for batched logging (FileLoggerChannel may delay until sealed), do not persist (SessionLogWriter waits for `Sealed=true`). Triggered by: idle quantum, max-bytes ceiling mid-stream, live-region tail-mask commit.
+
+Channels that cannot meaningfully distinguish (e.g., EarconProfile's bell-ring detector) ignore the flag.
+
+### 5.5 Closing recommendations (RFC-actionable bullets)
+
+Lifted from [`emission-paradigms.md` §4 lines 154–165](../research/emission-paradigms.md), the actionable summary for Cycle 34 implementation:
+
+- **Adopt a seam-hierarchy commit model** for the Stream pathway, evaluated on every Williams VT500 parser tick: `OSC 133;C/D` > newline > idle-quantum > max-bytes > max-time. Each stronger seam pre-empts weaker ones. This mirrors SSE's blank-line dispatch, IRC's CRLF rule, and HTTP chunked encoding's length-prefix authority while degrading gracefully when no shell cooperation is available.
+- **Default cadence parameters** (per §5.2 above): `idle_quantum_ms = 150`, `max_bytes_per_emit = 4096`, `max_time_without_emit = 2000`, `live_region_debounce_ms = 250`, `regime_switch_drain_ms = 500`. Externalise to TOML in a future micro-cycle.
+- **Detect live regions reactively from VT500 parser events**, ranked per §5.3. No per-shell regex heuristics — that path leads to VS Code's ConPTY-misalignment failure mode.
+- **Use LATEST semantics on the tail mask**: spinners, progress bars, `--More--` prompts, and tab-completion overwrites collapse to one announcement per idle quantum carrying the most recent state, drawn from Reactor's `BufferOverflowStrategy.LATEST`.
+- **Treat OSC 133 / OSC 633 markers as advisory, not authoritative**: when present they act as the strongest seam; when absent or out of order (as on Windows ConPTY per VS Code docs), the time/byte seams provide forward progress. Match VS Code's `IsWindows=True` posture by not assuming sequence positions are exact.
+- **Emit explicit `Sealed: bool` flag** on every chunk handed to NvdaChannel / FileLoggerChannel / UIA, mirroring RFC 9112 §8's incomplete-message contract. Consumers must tolerate `Sealed=false` chunks without crashing.
+- **Drain-checkpoint-swap on regime transitions** (per §6): on `ESC[?1049h` (or 47h/1047h), flush the Stream buffer with `Sealed=true`, checkpoint, freeze the linear substrate, swap to TUI pathway. On `ESC[?1049l`, drop the TUI substrate (tmux/xterm convention), resume the linear substrate after a `regime_switch_drain_ms` settle period.
+- **Never flush mid-CSI**: the Williams VT500 parser owns the "complete-sequence" boundary; the producer must not split an emission across an in-progress escape sequence, mirroring the HTML5 tokenizer's "implicit-abandonment-only-at-EOF" invariant.
+- **Cap the substrate accumulator** at `PerTupleCapBytes = 4_194_304` bytes (4 MB) per command zone (§3.5). Producers exceeding this limit force a forced flush + `Truncated: true` annotation — this prevents the IRC-style "overlong-line stalls the pipeline" failure.
+- **Persist the Final event on disposal**: SessionLogWriter always serialises the trailing buffer when the pipeline shuts down, mirroring HuggingFace TextStreamer's `end()` flush, avoiding the HTML5-tokenizer-style silent-abandonment failure.
+
+## 6. Drain-Checkpoint-Swap Protocol
+
+Lifted from [`emission-paradigms.md` §3.E lines 138–148](../research/emission-paradigms.md). This three-phase flow defines the Stream ↔ TUI substrate swap and is non-negotiable per the substrate-vs-host separation in [ADR 0001](../adr/0001-substrate-channel-dichotomy.md).
+
+### 6.1 Three-phase protocol
+
+> 1. On `ESC[?1049h` (or `47h`, `1047h` legacy), the Stream-pathway Coalescer flushes its pending buffer with `Sealed=true`, emits a "stream-suspended" checkpoint to NvdaChannel / FileLoggerChannel / UIA, and freezes the linear substrate.
+> 2. The TUI-pathway substrate (the screen-cell grid) becomes canonical.
+> 3. On `ESC[?1049l`, the TUI substrate is discarded (per tmux/xterm convention); the linear substrate resumes from its frozen state with a `regime_switch_drain_ms` settle period before any new bytes are committed.
+
+The streaming-systems analogues (Kafka consumer-commit, Flink barrier checkpoints) confirm the principle: a checkpoint is a moment at which the in-flight state is durable and the substrate-identity changes. For pty-speak specifically:
+
+- The in-flight buffer at the transition point is **drained** (Stream → TUI) — bytes already accumulated belong to the linear substrate and should be announced before the regime change. This matches `tail -f`'s drain-on-EOF behaviour.
+- TUI → Stream does **not** drain anything inbound from the alt-screen — that content was canonically the screen, not the linear stream. The screen substrate is dropped (matching tmux/xterm), and the linear substrate continues from where it was frozen. This is the "discard scrollback on alt-screen exit" pattern.
+- A failed transition (alt-screen entered without a clean exit, e.g., `vim` killed by signal) is recoverable: the next `\r\n` plus prompt emission in the Stream pathway re-establishes a seam, and the frozen prefix is re-announced with an `[interrupted]` marker.
+
+### 6.2 Spinner case (NOT alt-screen)
+
+Claude's thinking spinner does NOT enter alt-screen. It operates in the Stream pathway via `\r` + cursor-back overwrites of a single row. The drain-checkpoint-swap protocol therefore does not apply to spinners; live-region tail-mask handling (§5.3 #3 + #6) absorbs spinners within the Stream pathway. This is verified by the maintainer-reconfirm gate item (d) in Cycle 33's stopping criteria.
+
+### 6.3 The `more` paginator case (also NOT alt-screen)
+
+`dir /s | more` and similar paginators write the `--More--` prompt with `\r` + `ESC[K` (no alt-screen). The tail mask absorbs the prompt; on space-bar advance, the next chunk of bytes flushes via newline boundary. No drain-checkpoint-swap involved.
+
+### 6.4 Failure mode: alt-screen without clean exit
+
+A TUI killed by signal (`vim` → `kill -9`) leaves the terminal in alt-screen state. The next byte stream from the parent shell may include alt-screen-exit (`ESC[?1049l`) followed by a fresh prompt, OR it may not (depending on shell signal handling). The producer's resume logic must:
+
+- On observing `ESC[?1049l`: clean exit; resume linear stream after `regime_switch_drain_ms` settle.
+- On observing prompt detector fire WITHOUT a preceding `ESC[?1049l`: treat as "interrupted alt-screen exit"; emit a `[interrupted]` annotation on the next chunk; resume linear stream immediately.
+- On observing further bytes that DON'T match either pattern: continue freezing the linear substrate; the frozen state is recoverable when a future seam arrives.
+
+## 7. SessionTuple Finalize Contract
+
+The SessionTuple is the primary downstream consumer of the producer's high-water-mark commits. This section specifies how `LinearTextStream.finalizeHighWaterMark` replaces the runtime call to `SessionModel.fs:338-375` `extractContent` while preserving the SessionTuple shape and the on-disk JSONL schema.
+
+### 7.1 Current finalize path
+
+`SessionModel.applyAndCapture` (`SessionModel.fs:498-690`) is the state machine entrypoint. On `(Some active, PromptStart)` or `(Some active, CommandFinished exitCode)`, it calls `finalizeAndEnqueue` (`SessionModel.fs:406-436`), which:
+
+1. Calls `extractContent` to produce `(commandText, outputText)` from the snapshot.
+2. Captures `now: DateTime` for `CommandFinishedAt`.
+3. Constructs the SessionTuple record.
+4. Returns `(state', SessionTuple option)` for the composition root to dispatch to `SessionLogWriterSink`.
+
+### 7.2 Post-Cycle-34 finalize path
+
+Replace step 1 with `LinearTextStream.finalizeHighWaterMark`. The function returns a `FinalizedChunk`:
+
+```fsharp
+type FinalizedChunk =
+    { CommandText: string         // bytes between PromptStart and CommandStart
+      OutputText: string          // bytes between CommandStart and CommandFinished
+      Truncated: bool             // 4 MB cap was hit
+      Sealed: bool                // always true at finalize time
+      ProducerWaterMark: int64 }  // for diagnostic correlation
+```
+
+The producer maintains internal markers for prompt-start and command-start positions in its committed buffer. On `finalizeHighWaterMark`, it slices the buffer between those markers, returns the slice as `CommandText` / `OutputText`, and advances its internal "last-finalized" watermark.
+
+Steps 2–4 of the existing finalize path are unchanged. `extractContent` remains in `SessionModel.fs` as **runtime-unwired but byte-preserved** for any future session-restore-from-disk implementation that re-uses its row-walking logic against a serialized snapshot.
+
+### 7.3 SessionTuple record shape — unchanged
+
+The SessionTuple record (`SessionModel.fs:84-133`) is unchanged. Field-by-field:
+
+- `Id: Guid` — unchanged.
+- `CommandId: string option` — unchanged (OSC 133 `aid=` correlation).
+- `ShellId: string` — unchanged.
+- `PromptStartedAt: DateTime` — unchanged.
+- `CommandStartedAt: DateTime option` — unchanged.
+- `OutputStartedAt: DateTime option` — unchanged.
+- `CommandFinishedAt: DateTime option` — unchanged.
+- `PromptText: string` — unchanged (captured at PromptStart → CommandStart transition; from `boundary.MatchedRowText`).
+- `CommandText: string` — **sourced from `FinalizedChunk.CommandText`** instead of `extractContent`'s row-walk.
+- `OutputText: string` — **sourced from `FinalizedChunk.OutputText`** instead of `extractContent`'s row-walk.
+- `ExitCode: int option` — unchanged.
+- `Sources: Map<BoundaryKind, BoundarySource>` — unchanged.
+- `ExtraParams: Map<string, string>` — **gain a new key `pty-speak.linear-stream.truncated = "true"`** when `FinalizedChunk.Truncated = true`. Consumers that announce can prefix `[output truncated]`.
+
+### 7.4 On-disk JSONL schema — unchanged
+
+`SessionLogWriter`'s JSONL format (`SessionModel.fs:867-906`) is byte-stable:
+
+- `schemaVersion: 1` on every record.
+- Record shape exactly mirrors the in-memory SessionTuple.
+- The new `pty-speak.linear-stream.truncated` key in `ExtraParams` is forward-compatible (existing consumers ignore unknown keys per the `ExtraParams: Map<string, string>` contract).
+
+The `MaxSessionSizeMb` cap (default 64 MB per session file at `SessionPersistence.fs:29`) is unchanged. The 4 MB per-tuple cap is a **separate constraint** that operates earlier in the pipeline.
+
+### 7.5 Shell-switch + Ctrl-C semantics
+
+Two finalize-path corner cases preserved verbatim:
+
+- **Shell-switch** (`Ctrl+Shift+1/2/3`) calls `SessionModel.finalizeIncomplete`, which finalises the active tuple with `CommandFinishedAt = now`, `ExitCode = None`, empty `CommandText` / `OutputText`. The producer must NOT retroactively finalize partial output after shell-switch; the tuple is sealed at that instant. The producer's `checkpointAndFreeze` is called before shell-switch finalize; subsequent bytes start a new linear stream for the new shell.
+- **Ctrl-C at prompt** mid-output → the next `PromptStart` arrives; `applyAndCapture` calls `finalizeAndEnqueue` with the interrupt path. The producer's `finalizeHighWaterMark` returns whatever bytes accumulated since `CommandStartedAt`; this is now the truncated `OutputText`. Consumers see a "command interrupted" tuple with whatever output the user-visible part had.
+
+### 7.6 Alt-screen interaction
+
+`SessionModel.applyAndCapture` has an `IsAltScreenActive` guard (`SessionModel.fs:527`) that suppresses tuple state-machine transitions during alt-screen. The producer respects this: `finalizeHighWaterMark` is only called when alt-screen is NOT active; the producer's `checkpointAndFreeze` runs on alt-screen entry. If alt-screen is active during a SessionModel state-machine event (which the existing guard prevents), the producer's behavior is undefined — but the existing guard makes this a non-issue.
+
+## 8. The Three Exemplar Canonical Displays
+
+This section names the three exemplar canonical displays at high level. Full per-primitive specs (UIA control types, ARIA role analogs, NVDA reading patterns, JAWS virtual cursor behavior, Narrator behavior, interaction contracts, substrate consumption, update cadence, output channel routing) live in [`docs/CANONICAL-DISPLAY-CATALOG.md`](../CANONICAL-DISPLAY-CATALOG.md).
+
+The framing follows [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) §5: three exemplars cover the dominant interaction archetypes; a named-but-not-specified extension-points list captures the future workload taxonomy without locking it.
+
+### 8.1 Exemplar 1 — Raw Text
+
+The append-mostly canonical display for assistant prose, command output, long-running tool stdout. Single highest-traffic primitive in the Claude Code workload.
+
+- **Substrate:** Linear-text producer (this RFC's core deliverable).
+- **UIA control type:** `ControlType.Document` + `ITextProvider` + `ITextProvider2` exposing `DocumentRange` and `RangeFromPoint`; `ITextRangeProvider` supporting `Move` / `MoveEndpointByUnit` for `TextUnit.Character/Word/Line/Paragraph/Document`.
+- **ARIA role analog:** `role="log"` with `aria-live="polite"`, `aria-atomic="false"`, `aria-relevant="additions text"`.
+- **NVDA reading pattern:** Browse mode, arrow keys read by line; `NVDA+UpArrow` / `NVDA+DownArrow` for say-all from caret; quick-nav `h` / `Shift+h` for semantic-block boundaries.
+- **Update cadence:** Live polite. Coalesce appends with the producer's `live_region_debounce_ms` (250 ms) keyed on word-boundary detection. Per-token announcement is forbidden.
+- **Channel routing:** NVDA UIA (native), self-voicing TTS (native), earcon (block-boundary semantics), refreshable braille (native via UIA), spatial audio (optional, block-azimuth), FileLogger (native), WPF visual (native).
+- **CommandOutputTuple wrapper:** Per the post-Cycle-31a doc tweak ([PR #236](https://github.com/KyleKeane/pty-speak/pull/236)), the history sub-pane consumes raw-text exemplars wrapped as CommandOutputTuple primitives — command + output + exit-code as a single semantically-navigable region. Quick-nav: `h` / `Shift+h` (command boundaries), `o` / `Shift+o` (output blocks), `Alt+Up` / `Alt+Down` (tuple boundaries).
+
+Full spec: [CANONICAL-DISPLAY-CATALOG.md §1 Exemplar 1](../CANONICAL-DISPLAY-CATALOG.md).
+
+### 8.2 Exemplar 2 — Interactive List
+
+Vertical or horizontal selection menu. Distinguished from raw text by **selection semantics** — the user's keystroke commits a choice rather than appending to a stream.
+
+- **Substrate:** Derived semantic-event store. The `SelectionDetector` (Cycle 29a) consumes the linear-text producer's bytes (post-Cycle 35 inversion) and emits `SelectionShown` / `SelectionItem` / `SelectionDismissed` semantic events; the `SelectionProfile` (Cycle 29b) translates them.
+- **UIA control type:** `ControlType.List` + `ISelectionProvider` (single-select default; multi-select for `fzf -m`); each item `ControlType.ListItem` + `ISelectionItemProvider`.
+- **ARIA role analog:** `role="listbox"` with `aria-orientation="vertical"` (or `horizontal` per layout), `aria-required="true"`, single-select via `aria-selected`.
+- **NVDA reading pattern:** Focus mode auto-entered; arrow keys move selection; first-letter type-ahead jumps by `Name`; `Insert+F7` Elements List shows options under "Form fields" / "Lists".
+- **Update cadence:** Snapshot-on-render; one `NotificationKind.Other` + `NotificationProcessing.ImportantAll` event on appearance; selection-follows-focus fires `ElementSelectedEvent` per arrow press.
+- **Channel routing:** NVDA UIA (native), self-voicing TTS (native), earcon (boundary tick + decision earcon mandatory for prompt-class), refreshable braille (native via UIA), FileLogger (native), WPF visual (native).
+- **ConfirmationPrompt hybrid:** When the interactive list carries assertive-notification semantics (Claude tool-use confirmation, `apt`'s `Continue? [Y/n]`), the catalog notes the hybrid alert+selection pattern as a related primitive that combines this exemplar's selection contract with `role="alertdialog"` modality. Full implementation lands in a future cycle when both halves are stable.
+
+Full spec: [CANONICAL-DISPLAY-CATALOG.md §2 Exemplar 2](../CANONICAL-DISPLAY-CATALOG.md).
+
+### 8.3 Exemplar 3 — Form with Text Input
+
+Field-with-label primitive for shell prompts that require typed input (`Read-Host`, password prompts, `set /p`, future Claude tool-use approve-with-comment forms).
+
+- **Substrate:** Linear-text producer + future `InputPathway` (Cycle 38). The form detector (`FormProfile`, Cycle 38a) consumes linear-text bytes and emits `FormPrompt` semantic events; the UIA peer (Cycle 38b) translates.
+- **UIA control type:** `ControlType.Group` containing one or more `ControlType.Edit` children with `IValueProvider` (read-only after submission, `IsReadOnly=true`).
+- **ARIA role analog:** `role="form"` with descendant `role="textbox"` fields and `aria-label`.
+- **NVDA reading pattern:** Focus mode auto-entered (forms-mode); Tab between fields; Enter submits.
+- **Update cadence:** Live polite for typed-echo (Stage 6 typed-echo coalescer reused); snapshot at submit.
+- **Channel routing:** NVDA UIA (native), self-voicing TTS (native, with redaction for password fields), earcon (field tick), refreshable braille (native via UIA), FileLogger (native, redacted for password fields), WPF visual (native).
+- **Implementation timing:** Cycle 38 (input framework cycle). The exemplar is named here for completeness of the three-exemplar set; the spec lifted from [CORE-ABSTRACTION-BOUNDARY.md §5 Exemplar 3](../CORE-ABSTRACTION-BOUNDARY.md) into the catalog, not implemented in Cycle 34.
+
+Full spec: [CANONICAL-DISPLAY-CATALOG.md §3 Exemplar 3](../CANONICAL-DISPLAY-CATALOG.md).
+
+### 8.4 Extension points (named, not specified)
+
+The catalog names these as future canonical displays without locking the spec:
+
+- **SeverityAlert** — single-shot interruptive announcement of error/warning/fatal. `role="alert"`, assertive interrupt. Detector consumes ANSI-red + lexical patterns (`error:` / `panic` / `warning`).
+- **IndeterminateProgress** — spinner-class ongoing activity. `role="status"` + `aria-busy="true"` + earcon-driven start/end. **No `IRangeValueProvider`, no per-frame UIA events.** This exemplar's current Cycle 29b regressions (~80 announcements per Claude turn) motivate getting this right out of the gate when the future cycle ships.
+- **CommandOutputTuple** — described as a wrapper for raw-text exemplar in §8.1; named here as a discrete extension point because its UIA contract (`ControlType.Group` wrapping `Edit` + `Document` + `Text` for exit code) is distinct from raw-text's contract.
+- **Tier-2 (deferred)**: DiffView, CodeBlockWithSyntaxStructure, DeterminateProgress, FormInputGroup (specific form variants beyond the generic Exemplar 3), TabularDataDisplay.
+- **Tier-3 (research / defer)**: HierarchicalTreeDisclosure (`npm ls`, `git log --graph`), SpatialAudioStatusField (HRTF-spatialized ambient tones), MultiRegionFocusManager (composite multi-region focus arbitration).
+
+The plan deliberately ships only three exemplars to avoid premature taxonomy lock-in. The extension points are named so future cycles have a coherent vocabulary; their full specs land when concrete workloads demand them.
+
+## 9. Risks + Mitigations
+
+This section extends the [Strategic plan](../PROJECT-PLAN-2026-05-09.md) §4 risk register with RFC-specific concerns.
+
+| # | Risk                                                                                              | Detection                                                                                  | Mitigation                                                                                                                                                                              |
+|---|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| A | Tail-mask false positives on benign repaints (e.g., shell prompt redraws during typed input).     | Cycle 6 typed-echo regression tests; Stage 6 unit-test suite.                              | The detector ranks (§5.3) only mark the row tail-masked when overwrite-class bytes are observed. Stage 6 suppression in the Coalescer's input pipeline still runs.                      |
+| B | 4 MB per-tuple cap collides with legitimate large outputs (`dir /s` on 200K-file tree → ~16 MB).  | Cycle 36 advanced-CMD content matrix row 2.                                                | Drop-oldest semantics + `Truncated=true` annotation; consumer-side `[output truncated]` prefix. If the median legitimate workload regularly exceeds 4 MB, raise the cap in a follow-up. |
+| C | Sealed/unsealed event semantics confuse channels that need atomic announce.                       | Channel-test review in Cycle 35.                                                           | NvdaChannel implementation: `Sealed=false` → `LiveRegionChanged` (polite); `Sealed=true` → assertive announce per existing semantic mapping. FileLoggerChannel: log both, mark sealed.   |
+| D | Producer's tail-mask LATEST semantics drop intermediate progress info that some users want.       | Maintainer NVDA validation post-Cycle 35.                                                  | The cap configurable; user can lower `live_region_debounce_ms` to 50 ms to hear intermediate states. Future cycle could expose per-shell tuning.                                        |
+| E | Drain-checkpoint-swap settle period (`regime_switch_drain_ms = 500 ms`) feels laggy.              | Maintainer NVDA validation post-Cycle 35; maintainer can tune via TOML.                    | Future micro-cycle externalises to `[coalescer]` TOML; documented in USER-SETTINGS.md as a tunable.                                                                                     |
+| F | Heuristic prompt detector (`HeuristicPromptDetector.fs:202-335`) misses on a new shell.           | Stage 7-issues `[heuristic-prompt-detector]` tracking; manual report from maintainer.      | Non-RFC concern; pre-existing detector gap. The producer's `finalizeHighWaterMark` only fires when the detector fires — if the detector never fires, the tuple never finalizes.        |
+| G | `extractContent` is preserved verbatim but never executed at runtime — accidentally deleted.      | Cycle-N PR review; CI lint?                                                                | Add a comment in `SessionModel.fs:338` reading `// Cycle 34: preserved for any future session-restore-from-disk implementation. NOT runtime-wired post-Cycle 34.`                       |
+| H | Research doc earcon-frequency conflict (≥125 Hz vs CONTRIBUTING.md's <180 Hz floor).              | Reviewer comparing this RFC to CONTRIBUTING.md.                                            | RFC §11 glossary explicitly defers to CONTRIBUTING.md; the research's wider bound is flagged as a future tuning experiment (not a current production constraint).                       |
+| I | Cycle 33 RFC text drifts as Cycle 34 implementation discovers contract gaps.                      | RFC review on every Cycle 34+ PR.                                                          | RFC versioning: snapshot at adoption time; explicit "amended in Cycle N" notes inline; major changes require ADR-style maintainer authorization.                                        |
+| J | The two research docs (sources cited extensively) get edited or removed.                          | Markdown link checker on every PR; RFC's citations are anchored to file paths.             | The research docs are now in-repo as authoritative references; treat them as immutable like `spec/tech-plan.md` (per the spec-immutability discipline in CLAUDE.md).                     |
+| K | `IsAltScreenActive` guard at `SessionModel.fs:527` is bypassed by a future code change.           | Cycle-N test; Cycle 35+ inversion will exercise this path.                                 | Cycle 34 adds an explicit `LinearTextStreamTests.fs` fact: "alt-screen active → finalizeHighWaterMark MUST throw or return None"; pin the contract.                                     |
+
+## 10. Acceptance Criteria for Cycle 34
+
+Cycle 34 implementation must satisfy these contracts to honor this RFC. Each is a concrete, testable invariant:
+
+### 10.1 Producer module exists
+
+- `src/Terminal.Core/LinearTextStream.fs` exists with the public surface specified in §3.1 (or a Cycle 34-justified variant).
+- `Terminal.Core.fsproj` lists it in compile order before `SessionModel.fs` (so SessionModel can reference `LinearTextStream.FinalizedChunk`).
+- The portability CI lint (Cycle 31a) continues to pass — no host-specific imports introduced.
+
+### 10.2 Seam hierarchy implemented
+
+- §5.1's five-tier seam hierarchy is implemented as `LinearTextStream.append`'s commit logic.
+- Order is enforced: a parser tick that satisfies multiple seams emits ONCE, with the strongest seam's `Sealed` flag prevailing.
+- Test fixtures in `tests/Tests.Unit/LinearTextStreamTests.fs` exercise each seam in isolation + each pair-overlap case.
+
+### 10.3 Live-region detection ranked
+
+- §5.3's seven-rank classifier is implemented and runs from VT500 parser events (not a separate parsing pass).
+- Test fixtures cover each rank (alt-screen toggle, full-erase, bare CR, EL, CUU+printable, CUB+printable, RI at row 0).
+- Spinner workload (10 Hz `\b\r` cycle) collapses to ≤ 4 emissions per second (`live_region_debounce_ms = 250 ms` → 4 Hz max).
+
+### 10.4 Drain-checkpoint-swap
+
+- §6.1's three-phase protocol is implemented at `LinearTextStream.checkpointAndFreeze` + `resumeFromFreeze`.
+- Test fixtures cover: clean alt-screen entry+exit; alt-screen entry without exit; alt-screen exit without preceding entry (defensive).
+
+### 10.5 SessionTuple finalize
+
+- `SessionModel.applyAndCapture` calls `LinearTextStream.finalizeHighWaterMark` instead of `extractContent` on every PromptStart and CommandFinished arm.
+- All existing SessionModelTests stay green (the SessionTuple shape is unchanged; only the source of `CommandText` / `OutputText` shifts).
+- `extractContent` remains in `SessionModel.fs:338-375` as runtime-unwired but byte-preserved (with the comment from Risk G mitigation).
+
+### 10.6 4 MB per-tuple cap
+
+- Pathological input (synthetic 10 MB byte stream between two prompts) produces a SessionTuple with `Truncated: true` in `ExtraParams` and `OutputText.Length ≤ 4 MB`.
+- Drop-oldest semantics: the SessionTuple's `OutputText` contains the most-recent ≤4 MB, not the first ≤4 MB.
+
+### 10.7 Sealed flag round-trip
+
+- Every `OutputEvent` emerging from the producer has the `Sealed: bool` extension set.
+- NvdaChannel + FileLoggerChannel + EarconChannel handle `Sealed=true` and `Sealed=false` correctly per §5.4.
+- `IOutputSinkTests` (Cycle 31a) gain a fact: "Sealed=false event does NOT trigger NvdaChannel announce; Sealed=true does".
+
+### 10.8 Diagnostic bundle integration
+
+- `Ctrl+Shift+D` adds `--- LINEAR STREAM (last 64KB) ---` section between `--- SESSION LOG ---` and `--- ENVIRONMENT ---` in the bundle.
+- Sibling file: `linear-stream-<yyyy-MM-dd-HH-mm-ss-fff>.txt` in `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\`.
+- 64KB inline cap respected; full stream on disk; Cycle 29b iOS-paste-crash incident does not recur.
+
+### 10.9 NVDA regression check
+
+- All Cycle 29b NVDA fixtures pass with identical wording (regression check; the substrate inversion must not regress NVDA reading).
+- All Cycle 31a / 32a fixtures pass.
+
+### 10.10 Test count
+
+- `tests/Tests.Unit/LinearTextStreamTests.fs` ships ~25 facts covering: append, backspace, `\r`, alt-screen freeze, prompt finalize, live-region commit, 4 MB cap, sealed/unsealed, drain-checkpoint-swap.
+
+## 11. Glossary (vocabulary adopted in this RFC)
+
+These terms are project-canonical post-RFC adoption. Future docs and CHANGELOG entries should use these terms verbatim; older terms persist in pre-RFC text but are no longer preferred for new prose.
+
+| Term                          | Definition                                                                                                                                                                                                                                              | Replaces (in pre-RFC docs)                                |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| **Tail mask**                 | Per-row state marking content as overwrite-in-place (not appendable to the substrate). Spinners, progress bars, `--More--` paginators live here. LATEST semantics: most recent state wins; intermediates dropped. Source: emission-paradigms.md §3.A.   | "live region pointer" (CORE-ABSTRACTION-BOUNDARY.md §7) |
+| **Drain-checkpoint-swap**     | Three-phase Stream ↔ TUI substrate transition: (1) flush pending Stream buffer with `Sealed=true`; (2) freeze linear substrate, swap to TUI; (3) on exit, drop TUI substrate, resume linear after `regime_switch_drain_ms` settle. Source: emission-paradigms.md §3.E. | "alt-screen freeze" (CORE-ABSTRACTION-BOUNDARY.md §7)    |
+| **Seam hierarchy**            | Five-priority emission trigger ordering: semantic-prompt > newline > idle > max-bytes > max-time. Stronger seams pre-empt weaker. Source: emission-paradigms.md §3.A.                                                                                  | "idle quanta as commit points" (CORE-ABSTRACTION-BOUNDARY.md §7) |
+| **Substrate-of-truth**        | The canonical source from which all derived projections are computed. Linear text is the substrate-of-truth for linear workloads; the screen grid is the substrate-of-truth for alt-screen TUI workloads. Source: Output-paradigms.md §5.              | informal use throughout pre-RFC docs                     |
+| **Literal-language convention** | The discipline of using *select / mark / announce / present / read / focused / current* for accessibility-bearing prose; eliminating sight metaphors *highlight / view / show*. Source: Output-paradigms.md Front Matter.                              | new — adopt in CONTRIBUTING.md doc-style guidance         |
+| **Sealed / Unsealed events**  | Mid-stream events carry a `Sealed: bool` extension. Unsealed events are advisory (profiles may show provisional state but must not commit irreversibly); sealed events are authoritative. Mirrors RFC 9112 §8 incomplete-message contract.             | formalises CORE-ABSTRACTION-BOUNDARY.md §7's `Sealed: bool` mention |
+| **High-water-mark commit**    | The producer's act of finalising a slice of the committed buffer at a seam crossing. Replaces `extractContent`'s row-walk. Source: this RFC §3.                                                                                                        | new                                                      |
+| **Producer / consumer**       | The producer is `LinearTextStream` (substrate-side, append-only). Consumers are downstream stages (Coalescer, profiles, channels) that read from the producer's emitted chunks. Source: this RFC §3.                                                  | informal use                                             |
+
+### Earcon frequency clarification
+
+[`docs/research/Output-paradigms.md`](../research/Output-paradigms.md) §1.1 cites Brewster guidelines (≥125 Hz, ≤5 kHz, multi-harmonic timbre, rhythmic motif rather than pitch alone). [`CONTRIBUTING.md`](../../CONTRIBUTING.md) line 200 specifies the tighter empirical constraint: "Earcons stay out of the speech band. Frequencies must be either below 180 Hz or above 1.5 kHz."
+
+This RFC defers to CONTRIBUTING.md as the production constraint. The research's wider lower bound (125 Hz) is a future tuning experiment, not a current standard. The Cycle 11+ NVDA-validation rounds that pinned 180 Hz / 1.5 kHz remain authoritative until a future cycle re-validates with the wider range.
+
+## 12. Cross-references
+
+- [`docs/CORE-ABSTRACTION-BOUNDARY.md`](../CORE-ABSTRACTION-BOUNDARY.md) — architectural framing; this RFC is the first concrete substrate-side spec implementing §1's four-part assertion.
+- [`docs/CANONICAL-DISPLAY-CATALOG.md`](../CANONICAL-DISPLAY-CATALOG.md) — full per-primitive specs for the three exemplars + extension points named in §8.
+- [`docs/adr/0001-substrate-channel-dichotomy.md`](../adr/0001-substrate-channel-dichotomy.md) — the architectural ADR; this RFC is the first downstream implementation cycle's design doc.
+- [`docs/PROJECT-PLAN-2026-05-09.md`](../PROJECT-PLAN-2026-05-09.md) — strategic plan; Cycle 33 is the pivot gate before Cycle 34 implementation.
+- [`docs/research/emission-paradigms.md`](../research/emission-paradigms.md) — primary source for §5 emission protocol + §6 drain-checkpoint-swap.
+- [`docs/research/Output-paradigms.md`](../research/Output-paradigms.md) — primary source for §8 three exemplars (high-level) + the catalog (full per-primitive spec).
+- [`docs/STAGE-7-ISSUES.md`](../STAGE-7-ISSUES.md) — Stage 7 findings that motivated the substrate inversion; closed scope (Cycle 32a `[output-selection]`) and open scope (Stage 8e-B UIA listbox peer).
+- [`docs/PANE-MODEL.md`](../PANE-MODEL.md) — three-sub-pane interaction paradigm; the linear-text producer's high-water-mark commits feed the history sub-pane's CommandOutputTuple navigation primitive.
+- [`SessionModel.fs:338-375`](../../src/Terminal.Core/SessionModel.fs) — `extractContent` (the path being replaced).
+- [`SessionModel.fs:498-690`](../../src/Terminal.Core/SessionModel.fs) — `applyAndCapture` (the consumer that calls `extractContent` today; will call `LinearTextStream.finalizeHighWaterMark` post-Cycle-34).
+- [`Coalescer.fs`](../../src/Terminal.Core/Coalescer.fs) — restructured by PR-N 2026-05-04; producer attaches at the input edge.
+- [`HeuristicPromptDetector.fs:202-335`](../../src/Terminal.Core/HeuristicPromptDetector.fs) — prompt-boundary fire that triggers `finalizeHighWaterMark`.
+- [`Diagnostics.fs:860-915`](../../src/Terminal.App/Diagnostics.fs) — `formatDiagnosticBundle`; Cycle 34 inserts `--- LINEAR STREAM (last 64KB) ---` between SESSION LOG and ENVIRONMENT.
+
+## Versioning + maintenance
+
+Snapshot model per the established research-stage discipline. Top-of-doc front matter carries `Snapshot: YYYY-MM-DD`. Trigger conditions for re-snapshot:
+
+- Cycle 34 ships `LinearTextStream.fs` — RFC's "Acceptance Criteria" section gets a "shipped 2026-MM-DD" notation per acceptance bullet.
+- Cycle 35 inverts the Stream profile against the producer — RFC §3.3 hookpoint description updates to reflect the inverted call path.
+- Cycle 36 retires the screen-grid path for non-alt-screen workloads — RFC §3.6 gets a "session-restore-from-disk: still out of scope as of Cycle 36" note.
+- A maintainer-authored amendment (per spec-immutability discipline) updates a load-bearing constraint — a dated "Amended in Cycle N" note is appended to the affected section.
+


### PR DESCRIPTION
## Summary

**Doc-only pivot-gate cycle** locking the substrate-inversion design before any code lands. No behaviour change. Two new authoritative docs + cross-reference updates so future cycles read against a stable spec.

This cycle is the **architectural lock for the next ~8 cycles** (34-38) of substrate-inversion work. Cycle 34 implements the `LinearTextStream` producer module against the RFC's contract; Cycles 35-36 invert the Stream profile against it; Cycles 37-38 build interactive list + form-with-text-input on the inverted substrate. The RFC + catalog supersede the informal streaming-incomplete protocol in `docs/CORE-ABSTRACTION-BOUNDARY.md` §7 for normative spec.

## What changed

- **`docs/rfc/0001-linear-text-substrate.md`** (new, ~610 LOC) — the pivot-gate RFC. 12 sections covering: motivation, current `extractContent` path being replaced (`SessionModel.fs:338-375`), LinearTextStream producer design (module shape + buffer + Coalescer hookpoint + 4 MB cap + session-restore explicitly out of scope), inversion of cause and effect, **streaming-incomplete emission protocol** (seam hierarchy + cadence parameters table + ranked live-region detection + sealed/unsealed extension; lifted verbatim from `docs/research/emission-paradigms.md` §3.A-§3.D and §4 closing recommendations), drain-checkpoint-swap protocol, SessionTuple finalize contract, three exemplar canonical displays at high level, risks + mitigations (11 items), acceptance criteria for Cycle 34 (10 testable invariants), glossary of adopted vocabulary.
- **`docs/CANONICAL-DISPLAY-CATALOG.md`** (new, ~400 LOC) — companion catalog with full per-primitive specs for the three exemplars: **Raw Text** (with CommandOutputTuple wrapper for the history sub-pane), **Interactive List** (with ConfirmationPrompt hybrid for assertive-notification cases), **Form with Text Input**. Each exemplar covers UIA control type, required pattern providers, ARIA role analog, NVDA / JAWS / Narrator behavior, interaction contract, substrate consumption, update cadence, output channel routing, example workloads. Extension points (SeverityAlert, IndeterminateProgress, CommandOutputTuple, Tier-2 deferred, Tier-3 deferred) listed with one-paragraph descriptions. Output channel routing matrix at the end.
- **`docs/CORE-ABSTRACTION-BOUNDARY.md`** §7 — streaming-incomplete protocol summary updated with adopted vocabulary (tail mask, drain-checkpoint-swap, seam hierarchy, sealed/unsealed). §10 — cross-references expanded with the new RFC + catalog + the two research docs.
- **`CLAUDE.md`** "Reading order at session start" — items 6 + 7 added for the RFC + catalog; subsequent items renumbered.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## Vocabulary adopted (project-canonical post-RFC)

| Term | Replaces |
|---|---|
| **Tail mask** | "live region pointer" |
| **Drain-checkpoint-swap** | "alt-screen freeze" |
| **Seam hierarchy** | "idle quanta as commit points" |
| **Substrate-of-truth** | informal use |
| **Literal-language convention** | new — *select / mark / announce / present / read / focused / current* |
| **Sealed / unsealed events** | formalises §7's `Sealed: bool` mention |
| **High-water-mark commit** | new — replaces `extractContent`'s row-walk post-Cycle 34 |
| **Producer / consumer** | informal use |

## Earcon frequency clarification

The research's Brewster guidance (≥125 Hz, ≤5 kHz) conflicts with `CONTRIBUTING.md`'s tighter empirical bound (<180 Hz or >1.5 kHz). The RFC defers to CONTRIBUTING.md as the production constraint; the research's wider lower bound is flagged as a future tuning experiment. **No change to CONTRIBUTING.md in this PR.**

## Stopping gate (per the strategic plan)

Maintainer reads RFC + catalog before Cycle 34 implementation begins; signs off on:

- (a) tail-mask vs. brief-drop-to-TuiPathway for live-region content
- (b) 4 MB per-tuple cap appropriateness
- (c) freeze-on-alt-screen handles spinner case (spinners do NOT enter alt-screen)
- (d) three exemplar canonical displays accepted as the working catalog seed
- (e) earcon frequency conflict resolved in favor of CONTRIBUTING.md's tighter bounds

## Test plan

Strictly docs-only — only `.md` files modified; no `.fs` / `.csproj` / workflow / TOML / YAML files touched. Per CLAUDE.md "Docs-only PRs may merge after only the markdown link check passes", merging when the link check is green.

- [ ] Markdown link check passes (the RFC + catalog have many cross-references; this is the primary CI gate).
- [x] Workflow lint passes (no workflow changes).
- [x] Portability lint passes (no F# code changes).
- [x] Build/test passes (no code changes; should be a no-op).

## Configurability note

No new candidate user settings introduced in this PR (it's a doc-only spec; the `[coalescer]` TOML section that the RFC mentions is a future micro-cycle's concern post-Cycle-34 implementation per [`USER-SETTINGS.md`](https://github.com/KyleKeane/pty-speak/blob/main/docs/USER-SETTINGS.md) deferral pattern).

## Architectural note

The RFC is the **first concrete substrate-side spec implementing ADR 0001's substrate / channel dichotomy**. Together with the catalog, it locks the design for the largest architectural shift in the framework plan: the inversion of cause and effect, where bytes (the parser-emitted stream) become the substrate-of-truth and the screen grid demotes to its rightful role as the substrate-of-truth for alt-screen TUI workloads only.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_