### PR TITLE
feat(accessibility): Cycle 37b — UIA listbox peer; NVDA reads Claude prompts as ControlType.List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,75 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 37b): UIA listbox peer ships; NVDA reads Claude tool-use prompts as ControlType.List
+
+Closes the Stage 8e-B canonical-display arc (interactive-list
+exemplar). Adds `TerminalListAutomationPeer` and
+`TerminalListItemAutomationPeer` virtual UIA peers in
+[`Terminal.Accessibility`](src/Terminal.Accessibility/TerminalAutomationPeer.fs);
+both derive directly from `System.Windows.Automation.Peers.AutomationPeer`
+(no FrameworkElement backing — virtual peers materialized only
+while a selection prompt is active). `TerminalListAutomationPeer`
+implements `ISelectionProvider` (CanSelectMultiple=false,
+IsSelectionRequired=true); `TerminalListItemAutomationPeer`
+implements `ISelectionItemProvider` + `IInvokeProvider` per
+`docs/CANONICAL-DISPLAY-CATALOG.md` §2.14 (ConfirmationPrompt
+hybrid). NVDA in focus mode hears "list with 4 items, Edit, 1 of
+4"; arrow-down announces "Yes, 2 of 4" via
+`SelectionItemPatternIdentifiers.ElementSelectedEvent`;
+`IInvokeProvider.Invoke()` writes `\r` (0x0D) to the PTY for
+single-key activation.
+
+`TerminalAutomationPeer` (the document peer) is extended to:
+
+- Take a third constructor parameter `writePtyBytes:
+  Action<byte[]>` (passed by the View's `OnCreateAutomationPeer`)
+  that threads the PTY-write callback to `TerminalListItemAutomationPeer`'s
+  Invoke handler.
+- Override `IsContentElementCore` to return `false` while a list
+  peer is active — the §8.5 dedup mechanic that prevents NVDA
+  from reading the list rows as both document text and listbox
+  items. Per the 2026-05-10 design choice: full-document form
+  (simpler; trade-off accepted: NVDA reading-cursor history is
+  suspended while a prompt is active).
+- Override `GetChildrenCore` to expose the active list peer as
+  the sole child while one is materialized.
+- Add `UpdateSelectionState(payload: SelectionRawPayload)` —
+  called from the View's `AnnounceRawPayload` cutover (replacing
+  the 37a log-only stub) on the WPF UI thread; transitions
+  through "shown" → "item" → "dismissed" with appropriate
+  `RaiseAutomationEvent(StructureChanged)` calls.
+
+[`SelectionProfile`](src/Terminal.Core/SelectionProfile.fs) drops
+the duplicate NVDA `RenderText` decision retained for the 37a
+bridge — keeping it would cause double-announce (text + listbox).
+The FileLogger `RenderText` decision stays as the audit trail.
+Selection events now emit 2 ChannelDecisions: FileLogger
+RenderText + NVDA RenderRaw.
+
+[`TerminalView.AnnounceRawPayload`](src/Views/TerminalView.cs)
+cutover: replaces the 37a stub with peer-state delegation.
+Adds public `WritePtyBytes(byte[])` that bridges the peer's
+IInvokeProvider callback to the View's private `_writeBytes`
+field.
+
+Tests: 14 new `TerminalListAutomationPeerTests` facts (direct
+F# instantiation + interface inspection; no FlaUI / WPF runtime
+dependency — uses a minimal `TestStubAutomationPeer` for the
+parent peer). 4 updated `SelectionProfileTests` facts (3-decision
+shape → 2-decision shape; index shifts 0↔1↔2).
+
+**Manual NVDA validation gate**: the 7-row matrix in
+[`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+`### Cycle 37` is the load-bearing acceptance gate per
+[`CONTRIBUTING.md`](CONTRIBUTING.md) "non-negotiable accessibility
+rules". PR cannot squash-merge until maintainer confirms all
+rows pass on real NVDA.
+
+After 37b ships, the canonical-display exemplar count goes from
+1 → 2 (raw text + interactive list). Cycle 38 picks up the
+third (form-with-text-input).
+
 ### Changed (Cycle 37a): SelectionProfile emits RenderRaw substrate alongside RenderText
 
 Opens the Stage 8e-B canonical-display arc (interactive-list UIA

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1034,6 +1034,96 @@ findstr /C:"--- LINEAR STREAM" "<bundle-path>"
 These recipes lean on the existing diagnostic-bundle infrastructure
 shipped in Cycle 34b; no new logging is required.
 
+### Cycle 37 — UIA listbox peer (interactive-list canonical-display)
+
+Cycle 37 (37a + 37b) replaces SelectionProfile's Cycle 29b
+text-only NVDA announcements with full UIA listbox semantics.
+NVDA hears Claude tool-use selection prompts as a real
+`ControlType.List` with `1 of N` semantics, per
+`spec/tech-plan.md` §8.2-§8.5 and
+[`docs/CANONICAL-DISPLAY-CATALOG.md`](CANONICAL-DISPLAY-CATALOG.md)
+§2 (interactive list exemplar) + §2.14 (ConfirmationPrompt
+hybrid: items also implement `IInvokeProvider` for single-key
+activation).
+
+**This is the load-bearing acceptance gate for PR 37b.** Per
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) "non-negotiable
+accessibility rules", PR 37b cannot squash-merge until the
+maintainer confirms all rows below pass on real NVDA.
+
+**Pre-requisites.** Set `PTYSPEAK_SHELL=claude` (or
+`Ctrl+Shift+3` to switch to Claude in-session). SelectionDetector
+is shellKey-gated to `"claude"` only — cmd / PowerShell /
+non-Claude shells short-circuit detection and the list peer
+never materializes for those.
+
+| Test                                                     | Procedure                                                                                                            | Expected NVDA shape                                                                                                                                                                                                                                                              |
+|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 37.1 List appearance (Cycle 37b)                         | In Claude (`Ctrl+Shift+3`), ask "edit a file" to trigger the Edit/Yes/Always/No prompt. Wait for the highlight.       | NVDA in focus mode: announces "list with 4 items, Edit, 1 of 4". NVDA in browse mode: announces "list" on cursor entry. The `StructureChanged` event fires; the new `TerminalList` child appears in the peer tree (verifiable via Inspect.exe).                                  |
+| 37.2 Browse-mode item navigation (Cycle 37b)             | NVDA+Down or right-arrow to navigate the list cells in browse mode.                                                  | Each item announces with its number/total: "Yes, 2 of 4", "Always, 3 of 4", "No, 4 of 4". UIA `PositionInSet` / `SizeOfSet` populated correctly per `TerminalListItemAutomationPeer.GetPositionInSetCore`/`GetSizeOfSetCore`.                                                     |
+| 37.3 Highlight movement (terminal-side, Cycle 37b)       | With NVDA in focus mode, press the keyboard's Down arrow (PTY echoes; Claude shifts highlight).                      | NVDA announces the new selection: "Yes, 2 of 4". The `SelectionItemPatternIdentifiers.ElementSelectedEvent` fires from `TerminalListAutomationPeer.UpdateSelection`; NVDA refocuses to the new item.                                                                              |
+| 37.4 Invoke (Enter on selected item, Cycle 37b)          | With NVDA in focus mode on the selected item, press Enter (NVDA's Enter key in focus mode invokes the focused item). | The PTY receives `\r` (0x0D byte) via `IInvokeProvider.Invoke()` → `TerminalView.WritePtyBytes`. The prompt dismisses; "selection dismissed" structural event fires (StructureChanged); list peer drops from `GetChildren`. Claude proceeds with the chosen action.               |
+| 37.5 Dismissal cleanup (Cycle 37b)                       | After the prompt disappears (via Enter or terminal-side Esc), navigate document with NVDA reading cursor.            | The list peer is gone (verified via Inspect.exe — `TerminalView` child count returns to 0). Document `IsContentElementCore` returns to `true`; reading cursor works again on document text.                                                                                      |
+| 37.6 Document dedup (full-document IsContentElement, Cycle 37b) | While the list is showing, attempt to read terminal text with NVDA reading cursor (Insert+Up/Down).                  | Reading cursor cannot enter the document (full-document `IsContentElement = false` while list active per the 2026-05-10 design choice). Documented limitation; iterate to per-range exclusion in a follow-up if the trade-off bites the maintainer's reading flow.               |
+| 37.7 cmd `choice` non-claude shell (Cycle 37b)           | In cmd (`Ctrl+Shift+1`), run `choice /c YN /m "Continue?"`. Type `Y`.                                                | `cmd choice` is prompt-line, not a multi-row interactive list. SelectionDetector is shellKey-gated to `"claude"` only. The list peer never materializes. Verify via FileLogger: `Ctrl+Shift+D` bundle's `--- FILELOGGER ACTIVE LOG ---` shows ZERO `Semantic=SelectionShown` lines during the cmd session. |
+
+**Diagnostic decoders for Cycle 37b:**
+
+- **NVDA reads selection text but no listbox structure** →
+  the cutover may not be in effect. Capture
+  `Ctrl+Shift+D` bundle and grep
+  `--- FILELOGGER ACTIVE LOG ---` for `Semantic=SelectionShown`
+  rows. The text payload should be present (FileLogger keeps
+  the audit trail), but no `RawPayload received` warning lines
+  (those would indicate the View's `AnnounceRawPayload` is
+  receiving an unexpected payload type).
+- **NVDA hears the list announcement TWICE** ("selection
+  prompt: Edit, Yes, Always, No (selected: Yes)" then
+  "list with 4 items, Edit, 1 of 4") → Cycle 37b's
+  `SelectionProfile.fs` cleanup may have regressed; the
+  duplicate NVDA `RenderText` decision is still being emitted.
+  Pin-test failure on `SelectionProfile`'s `decisions.Length =
+  2` invariant catches this at CI.
+- **List peer doesn't appear in NVDA's UIA tree at all** →
+  use Inspect.exe to walk the tree. If the `TerminalView`
+  Document peer has no `TerminalList` child while a Claude
+  prompt is showing, `TerminalAutomationPeer.UpdateSelectionState`
+  is not firing. Capture FileLogger; grep
+  `Semantic=SelectionShown` to confirm the substrate is
+  emitting the event.
+- **`IInvokeProvider.Invoke()` fires but PTY doesn't
+  receive `\r`** → `TerminalView.WritePtyBytes` may be
+  short-circuiting (`_writeBytes` is null because `SetPtyHost`
+  wasn't called yet). Reproduce with the app already in steady
+  state (post-startup); the wiring race only happens during
+  the very first second after launch.
+- **Cycle 37c arrives** with NVDA list-mode arrow-key
+  translation (NVDA in focus mode pressing Down sends Down to
+  the peer, peer translates to PTY arrow byte). 37b ships
+  read-only UIA semantics: NVDA hears the list correctly but
+  can't drive selection from focus mode without falling
+  through to the input layer (which works today via PTY echo).
+
+**FileLogger grep recipes (post-merge dogfood verification).**
+
+```cmd
+:: cmd — verify the substrate is emitting SelectionShown for Claude sessions
+findstr /C:"Semantic=SelectionShown" "%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<latest>.txt"
+:: Expected: one or more rows during a Claude session that triggered a tool-use prompt.
+```
+
+```cmd
+:: cmd — verify NO unexpected RawPayload type errors
+findstr /C:"AnnounceRawPayload received unexpected" "%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\snapshot-<latest>.txt"
+:: Expected: zero rows. Any match indicates payload type drift between substrate and channel.
+```
+
+```powershell
+# PowerShell — same checks
+Select-String -Pattern "Semantic=SelectionShown" -Path "$env:LOCALAPPDATA\PtySpeak\diagnostic-snapshots\snapshot-*.txt"
+Select-String -Pattern "AnnounceRawPayload received unexpected" -Path "$env:LOCALAPPDATA\PtySpeak\diagnostic-snapshots\snapshot-*.txt"
+```
+
 ## Recording results
 
 For each release tag:

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -56,14 +56,274 @@ do ()
 /// the peer doesn't have to know about the screen-snapshot
 /// machinery; the view holds the closure over its own `_screen`
 /// field and the peer just hands the provider through to UIA.
-type internal TerminalAutomationPeer(owner: FrameworkElement, textProvider: ITextProvider) =
+///
+/// **Cycle 37b** — constructor extended with `writePtyBytes:
+/// Action<byte[]>` so child `TerminalListItemAutomationPeer`
+/// instances can fire `IInvokeProvider.Invoke()` → `\r` byte
+/// onto the PTY (Claude tool-use prompt accepts the highlighted
+/// choice on Enter). The View's `OnCreateAutomationPeer` passes
+/// `this.WritePtyBytes` (a public method that wraps the
+/// View's private `_writeBytes` field).
+type internal TerminalListAutomationPeer
+    (parent: AutomationPeer,
+     initialPayload: SelectionRawPayload,
+     writePtyBytes: Action<byte[]>) =
+    inherit AutomationPeer()
+
+    let mutable selectedIndex : int = initialPayload.SelectedIndex
+    let itemCount : int = initialPayload.ItemCount
+    let allItems : string[] = initialPayload.AllItems
+
+    /// ListItem peers built lazily on first access (typically
+    /// from the UIA-thread `GetChildrenCore` call) and cached
+    /// for the list's lifetime. Avoiding the `as this` /
+    /// class-let-binding initialization-soundness pattern
+    /// (FS0021 under TreatWarningsAsErrors); deferring
+    /// construction to a `member` ensures `this` is fully bound
+    /// when the items are built.
+    let mutable cachedItems : TerminalListItemAutomationPeer[] | null = null
+
+    member private this.EnsureItems() : TerminalListItemAutomationPeer[] =
+        match cachedItems with
+        | null ->
+            let arr =
+                allItems
+                |> Array.mapi (fun i text ->
+                    TerminalListItemAutomationPeer(this, text, i, writePtyBytes))
+            cachedItems <- arr
+            arr
+        | arr -> arr
+
+    member internal _.SelectedIndex
+        with get () = selectedIndex
+        and set v = selectedIndex <- v
+
+    member internal _.ItemCount = itemCount
+
+    /// Called by the parent peer when a SelectionItem event
+    /// arrives. Mutates state + raises the per-item selection
+    /// event so NVDA shifts focus to the new selected item.
+    member this.UpdateSelection(newSelectedIndex: int) =
+        let items = this.EnsureItems()
+        selectedIndex <- newSelectedIndex
+        if newSelectedIndex >= 0 && newSelectedIndex < items.Length then
+            let target = items.[newSelectedIndex]
+            target.RaiseAutomationEvent(
+                SelectionItemPatternIdentifiers.ElementSelectedEvent)
+
+    interface ISelectionProvider with
+        member _.CanSelectMultiple = false
+        member _.IsSelectionRequired = true
+        member this.GetSelection() : IRawElementProviderSimple[] =
+            // F# interface members typed-as-the-implementing
+            // class via `member this.X`; direct call to private
+            // `EnsureItems` works without downcast.
+            let items = this.EnsureItems()
+            if selectedIndex >= 0 && selectedIndex < items.Length then
+                let peer = items.[selectedIndex] :> AutomationPeer
+                let provider = AutomationPeer.ProviderFromPeer(peer)
+                [| provider |]
+            else
+                Array.empty<IRawElementProviderSimple>
+
+    override this.GetChildrenCore() =
+        let items = this.EnsureItems()
+        let list = ResizeArray<AutomationPeer>(items.Length)
+        for p in items do
+            list.Add(p :> AutomationPeer)
+        list
+
+    override _.GetClassNameCore() = "TerminalList"
+    override _.GetAutomationControlTypeCore() = AutomationControlType.List
+    override _.GetNameCore() = "Selection prompt"
+    override _.IsContentElementCore() = true
+    override _.IsControlElementCore() = true
+
+    // Remaining AutomationPeer abstract overrides. The list peer
+    // is virtual (no FrameworkElement backing) so geometry +
+    // focusability concepts don't directly apply; safe defaults
+    // mirror the document peer's behaviour delegated through
+    // FrameworkElementAutomationPeer in the parent.
+    override _.GetBoundingRectangleCore() = System.Windows.Rect.Empty
+    override _.GetClickablePointCore() = System.Windows.Point()
+    override _.HasKeyboardFocusCore() = false
+    override _.IsEnabledCore() = true
+    override _.IsKeyboardFocusableCore() = true
+    override _.IsOffscreenCore() = false
+    override _.IsPasswordCore() = false
+    override _.IsRequiredForFormCore() = false
+    override _.SetFocusCore() = ()
+
+    /// Returns the parent peer so UIA tree navigation walks back
+    /// to `TerminalAutomationPeer` (Document) → `TerminalView`
+    /// (the FrameworkElement). Without this, the virtual list
+    /// peer is orphaned in the tree.
+    override _.GetParent() = parent
+
+    override this.GetPattern(patternInterface: PatternInterface) : obj | null =
+        match patternInterface with
+        | PatternInterface.Selection ->
+            let result : obj | null = (this :> ISelectionProvider) :> obj
+            result
+        | _ -> null
+
+/// Cycle 37b — virtual UIA peer for a single item within a
+/// detected selection list. Implements `ISelectionItemProvider`
+/// (NVDA's "is this the selected one?" interrogation +
+/// PositionInSet/SizeOfSet) and `IInvokeProvider` (single-key
+/// activation: NVDA in focus mode pressing Enter on the
+/// selected item writes `\r` to the PTY, which Claude
+/// interprets as "press the highlighted choice"). Per
+/// `docs/CANONICAL-DISPLAY-CATALOG.md` §2.14 ConfirmationPrompt
+/// hybrid contract.
+///
+/// `parent` is `TerminalListAutomationPeer` so this peer can
+/// query the parent's mutable `SelectedIndex` (no per-item
+/// state; the listbox owns the cursor). Mutual recursion via
+/// `and` resolves the forward reference from the parent's
+/// `itemPeers` field.
+and internal TerminalListItemAutomationPeer
+    (parent: TerminalListAutomationPeer,
+     text: string,
+     index: int,
+     writePtyBytes: Action<byte[]>) =
+    inherit AutomationPeer()
+
+    interface ISelectionItemProvider with
+        member _.IsSelected = parent.SelectedIndex = index
+        member _.SelectionContainer =
+            AutomationPeer.ProviderFromPeer(parent :> AutomationPeer)
+        // Selection mutation from UIA is read-only in 37b — the
+        // PTY drives selection via arrow-key echoes, which the
+        // detector re-fires as SelectionItem events. Stage 8e-C
+        // generalizes this to UIA-driven Select() that writes
+        // arrow bytes to the PTY.
+        member _.Select() = ()
+        member _.AddToSelection() = ()
+        member _.RemoveFromSelection() = ()
+
+    interface IInvokeProvider with
+        member _.Invoke() =
+            // Send Enter byte (`\r` = 0x0D) to PTY. Claude's
+            // tool-use prompt accepts the highlighted choice on
+            // Enter. cmd `choice` and other shells with
+            // different activation keys are out of scope for
+            // 37b (SelectionDetector is shellKey-gated to
+            // "claude").
+            writePtyBytes.Invoke([| 0x0Duy |])
+
+    override _.GetClassNameCore() = "TerminalListItem"
+    override _.GetAutomationControlTypeCore() = AutomationControlType.ListItem
+    override _.GetNameCore() = text
+    override _.IsContentElementCore() = true
+    override _.IsControlElementCore() = true
+    override _.GetPositionInSetCore() = index + 1
+    override _.GetSizeOfSetCore() = parent.ItemCount
+
+    // Remaining AutomationPeer abstract overrides. ListItem peers
+    // are virtual; focus semantics defer to the PTY-side cursor.
+    override _.GetBoundingRectangleCore() = System.Windows.Rect.Empty
+    override _.GetClickablePointCore() = System.Windows.Point()
+    override _.HasKeyboardFocusCore() = false
+    override _.IsEnabledCore() = true
+    override _.IsKeyboardFocusableCore() = true
+    override _.IsOffscreenCore() = false
+    override _.IsPasswordCore() = false
+    override _.IsRequiredForFormCore() = false
+    override _.SetFocusCore() = ()
+
+    /// Returns the parent list peer so UIA tree navigation walks
+    /// ListItem → List → Document.
+    override _.GetParent() = parent :> AutomationPeer
+
+    override this.GetPattern(patternInterface: PatternInterface) : obj | null =
+        match patternInterface with
+        | PatternInterface.SelectionItem ->
+            let result : obj | null = (this :> ISelectionItemProvider) :> obj
+            result
+        | PatternInterface.Invoke ->
+            let result : obj | null = (this :> IInvokeProvider) :> obj
+            result
+        | _ -> null
+
+/// Stage 4 / Cycle 37b — UIA peer that exposes `TerminalView`
+/// to the WPF Automation tree as a Document with the Text
+/// pattern, plus (Cycle 37b) child `TerminalListAutomationPeer`
+/// instances when a Claude tool-use selection prompt is active.
+type internal TerminalAutomationPeer
+    (owner: FrameworkElement,
+     textProvider: ITextProvider,
+     writePtyBytes: Action<byte[]>) =
     inherit FrameworkElementAutomationPeer(owner)
+
+    /// Cycle 37b — currently-active list peer, materialized when
+    /// `UpdateSelectionState` receives a `"shown"` payload + dropped
+    /// when it receives a `"dismissed"` payload. The peer's
+    /// presence drives `IsContentElementCore` (false while
+    /// active per spec §8.5 dedup) and `GetChildrenCore` (returns
+    /// the list peer as the sole child while active).
+    let mutable currentListPeer : TerminalListAutomationPeer option = None
 
     override _.GetAutomationControlTypeCore() = AutomationControlType.Document
     override _.GetClassNameCore() = "TerminalView"
     override _.GetNameCore() = "Terminal"
     override _.IsControlElementCore() = true
-    override _.IsContentElementCore() = true
+
+    /// Cycle 37b — full-document content-element suppression
+    /// while a list peer is materialized. Per
+    /// `spec/tech-plan.md` §8.5 dedup: NVDA reads the list peer
+    /// (and only the list peer) for the selection rows. The
+    /// pragmatic full-document form (chosen 2026-05-10) trades
+    /// off NVDA reading-cursor history browse during a prompt;
+    /// per-range exclusion via `GetVisibleRanges` can iterate
+    /// post-merge if the trade-off bites.
+    override _.IsContentElementCore() =
+        match currentListPeer with
+        | Some _ -> false
+        | None -> true
+
+    /// Cycle 37b — return the active list peer as the sole
+    /// child while a selection is active; defer to base
+    /// implementation otherwise. This is the hook that makes
+    /// the virtual list peer visible in NVDA's UIA tree walk.
+    override this.GetChildrenCore() =
+        match currentListPeer with
+        | Some lp ->
+            let list = ResizeArray<AutomationPeer>(1)
+            list.Add(lp :> AutomationPeer)
+            list
+        | None -> base.GetChildrenCore()
+
+    /// Cycle 37b — promotes the 37a stub to peer-state update.
+    /// Called from `TerminalView.AnnounceRawPayload` on the WPF
+    /// UI thread (via the 37a `Dispatcher.Invoke` wrapper).
+    /// Mutates `currentListPeer` + raises StructureChanged on
+    /// the parent + delegates per-item selection to the active
+    /// list peer.
+    member this.UpdateSelectionState(payload: SelectionRawPayload) =
+        match payload.Kind with
+        | "shown" ->
+            let lp = TerminalListAutomationPeer(this, payload, writePtyBytes)
+            currentListPeer <- Some lp
+            this.RaiseAutomationEvent(AutomationEvents.StructureChanged)
+        | "item" ->
+            match currentListPeer with
+            | Some lp -> lp.UpdateSelection(payload.SelectedIndex)
+            | None ->
+                // SelectionItem arrived without a preceding
+                // SelectionShown — defensive skip. Per the
+                // detector burst protocol, SelectionShown
+                // always precedes SelectionItem; this branch
+                // catches state drift only.
+                ()
+        | "dismissed" ->
+            currentListPeer <- None
+            this.RaiseAutomationEvent(AutomationEvents.StructureChanged)
+        | _ ->
+            // Unknown Kind — forward-compat: future selection
+            // kinds (e.g. multi-select pickers) land here without
+            // throwing.
+            ()
 
     /// Add the Text pattern to this peer. For every other
     /// pattern interface we defer to the base implementation

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -109,7 +109,7 @@ type internal TerminalListAutomationPeer
         if newSelectedIndex >= 0 && newSelectedIndex < items.Length then
             let target = items.[newSelectedIndex]
             target.RaiseAutomationEvent(
-                SelectionItemPatternIdentifiers.ElementSelectedEvent)
+                AutomationEvents.SelectionItemPatternOnElementSelected)
 
     interface ISelectionProvider with
         member _.CanSelectMultiple = false
@@ -117,11 +117,13 @@ type internal TerminalListAutomationPeer
         member this.GetSelection() : IRawElementProviderSimple[] =
             // F# interface members typed-as-the-implementing
             // class via `member this.X`; direct call to private
-            // `EnsureItems` works without downcast.
+            // `EnsureItems` + protected-instance
+            // `ProviderFromPeer` (inherited from AutomationPeer)
+            // both work without downcast.
             let items = this.EnsureItems()
             if selectedIndex >= 0 && selectedIndex < items.Length then
                 let peer = items.[selectedIndex] :> AutomationPeer
-                let provider = AutomationPeer.ProviderFromPeer(peer)
+                let provider = this.ProviderFromPeer(peer)
                 [| provider |]
             else
                 Array.empty<IRawElementProviderSimple>
@@ -154,16 +156,17 @@ type internal TerminalListAutomationPeer
     override _.IsRequiredForFormCore() = false
     override _.SetFocusCore() = ()
 
-    /// Returns the parent peer so UIA tree navigation walks back
-    /// to `TerminalAutomationPeer` (Document) → `TerminalView`
-    /// (the FrameworkElement). Without this, the virtual list
-    /// peer is orphaned in the tree.
-    override _.GetParent() = parent
+    // GetParent() is non-virtual on AutomationPeer (FS0855). The
+    // parent relationship is established via the document peer's
+    // GetChildrenCore returning this list peer; UIA's tree
+    // walker handles the upward walk via internal framework
+    // bookkeeping.
 
     override this.GetPattern(patternInterface: PatternInterface) : obj | null =
         match patternInterface with
         | PatternInterface.Selection ->
-            let result : obj | null = (this :> ISelectionProvider) :> obj
+            let provider = this :> ISelectionProvider
+            let result : obj | null = provider
             result
         | _ -> null
 
@@ -191,8 +194,8 @@ and internal TerminalListItemAutomationPeer
 
     interface ISelectionItemProvider with
         member _.IsSelected = parent.SelectedIndex = index
-        member _.SelectionContainer =
-            AutomationPeer.ProviderFromPeer(parent :> AutomationPeer)
+        member this.SelectionContainer =
+            this.ProviderFromPeer(parent :> AutomationPeer)
         // Selection mutation from UIA is read-only in 37b — the
         // PTY drives selection via arrow-key echoes, which the
         // detector re-fires as SelectionItem events. Stage 8e-C
@@ -232,17 +235,19 @@ and internal TerminalListItemAutomationPeer
     override _.IsRequiredForFormCore() = false
     override _.SetFocusCore() = ()
 
-    /// Returns the parent list peer so UIA tree navigation walks
-    /// ListItem → List → Document.
-    override _.GetParent() = parent :> AutomationPeer
+    // GetParent() is non-virtual on AutomationPeer (FS0855). The
+    // parent relationship is established via the list peer's
+    // GetChildrenCore returning this item peer.
 
     override this.GetPattern(patternInterface: PatternInterface) : obj | null =
         match patternInterface with
         | PatternInterface.SelectionItem ->
-            let result : obj | null = (this :> ISelectionItemProvider) :> obj
+            let provider = this :> ISelectionItemProvider
+            let result : obj | null = provider
             result
         | PatternInterface.Invoke ->
-            let result : obj | null = (this :> IInvokeProvider) :> obj
+            let provider = this :> IInvokeProvider
+            let result : obj | null = provider
             result
         | _ -> null
 

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -156,6 +156,25 @@ type internal TerminalListAutomationPeer
     override _.IsRequiredForFormCore() = false
     override _.SetFocusCore() = ()
 
+    // String-valued metadata abstracts. Empty strings match the
+    // .NET 9 convention for "no value" — UIA clients (NVDA,
+    // Inspect.exe) interpret as unset rather than the literal
+    // empty string.
+    override _.GetAcceleratorKeyCore() = ""
+    override _.GetAccessKeyCore() = ""
+    override _.GetAutomationIdCore() = "TerminalList"
+    override _.GetHelpTextCore() = ""
+    override _.GetItemStatusCore() = ""
+    override _.GetItemTypeCore() = ""
+    // No labeled-by relationship; AutomationPeer's documented
+    // semantic for "none" is null. F# 9's view of the WPF
+    // reference assembly types `AutomationPeer` (rather than
+    // `AutomationPeer | null`); `Unchecked.defaultof<_>`
+    // produces null at runtime without the strict-nullness
+    // diagnostic.
+    override _.GetLabeledByCore() = Unchecked.defaultof<AutomationPeer>
+    override _.GetOrientationCore() = AutomationOrientation.None
+
     // GetParent() is non-virtual on AutomationPeer (FS0855). The
     // parent relationship is established via the document peer's
     // GetChildrenCore returning this list peer; UIA's tree
@@ -234,6 +253,23 @@ and internal TerminalListItemAutomationPeer
     override _.IsPasswordCore() = false
     override _.IsRequiredForFormCore() = false
     override _.SetFocusCore() = ()
+
+    // ListItem leaf-node: no children. Empty list (not null)
+    // matches the .NET 9 non-null `List<AutomationPeer>` return
+    // type per the F# 9 view of the WPF reference assembly.
+    override _.GetChildrenCore() = System.Collections.Generic.List<AutomationPeer>()
+
+    // String-valued metadata abstracts. ItemText is reserved
+    // for the ListItem's name; AutomationId differentiates
+    // siblings within the parent list peer.
+    override _.GetAcceleratorKeyCore() = ""
+    override _.GetAccessKeyCore() = ""
+    override _.GetAutomationIdCore() = sprintf "TerminalListItem[%d]" index
+    override _.GetHelpTextCore() = ""
+    override _.GetItemStatusCore() = ""
+    override _.GetItemTypeCore() = ""
+    override _.GetLabeledByCore() = Unchecked.defaultof<AutomationPeer>
+    override _.GetOrientationCore() = AutomationOrientation.None
 
     // GetParent() is non-virtual on AutomationPeer (FS0855). The
     // parent relationship is established via the list peer's

--- a/src/Terminal.Core/SelectionProfile.fs
+++ b/src/Terminal.Core/SelectionProfile.fs
@@ -36,17 +36,17 @@ namespace Terminal.Core
 ///   additive observer for the events it claims; mirrors the
 ///   `EarconProfile` pattern exactly).
 ///
-/// **Cycle 37a (Stage 8e-B substrate).** Apply now emits a
-/// THIRD ChannelDecision per Selection event: an NVDA-channel
-/// `RenderRaw` payload of type `SelectionRawPayload` carrying
-/// the UIA listbox metadata. The pre-existing NVDA-channel
-/// `RenderText` decision is retained for the bridge interval
-/// between 37a (substrate) and 37b (peers) — NVDA continues to
-/// announce text from `RenderText` while the
-/// `Terminal.Accessibility` peer is being built. 37b drops the
-/// duplicate NVDA `RenderText` decision once the peer takes
-/// over; FileLogger's `RenderText` decision is preserved as
-/// the audit trail.
+/// **Cycle 37b (Stage 8e-B peer cutover).** Apply emits TWO
+/// ChannelDecisions per Selection event: a FileLogger-channel
+/// `RenderText` (audit trail) and an NVDA-channel `RenderRaw`
+/// payload of type `SelectionRawPayload` carrying the UIA
+/// listbox metadata. The 37a interim NVDA-channel `RenderText`
+/// decision has been dropped now that
+/// `TerminalListAutomationPeer` (in `Terminal.Accessibility`)
+/// takes over the announce semantics — NVDA hears the list as
+/// a real `ControlType.List` with `1 of 4` semantics, not as
+/// rendered plain text. The FileLogger text decision remains
+/// for the audit trail (paste-back debugging post-incident).
 ///
 /// **No Parameters record.** Profile is stateless (the tunable
 /// thresholds live on `SelectionDetector.Parameters`, not here).
@@ -101,13 +101,6 @@ module SelectionProfile =
             | _ -> None
         | None -> None
 
-    /// Build an NVDA-channel decision carrying the supplied
-    /// already-sanitised text. Mirrors `EarconProfile`'s
-    /// `earconDecision` helper.
-    let private nvdaDecision (text: string) : ChannelDecision =
-        { Channel = NvdaChannel.id
-          Render = RenderText text }
-
     /// Build a FileLogger-channel decision carrying the supplied
     /// text. The detector's payloads are already sanitised via
     /// `AnnounceSanitiser.sanitise`; the rendered text we add
@@ -132,17 +125,18 @@ module SelectionProfile =
           Render = RenderRaw (payload :> obj) }
 
     /// Construct the decisions array for a single Selection event.
-    /// 37a emits THREE decisions (Option A bridge): NVDA
-    /// `RenderText` so NVDA continues to announce during the 37a
-    /// interim window; FileLogger `RenderText` for the audit
-    /// trail; NVDA `RenderRaw` carrying the UIA payload for the
-    /// 37b peer to consume.
+    /// Cycle 37b emits TWO decisions: FileLogger `RenderText` for
+    /// the audit trail (paste-back debugging) + NVDA `RenderRaw`
+    /// carrying the UIA payload for `TerminalListAutomationPeer`
+    /// to consume. The 37a-interim NVDA `RenderText` decision was
+    /// dropped now that the peer takes over the announce
+    /// semantics — keeping it would cause double-announce (text
+    /// + listbox).
     let private selectionDecisions
             (text: string)
             (payload: SelectionRawPayload)
             : ChannelDecision[] =
-        [| nvdaDecision text
-           fileLoggerDecision text
+        [| fileLoggerDecision text
            rawDecision payload |]
 
     /// Cycle 37a — build the raw payload for a `SelectionShown`

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -343,29 +343,47 @@ public class TerminalView : FrameworkElement
     }
 
     /// <summary>
-    /// Cycle 37a — receives <see cref="Terminal.Core.RenderInstruction.RenderRaw"/>
+    /// Cycle 37b — receives <see cref="Terminal.Core.RenderInstruction.RenderRaw"/>
     /// payloads marshalled from <see cref="Terminal.Core.NvdaChannel"/> via the
-    /// composition root's <c>marshalRawPayload</c> callback. Cycle 37a stubs
-    /// this method as log-only; Cycle 37b promotes it to peer-state update +
-    /// UIA event raise on the active <c>TerminalAutomationPeer</c>.
+    /// composition root's <c>marshalRawPayload</c> callback, and routes
+    /// <see cref="Terminal.Core.SelectionRawPayload"/> to the active
+    /// <see cref="Terminal.Accessibility.TerminalAutomationPeer"/>'s
+    /// <c>UpdateSelectionState</c>, which materializes / mutates / drops the
+    /// virtual list peer and raises UIA events. Cycle 37a stubbed this as
+    /// log-only; Cycle 37b promotes to peer-state update.
     /// </summary>
     /// <remarks>
-    /// Logging metadata only (payload type name + activityId), per SECURITY.md
-    /// "Logging chokepoint" policy. Payload contents (e.g. selection list
-    /// item text) are sanitised at the producer boundary
-    /// (<c>SelectionDetector</c> applies <c>AnnounceSanitiser.sanitise</c>),
-    /// but the stub doesn't forward them to NVDA — Option A bridge keeps the
-    /// existing <c>RenderText</c> NVDA decision active so NVDA continues
-    /// reading the text representation during the 37a interim.
+    /// Threading: this method runs on the WPF UI thread (the composition
+    /// root in <c>Program.fs</c> wraps the call in <c>Dispatcher.Invoke</c>).
+    /// <c>UpdateSelectionState</c> mutates peer fields and calls
+    /// <c>RaiseAutomationEvent</c> directly — both safe on the UI thread
+    /// without further marshalling.
+    ///
+    /// If <c>UIElementAutomationPeer.FromElement</c> returns null (no UIA
+    /// client has connected yet to trigger lazy peer creation), the
+    /// <c>?.</c> null-conditional short-circuits and the update is silently
+    /// dropped. This matches the existing <see cref="Announce"/> path's
+    /// behaviour for the no-UIA-client case.
+    ///
+    /// Unknown payload types fall to the warning-log branch so type drift
+    /// surfaces in <c>Ctrl+Shift+D</c> bundles for triage.
     /// </remarks>
     public void AnnounceRawPayload(object payload, string activityId)
     {
-        var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.AnnounceRawPayload");
-        var typeName = payload?.GetType().Name ?? "null";
-        Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(
-            log,
-            "RawPayload received (Cycle 37a stub). ActivityId={ActivityId} PayloadType={PayloadType}",
-            activityId, typeName);
+        if (payload is Terminal.Core.SelectionRawPayload selPayload)
+        {
+            var peer = UIElementAutomationPeer.FromElement(this) as TerminalAutomationPeer;
+            peer?.UpdateSelectionState(selPayload);
+        }
+        else
+        {
+            var log = Terminal.Core.Logger.get("PtySpeak.Views.TerminalView.AnnounceRawPayload");
+            var typeName = payload?.GetType().Name ?? "null";
+            Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(
+                log,
+                "AnnounceRawPayload received unexpected payload type. ActivityId={ActivityId} PayloadType={PayloadType}",
+                activityId, typeName);
+        }
     }
 
     /// <summary>
@@ -993,7 +1011,20 @@ public class TerminalView : FrameworkElement
     /// the element's lifetime — there's no need to memoize here.
     /// </summary>
     protected override AutomationPeer OnCreateAutomationPeer()
-        => new TerminalAutomationPeer(this, TextProvider);
+        => new TerminalAutomationPeer(this, TextProvider, this.WritePtyBytes);
+
+    /// <summary>
+    /// Cycle 37b — public bridge from
+    /// <see cref="Terminal.Accessibility.TerminalListItemAutomationPeer"/>'s
+    /// <c>IInvokeProvider.Invoke()</c> callback to the View's private
+    /// <c>_writeBytes</c> field. Wraps a null check so an Invoke
+    /// firing before <see cref="SetPtyHost"/> is wired silently no-ops
+    /// rather than throwing — UIA clients (NVDA, Inspect.exe) may
+    /// connect to the peer before the composition root finishes
+    /// wiring the PTY host.
+    /// </summary>
+    public void WritePtyBytes(byte[] bytes)
+        => _writeBytes?.Invoke(bytes);
 
     protected override Size MeasureOverride(Size availableSize)
     {

--- a/tests/Tests.Unit/SelectionProfileTests.fs
+++ b/tests/Tests.Unit/SelectionProfileTests.fs
@@ -4,21 +4,19 @@ open System
 open Xunit
 open Terminal.Core
 
-/// Stage 8e-A part 2 (Cycle 29b) — pins the SelectionProfile's
-/// Apply contract:
+/// Stage 8e-A part 2 (Cycle 29b) / Cycle 37b — pins the
+/// SelectionProfile's Apply contract:
 ///   * id is "selection".
 ///   * SelectionShown / SelectionItem / SelectionDismissed each
-///     emit one pair with THREE ChannelDecisions: NVDA RenderText
-///     (Option A bridge so NVDA continues reading text during the
-///     37a interim window), FileLogger RenderText (audit trail),
-///     and NVDA RenderRaw carrying the SelectionRawPayload UIA-
-///     free metadata for Cycle 37b's Terminal.Accessibility peer
-///     to consume.
-///   * The first two decisions carry `RenderText` payloads
-///     constructed from `Extensions` data (empty-payload trick
-///     mirrors 8d.2's EarconProfile pattern).
-///   * The third decision carries a `RenderRaw` payload of type
-///     `SelectionRawPayload` per Cycle 37a contract.
+///     emit one pair with TWO ChannelDecisions: FileLogger
+///     RenderText (audit trail) + NVDA RenderRaw carrying the
+///     SelectionRawPayload UIA-free metadata. Cycle 37b dropped
+///     the duplicate NVDA RenderText decision now that
+///     Terminal.Accessibility's TerminalListAutomationPeer
+///     takes over the announce semantics — keeping it would
+///     cause double-announce (text + listbox).
+///   * Decision[0] is FileLogger RenderText; Decision[1] is
+///     NVDA RenderRaw.
 ///   * Foreign Semantic categories return `[||]` (purely
 ///     additive observer).
 ///   * Tick + Reset are no-ops.
@@ -143,17 +141,16 @@ let ``create returns a Profile whose Id matches the module-level id`` () =
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``SelectionShown Apply emits one pair with three ChannelDecisions (NVDA text + FileLogger text + NVDA raw, Cycle 37a)`` () =
+let ``SelectionShown Apply emits one pair with two ChannelDecisions (FileLogger text + NVDA raw, Cycle 37b)`` () =
     let profile = SelectionProfile.create ()
     let event =
         selectionShownEvent [| "Edit"; "Yes"; "Always"; "No" |] 1
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(3, decisions.Length)
-    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
-    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
-    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
+    Assert.Equal(2, decisions.Length)
+    Assert.Equal(FileLoggerChannel.id, decisions.[0].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[1].Channel)
 
 [<Fact>]
 let ``SelectionShown rendered text formats list with selected item highlighted`` () =
@@ -185,13 +182,13 @@ let ``SelectionShown falls back to count summary when AllItems missing`` () =
     Assert.Equal("selection prompt, 4 items", text)
 
 [<Fact>]
-let ``SelectionShown emits RenderRaw with Kind="shown" and AllItems populated (Cycle 37a)`` () =
+let ``SelectionShown emits RenderRaw with Kind="shown" and AllItems populated (Cycle 37b)`` () =
     let profile = SelectionProfile.create ()
     let event =
         selectionShownEvent [| "Edit"; "Yes"; "Always"; "No" |] 1
     let pairs = profile.Apply event
     let _, decisions = pairs.[0]
-    let payload = renderRaw decisions.[2]
+    let payload = renderRaw decisions.[1]
     Assert.Equal("shown", payload.Kind)
     Assert.Equal(4, payload.ItemCount)
     Assert.Equal(1, payload.SelectedIndex)
@@ -226,25 +223,24 @@ let ``SelectionItem (this item != selected) renders "%s, %d of %d"`` () =
     Assert.Equal("Edit, 1 of 4", text)
 
 [<Fact>]
-let ``SelectionItem emits NVDA text + FileLogger text + NVDA raw triple (Cycle 37a)`` () =
+let ``SelectionItem emits FileLogger text + NVDA raw pair (Cycle 37b)`` () =
     let profile = SelectionProfile.create ()
     let event = selectionItemEvent "Yes" 1 1 4
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(3, decisions.Length)
-    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
-    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
-    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
+    Assert.Equal(2, decisions.Length)
+    Assert.Equal(FileLoggerChannel.id, decisions.[0].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[1].Channel)
 
 [<Fact>]
-let ``SelectionItem emits RenderRaw with Kind="item" and ItemText/ItemIndex populated (Cycle 37a)`` () =
+let ``SelectionItem emits RenderRaw with Kind="item" and ItemText/ItemIndex populated (Cycle 37b)`` () =
     let profile = SelectionProfile.create ()
     // selectedIdx = 1, itemIdx = 0 → "Edit", not the selected item.
     let event = selectionItemEvent "Edit" 0 1 4
     let pairs = profile.Apply event
     let _, decisions = pairs.[0]
-    let payload = renderRaw decisions.[2]
+    let payload = renderRaw decisions.[1]
     Assert.Equal("item", payload.Kind)
     Assert.Equal(4, payload.ItemCount)
     Assert.Equal(1, payload.SelectedIndex)
@@ -257,19 +253,17 @@ let ``SelectionItem emits RenderRaw with Kind="item" and ItemText/ItemIndex popu
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``SelectionDismissed renders literal "selection dismissed" + RenderRaw with Kind="dismissed" (Cycle 37a)`` () =
+let ``SelectionDismissed renders literal "selection dismissed" + RenderRaw with Kind="dismissed" (Cycle 37b)`` () =
     let profile = SelectionProfile.create ()
     let event = selectionDismissedEvent ()
     let pairs = profile.Apply event
     Assert.Equal(1, pairs.Length)
     let _, decisions = pairs.[0]
-    Assert.Equal(3, decisions.Length)
-    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
-    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
-    Assert.Equal(NvdaChannel.id, decisions.[2].Channel)
+    Assert.Equal(2, decisions.Length)
+    Assert.Equal(FileLoggerChannel.id, decisions.[0].Channel)
+    Assert.Equal(NvdaChannel.id, decisions.[1].Channel)
     Assert.Equal("selection dismissed", renderText decisions.[0])
-    Assert.Equal("selection dismissed", renderText decisions.[1])
-    let payload = renderRaw decisions.[2]
+    let payload = renderRaw decisions.[1]
     Assert.Equal("dismissed", payload.Kind)
     Assert.Equal(0, payload.ItemCount)
     Assert.Equal(-1, payload.SelectedIndex)

--- a/tests/Tests.Unit/TerminalListAutomationPeerTests.fs
+++ b/tests/Tests.Unit/TerminalListAutomationPeerTests.fs
@@ -68,6 +68,14 @@ type private TestStubAutomationPeer() =
     override _.IsPasswordCore() = false
     override _.IsRequiredForFormCore() = false
     override _.SetFocusCore() = ()
+    override _.GetAcceleratorKeyCore() = ""
+    override _.GetAccessKeyCore() = ""
+    override _.GetAutomationIdCore() = "test-stub"
+    override _.GetHelpTextCore() = ""
+    override _.GetItemStatusCore() = ""
+    override _.GetItemTypeCore() = ""
+    override _.GetLabeledByCore() = Unchecked.defaultof<AutomationPeer>
+    override _.GetOrientationCore() = AutomationOrientation.None
 
 // ---------------------------------------------------------------------
 // Fixture builders

--- a/tests/Tests.Unit/TerminalListAutomationPeerTests.fs
+++ b/tests/Tests.Unit/TerminalListAutomationPeerTests.fs
@@ -1,0 +1,232 @@
+module PtySpeak.Tests.Unit.TerminalListAutomationPeerTests
+
+open System
+open System.Windows.Automation
+open System.Windows.Automation.Peers
+open System.Windows.Automation.Provider
+open Xunit
+open Terminal.Core
+open Terminal.Accessibility
+
+/// Cycle 37b — pins the TerminalListAutomationPeer +
+/// TerminalListItemAutomationPeer contract:
+///
+///   * List peer reports `ControlType.List`; ListItem peer
+///     reports `ControlType.ListItem`.
+///   * `GetChildren()` returns N items matching `ItemCount`.
+///   * `ISelectionProvider`: `CanSelectMultiple = false`,
+///     `IsSelectionRequired = true`.
+///   * `UpdateSelection(newIdx)` mutates parent's
+///     `SelectedIndex`; ListItem.`IsSelected` reflects parent
+///     state.
+///   * `ListItem.GetPositionInSet` / `GetSizeOfSet` populated.
+///   * `ListItem.GetPattern(SelectionItem | Invoke)` returns
+///     non-null pattern providers.
+///   * `IInvokeProvider.Invoke()` writes `\r` (0x0D) to the
+///     PTY via the supplied `writePtyBytes` callback.
+///
+/// **What these tests do NOT cover** (manual NVDA matrix in
+/// `docs/ACCESSIBILITY-TESTING.md` Cycle 37 covers it):
+///
+///   * UIA event raising visible to a live UIA client. Tests
+///     run outside the WPF host so `RaiseAutomationEvent` is a
+///     no-op (it doesn't throw — that's the relevant
+///     invariant for these unit tests).
+///   * `ProviderFromPeer` returns null outside the WPF tree;
+///     `ISelectionProvider.GetSelection()` is exercised at the
+///     "doesn't throw, returns array of length 0 or 1" level
+///     but the array's contents (the wrapped peer) aren't
+///     asserted.
+///   * `TerminalAutomationPeer.UpdateSelectionState` end-to-end
+///     transitions — that needs a real `FrameworkElement`
+///     parent, which requires a WPF runtime context (covered
+///     by manual NVDA matrix instead).
+
+// ---------------------------------------------------------------------
+// Test stub: minimal AutomationPeer that satisfies F#'s abstract-
+// override checklist for use as a parent in TerminalListAutomationPeer's
+// constructor. Outside the WPF tree, most peer methods are never
+// invoked anyway — this stub exists to satisfy the type signature.
+// ---------------------------------------------------------------------
+
+type private TestStubAutomationPeer() =
+    inherit AutomationPeer()
+
+    override _.GetAutomationControlTypeCore() = AutomationControlType.Custom
+    override _.GetClassNameCore() = "TestStubPeer"
+    override _.GetNameCore() = "test-stub"
+    override _.GetBoundingRectangleCore() = System.Windows.Rect.Empty
+    override _.GetClickablePointCore() = System.Windows.Point()
+    override _.GetChildrenCore() = System.Collections.Generic.List<AutomationPeer>()
+    override _.GetPattern(_) : obj | null = null
+    override _.HasKeyboardFocusCore() = false
+    override _.IsContentElementCore() = true
+    override _.IsControlElementCore() = true
+    override _.IsEnabledCore() = true
+    override _.IsKeyboardFocusableCore() = false
+    override _.IsOffscreenCore() = false
+    override _.IsPasswordCore() = false
+    override _.IsRequiredForFormCore() = false
+    override _.SetFocusCore() = ()
+
+// ---------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------
+
+let private shownPayload (items: string[]) (selectedIdx: int) : SelectionRawPayload =
+    { Kind = "shown"
+      ItemCount = items.Length
+      SelectedIndex = selectedIdx
+      ItemIndex = -1
+      AllItems = items
+      ItemText = "" }
+
+let private noOpWrite : Action<byte[]> = Action<byte[]>(fun _ -> ())
+
+let private makeListPeer
+        (items: string[])
+        (selectedIdx: int)
+        (write: Action<byte[]>)
+        : TerminalListAutomationPeer =
+    let parent = TestStubAutomationPeer() :> AutomationPeer
+    let payload = shownPayload items selectedIdx
+    TerminalListAutomationPeer(parent, payload, write)
+
+// ---------------------------------------------------------------------
+// TerminalListAutomationPeer
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``TerminalListAutomationPeer reports ControlType.List`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "No" |] 0 noOpWrite
+    Assert.Equal(
+        AutomationControlType.List,
+        (peer :> AutomationPeer).GetAutomationControlType())
+
+[<Fact>]
+let ``TerminalListAutomationPeer reports ClassName "TerminalList"`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "No" |] 0 noOpWrite
+    Assert.Equal(
+        "TerminalList",
+        (peer :> AutomationPeer).GetClassName())
+
+[<Fact>]
+let ``TerminalListAutomationPeer reports Name "Selection prompt"`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "No" |] 0 noOpWrite
+    Assert.Equal(
+        "Selection prompt",
+        (peer :> AutomationPeer).GetName())
+
+[<Fact>]
+let ``GetChildren returns N items matching ItemCount`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "Always"; "No" |] 1 noOpWrite
+    let children = (peer :> AutomationPeer).GetChildren()
+    Assert.NotNull(children)
+    Assert.Equal(4, children.Count)
+
+[<Fact>]
+let ``ISelectionProvider reports CanSelectMultiple=false and IsSelectionRequired=true`` () =
+    let peer = makeListPeer [| "Edit"; "Yes" |] 0 noOpWrite
+    let provider = peer :> ISelectionProvider
+    Assert.False(provider.CanSelectMultiple)
+    Assert.True(provider.IsSelectionRequired)
+
+[<Fact>]
+let ``ISelectionProvider.GetSelection returns array of length 1 when selected index is in range`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "Always"; "No" |] 2 noOpWrite
+    let provider = peer :> ISelectionProvider
+    let selection = provider.GetSelection()
+    // ProviderFromPeer returns null outside WPF tree, so the
+    // array entry may be null — what we pin here is the LENGTH
+    // (1 means "we found the selected item").
+    Assert.Equal(1, selection.Length)
+
+[<Fact>]
+let ``ISelectionProvider.GetSelection returns empty when SelectedIndex is out of range`` () =
+    let peer = makeListPeer [| "Edit"; "Yes" |] -1 noOpWrite
+    let provider = peer :> ISelectionProvider
+    let selection = provider.GetSelection()
+    Assert.Equal(0, selection.Length)
+
+[<Fact>]
+let ``UpdateSelection mutates SelectedIndex and does not throw`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "Always"; "No" |] 0 noOpWrite
+    Assert.Equal(0, peer.SelectedIndex)
+    peer.UpdateSelection(2)
+    Assert.Equal(2, peer.SelectedIndex)
+
+[<Fact>]
+let ``GetPattern(Selection) returns the ISelectionProvider; other patterns return null`` () =
+    let peer = makeListPeer [| "Edit"; "Yes" |] 0 noOpWrite
+    let basePeer = peer :> AutomationPeer
+    Assert.NotNull(basePeer.GetPattern(PatternInterface.Selection))
+    Assert.Null(basePeer.GetPattern(PatternInterface.Invoke))
+    Assert.Null(basePeer.GetPattern(PatternInterface.Text))
+
+// ---------------------------------------------------------------------
+// TerminalListItemAutomationPeer
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``TerminalListItemAutomationPeer reports ControlType.ListItem`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "No" |] 0 noOpWrite
+    let children = (peer :> AutomationPeer).GetChildren()
+    let firstChild = children.[0]
+    Assert.Equal(
+        AutomationControlType.ListItem,
+        firstChild.GetAutomationControlType())
+
+[<Fact>]
+let ``ListItem reports correct GetPositionInSet and GetSizeOfSet`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "Always"; "No" |] 1 noOpWrite
+    let children = (peer :> AutomationPeer).GetChildren()
+    Assert.Equal(1, children.[0].GetPositionInSet())
+    Assert.Equal(2, children.[1].GetPositionInSet())
+    Assert.Equal(4, children.[0].GetSizeOfSet())
+    Assert.Equal(4, children.[3].GetSizeOfSet())
+
+[<Fact>]
+let ``ListItem.IsSelected reflects parent.SelectedIndex`` () =
+    let peer = makeListPeer [| "Edit"; "Yes"; "Always"; "No" |] 1 noOpWrite
+    let children = (peer :> AutomationPeer).GetChildren()
+    let getIsSelected (i: int) =
+        let item = children.[i] :?> TerminalListItemAutomationPeer
+        (item :> ISelectionItemProvider).IsSelected
+    // Parent's SelectedIndex = 1; only ListItem at index 1 is selected.
+    Assert.False(getIsSelected 0)
+    Assert.True(getIsSelected 1)
+    Assert.False(getIsSelected 2)
+    Assert.False(getIsSelected 3)
+    // Mutate selection; ListItem state follows.
+    peer.UpdateSelection(3)
+    Assert.False(getIsSelected 0)
+    Assert.False(getIsSelected 1)
+    Assert.False(getIsSelected 2)
+    Assert.True(getIsSelected 3)
+
+[<Fact>]
+let ``ListItem GetPattern(SelectionItem) returns ISelectionItemProvider`` () =
+    let peer = makeListPeer [| "Edit"; "Yes" |] 0 noOpWrite
+    let firstChild = (peer :> AutomationPeer).GetChildren().[0]
+    let pattern = firstChild.GetPattern(PatternInterface.SelectionItem)
+    Assert.NotNull(pattern)
+    Assert.IsAssignableFrom<ISelectionItemProvider>(pattern) |> ignore
+
+[<Fact>]
+let ``ListItem GetPattern(Invoke) returns IInvokeProvider`` () =
+    let peer = makeListPeer [| "Edit"; "Yes" |] 0 noOpWrite
+    let firstChild = (peer :> AutomationPeer).GetChildren().[0]
+    let pattern = firstChild.GetPattern(PatternInterface.Invoke)
+    Assert.NotNull(pattern)
+    Assert.IsAssignableFrom<IInvokeProvider>(pattern) |> ignore
+
+[<Fact>]
+let ``ListItem.Invoke writes 0x0D (Enter) to the PTY via writePtyBytes`` () =
+    let captured = ResizeArray<byte[]>()
+    let recorder = Action<byte[]>(fun bytes -> captured.Add(bytes))
+    let peer = makeListPeer [| "Edit"; "Yes" |] 0 recorder
+    let firstChild = (peer :> AutomationPeer).GetChildren().[0]
+    let invoke = firstChild.GetPattern(PatternInterface.Invoke) :?> IInvokeProvider
+    invoke.Invoke()
+    Assert.Equal(1, captured.Count)
+    Assert.Equal<byte[]>([| 0x0Duy |], captured.[0])

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="IOutputSinkTests.fs" />
     <Compile Include="EarconProfileTests.fs" />
     <Compile Include="SelectionProfileTests.fs" />
+    <Compile Include="TerminalListAutomationPeerTests.fs" />
     <Compile Include="OutputDispatcherTests.fs" />
     <Compile Include="KeyEncodingTests.fs" />
     <Compile Include="FileLoggerTests.fs" />


### PR DESCRIPTION
## Summary

Cycle 37b — closes the Stage 8e-B canonical-display arc (interactive-list exemplar). Replaces SelectionProfile's Cycle 29b text-only NVDA announcements with full UIA listbox semantics. NVDA in focus mode hears Claude tool-use prompts as `ControlType.List` with `1 of N` semantics; arrow-down announces "Yes, 2 of 4" via `SelectionItemPatternIdentifiers.ElementSelectedEvent`; `IInvokeProvider.Invoke()` writes `\r` (0x0D) to the PTY for single-key activation per [`docs/CANONICAL-DISPLAY-CATALOG.md`](docs/CANONICAL-DISPLAY-CATALOG.md) §2.14 ConfirmationPrompt hybrid.

## New peer types

[`Terminal.Accessibility/TerminalAutomationPeer.fs`](src/Terminal.Accessibility/TerminalAutomationPeer.fs):

- **`TerminalListAutomationPeer`** — virtual peer (derives directly from `AutomationPeer`; no FrameworkElement backing). Implements `ISelectionProvider` (CanSelectMultiple=false, IsSelectionRequired=true). Mutually recursive (`and` chain) with the ListItem peer. Lazy item construction in `EnsureItems()` member sidesteps F# 9 `as this` / class-let-binding init-soundness (FS0021 under TreatWarningsAsErrors).
- **`TerminalListItemAutomationPeer`** — ListItem-controltype peer; implements `ISelectionItemProvider` (IsSelected reflects parent.SelectedIndex; SelectionContainer wraps parent via `ProviderFromPeer`) + `IInvokeProvider` (Invoke() writes `0x0D` Enter byte via supplied `writePtyBytes` callback). GetPositionInSet/GetSizeOfSet populated.

## TerminalAutomationPeer (document peer) extensions

- Third constructor parameter `writePtyBytes: Action<byte[]>` threaded through from `TerminalView.OnCreateAutomationPeer`.
- `currentListPeer: TerminalListAutomationPeer option` mutable field driving `IsContentElementCore` + `GetChildrenCore` + `UpdateSelectionState`.
- `IsContentElementCore` returns `false` while a list peer is active (full-document dedup per `spec/tech-plan.md` §8.5; the 2026-05-10 design choice traded NVDA reading-cursor history during prompts for simplicity).
- `GetChildrenCore` returns the active list peer as the sole child while materialized.
- New `UpdateSelectionState(payload: SelectionRawPayload)` member — promotes the 37a log-only stub to peer-state update; transitions through "shown" → "item" → "dismissed" with appropriate `RaiseAutomationEvent(StructureChanged)`. Called from the View's `AnnounceRawPayload` on the WPF UI thread (via the 37a `Dispatcher.Invoke` wrapper) — no additional thread marshalling.

## TerminalView.cs

- New public `WritePtyBytes(byte[])` method bridging the peer's `IInvokeProvider` callback to the View's private `_writeBytes` field (defensive `?.Invoke` for the not-yet-wired case).
- `OnCreateAutomationPeer` extended to pass `this.WritePtyBytes` as the third constructor arg.
- `AnnounceRawPayload` cutover: replaces the 37a stub with `peer?.UpdateSelectionState(selPayload)` delegation.

## SelectionProfile.fs

- Drops the duplicate NVDA `RenderText` decision retained for the 37a bridge — keeping it would cause double-announce (text + listbox). FileLogger `RenderText` decision remains as the audit trail.
- Selection events now emit 2 ChannelDecisions: `[FileLogger RenderText, NVDA RenderRaw]` (was 3 in 37a).

## Tests

- [`tests/Tests.Unit/TerminalListAutomationPeerTests.fs`](tests/Tests.Unit/TerminalListAutomationPeerTests.fs) — new file, 232 lines, **14 facts**. Direct F# instantiation + interface inspection; no FlaUI / WPF runtime dependency. Uses minimal `TestStubAutomationPeer` for the parent peer (15 abstract overrides, mostly safe defaults). Pins: ControlType + ClassName + Name; GetChildren item count; `ISelectionProvider` invariants; `UpdateSelection` mutation; ListItem ControlType; PositionInSet/SizeOfSet; IsSelected reflects parent state across mutation; `GetPattern` returns expected interfaces; `IInvokeProvider.Invoke` writes `0x0D` byte.
- [`tests/Tests.Unit/SelectionProfileTests.fs`](tests/Tests.Unit/SelectionProfileTests.fs) — 4 facts updated for 2-decision shape (was 3-decision in 37a). Index shifts 0↔1↔2; `decisions.Length = 2`.

## Manual NVDA validation gate (load-bearing acceptance)

The 7-row matrix in [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md) `### Cycle 37 — UIA listbox peer (interactive-list canonical-display)` is the load-bearing acceptance gate per [`CONTRIBUTING.md`](CONTRIBUTING.md) "non-negotiable accessibility rules". **PR cannot squash-merge until maintainer confirms all rows pass on real NVDA.**

The matrix covers:
1. List appearance (Edit/Yes/Always/No prompt; "list with 4 items, Edit, 1 of 4").
2. Browse-mode item navigation (PositionInSet/SizeOfSet).
3. Highlight movement (terminal-side; SelectionItemPatternOnElementSelected).
4. Invoke (Enter via NVDA focus mode → PTY receives `\r`).
5. Dismissal cleanup (peer drops; IsContentElement returns to true).
6. Document dedup (full-document IsContentElement=false trade-off documented).
7. cmd `choice` non-claude shell smoke (peer never materializes; SelectionDetector shellKey-gated to "claude").

Plus diagnostic decoders + FileLogger grep recipes for post-merge dogfood verification.

## After 37b ships

Canonical-display exemplar count: **1 → 2** (raw text + interactive list). Cycle 38 picks up the third (form-with-text-input). Stage 10 (review-mode + quick-nav) becomes the first non-built-in consumer of the framework taxonomy on top.

## Test plan

- [ ] `Build and test (windows-latest)` green — compile (F# 9 strict-nullness clean) + 945+ unit tests including 14 new TerminalListAutomationPeerTests + 4 updated SelectionProfileTests.
- [ ] `Workflow lint`, `Portability lint (substrate / channel boundary)`, `Markdown link check` green.
- [ ] **Manual NVDA matrix run** (the 7-row matrix above). Maintainer to report outcomes; PR blocks on this.
- [ ] Optional: Inspect.exe sanity — `TerminalView (Document)` → `TerminalList (List)` → 4 × `TerminalListItem (ListItem)` while a Claude prompt is active.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_