### PR TITLE
feat(substrate): Cycle 34b — producer wiring + Ctrl+Shift+D bundle integration + cross-thread locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,112 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 34b): producer composition wiring + Ctrl+Shift+D bundle integration + cross-thread locking
+
+Wires the Cycle 34a `LinearTextStream` producer at the parser-
+emit edge (`Program.fs:108`), constructs the producer instance
+in the composition root (`Program.fs:~731`), adds the
+`--- LINEAR STREAM (last 64KB) ---` section to the
+`Ctrl+Shift+D` diagnostic bundle, and adds a `lock state.Gate`
+guard around the producer's `Committed` buffer access for
+cross-thread safety.
+
+**No user-visible behaviour change** for typical sessions —
+the producer's emitted `CommitNotification`s are still
+discarded (Cycle 35 wires the Stream profile to subscribe).
+The only observable effect is the new bundle section
+populating with whatever bytes the producer captured during
+the session.
+
+- **`src/Terminal.Core/LinearTextStream.fs`** — adds
+  `member val internal Gate: obj = obj () with get` to the `T`
+  class. Wraps `appendCommittedWithCap`, `getLastBytes`, and
+  `finalizeHighWaterMark` in `lock state.Gate (fun () -> ...)`.
+  Pattern mirrors `Screen.SnapshotRows` at `Screen.fs:541-553`.
+  Without the gate, the diagnostic-bundle's background-task
+  call to `getLastBytes` could race with PathwayPump's
+  `appendCommittedWithCap` (`ResizeArray.AddRange` /
+  `RemoveRange` shifts indices mid-iteration → potential
+  `IndexOutOfRangeException`). The 25 producer tests
+  continue to pass unchanged (single-threaded test
+  assertions don't exercise the race).
+- **`src/Terminal.App/Program.fs:~731`** — constructs the
+  producer:
+  ```fsharp
+  let mutable linearStream =
+      LinearTextStream.create LinearTextStream.defaultParameters
+  ```
+- **`src/Terminal.App/Program.fs:108`** (inside
+  `startReaderLoop`) — feeds bytes + parser events to the
+  producer immediately after `Parser.feedArray`:
+  ```fsharp
+  let _, _ =
+      LinearTextStream.append
+          linearStream
+          DateTime.UtcNow
+          chunk
+          events
+  ```
+  Returned notifications + state are intentionally discarded
+  (Cycle 35 wires the Stream profile to consume).
+- **`src/Terminal.App/Program.fs:85-93`** — `startReaderLoop`
+  signature gains a `linearStream: LinearTextStream.T`
+  parameter (8th of 9). Composition-root call site at
+  `Program.fs:~2266` passes the new argument.
+- **`src/Terminal.App/Diagnostics.fs:~779-790`** — adds
+  `resolveLinearStreamPath` mirroring the existing
+  `resolveSnapshotPath` (lines 772-777). Sibling file lands
+  at `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\linear-
+  stream-<yyyy-MM-dd-HH-mm-ss-fff>.txt` with the same
+  timestamp as the bundle for mechanical cross-referencing.
+- **`src/Terminal.App/Diagnostics.fs:860-867`** —
+  `formatDiagnosticBundle` signature gains a 7th parameter
+  `linearStreamSection: string`. The body emits a new
+  `--- LINEAR STREAM (last 64KB) ---` section between
+  `--- SESSION LOG ---` and `--- ENVIRONMENT ---`.
+- **`src/Terminal.App/Diagnostics.fs:958-966`** —
+  `runFullBattery` signature gains an 8th resolver parameter
+  `resolveLinearStream: unit -> LinearTextStream.T`. Inside
+  the task block (~line 1124), the resolver is called; the
+  full stream bytes are written to the sibling file
+  (defensively, with try/log on failure); the last 64 KB
+  are UTF-8-decoded + sanitised via
+  `AnnounceSanitiser.sanitise` (strips C0 controls, DEL,
+  C1 controls; preserves printable Unicode); the resulting
+  inline section text is passed to `formatDiagnosticBundle`.
+- **`src/Terminal.App/Program.fs:~2015`** — the
+  `runDiagnostic` closure gains an 8th resolver `(fun () ->
+  linearStream)` that captures the producer cell at
+  hotkey-press time (mirrors the existing resolver pattern
+  for hot-switch resilience).
+
+**Cycle 29b iOS-paste-crash prevention:** the bundle's inline
+LinearTextStream section is hard-capped at 64 KB. Bundles
+stay paste-friendly; full forensic content lives in the
+sibling file referenced by the `(source: <path>)` line at
+the start of the section.
+
+**Sanitisation rationale:** raw PTY bytes include ANSI
+escape sequences, bell characters, etc. Without
+sanitisation the bundle would render as a mangled mess in
+chat / triage tools. `AnnounceSanitiser.sanitise` (declared
+at `AnnounceSanitiser.fs:53-68`) strips control characters
+while preserving printable Unicode (including the U+FFFD
+replacement char that `Encoding.UTF8.GetString` may produce
+for partial multi-byte sequences at the 64 KB boundary).
+
+**Cycle 34 stage complete.** With 34a (producer module +
+tests) and 34b (composition wiring + diagnostic
+integration), the LinearTextStream substrate is live in
+the running app — capturing PTY bytes parallel-to-screen,
+emitting CommitNotifications nothing yet consumes, and
+exposing a sanitised tail through the diagnostic bundle.
+Cycle 35 (Stream profile rebuild on linear substrate) is
+the next push; it wires the first consumer for the
+producer's CommitNotifications and flips
+`SessionModel.applyAndCapture` from `extractContent` to
+`LinearTextStream.finalizeHighWaterMark`.
+
 ### Added (Cycle 34a): `LinearTextStream` producer module + tests (substrate-only, parallel-to-screen)
 
 First code cycle of the substrate-inversion arc that started

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -776,6 +776,20 @@ module Diagnostics =
         let dir = Path.Combine(root, "PtySpeak", "diagnostic-snapshots")
         Path.Combine(dir, sprintf "snapshot-%s.txt" stamp)
 
+    /// Cycle 34b — sibling-file path for the LinearTextStream
+    /// FULL stream content (the bundle inlines only the last
+    /// 64 KB; the full stream goes here so a maintainer can
+    /// reference it for forensics without bloating the
+    /// clipboard payload). Mirrors `resolveSnapshotPath`'s
+    /// pattern with the same timestamp so the two files are
+    /// mechanically cross-referenceable.
+    let private resolveLinearStreamPath (now: DateTime) : string =
+        let root =
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        let stamp = now.ToString("yyyy-MM-dd-HH-mm-ss-fff")
+        let dir = Path.Combine(root, "PtySpeak", "diagnostic-snapshots")
+        Path.Combine(dir, sprintf "linear-stream-%s.txt" stamp)
+
     // ---------------------------------------------------------------
     // Cycle 25b — diagnostic-dump bundle
     // ---------------------------------------------------------------
@@ -864,6 +878,7 @@ module Diagnostics =
             (fileLoggerLogPath: string option)
             (configPath: string)
             (sessionLogSummary: string)
+            (linearStreamSection: string)
             : string =
         let sb = StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
@@ -905,6 +920,17 @@ module Diagnostics =
 
         appendLine "--- SESSION LOG ---"
         appendLine sessionLogSummary
+        appendLine ""
+
+        // Cycle 34b — LinearTextStream tail (last 64 KB inline;
+        // full stream lives in a sibling `linear-stream-<ts>.txt`
+        // file referenced by the section header). The 64 KB cap
+        // is hard per the Cycle 29b iOS-paste-crash incident:
+        // bundles must stay paste-friendly. Caller pre-formats
+        // the section text (UTF-8 decode + AnnounceSanitiser
+        // strip controls) before passing here.
+        appendLine "--- LINEAR STREAM (last 64KB) ---"
+        appendLine linearStreamSection
         appendLine ""
 
         appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"
@@ -963,6 +989,7 @@ module Diagnostics =
             (resolveSessionSnapshot: unit -> SessionModelSnapshot)
             (resolveFileLoggerLogPath: unit -> string option)
             (resolveSessionLogSummary: unit -> string)
+            (resolveLinearStream: unit -> LinearTextStream.T)
             : unit =
         let log = Logger.get "Terminal.App.Diagnostics.runFullBattery"
         let _ =
@@ -1120,6 +1147,49 @@ module Diagnostics =
                     let fileLoggerLogPath = resolveFileLoggerLogPath ()
                     let sessionLogSummary = resolveSessionLogSummary ()
                     let snapshotPath = resolveSnapshotPath now
+
+                    // Cycle 34b — capture the LinearTextStream
+                    // tail for the bundle's `--- LINEAR STREAM
+                    // (last 64KB) ---` section + write the FULL
+                    // stream to a sibling `linear-stream-<ts>.txt`
+                    // file. The 64KB inline cap protects the
+                    // clipboard payload from the Cycle 29b iOS-
+                    // paste-crash failure mode; the sibling file
+                    // gives forensics access to the full content.
+                    let linearStream = resolveLinearStream ()
+                    let linearStreamSiblingPath =
+                        resolveLinearStreamPath now
+                    let allLinearBytes =
+                        LinearTextStream.getLastBytes linearStream Int32.MaxValue
+                    try
+                        // F# 9 nullness: Path.GetDirectoryName
+                        // returns string? (null for root paths
+                        // or empty input). Narrow per the
+                        // existing `DiagnosticLogWriter` pattern
+                        // (`Diagnostics.fs:328-332`).
+                        match Path.GetDirectoryName(linearStreamSiblingPath) with
+                        | null -> ()
+                        | dir when String.IsNullOrEmpty dir -> ()
+                        | dir ->
+                            Directory.CreateDirectory(dir) |> ignore
+                        File.WriteAllBytes(
+                            linearStreamSiblingPath,
+                            allLinearBytes)
+                    with ex ->
+                        log.LogWarning(
+                            ex,
+                            "Diagnostic: failed to write linear-stream sibling file at {Path}",
+                            linearStreamSiblingPath)
+                    let tailBytes =
+                        LinearTextStream.getLastBytes linearStream 64
+                    let tailText =
+                        try
+                            System.Text.Encoding.UTF8.GetString(tailBytes)
+                            |> AnnounceSanitiser.sanitise
+                        with _ -> "(UTF-8 decode failed)"
+                    let linearStreamSection =
+                        sprintf "(source: %s)\n%s" linearStreamSiblingPath tailText
+
                     let bundle =
                         formatDiagnosticBundle
                             now
@@ -1128,6 +1198,7 @@ module Diagnostics =
                             fileLoggerLogPath
                             configPath
                             sessionLogSummary
+                            linearStreamSection
                     let writtenPath = writeSnapshotFile log snapshotPath bundle
                     let savedFragment =
                         match writtenPath with

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -88,6 +88,7 @@ module Program =
             (parser: Parser)
             (screen: Screen)
             (view: TerminalView)
+            (linearStream: LinearTextStream.T)
             (notifications: System.Threading.Channels.ChannelWriter<PumpInput>)
             (onChunkRead: int -> unit)
             (ct: CancellationToken) : Task =
@@ -106,6 +107,20 @@ module Program =
                             // shell).
                             onChunkRead chunk.Length
                             let events = Parser.feedArray parser chunk
+                            // Cycle 34b — feed the LinearTextStream
+                            // producer parallel-to-screen. Emitted
+                            // CommitNotifications are intentionally
+                            // discarded here (Cycle 35 wires the
+                            // Stream profile to subscribe). The
+                            // returned T is the same class reference
+                            // as `linearStream` (state mutates
+                            // in-place); discard.
+                            let _, _ =
+                                LinearTextStream.append
+                                    linearStream
+                                    DateTime.UtcNow
+                                    chunk
+                                    events
                             if events.Length > 0 then
                                 let action () =
                                     for e in events do screen.Apply(e)
@@ -729,6 +744,15 @@ module Program =
         let cts = new CancellationTokenSource()
         let screen = Screen(rows = ScreenRows, cols = ScreenCols)
         let parser = Parser.create ()
+        // Cycle 34b — construct the LinearTextStream producer
+        // (Cycle 34a's `LinearTextStream.fs`). Runs parallel-
+        // to-screen with no consumers in 34b; Cycle 35 wires
+        // the Stream profile to subscribe to its emitted
+        // CommitNotifications. Held in a `mutable` cell for
+        // clarity; the underlying class reference is stable
+        // across `append` calls (T is mutable internally).
+        let mutable linearStream =
+            LinearTextStream.create LinearTextStream.defaultParameters
         window.TerminalSurface.SetScreen(screen)
 
         // Cycle 32b — first consumer of the IDisplayBuffer boundary
@@ -2013,6 +2037,13 @@ module Program =
                 // mode/path are resolved at press-time and reflect
                 // any reload-on-shell-switch that happened since.
                 buildSessionLogSummary
+                // Cycle 34b — LinearTextStream resolver for the
+                // bundle's `--- LINEAR STREAM (last 64KB) ---`
+                // section. The producer's class reference is
+                // stable across the session (no shell-switch
+                // reconstruction yet), so the closure captures
+                // the same `linearStream` cell on every press.
+                (fun () -> linearStream)
 
         // Cycle 22b — Ctrl+Shift+Y. Closure captures
         // `currentSession` from compose-local scope. Resolves
@@ -2259,6 +2290,7 @@ module Program =
                     parser
                     screen
                     window.TerminalSurface
+                    linearStream
                     pumpChannel.Writer
                     (fun _ -> lastReadUtc <- DateTimeOffset.UtcNow)
                     cts.Token

--- a/src/Terminal.Core/LinearTextStream.fs
+++ b/src/Terminal.Core/LinearTextStream.fs
@@ -176,6 +176,18 @@ module LinearTextStream =
     /// property setters and `ResizeArray` in-place mutation.
     [<Sealed>]
     type T internal (parameters: Parameters) =
+        /// Cycle 34b — synchronization gate for cross-thread
+        /// access. The producer is single-threaded for `append`
+        /// / `tick` (PathwayPump worker), but the diagnostic
+        /// bundle (`Ctrl+Shift+D`, runs on a background task
+        /// thread per `Diagnostics.runFullBattery:958-969`)
+        /// reads `Committed` via `getLastBytes`. Without the
+        /// gate, concurrent `ResizeArray.AddRange` /
+        /// `RemoveRange` (eviction) shifts indices mid-read.
+        /// Pattern mirrors `Screen.SnapshotRows` at
+        /// `Screen.fs:541-553` (`lock gate (fun () -> ...)`).
+        /// All Committed mutations + reads MUST hold this gate.
+        member val internal Gate: obj = obj () with get
         member val internal Committed: ResizeArray<byte> = ResizeArray<byte>() with get
         member val internal Pending: ResizeArray<byte> = ResizeArray<byte>() with get
         member val internal Parameters: Parameters = parameters with get
@@ -333,13 +345,18 @@ module LinearTextStream =
     /// cap is reached, drop the oldest excess bytes from the
     /// head and flag truncation. Mutates `state.Committed` and
     /// may set `state.Truncated`.
+    ///
+    /// Cycle 34b — wrapped in `lock state.Gate` for cross-
+    /// thread safety with the `Ctrl+Shift+D` `getLastBytes`
+    /// reader. See T type's Gate doc for rationale.
     let private appendCommittedWithCap (state: T) (bytes: byte[]) : unit =
-        state.Committed.AddRange(bytes)
-        let cap = state.Parameters.PerTupleCapBytes
-        if state.Committed.Count > cap then
-            let excess = state.Committed.Count - cap
-            state.Committed.RemoveRange(0, excess)
-            state.Truncated <- true
+        lock state.Gate (fun () ->
+            state.Committed.AddRange(bytes)
+            let cap = state.Parameters.PerTupleCapBytes
+            if state.Committed.Count > cap then
+                let excess = state.Committed.Count - cap
+                state.Committed.RemoveRange(0, excess)
+                state.Truncated <- true)
 
     /// Drain the pending buffer into a sealed/unsealed
     /// EmittedChunk. Returns the chunk + clears pending.
@@ -697,47 +714,51 @@ module LinearTextStream =
     /// `PromptStartOffset` / `OutputStartOffset` markers set
     /// during OSC 133 parsing.
     let finalizeHighWaterMark (state: T) : FinalizedChunk * T =
-        let totalBytes = state.Committed.Count
-        let promptStart = int state.PromptStartOffset
-        let outputStart = int state.OutputStartOffset
+        // Cycle 34b — `lock state.Gate` ensures the slice
+        // `Array.sub` reads + the offset markers see a
+        // consistent buffer state. See T.Gate doc.
+        lock state.Gate (fun () ->
+            let totalBytes = state.Committed.Count
+            let promptStart = int state.PromptStartOffset
+            let outputStart = int state.OutputStartOffset
 
-        let commandText =
-            if outputStart > promptStart && promptStart >= 0 then
-                let cmdLen = outputStart - promptStart
-                if cmdLen > 0 && promptStart + cmdLen <= totalBytes then
+            let commandText =
+                if outputStart > promptStart && promptStart >= 0 then
+                    let cmdLen = outputStart - promptStart
+                    if cmdLen > 0 && promptStart + cmdLen <= totalBytes then
+                        let bytes =
+                            Array.sub
+                                (state.Committed.ToArray())
+                                promptStart
+                                cmdLen
+                        System.Text.Encoding.UTF8.GetString(bytes)
+                    else ""
+                else ""
+
+            let outputText =
+                if outputStart >= 0 && outputStart < totalBytes then
+                    let outLen = totalBytes - outputStart
                     let bytes =
                         Array.sub
                             (state.Committed.ToArray())
-                            promptStart
-                            cmdLen
+                            outputStart
+                            outLen
                     System.Text.Encoding.UTF8.GetString(bytes)
                 else ""
-            else ""
 
-        let outputText =
-            if outputStart >= 0 && outputStart < totalBytes then
-                let outLen = totalBytes - outputStart
-                let bytes =
-                    Array.sub
-                        (state.Committed.ToArray())
-                        outputStart
-                        outLen
-                System.Text.Encoding.UTF8.GetString(bytes)
-            else ""
+            let chunk =
+                { CommandText = commandText
+                  OutputText = outputText
+                  Truncated = state.Truncated
+                  Sealed = true
+                  ProducerWaterMark = state.HighWaterMark }
 
-        let chunk =
-            { CommandText = commandText
-              OutputText = outputText
-              Truncated = state.Truncated
-              Sealed = true
-              ProducerWaterMark = state.HighWaterMark }
+            // Reset per-tuple state for the next command.
+            state.PromptStartOffset <- state.HighWaterMark
+            state.OutputStartOffset <- state.HighWaterMark
+            state.Truncated <- false
 
-        // Reset per-tuple state for the next command.
-        state.PromptStartOffset <- state.HighWaterMark
-        state.OutputStartOffset <- state.HighWaterMark
-        state.Truncated <- false
-
-        (chunk, state)
+            (chunk, state))
 
     // --------------------------------------------------------
     // Diagnostic accessor (for Cycle 34b Ctrl+Shift+D)
@@ -748,15 +769,20 @@ module LinearTextStream =
     /// Cycle 34b uses this for the `--- LINEAR STREAM ---`
     /// section of the diagnostic bundle.
     let getLastBytes (state: T) (kilobytes: int) : byte[] =
-        let want = kilobytes * 1024
-        let available = state.Committed.Count
-        let take = min want available
-        let start = available - take
-        if take <= 0 then [||]
-        else
-            let result = Array.zeroCreate take
-            // ResizeArray.CopyTo doesn't take a slice; use
-            // index-based copy.
-            for i in 0 .. take - 1 do
-                result.[i] <- state.Committed.[start + i]
-            result
+        // Cycle 34b — `lock state.Gate` ensures atomic copy
+        // even when PathwayPump's `append` is concurrently
+        // mutating `Committed` (cross-thread call from the
+        // diagnostic bundle's background task; see T.Gate doc).
+        lock state.Gate (fun () ->
+            let want = kilobytes * 1024
+            let available = state.Committed.Count
+            let take = min want available
+            let start = available - take
+            if take <= 0 then [||]
+            else
+                let result = Array.zeroCreate take
+                // ResizeArray.CopyTo doesn't take a slice; use
+                // index-based copy.
+                for i in 0 .. take - 1 do
+                    result.[i] <- state.Committed.[start + i]
+                result)


### PR DESCRIPTION
## Summary

Wires the Cycle 34a `LinearTextStream` producer at the parser-emit edge (`Program.fs:108`), constructs the producer instance in the composition root (`Program.fs:~731`), adds the `--- LINEAR STREAM (last 64KB) ---` section to the `Ctrl+Shift+D` diagnostic bundle, and adds a `lock state.Gate` guard around the producer's `Committed` buffer access for cross-thread safety.

**No user-visible behaviour change** for typical sessions — the producer's emitted `CommitNotification`s are still discarded (Cycle 35 wires the Stream profile to subscribe). The only observable effect is the new bundle section populating with whatever bytes the producer captured during the session.

## What changed

- **`src/Terminal.Core/LinearTextStream.fs`** — adds `T.Gate` (obj) + wraps `appendCommittedWithCap`, `getLastBytes`, and `finalizeHighWaterMark` in `lock state.Gate`. Pattern mirrors `Screen.SnapshotRows` at `Screen.fs:541-553`. Without the gate, the diagnostic-bundle's background-task call to `getLastBytes` could race with PathwayPump's `appendCommittedWithCap` (`ResizeArray.AddRange` / `RemoveRange` shifts indices mid-iteration → potential `IndexOutOfRangeException`). 25 producer tests continue to pass unchanged.
- **`src/Terminal.App/Program.fs:~731`** — constructs `mutable linearStream = LinearTextStream.create LinearTextStream.defaultParameters`.
- **`src/Terminal.App/Program.fs:108`** (inside `startReaderLoop`) — feeds bytes + parser events to the producer immediately after `Parser.feedArray`. Returned notifications + state intentionally discarded.
- **`src/Terminal.App/Program.fs:85-93`** — `startReaderLoop` signature gains a `linearStream: LinearTextStream.T` parameter (8th of 9). Composition-root call site at `Program.fs:~2266` passes the new argument.
- **`src/Terminal.App/Diagnostics.fs:~779-790`** — `resolveLinearStreamPath` mirrors `resolveSnapshotPath` (lines 772-777). Sibling file lands at `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\linear-stream-<yyyy-MM-dd-HH-mm-ss-fff>.txt` with the same timestamp as the bundle for mechanical cross-referencing.
- **`src/Terminal.App/Diagnostics.fs:860-867`** — `formatDiagnosticBundle` signature gains a 7th parameter `linearStreamSection: string`. Body emits a new `--- LINEAR STREAM (last 64KB) ---` section between `--- SESSION LOG ---` and `--- ENVIRONMENT ---`.
- **`src/Terminal.App/Diagnostics.fs:958-966`** — `runFullBattery` signature gains an 8th resolver `resolveLinearStream: unit -> LinearTextStream.T`. Inside the task block (~line 1124), the resolver is called; the full stream bytes are written to the sibling file (defensively, with try/log on failure); the last 64 KB are UTF-8-decoded + sanitised via `AnnounceSanitiser.sanitise`; the resulting inline section text is passed to `formatDiagnosticBundle`.
- **`src/Terminal.App/Program.fs:~2015`** — `runDiagnostic` closure gains an 8th resolver `(fun () -> linearStream)` capturing the producer cell at hotkey-press time.
- **`CHANGELOG.md`** — `[Unreleased]` entry covering all of the above.

## Cycle 29b iOS-paste-crash prevention

The bundle's inline LinearTextStream section is hard-capped at 64 KB. Bundles stay paste-friendly; full forensic content lives in the sibling file referenced by the `(source: <path>)` line at the start of the section.

## Sanitisation rationale

Raw PTY bytes include ANSI escape sequences, bell characters, etc. Without sanitisation the bundle would render as a mangled mess in chat / triage tools. `AnnounceSanitiser.sanitise` (declared at `AnnounceSanitiser.fs:53-68`) strips control characters while preserving printable Unicode (including the U+FFFD replacement char that `Encoding.UTF8.GetString` may produce for partial multi-byte sequences at the 64 KB boundary).

## Test plan

- [x] Standard CI (Build + test on windows-latest, Workflow lint, Markdown link check, Portability lint) passes — F# code compiles; existing test surface (Cycle 31a IOutputSinkTests, Cycle 32a ConfigTests, Cycle 34a LinearTextStreamTests) stays green.
- [x] Portability lint continues to pass — no host-specific imports introduced into substrate code.
- [ ] **Maintainer manual smoke test (post-merge):** launch pty-speak, run `dir`, press `Ctrl+Shift+D`, verify the bundle's new `--- LINEAR STREAM (last 64KB) ---` section captures sane content (not raw ANSI escapes — sanitisation working). Verify the sibling file `linear-stream-<timestamp>.txt` lands in `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\` alongside the bundle.

## What this PR deliberately omits

- **Does NOT consume the producer's `CommitNotification`s.** They're discarded after `append` returns. Cycle 35 wires the Stream profile to subscribe.
- **Does NOT cut over `SessionModel.applyAndCapture` to use `LinearTextStream.finalizeHighWaterMark`.** Cycle 35 ships that with the Stream-profile inversion.
- **Does NOT call `LinearTextStream.checkpointAndFreeze` / `resumeFromFreeze` from PathwayPump.** Cycle 35 wires alt-screen entry/exit handling.
- **Does NOT add tests for the diagnostic-bundle integration.** The bundle's content is manually NVDA-validated per CONTRIBUTING.md "Tests" §"NVDA: manual for each release"; no automated tests for `formatDiagnosticBundle` exist today.

## Cycle 34 stage complete

With 34a (producer module + tests) and 34b (composition wiring + diagnostic integration), the LinearTextStream substrate is **live in the running app** — capturing PTY bytes parallel-to-screen, emitting CommitNotifications nothing yet consumes, and exposing a sanitised tail through the diagnostic bundle. Cycle 35 (Stream profile rebuild on linear substrate) is the next push; it wires the first consumer for the producer's CommitNotifications and flips `SessionModel.applyAndCapture` from `extractContent` to `LinearTextStream.finalizeHighWaterMark`.

## Configurability note

No new candidate user settings introduced. Per CONTRIBUTING.md "Consider configurability when iterating": the producer's cadence parameters remain constants in `LinearTextStream.fs`; future micro-cycle externalises to `[coalescer]` TOML per the Cycle 32a `[profile.selection]` precedent.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_