### PR TITLE
feat(selection): Cycle 37a — SelectionProfile emits RenderRaw substrate alongside RenderText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 37a): SelectionProfile emits RenderRaw substrate alongside RenderText
+
+Opens the Stage 8e-B canonical-display arc (interactive-list UIA
+listbox peer). `SelectionProfile.Apply` now emits a third
+`ChannelDecision` per Selection event: an NVDA-channel
+`RenderRaw` decision carrying a new
+[`SelectionRawPayload`](src/Terminal.Core/OutputEventTypes.fs)
+record (UIA-free snapshot of the selection state — discriminator,
+item count, indices, item text array). The pre-existing NVDA
+`RenderText` decision is kept for the bridge interval between
+37a and 37b — NVDA continues to read the rendered text as it has
+since Cycle 29b. Cycle 37b promotes the substrate to a
+`Terminal.Accessibility` UIA peer (drops the duplicate NVDA
+`RenderText` decision; the FileLogger `RenderText` decision
+stays as the audit trail).
+
+[`Terminal.Core.NvdaChannel`](src/Terminal.Core/NvdaChannel.fs)
+gains a second `marshalRawPayload` callback parameter alongside
+the existing `marshalAnnounce`. The composition root in
+[`Program.fs`](src/Terminal.App/Program.fs) wires it via the WPF
+dispatcher to a new
+[`TerminalView.AnnounceRawPayload`](src/Views/TerminalView.cs)
+method (Cycle 37a stub: log-only; Cycle 37b: peer-state update +
+UIA event raise).
+
+No behaviour change visible to NVDA users in 37a — the
+`RenderRaw` decisions feed the View stub which logs and
+no-ops. Sets up Cycle 37b's peer types
+(`TerminalListAutomationPeer` + `TerminalListItemAutomationPeer`)
+to consume the substrate without further substrate churn.
+
+Tests: 6 new `SelectionProfileTests` facts (3 cover the
+3-decision shape per event; 3 cover `SelectionRawPayload`
+field invariants for `Kind` ∈ {"shown", "item", "dismissed"});
+1 updated `NvdaChannelTests` fact (`RenderRaw` now routes to
+the second marshal callback rather than skipping silently);
+14 mechanical `NvdaChannel.create` call-site updates to thread
+the new parameter (no behaviour change to those tests).
+
 ### Documented (Cycle 36): substrate-inversion arc validation matrix backfilled into ACCESSIBILITY-TESTING.md
 
 Closes the substrate-inversion arc's documentation work. Adds a

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -927,10 +927,18 @@ module Program =
         // worker. Behaviour-identical to Stage 7 / Stage 8a in
         // throughput + ordering.
         let nvdaChannel =
-            NvdaChannel.create (fun (msg, activityId) ->
-                let action () =
-                    window.TerminalSurface.Announce(msg, activityId)
-                window.Dispatcher.Invoke(Action(action)))
+            NvdaChannel.create
+                (fun (msg, activityId) ->
+                    let action () =
+                        window.TerminalSurface.Announce(msg, activityId)
+                    window.Dispatcher.Invoke(Action(action)))
+                (fun (payload, activityId) ->
+                    // Cycle 37a — RenderRaw routing. View stub logs only;
+                    // Cycle 37b promotes to peer-state update on the
+                    // active TerminalAutomationPeer.
+                    let action () =
+                        window.TerminalSurface.AnnounceRawPayload(payload, activityId)
+                    window.Dispatcher.Invoke(Action(action)))
         OutputDispatcher.ChannelRegistry.register nvdaChannel
         // Stage 8c — FileLogger as a first-class channel. Every
         // event the Stream profile emits now lands in the rolling

--- a/src/Terminal.Core/NvdaChannel.fs
+++ b/src/Terminal.Core/NvdaChannel.fs
@@ -7,17 +7,20 @@ namespace Terminal.Core
 /// (`output → ImportantAll`, everything else → `MostRecent`,
 /// implemented at `src/Views/TerminalView.cs:292-298`).
 ///
-/// The channel is constructed with a marshalling callback the
+/// The channel is constructed with TWO marshalling callbacks the
 /// caller (`src/Terminal.App/Program.fs`) binds to the WPF
 /// dispatcher hop. This keeps `Terminal.Core` free of WPF
 /// dependencies; the caller bridges:
 ///
 /// ```fsharp
 /// let nvda =
-///     NvdaChannel.create (fun (msg, activityId) ->
-///         window.Dispatcher.InvokeAsync(Action(fun () ->
-///             window.TerminalSurface.Announce(msg, activityId)))
-///         |> ignore)
+///     NvdaChannel.create
+///         (fun (msg, activityId) ->
+///             window.Dispatcher.Invoke(Action(fun () ->
+///                 window.TerminalSurface.Announce(msg, activityId))))
+///         (fun (payload, activityId) ->
+///             window.Dispatcher.Invoke(Action(fun () ->
+///                 window.TerminalSurface.AnnounceRawPayload(payload, activityId))))
 /// ```
 ///
 /// **8a does NOT consult `OutputEvent.Priority`.** The
@@ -35,11 +38,20 @@ namespace Terminal.Core
 /// 8c FileLogger channel) may choose to log mode barriers even
 /// with empty payloads.
 ///
-/// **Earcon / Raw render skip.** `RenderEarcon` is the
-/// producer-side instruction for the 8d Earcon channel;
-/// `RenderRaw` is opaque per-channel data (e.g. UIA-listbox
-/// metadata in 8e). NVDA channel ignores both — the dispatcher
-/// fans them to their respective channels separately.
+/// **Earcon skip.** `RenderEarcon` is the producer-side
+/// instruction for the 8d Earcon channel; the NVDA channel
+/// ignores it — the dispatcher fans earcons to the WASAPI
+/// channel separately.
+///
+/// **Raw payload routing (Cycle 37a).** `RenderRaw` carries
+/// channel-specific opaque payloads (e.g. the
+/// `SelectionRawPayload` UIA listbox metadata that Cycle 37b's
+/// `Terminal.Accessibility` peer consumes). The NVDA channel
+/// routes `RenderRaw` to the `marshalRawPayload` callback
+/// distinct from the text marshal — keeping the WPF
+/// dispatcher hop in the View layer (where UIA peer state
+/// updates can run on the UI thread) without coupling
+/// `Terminal.Core` to UIA types.
 module NvdaChannel =
 
     /// Stable channel identifier registered with the dispatcher's
@@ -75,10 +87,16 @@ module NvdaChannel =
         | SemanticCategory.Custom _ -> ActivityIds.output
 
     /// Construct a Channel that announces via the supplied
-    /// marshalling callback. The callback receives `(message,
-    /// activityId)` and is responsible for the WPF dispatcher
-    /// hop + the actual `TerminalView.Announce` call.
-    let create (marshalAnnounce: string * string -> unit) : Channel =
+    /// marshalling callbacks. `marshalAnnounce` receives
+    /// `(message, activityId)` for `RenderText` /
+    /// `RenderText2` payloads (Stage 8a contract).
+    /// `marshalRawPayload` receives `(payload, activityId)` for
+    /// `RenderRaw` payloads (Cycle 37a contract). Both are
+    /// responsible for their own WPF dispatcher hop.
+    let create
+            (marshalAnnounce: string * string -> unit)
+            (marshalRawPayload: obj * string -> unit)
+            : Channel =
         { Id = id
           Send =
             fun event render ->
@@ -93,4 +111,5 @@ module NvdaChannel =
                     // until later stages.
                     marshalAnnounce (precise, activityId)
                 | RenderEarcon _ -> ()
-                | RenderRaw _ -> () }
+                | RenderRaw payload ->
+                    marshalRawPayload (payload, activityId) }

--- a/src/Terminal.Core/OutputEventTypes.fs
+++ b/src/Terminal.Core/OutputEventTypes.fs
@@ -330,6 +330,53 @@ module SelectionExtensions =
     [<Literal>]
     let Source = "selection.source"
 
+/// Cycle 37a (Stage 8e-B substrate) — UIA-free snapshot of a
+/// Selection event, carried as the payload of
+/// `RenderInstruction.RenderRaw` for `SelectionShown` /
+/// `SelectionItem` / `SelectionDismissed`. Cycle 37b's
+/// `Terminal.Accessibility` peer reads these fields and
+/// translates them to UIA `ControlType.List` /
+/// `ControlType.ListItem` peer state; substrate code stays
+/// free of UIA references per `docs/CORE-ABSTRACTION-BOUNDARY.md`
+/// §1.6.
+///
+/// `Kind` is the discriminator: `"shown"` / `"item"` /
+/// `"dismissed"`. Values are pinned as string literals for
+/// stable cross-assembly pattern-matching from
+/// `Terminal.Accessibility` (which reads this record at the
+/// channel boundary). The catch-all guard in 37b's
+/// `UpdateSelectionState` ignores unknown `Kind` values rather
+/// than throwing — forward-compatible with future selection
+/// kinds.
+///
+/// Field invariants (mirror the `SelectionExtensions` schema):
+/// * `"shown"`: `AllItems` populated; `SelectedIndex` >= 0 (or
+///   -1 for missing-data fallback); `ItemIndex` = -1;
+///   `ItemText` = "".
+/// * `"item"`: `AllItems` = `[||]`; `ItemIndex` >= 0;
+///   `ItemText` populated.
+/// * `"dismissed"`: all numeric fields = -1 / 0; `AllItems` =
+///   `[||]`; `ItemText` = "".
+type SelectionRawPayload =
+    { /// Discriminator: "shown" | "item" | "dismissed".
+      Kind: string
+      /// Total item count in the selection list. Zero for
+      /// "dismissed".
+      ItemCount: int
+      /// 0-based index of the currently-selected item across
+      /// the list. -1 for "dismissed" (or missing-data
+      /// fallback on "shown" / "item").
+      SelectedIndex: int
+      /// 0-based index of THIS event's item. Populated for
+      /// "item" only; -1 for "shown" / "dismissed".
+      ItemIndex: int
+      /// Full ordered list of item rendered text. Populated
+      /// for "shown" only; `[||]` for "item" / "dismissed".
+      AllItems: string[]
+      /// THIS item's rendered text. Populated for "item"
+      /// only; "" for "shown" / "dismissed".
+      ItemText: string }
+
 /// First-class boundary surface for output channels — the
 /// "channel" side of the substrate / channel dichotomy per
 /// `docs/CORE-ABSTRACTION-BOUNDARY.md` §3 + ADR 0001.

--- a/src/Terminal.Core/SelectionProfile.fs
+++ b/src/Terminal.Core/SelectionProfile.fs
@@ -36,14 +36,17 @@ namespace Terminal.Core
 ///   additive observer for the events it claims; mirrors the
 ///   `EarconProfile` pattern exactly).
 ///
-/// **What 8e-B will change.** The UIA listbox peer arrives in
-/// Stage 8e-B, lifting the text-only `RenderText` decisions to
-/// `RenderRaw` payloads carrying UIA listbox metadata
-/// (`SelectionExtensions.AllItems` / `TopRow` / `BottomRow`
-/// already populated by the detector for this purpose). NVDA
-/// will then read the list as a real listbox with `1 of 4` /
-/// `2 of 4` semantics from UIA's `IItemContainerProvider`
-/// instead of from this profile's plain-text rendering.
+/// **Cycle 37a (Stage 8e-B substrate).** Apply now emits a
+/// THIRD ChannelDecision per Selection event: an NVDA-channel
+/// `RenderRaw` payload of type `SelectionRawPayload` carrying
+/// the UIA listbox metadata. The pre-existing NVDA-channel
+/// `RenderText` decision is retained for the bridge interval
+/// between 37a (substrate) and 37b (peers) — NVDA continues to
+/// announce text from `RenderText` while the
+/// `Terminal.Accessibility` peer is being built. 37b drops the
+/// duplicate NVDA `RenderText` decision once the peer takes
+/// over; FileLogger's `RenderText` decision is preserved as
+/// the audit trail.
 ///
 /// **No Parameters record.** Profile is stateless (the tunable
 /// thresholds live on `SelectionDetector.Parameters`, not here).
@@ -114,13 +117,94 @@ module SelectionProfile =
         { Channel = FileLoggerChannel.id
           Render = RenderText text }
 
+    /// Cycle 37a — build an NVDA-channel decision carrying the
+    /// `SelectionRawPayload` UIA-free snapshot. NvdaChannel
+    /// routes this to `marshalRawPayload`, which the composition
+    /// root binds to `TerminalView.AnnounceRawPayload` (37a stub
+    /// in the View; 37b promotes to peer-state update).
+    ///
+    /// `:>` upcast (preserves non-null) rather than `box`
+    /// (F# 9 nullness annotates `box: 'T -> obj | null`, which
+    /// can't satisfy `RenderRaw of payload: obj`). Mirrors the
+    /// NvdaChannelTests fixture pattern.
+    let private rawDecision (payload: SelectionRawPayload) : ChannelDecision =
+        { Channel = NvdaChannel.id
+          Render = RenderRaw (payload :> obj) }
+
     /// Construct the decisions array for a single Selection event.
-    /// Both NVDA and FileLogger receive the same text so a
-    /// paste-back of the FileLogger log carries the same semantic
-    /// content NVDA spoke.
-    let private selectionDecisions (text: string) : ChannelDecision[] =
+    /// 37a emits THREE decisions (Option A bridge): NVDA
+    /// `RenderText` so NVDA continues to announce during the 37a
+    /// interim window; FileLogger `RenderText` for the audit
+    /// trail; NVDA `RenderRaw` carrying the UIA payload for the
+    /// 37b peer to consume.
+    let private selectionDecisions
+            (text: string)
+            (payload: SelectionRawPayload)
+            : ChannelDecision[] =
         [| nvdaDecision text
-           fileLoggerDecision text |]
+           fileLoggerDecision text
+           rawDecision payload |]
+
+    /// Cycle 37a — build the raw payload for a `SelectionShown`
+    /// event. Pulls `AllItems` + `ItemCount` + `SelectedIndex`
+    /// from Extensions; `ItemIndex` is -1 (per the SelectionShown
+    /// invariant — the burst's per-item index belongs to
+    /// SelectionItem events). Missing-data fallback uses -1 for
+    /// `SelectedIndex` so the peer can detect malformed events
+    /// and skip raising the focus event rather than guessing.
+    let private buildShownPayload (event: OutputEvent) : SelectionRawPayload =
+        let allItems =
+            tryReadStringArray event SelectionExtensions.AllItems
+            |> Option.defaultValue [||]
+        let count =
+            tryReadInt event SelectionExtensions.ItemCount
+            |> Option.defaultValue allItems.Length
+        let selectedIdx =
+            tryReadInt event SelectionExtensions.SelectedIndex
+            |> Option.defaultValue -1
+        { Kind = "shown"
+          ItemCount = count
+          SelectedIndex = selectedIdx
+          ItemIndex = -1
+          AllItems = allItems
+          ItemText = "" }
+
+    /// Cycle 37a — build the raw payload for a `SelectionItem`
+    /// event. Pulls `ItemText`, `ItemIndex`, `SelectedIndex`,
+    /// `ItemCount` from Extensions. `AllItems` is `[||]`
+    /// (SelectionItem events don't repeat the full list — the
+    /// 37b peer caches it from the most recent SelectionShown).
+    let private buildItemPayload (event: OutputEvent) : SelectionRawPayload =
+        let text =
+            tryReadString event SelectionExtensions.ItemText
+            |> Option.defaultValue ""
+        let itemIdx =
+            tryReadInt event SelectionExtensions.ItemIndex
+            |> Option.defaultValue -1
+        let selectedIdx =
+            tryReadInt event SelectionExtensions.SelectedIndex
+            |> Option.defaultValue -1
+        let count =
+            tryReadInt event SelectionExtensions.ItemCount
+            |> Option.defaultValue 0
+        { Kind = "item"
+          ItemCount = count
+          SelectedIndex = selectedIdx
+          ItemIndex = itemIdx
+          AllItems = [||]
+          ItemText = text }
+
+    /// Cycle 37a — sentinel payload for `SelectionDismissed`.
+    /// All numeric fields default to -1 / 0; the 37b peer uses
+    /// `Kind = "dismissed"` to drop its child peer + raise
+    /// `StructureChanged`.
+    let private dismissedPayload : SelectionRawPayload =
+        { Kind = "dismissed"
+          ItemCount = 0
+          SelectedIndex = -1
+          ItemIndex = -1
+          AllItems = [||]
+          ItemText = "" }
 
     /// Render the user-facing text for a `SelectionShown` event.
     /// Pulls `AllItems` + `SelectedIndex` from Extensions and
@@ -183,11 +267,13 @@ module SelectionProfile =
             fun event ->
                 match event.Semantic with
                 | SemanticCategory.SelectionShown ->
-                    [| event, selectionDecisions (renderShown event) |]
+                    let payload = buildShownPayload event
+                    [| event, selectionDecisions (renderShown event) payload |]
                 | SemanticCategory.SelectionItem ->
-                    [| event, selectionDecisions (renderItem event) |]
+                    let payload = buildItemPayload event
+                    [| event, selectionDecisions (renderItem event) payload |]
                 | SemanticCategory.SelectionDismissed ->
-                    [| event, selectionDecisions "selection dismissed" |]
+                    [| event, selectionDecisions "selection dismissed" dismissedPayload |]
                 | _ ->
                     // No decision for other Semantic categories.
                     [||]

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -343,6 +343,32 @@ public class TerminalView : FrameworkElement
     }
 
     /// <summary>
+    /// Cycle 37a — receives <see cref="Terminal.Core.RenderInstruction.RenderRaw"/>
+    /// payloads marshalled from <see cref="Terminal.Core.NvdaChannel"/> via the
+    /// composition root's <c>marshalRawPayload</c> callback. Cycle 37a stubs
+    /// this method as log-only; Cycle 37b promotes it to peer-state update +
+    /// UIA event raise on the active <c>TerminalAutomationPeer</c>.
+    /// </summary>
+    /// <remarks>
+    /// Logging metadata only (payload type name + activityId), per SECURITY.md
+    /// "Logging chokepoint" policy. Payload contents (e.g. selection list
+    /// item text) are sanitised at the producer boundary
+    /// (<c>SelectionDetector</c> applies <c>AnnounceSanitiser.sanitise</c>),
+    /// but the stub doesn't forward them to NVDA — Option A bridge keeps the
+    /// existing <c>RenderText</c> NVDA decision active so NVDA continues
+    /// reading the text representation during the 37a interim.
+    /// </remarks>
+    public void AnnounceRawPayload(object payload, string activityId)
+    {
+        var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.AnnounceRawPayload");
+        var typeName = payload?.GetType().Name ?? "null";
+        Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(
+            log,
+            "RawPayload received (Cycle 37a stub). ActivityId={ActivityId} PayloadType={PayloadType}",
+            activityId, typeName);
+    }
+
+    /// <summary>
     /// App-reserved hotkey list. Stage 6 (keyboard input to PTY)
     /// MUST preserve every entry here — its <c>PreviewKeyDown</c>
     /// filter must NOT mark these key combinations

--- a/tests/Tests.Unit/IOutputSinkTests.fs
+++ b/tests/Tests.Unit/IOutputSinkTests.fs
@@ -33,7 +33,7 @@ let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEv
 let ``NvdaChannel record coerces to IOutputSink and round-trips RenderText`` () =
     let calls = ResizeArray<string * string>()
     let recorder (msg, activityId) = calls.Add((msg, activityId))
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder (fun _ -> ())
     let sink = channel :> IOutputSink
     Assert.Equal(NvdaChannel.id, sink.Id)
     let event = buildEvent SemanticCategory.StreamChunk "hello"
@@ -46,7 +46,7 @@ let ``NvdaChannel record coerces to IOutputSink and round-trips RenderText`` () 
 let ``NvdaChannel via IOutputSink preserves empty-payload skip`` () =
     let calls = ResizeArray<string * string>()
     let recorder (msg, activityId) = calls.Add((msg, activityId))
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder (fun _ -> ())
     let sink = channel :> IOutputSink
     let event = buildEvent SemanticCategory.StreamChunk ""
     sink.Send event (RenderText "")

--- a/tests/Tests.Unit/NvdaChannelTests.fs
+++ b/tests/Tests.Unit/NvdaChannelTests.fs
@@ -4,10 +4,15 @@ open Xunit
 open Terminal.Core
 
 /// Stage 8a — pins the NVDA channel's `Semantic → ActivityId`
-/// mapping and the empty-payload skip + RenderEarcon /
-/// RenderRaw skip contracts. The mapping must reproduce the
-/// Stage-7 drain's activity-ID vocabulary exactly so the post-
-/// retrofit NVDA reading is identical.
+/// mapping and the empty-payload skip + RenderEarcon skip
+/// contracts. The mapping must reproduce the Stage-7 drain's
+/// activity-ID vocabulary exactly so the post-retrofit NVDA
+/// reading is identical.
+///
+/// Cycle 37a — `RenderRaw` no longer skips silently; it
+/// routes to a second `marshalRawPayload` callback distinct
+/// from the text marshal. Tests recording RenderRaw payloads
+/// use the `rawCalls` recorder.
 ///
 /// **8a does NOT consult `Priority`.** The behaviour-identical
 /// contract preserves Stage 7's
@@ -20,15 +25,26 @@ open Terminal.Core
 ///
 /// The channel implementation lives at
 /// `src/Terminal.Core/NvdaChannel.fs`. The marshal callback
-/// signature `(string * string) -> unit` is what the
-/// composition root in `src/Terminal.App/Program.fs` binds to
-/// the WPF dispatcher hop; the tests call `create` with a
-/// recording callback and assert against the recorded calls.
+/// signatures `(string * string) -> unit` and
+/// `(obj * string) -> unit` are what the composition root in
+/// `src/Terminal.App/Program.fs` binds to the WPF dispatcher
+/// hop; the tests call `create` with recording callbacks and
+/// assert against the recorded calls.
 
 let private makeRecorder () : ResizeArray<string * string> * (string * string -> unit) =
     let calls = ResizeArray<string * string>()
     let recorder (msg, activityId) = calls.Add((msg, activityId))
     calls, recorder
+
+let private makeRawRecorder () : ResizeArray<obj * string> * (obj * string -> unit) =
+    let calls = ResizeArray<obj * string>()
+    let recorder (payload, activityId) = calls.Add((payload, activityId))
+    calls, recorder
+
+/// Test helper: bind the no-op raw recorder when a test only
+/// cares about the text marshal channel. Mirrors the original
+/// 1-arg `NvdaChannel.create` ergonomic.
+let private noOpRawRecorder : obj * string -> unit = fun _ -> ()
 
 let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEvent =
     OutputEvent.create semantic Priority.Polite "test" payload
@@ -38,7 +54,7 @@ let private buildEvent (semantic: SemanticCategory) (payload: string) : OutputEv
 [<Fact>]
 let ``StreamChunk routes to ActivityIds.output`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.StreamChunk "ls"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(1, calls.Count)
@@ -47,7 +63,7 @@ let ``StreamChunk routes to ActivityIds.output`` () =
 [<Fact>]
 let ``ParserError routes to ActivityIds.error`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.ParserError "boom"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("boom", ActivityIds.error), calls.[0])
@@ -55,7 +71,7 @@ let ``ParserError routes to ActivityIds.error`` () =
 [<Fact>]
 let ``ErrorLine routes to ActivityIds.error`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.ErrorLine "npm ERR!"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("npm ERR!", ActivityIds.error), calls.[0])
@@ -63,7 +79,7 @@ let ``ErrorLine routes to ActivityIds.error`` () =
 [<Fact>]
 let ``WarningLine routes to ActivityIds.error`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.WarningLine "deprecated API"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("deprecated API", ActivityIds.error), calls.[0])
@@ -71,7 +87,7 @@ let ``WarningLine routes to ActivityIds.error`` () =
 [<Fact>]
 let ``AltScreenEntered routes to ActivityIds.mode`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.AltScreenEntered "x"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("x", ActivityIds.mode), calls.[0])
@@ -79,7 +95,7 @@ let ``AltScreenEntered routes to ActivityIds.mode`` () =
 [<Fact>]
 let ``ModeBarrier routes to ActivityIds.mode`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.ModeBarrier "y"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("y", ActivityIds.mode), calls.[0])
@@ -92,7 +108,7 @@ let ``Custom Semantic routes to ActivityIds.output as the pre-claim default`` ()
     // row would still announce on the streaming channel rather
     // than nothing.
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent (SemanticCategory.Custom "git-prompt-segment") "main *"
     channel.Send event (RenderText event.Payload)
     Assert.Equal(("main *", ActivityIds.output), calls.[0])
@@ -104,7 +120,7 @@ let ``RenderText with empty string does not invoke the marshal callback`` () =
     // Stage 7 drain skipped Announce on empty messages (mode
     // barriers carry "") — the channel preserves that contract.
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.ModeBarrier ""
     channel.Send event (RenderText "")
     Assert.Equal(0, calls.Count)
@@ -112,7 +128,7 @@ let ``RenderText with empty string does not invoke the marshal callback`` () =
 [<Fact>]
 let ``RenderText2 with empty Precise register does not invoke the callback`` () =
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.StreamChunk "approx"
     channel.Send event (RenderText2 ("approx", ""))
     Assert.Equal(0, calls.Count)
@@ -122,7 +138,7 @@ let ``RenderText2 picks the Precise register for the marshal callback`` () =
     // 8a always renders Precise — no user-facing verbosity
     // hotkey ships until later stages.
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.StreamChunk "hello"
     channel.Send event (RenderText2 ("approx-form", "precise-form"))
     Assert.Equal(("precise-form", ActivityIds.output), calls.[0])
@@ -133,23 +149,33 @@ let ``RenderText2 picks the Precise register for the marshal callback`` () =
 let ``RenderEarcon does not invoke the NVDA marshal callback`` () =
     // Earcons go to the EarconChannel (8d), not NVDA.
     let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     let event = buildEvent SemanticCategory.BellRang ""
     channel.Send event (RenderEarcon "bell-ping")
     Assert.Equal(0, calls.Count)
 
 [<Fact>]
-let ``RenderRaw does not invoke the NVDA marshal callback`` () =
-    // Raw payloads are channel-specific; the NVDA channel
-    // ignores them.
-    let calls, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+let ``RenderRaw routes to marshalRawPayload, not marshalAnnounce (Cycle 37a)`` () =
+    // Cycle 37a — RenderRaw payloads are routed to the second
+    // marshal callback so 37b's TerminalView.AnnounceRawPayload
+    // can update peer state on the UI thread without going
+    // through the text-announce path. The text marshal must NOT
+    // fire for RenderRaw — that's the 37a contract that
+    // separates the UIA-peer pathway from the text pathway.
+    let textCalls, textRecorder = makeRecorder ()
+    let rawCalls, rawRecorder = makeRawRecorder ()
+    let channel = NvdaChannel.create textRecorder rawRecorder
     let event = buildEvent SemanticCategory.SelectionShown ""
     // Use `:>` upcast (preserves non-null) rather than `box`
     // (F# 9 nullness annotates `box: 'T -> obj | null`, which
     // can't satisfy `RenderRaw of payload: obj`).
-    channel.Send event (RenderRaw ("uia-listbox-metadata" :> obj))
-    Assert.Equal(0, calls.Count)
+    let payload = ("uia-listbox-metadata" :> obj)
+    channel.Send event (RenderRaw payload)
+    Assert.Equal(0, textCalls.Count)
+    Assert.Equal(1, rawCalls.Count)
+    let recordedPayload, recordedActivityId = rawCalls.[0]
+    Assert.Same(payload, recordedPayload)
+    Assert.Equal(ActivityIds.output, recordedActivityId)
 
 // ---- Channel identity ------------------------------------------
 
@@ -160,5 +186,5 @@ let ``NvdaChannel.id is the stable string registered with the dispatcher`` () =
 [<Fact>]
 let ``create returns a Channel whose Id matches the module-level id`` () =
     let _, recorder = makeRecorder ()
-    let channel = NvdaChannel.create recorder
+    let channel = NvdaChannel.create recorder noOpRawRecorder
     Assert.Equal(NvdaChannel.id, channel.Id)

--- a/tests/Tests.Unit/SelectionProfileTests.fs
+++ b/tests/Tests.Unit/SelectionProfileTests.fs
@@ -8,10 +8,17 @@ open Terminal.Core
 /// Apply contract:
 ///   * id is "selection".
 ///   * SelectionShown / SelectionItem / SelectionDismissed each
-///     emit one pair with two ChannelDecisions (NVDA + FileLogger).
-///   * Decisions carry `RenderText` payloads constructed from
-///     `Extensions` data (empty-payload trick mirrors 8d.2's
-///     EarconProfile pattern).
+///     emit one pair with THREE ChannelDecisions: NVDA RenderText
+///     (Option A bridge so NVDA continues reading text during the
+///     37a interim window), FileLogger RenderText (audit trail),
+///     and NVDA RenderRaw carrying the SelectionRawPayload UIA-
+///     free metadata for Cycle 37b's Terminal.Accessibility peer
+///     to consume.
+///   * The first two decisions carry `RenderText` payloads
+///     constructed from `Extensions` data (empty-payload trick
+///     mirrors 8d.2's EarconProfile pattern).
+///   * The third decision carries a `RenderRaw` payload of type
+///     `SelectionRawPayload` per Cycle 37a contract.
 ///   * Foreign Semantic categories return `[||]` (purely
 ///     additive observer).
 ///   * Tick + Reset are no-ops.
@@ -87,6 +94,37 @@ let private renderText (decision: ChannelDecision) : string =
         Assert.Fail(sprintf "expected RenderText, got %A" other)
         ""
 
+// Cycle 37a — extract the SelectionRawPayload from a
+// ChannelDecision; fail loudly if it isn't a `RenderRaw`
+// carrying a `SelectionRawPayload`. The fallback returns a
+// sentinel record so the function's return type satisfies F# 9
+// nullness — `Assert.Fail` throws, so the sentinel is never
+// observed by callers.
+let private renderRawSentinel : SelectionRawPayload =
+    { Kind = "<test-fail>"
+      ItemCount = 0
+      SelectedIndex = -1
+      ItemIndex = -1
+      AllItems = [||]
+      ItemText = "" }
+
+let private renderRaw (decision: ChannelDecision) : SelectionRawPayload =
+    match decision.Render with
+    | RenderRaw payload ->
+        match payload with
+        | :? SelectionRawPayload as p -> p
+        | _ ->
+            // %A formatter handles `string | null` (F# 9
+            // nullness on Type.FullName) without coercion.
+            Assert.Fail(
+                sprintf
+                    "expected SelectionRawPayload, got %A"
+                    (payload.GetType().FullName))
+            renderRawSentinel
+    | other ->
+        Assert.Fail(sprintf "expected RenderRaw, got %A" other)
+        renderRawSentinel
+
 // ---------------------------------------------------------------------
 // Profile identity
 // ---------------------------------------------------------------------
@@ -105,16 +143,17 @@ let ``create returns a Profile whose Id matches the module-level id`` () =
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``SelectionShown Apply emits one pair with two ChannelDecisions (NVDA + FileLogger)`` () =
+let ``SelectionShown Apply emits one pair with three ChannelDecisions (NVDA text + FileLogger text + NVDA raw, Cycle 37a)`` () =
     let profile = SelectionProfile.create ()
     let event =
         selectionShownEvent [| "Edit"; "Yes"; "Always"; "No" |] 1
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(2, decisions.Length)
+    Assert.Equal(3, decisions.Length)
     Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
     Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
 
 [<Fact>]
 let ``SelectionShown rendered text formats list with selected item highlighted`` () =
@@ -145,6 +184,23 @@ let ``SelectionShown falls back to count summary when AllItems missing`` () =
     let text = renderText decisions.[0]
     Assert.Equal("selection prompt, 4 items", text)
 
+[<Fact>]
+let ``SelectionShown emits RenderRaw with Kind="shown" and AllItems populated (Cycle 37a)`` () =
+    let profile = SelectionProfile.create ()
+    let event =
+        selectionShownEvent [| "Edit"; "Yes"; "Always"; "No" |] 1
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    let payload = renderRaw decisions.[2]
+    Assert.Equal("shown", payload.Kind)
+    Assert.Equal(4, payload.ItemCount)
+    Assert.Equal(1, payload.SelectedIndex)
+    Assert.Equal(-1, payload.ItemIndex)
+    Assert.Equal<string[]>(
+        [| "Edit"; "Yes"; "Always"; "No" |],
+        payload.AllItems)
+    Assert.Equal("", payload.ItemText)
+
 // ---------------------------------------------------------------------
 // SelectionItem rendering
 // ---------------------------------------------------------------------
@@ -170,32 +226,56 @@ let ``SelectionItem (this item != selected) renders "%s, %d of %d"`` () =
     Assert.Equal("Edit, 1 of 4", text)
 
 [<Fact>]
-let ``SelectionItem emits NVDA + FileLogger pair`` () =
+let ``SelectionItem emits NVDA text + FileLogger text + NVDA raw triple (Cycle 37a)`` () =
     let profile = SelectionProfile.create ()
     let event = selectionItemEvent "Yes" 1 1 4
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(2, decisions.Length)
+    Assert.Equal(3, decisions.Length)
     Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
     Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
+
+[<Fact>]
+let ``SelectionItem emits RenderRaw with Kind="item" and ItemText/ItemIndex populated (Cycle 37a)`` () =
+    let profile = SelectionProfile.create ()
+    // selectedIdx = 1, itemIdx = 0 → "Edit", not the selected item.
+    let event = selectionItemEvent "Edit" 0 1 4
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    let payload = renderRaw decisions.[2]
+    Assert.Equal("item", payload.Kind)
+    Assert.Equal(4, payload.ItemCount)
+    Assert.Equal(1, payload.SelectedIndex)
+    Assert.Equal(0, payload.ItemIndex)
+    Assert.Equal<string[]>([||], payload.AllItems)
+    Assert.Equal("Edit", payload.ItemText)
 
 // ---------------------------------------------------------------------
 // SelectionDismissed rendering
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``SelectionDismissed renders literal "selection dismissed"`` () =
+let ``SelectionDismissed renders literal "selection dismissed" + RenderRaw with Kind="dismissed" (Cycle 37a)`` () =
     let profile = SelectionProfile.create ()
     let event = selectionDismissedEvent ()
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(2, decisions.Length)
+    Assert.Equal(3, decisions.Length)
     Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
     Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
     Assert.Equal("selection dismissed", renderText decisions.[0])
     Assert.Equal("selection dismissed", renderText decisions.[1])
+    let payload = renderRaw decisions.[2]
+    Assert.Equal("dismissed", payload.Kind)
+    Assert.Equal(0, payload.ItemCount)
+    Assert.Equal(-1, payload.SelectedIndex)
+    Assert.Equal(-1, payload.ItemIndex)
+    Assert.Equal<string[]>([||], payload.AllItems)
+    Assert.Equal("", payload.ItemText)
 
 // ---------------------------------------------------------------------
 // Foreign Semantic categories — purely additive


### PR DESCRIPTION
## Summary

Cycle 37a — opens the Stage 8e-B canonical-display arc (interactive-list UIA listbox peer). Substrate-only PR: no behaviour change visible to NVDA users in 37a; sets up Cycle 37b's peer types (`TerminalListAutomationPeer` + `TerminalListItemAutomationPeer`) to consume the substrate without further substrate churn.

## Substrate changes

- **New `SelectionRawPayload` record** in [`OutputEventTypes.fs`](src/Terminal.Core/OutputEventTypes.fs) — UIA-free snapshot of a Selection event (`Kind` ∈ `{"shown", "item", "dismissed"}`, `ItemCount`, `SelectedIndex`, `ItemIndex`, `AllItems`, `ItemText`). Lives in `Terminal.Core` per the [`CORE-ABSTRACTION-BOUNDARY.md`](docs/CORE-ABSTRACTION-BOUNDARY.md) §1.6 substrate-purity constraint.
- **`SelectionProfile.Apply`** now emits **three** `ChannelDecision`s per Selection event (Option A bridge — see PR plan §16.6): NVDA `RenderText` (kept so NVDA reads text during 37a interim), FileLogger `RenderText` (audit trail), NVDA `RenderRaw` carrying `SelectionRawPayload` (Cycle 37b peer consumes).
- **`NvdaChannel.create`** gains a second `marshalRawPayload` callback parameter (typed `obj * string -> unit`). `RenderRaw` payloads now route to it instead of being silently dropped. Composition root in [`Program.fs`](src/Terminal.App/Program.fs) wires it via the WPF dispatcher to `TerminalView.AnnounceRawPayload`.
- **`TerminalView.AnnounceRawPayload(object, string)`** — Cycle 37a stub: log-only (debug level, metadata only per SECURITY.md "Logging chokepoint" policy). Cycle 37b promotes this to peer-state update + UIA event raise on the active `TerminalAutomationPeer`.

## Test changes

- [`SelectionProfileTests.fs`](tests/Tests.Unit/SelectionProfileTests.fs) — 14 existing facts updated for the 3-decision shape (`Length: 2 → 3`). 3 new facts pin `SelectionRawPayload` field invariants for `"shown"` / `"item"` / `"dismissed"` Kinds. New `renderRaw` helper extracts the payload from a `ChannelDecision` (mirrors the existing `renderText` helper pattern).
- [`NvdaChannelTests.fs`](tests/Tests.Unit/NvdaChannelTests.fs) — 1 fact rewritten ("RenderRaw routes to marshalRawPayload" replaces "RenderRaw skips silently"). 14 mechanical call-site updates to thread the new callback param. New `makeRawRecorder` + `noOpRawRecorder` test helpers.
- [`IOutputSinkTests.fs`](tests/Tests.Unit/IOutputSinkTests.fs) — 2 mechanical call-site updates.

## Bridge plan (Option A)

NVDA continues to read selection text from `RenderText` during the 37a interim window. Cycle 37b drops the duplicate NVDA `RenderText` decision once `TerminalListAutomationPeer` takes over the announce semantics; the FileLogger `RenderText` decision stays as the audit trail.

## Test plan

- [ ] `Build and test (windows-latest)` green — compile + 945+ unit tests including the 3 new `SelectionProfileTests` facts + the rewritten `NvdaChannelTests` fact for RenderRaw routing.
- [ ] `Workflow lint`, `Portability lint (substrate / channel boundary)`, `Markdown link check` green.
- [ ] Manual verification (post-merge dogfood): launch app, run a Claude prompt that triggers a tool-use selection, capture `Ctrl+Shift+D` bundle, grep `--- FILELOGGER ACTIVE LOG ---` for `RawPayload received (Cycle 37a stub). PayloadType=SelectionRawPayload` lines — confirms substrate is delivering payloads to the View stub.
- [ ] NVDA behaviour unchanged from Cycle 29b — selection prompts still read as text ("selection prompt: Edit, Yes, Always, No (selected: Yes)"). The RenderRaw path is wired but currently no-ops in the View; 37b promotes it.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_