### PR TITLE
refactor(substrate): Cycle 35c — Path B Levenshtein spinner gate scoped to ScreenDiff path only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,70 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 35c): Path B Levenshtein spinner gate scoped to ScreenDiff path only
+
+Closes the substrate-inversion arc (Cycles 33-35). The
+`isSpinnerSuppressed` gate (Cycle 11+ Levenshtein heuristic
+on row-hash recurrence) now only fires when `resolveSubstrateMode`
+returns `ScreenDiff`. On the Linear path, the gate is bypassed
+entirely — RFC 0001 §5.3 #3 tail-mask classifier already
+collapses spinner-class output (bare `\r`, `ESC[K` transition
+the current row to LATEST semantics), making the gate redundant.
+
+**Why scope rather than delete:** the gate stays compiled in
+because alt-screen TUIs and explicit `substrate_mode = "screen-diff"`
+opt-in still use the screen-diff substrate. Full deletion lives
+in the Cycle 39 cleanup once the screen-diff path itself is
+removable (per Section 13 of the strategic plan).
+
+**Why this matters:** the previous gating cost was small in
+the typical case but masked a real bug surface. A user's
+command that genuinely produces N rapid identical announces
+(e.g., a tool intentionally printing a heartbeat line every
+200ms) would get suppressed by the gate on the Linear path
+even though the user wants to hear each beat. Linear's
+tail-mask only suppresses overwrite-class bytes (`\r`-without-
+`\n`); append-class content flows through.
+
+- **`src/Terminal.Core/StreamPathway.fs:processCanonicalState`**
+  — hoist `resolveSubstrateMode` call BEFORE the spinner-suppress
+  check. Gate the `isSpinnerSuppressed` invocation on
+  `resolvedMode`: `if resolvedMode = Linear then false else
+  isSpinnerSuppressed parameters state now rowHashes contentHashes`.
+  The duplicate `resolveSubstrateMode` call previously inside
+  the leading-edge dispatch (line 817-820) is removed; the
+  hoisted value is reused. ~10 LOC.
+- **`tests/Tests.Unit/StreamPathwayTests.fs`** — 2 new facts:
+  - `Cycle 35c — SubstrateMode=Linear bypasses isSpinnerSuppressed
+    gate` — drives the alternating-frame sequence with
+    `SubstrateMode = Linear` and asserts `state.PerRowHistory`
+    + `state.HashHistory` remain empty (the gate's state
+    machine was never invoked).
+  - `Cycle 35c — SubstrateMode=ScreenDiff still gates spinners
+    (regression)` — sentinel: same alternating-frame sequence
+    with explicit `SubstrateMode = ScreenDiff`, asserts ≥1
+    suppression fires AND `state.PerRowHistory` is populated.
+- **`onTimerTick`**: unchanged — the trailing-edge dispatch
+  has no `isSpinnerSuppressed` call (the gate is leading-edge
+  only).
+- Existing 4 spinner-suppression facts (per-key, cross-row,
+  static-rows, GC-after-window) stay green via the
+  `legacyDefaultParameters` test wrapper which forces
+  `SubstrateMode = ScreenDiff`.
+
+**Substrate-inversion arc complete** with 35c. The Cycle 33-35
+sequence delivered:
+- Cycle 33: RFC + canonical-display catalog (doc).
+- Cycle 34a/b: `LinearTextStream` producer module + composition wiring + diagnostic bundle integration.
+- Cycle 35a: parallel linear-substrate path behind default-off TOML flag.
+- Cycle 35b: default flip to `Auto` + SessionModel hybrid cutover (linear path for OSC-133 shells; `extractContent` fallback for vanilla cmd / PowerShell).
+- Cycle 35c: Levenshtein spinner gate scoped to ScreenDiff fallback only.
+
+Cycle 36 (doc-only matrix backfill into ACCESSIBILITY-TESTING.md)
+is the only remaining substrate-arc work; future Cycle 39
+removes the screen-diff legacy when preconditions are met
+(per Section 13 of `/root/.claude/plans/we-do-not-need-fluffy-simon.md`).
+
 ### Changed (Cycle 35b): default `[pathway.stream] substrate_mode` flipped to `auto` + SessionModel hybrid cutover
 
 The headline behavioural change of the substrate-inversion arc.

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -759,8 +759,25 @@ module StreamPathway =
             [||]
         | _ ->
             gcHistory parameters state now
+            // Cycle 35c — resolve substrate mode early so the
+            // spinner gate can be skipped on the Linear path.
+            // Per RFC 0001 §5.3 #3, LinearTextStream's tail-mask
+            // already collapses spinner-class output (bare \r,
+            // ESC[K transition the current row to LATEST
+            // semantics). The Path B Levenshtein gate is a
+            // defensive measure for the screen-diff substrate
+            // where every spinner frame produces a row-hash
+            // difference; on Linear it's redundant and could
+            // mask legitimate rapid-repeat content (e.g.,
+            // heartbeat lines a tool intentionally prints
+            // every N ms).
+            let resolvedMode =
+                resolveSubstrateMode
+                    parameters.SubstrateMode
+                    canonical.IsAltScreenActive
             let suppress =
-                isSpinnerSuppressed parameters state now rowHashes contentHashes
+                if resolvedMode = Linear then false
+                else isSpinnerSuppressed parameters state now rowHashes contentHashes
             state.LastRowHashes <- ValueSome rowHashes
             if suppress then
                 state.LastFrameHash <- ValueSome frameHash
@@ -813,11 +830,10 @@ module StreamPathway =
                         // Auto: Linear if non-alt-screen; else
                         // ScreenDiff. Watermark advance happens
                         // only on emit (suppressed/empty payloads
-                        // don't lose bytes).
-                        let resolvedMode =
-                            resolveSubstrateMode
-                                parameters.SubstrateMode
-                                canonical.IsAltScreenActive
+                        // don't lose bytes). Cycle 35c — the
+                        // outer `resolvedMode` (hoisted before
+                        // the spinner gate) is reused here; no
+                        // need to recompute.
                         let payload, watermarkUpdate =
                             match resolvedMode with
                             | Linear ->

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -1690,3 +1690,103 @@ let ``Cycle 35a — Linear payload respects MaxAnnounceChars cap`` () =
             parameters state (at 0) (canonicalAt snap 0L) stream
     Assert.Equal(1, result.Length)
     Assert.Equal(30, result.[0].Payload.Length)
+
+// =====================================================================
+// Cycle 35c — isSpinnerSuppressed gate scoped to ScreenDiff path
+// =====================================================================
+//
+// The Path B Levenshtein gate (Cycle 11+) was a defensive
+// measure for the screen-diff substrate where every spinner
+// frame produces a row-hash difference. On the linear
+// substrate, RFC 0001 §5.3 #3 tail-mask classifier already
+// collapses spinner-class output (\r-without-\n, ESC[K
+// transition the current row to LATEST semantics). Cycle 35c
+// gates the spinner-suppress check on `resolvedMode`: only
+// invokes `isSpinnerSuppressed` when ScreenDiff. Linear path
+// returns `suppress = false` unconditionally, letting all
+// frames flow through to the dispatch.
+//
+// These two facts pin both halves: Linear bypasses (new
+// behaviour); ScreenDiff still gates (regression check
+// against future refactors weakening the screen-diff path).
+
+let private spinnerLinearParameters : StreamPathway.Parameters =
+    { StreamPathway.defaultParameters with
+        SubstrateMode = StreamPathway.Linear }
+
+let private spinnerScreenDiffParameters : StreamPathway.Parameters =
+    { StreamPathway.defaultParameters with
+        SubstrateMode = StreamPathway.ScreenDiff }
+
+[<Fact>]
+let ``Cycle 35c — SubstrateMode=Linear bypasses isSpinnerSuppressed gate`` () =
+    // Mirror the existing per-key spinner gate fact (line 263)
+    // but with SubstrateMode=Linear. The gate must NOT fire —
+    // every alternating frame should flow through the dispatch.
+    // (The Linear payload may be empty since the linearStream
+    // is fresh, but `result.Length` reflects whether the
+    // dispatch executed; suppression returns [||] BEFORE
+    // dispatch, so we're checking that it did not.)
+    let state = StreamPathway.createState ()
+    let stream = LinearTextStream.create LinearTextStream.defaultParameters
+    let frameA = snapshotOf 1 1 [ "A" ]
+    let frameB = snapshotOf 1 1 [ "B" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            spinnerLinearParameters state (at 0) (canonicalAt frameA 0L) stream
+    let mutable suppressedCount = 0
+    for i in 1 .. 14 do
+        let frame = if i % 2 = 1 then frameB else frameA
+        let result =
+            StreamPathway.processCanonicalState
+                spinnerLinearParameters state (at (i * 60))
+                (canonicalAt frame (int64 i)) stream
+        // result.Length = 0 happens for two distinct reasons on
+        // the Linear path: (a) spinner-suppress fired (the bug
+        // we're guarding against), (b) the linear stream's
+        // suffixSince returned empty (legitimate; the stream
+        // got no bytes between calls). To distinguish, check
+        // the FileLogger pattern the suppress arm emits — but
+        // the simpler test is to assert the suppression-related
+        // state didn't move: PerRowHistory + HashHistory should
+        // remain empty because isSpinnerSuppressed (which
+        // populates them) was never invoked.
+        if result.Length = 0 then suppressedCount <- suppressedCount + 1
+    // The empty linear stream means many frames will return
+    // empty payloads, but they should NOT count as
+    // suppression-by-gate. The load-bearing assertion is the
+    // PerRowHistory + HashHistory state below — those would
+    // be populated only if isSpinnerSuppressed ran.
+    Assert.Empty(state.PerRowHistory)
+    Assert.Empty(state.HashHistory)
+
+[<Fact>]
+let ``Cycle 35c — SubstrateMode=ScreenDiff still gates spinners (regression)`` () =
+    // Sentinel: the existing screen-diff path's spinner gate
+    // must keep firing. This guards against future refactors
+    // accidentally weakening the screen-diff fallback. Mirrors
+    // the original `per-key spinner gate fires after threshold`
+    // fact (line 263) with explicit ScreenDiff parameters.
+    let state = StreamPathway.createState ()
+    let stream = LinearTextStream.create LinearTextStream.defaultParameters
+    let frameA = snapshotOf 1 1 [ "A" ]
+    let frameB = snapshotOf 1 1 [ "B" ]
+    let _ =
+        StreamPathway.processCanonicalState
+            spinnerScreenDiffParameters state (at 0) (canonicalAt frameA 0L) stream
+    let mutable suppressedCount = 0
+    let mutable emittedCount = 0
+    for i in 1 .. 14 do
+        let frame = if i % 2 = 1 then frameB else frameA
+        let result =
+            StreamPathway.processCanonicalState
+                spinnerScreenDiffParameters state (at (i * 60))
+                (canonicalAt frame (int64 i)) stream
+        if i % 2 = 1 then
+            if result.Length = 0 then suppressedCount <- suppressedCount + 1
+            else emittedCount <- emittedCount + 1
+    Assert.True(suppressedCount >= 1,
+        sprintf "Expected screen-diff spinner-suppression to still fire; got %d suppressed, %d emitted"
+            suppressedCount emittedCount)
+    // Sanity: the gate's state machine WAS engaged on this path.
+    Assert.NotEmpty(state.PerRowHistory)


### PR DESCRIPTION
## Summary

Cycle 35c — closes the substrate-inversion arc (Cycles 33-35). The Path B Levenshtein spinner gate (`isSpinnerSuppressed`) now only fires when `resolveSubstrateMode` returns `ScreenDiff`. On the Linear path the gate is bypassed entirely.

**Why scope rather than delete:** the gate stays compiled in because alt-screen TUIs and explicit `substrate_mode = "screen-diff"` opt-in still use the screen-diff substrate. Full deletion lives in the Cycle 39 cleanup once the screen-diff path is removable (per Section 13 of the strategic plan).

**Why it matters:** the gate was a defensive measure for the screen-diff substrate where every spinner frame produces a row-hash difference. Linear's tail-mask (RFC 0001 §5.3 #3) already collapses overwrite-class output. Keeping the Levenshtein gate active on Linear was redundant AND potentially harmful — legitimate rapid-repeat content (heartbeat lines a tool intentionally prints every N ms) would get suppressed even though the user wants to hear each beat.

## Implementation

- **`src/Terminal.Core/StreamPathway.fs:processCanonicalState`** — hoist `resolveSubstrateMode` BEFORE the spinner check; gate the `isSpinnerSuppressed` invocation with `if resolvedMode = Linear then false else ...`. Remove the duplicate `resolveSubstrateMode` call inside the leading-edge dispatch (hoisted value is reused). `onTimerTick` unchanged — no spinner-gate call there.
- **`tests/Tests.Unit/StreamPathwayTests.fs`** — 2 new facts:
  - Linear bypasses gate: asserts `PerRowHistory` + `HashHistory` remain empty (the gate's state machine was never invoked).
  - ScreenDiff still gates (regression sentinel): asserts ≥1 suppression fires + `PerRowHistory` populated.
- Existing 4 spinner-suppression facts stay green via `legacyDefaultParameters` wrapper indirection (forces `SubstrateMode = ScreenDiff`).

## Substrate-inversion arc summary

After 35c merges:
- Cycle 33: RFC + canonical-display catalog (doc).
- Cycle 34a/b: `LinearTextStream` producer module + composition wiring + diagnostic bundle integration.
- Cycle 35a: parallel linear-substrate path behind default-off TOML flag.
- Cycle 35b: default flip to `Auto` + SessionModel hybrid cutover.
- Cycle 35c: Levenshtein spinner gate scoped to ScreenDiff fallback only.

Cycle 36 (doc-only matrix backfill into ACCESSIBILITY-TESTING.md) is the remaining substrate-arc work; future Cycle 39 removes screen-diff legacy when preconditions are met.

## Test plan

- [ ] CI build/test (windows-latest), workflow lint, link check, portability lint — all green.
- [ ] Maintainer dogfood (deferred to logging review): grep `Suppressed (spinner)` in a recent `Ctrl+Shift+D` bundle. Expected post-35c: those log lines disappear from Linear-path frames; remain on alt-screen ScreenDiff frames.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_