### PR TITLE
fix(substrate): LinearTextStream bare-CR vs CR-LF disambiguation regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,48 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Hotfix): LinearTextStream bare-CR vs CR-LF disambiguation regression
+
+Pre-existing 34a-era bug surfaced after Cycle 35b's `substrate_mode = "auto"`
+default flip routed Linear-substrate output for non-alt-screen frames.
+[`src/Terminal.Core/LinearTextStream.fs`](src/Terminal.Core/LinearTextStream.fs)
+`classifyLiveRegion` returned `EnterTailMask` for `\r` unconditionally,
+but the deferred resolution promised by the `previousEvent` parameter
+was never implemented in `append`. Result: every cmd / PowerShell output
+line (which all use `\r\n`) had its content moved to `TailMask` on the
+`\r` and never flushed (cmd doesn't emit OSC 133 sealed seams). The
+linear stream's `Committed` buffer only ever held bare `\n` bytes;
+`assembleSuffixFromStream` decoded these to whitespace the sanitiser
+stripped; NVDA heard nothing on cmd / PowerShell / Claude across all
+output. Confirmed via `Ctrl+Shift+D` diagnostic battery: `T1.Plain`
+echo test reported `EVENTS (0)` + `FAIL — missing=StreamChunk`; the
+linear-stream sibling file in the bundle was empty.
+
+Fix: defer the tail-mask transition on `\r`. New `PendingCRDeferred`
+flag on the producer's State; set when CR arrives. The next event
+resolves the ambiguity:
+
+- **CR followed by LF** → CRLF newline, no tail-mask. Clear the flag;
+  the LF handler runs normally (adds to Pending, marks
+  `encounteredLF`, advances `CurrentRow`).
+- **CR followed by anything else** (Print, CSI, etc.) → bare CR,
+  overwrite-in-place. Move `Pending` → `TailMask[currentRow]` BEFORE
+  processing the new event.
+
+The flag persists across chunks: a chunk ending with `\r` keeps the
+flag set so the FIRST event of the next chunk resolves correctly.
+
+After the fix, cmd / PowerShell output flows through Linear correctly
+and NVDA announces resume across all shells without the
+`substrate_mode = "screen-diff"` workaround.
+
+Tests: 6 new facts in
+[`tests/Tests.Unit/LinearTextStreamTests.fs`](tests/Tests.Unit/LinearTextStreamTests.fs)
+covering CRLF in same chunk, bare CR + tail-mask transition,
+chunk-spanning CR + LF (CRLF resolves), chunk-spanning CR + Print
+(bare CR resolves), multiple CRLF lines (the cmd output regression
+case), and empty chunk after deferred CR (flag persists).
+
 ### Changed (Cycle 37a): SelectionProfile emits RenderRaw substrate alongside RenderText
 
 Opens the Stage 8e-B canonical-display arc (interactive-list UIA

--- a/src/Terminal.Core/LinearTextStream.fs
+++ b/src/Terminal.Core/LinearTextStream.fs
@@ -221,6 +221,30 @@ module LinearTextStream =
         /// fallback.
         member val internal Osc133MarkersSetThisTuple: bool = false with get, set
 
+        /// Hotfix — bare-CR vs CR-LF disambiguation. RFC §5.3 #3
+        /// distinguishes a bare `\r` (overwrite-in-place spinner
+        /// frame; transitions current row into tail-mask) from
+        /// `\r\n` (a normal newline; just a row boundary, no
+        /// tail-mask). The disambiguation requires looking at
+        /// the NEXT event after `\r`. When `\r` arrives we set
+        /// this flag instead of immediately moving Pending →
+        /// TailMask; the next event resolves: if LF, clear flag
+        /// (CRLF = newline); if anything else, perform the
+        /// deferred tail-mask transition before processing the
+        /// new event. The state is preserved across chunks: a
+        /// chunk ending with `\r` keeps the flag set so the
+        /// FIRST event of the next chunk resolves correctly.
+        ///
+        /// Without this disambiguation, every cmd / PowerShell
+        /// output line (which all use `\r\n`) would be moved to
+        /// TailMask on the `\r` and never flushed (cmd doesn't
+        /// emit OSC 133 sealed seams). Result: `Committed`
+        /// only ever holds bare `\n` bytes; `assembleSuffixFromStream`
+        /// returns content the sanitiser strips; NVDA hears
+        /// nothing — the regression that surfaced after Cycle
+        /// 35b's default flip to `auto` substrate mode.
+        member val internal PendingCRDeferred: bool = false with get, set
+
     // --------------------------------------------------------
     // Construction
     // --------------------------------------------------------
@@ -486,6 +510,30 @@ module LinearTextStream =
             // parser's events but not from the linear stream.
 
             for event in events do
+                // Hotfix — resolve any deferred CR from the
+                // previous iteration (or the previous chunk if
+                // this is event[0] and the prior chunk ended
+                // with `\r`). If the current event is LF, the
+                // pair is `\r\n` — a normal newline boundary,
+                // no tail-mask transition. Otherwise, the bare
+                // `\r` was an overwrite-in-place; perform the
+                // EnterTailMask transition now (move Pending
+                // bytes that accumulated BEFORE the CR into
+                // TailMask for the current row).
+                if state.PendingCRDeferred then
+                    state.PendingCRDeferred <- false
+                    let isFollowingLF =
+                        match event with
+                        | Execute b when b = 0x0Auy -> true
+                        | _ -> false
+                    if not isFollowingLF then
+                        let pendingBytes = state.Pending.ToArray()
+                        state.Pending.Clear()
+                        state.TailMask <-
+                            Map.add state.CurrentRow pendingBytes state.TailMask
+                        state.TailMaskTimestamps <-
+                            Map.add state.CurrentRow now state.TailMaskTimestamps
+
                 // Special-case OSC 133 + alt-screen toggle
                 // FIRST since they take priority over any
                 // live-region effect; for everything else
@@ -552,6 +600,19 @@ module LinearTextStream =
                     state.Pending.Add(b)
                     encounteredLF <- true
                     state.CurrentRow <- state.CurrentRow + 1
+
+                | Execute b when b = 0x0Duy ->
+                    // CR. Defer the tail-mask decision to the
+                    // next event (resolved at the top of the
+                    // next iteration). If the next event is LF,
+                    // we have `\r\n` and no tail-mask is needed
+                    // (the LF handler increments CurrentRow).
+                    // Otherwise, the deferred-CR resolver will
+                    // perform the EnterTailMask transition.
+                    // Pre-empt the live-region classifier below
+                    // so it doesn't immediately tail-mask.
+                    state.PendingCRDeferred <- true
+                    handledByOsc133OrAltScreen <- true
 
                 | Print rune ->
                     // Printable Unicode codepoint. Encode as

--- a/src/Terminal.Core/LinearTextStream.fs
+++ b/src/Terminal.Core/LinearTextStream.fs
@@ -703,6 +703,36 @@ module LinearTextStream =
             // committed in idle_quantum_ms.
             let idleElapsed =
                 now - state.LastByteAt
+            let idleElapsedMs =
+                idleElapsed.TotalMilliseconds
+
+            // Hotfix companion — resolve a deferred CR if the
+            // idle quantum has elapsed. The bare-CR-then-silence
+            // pattern is the spinner pause: a chunk ended with
+            // `\r` and no subsequent event has arrived to resolve
+            // the ambiguity. Treat it as bare CR (overwrite-in-
+            // place) and move Pending → TailMask. Timestamp
+            // uses `LastByteAt` (when the CR landed), not `now`,
+            // so the LiveRegionDebounceMs check below sees the
+            // row as already settled and emits the
+            // LiveRegionUpdate this same tick. Without this,
+            // Fact 09 / Fact 14 would never emit a
+            // LiveRegionUpdate while the spinner is paused.
+            if state.PendingCRDeferred
+               && idleElapsedMs >= float state.Parameters.IdleQuantumMs
+            then
+                state.PendingCRDeferred <- false
+                if state.Pending.Count > 0 then
+                    let pendingBytes = state.Pending.ToArray()
+                    state.Pending.Clear()
+                    state.TailMask <-
+                        Map.add state.CurrentRow pendingBytes state.TailMask
+                    state.TailMaskTimestamps <-
+                        Map.add
+                            state.CurrentRow
+                            state.LastByteAt
+                            state.TailMaskTimestamps
+
             let pendingHasContent = state.Pending.Count > 0
 
             // Max-time check: no emit in max_time_without_emit.
@@ -712,8 +742,6 @@ module LinearTextStream =
                 timeSinceEmit.TotalMilliseconds
                 >= float state.Parameters.MaxTimeWithoutEmitMs
 
-            let idleElapsedMs =
-                idleElapsed.TotalMilliseconds
             let idleTriggered =
                 pendingHasContent
                 && idleElapsedMs >= float state.Parameters.IdleQuantumMs

--- a/tests/Tests.Unit/LinearTextStreamTests.fs
+++ b/tests/Tests.Unit/LinearTextStreamTests.fs
@@ -578,13 +578,15 @@ let ``Hotfix — chunk-spanning CR followed by LF in next chunk commits as CRLF 
     // Chunk 1: ends with `\r` (CR deferred at chunk boundary).
     let (_, state) = feed state t0 (ascii "line\r")
     // Chunk 2: starts with `\n`. The deferred CR resolver should see
-    // LF and treat as CRLF (no tail-mask).
+    // LF and treat as CRLF (no tail-mask). The LF marks
+    // encounteredLF; end-of-walk drainPending(unsealed) drains ALL
+    // of Pending (which contains "line" + "\n" + "more") to
+    // Committed. The key invariant for THIS test: "line" must
+    // appear in Committed (proving it wasn't stuck in TailMask).
     let (_, state) = feed state (after 5) (ascii "\nmore")
-    // After chunk 2, Pending has "more" (Print bytes since last seam).
-    // The `\n` in chunk 2 triggered drainPending which committed "line\n".
     let committed = LinearTextStream.getLastBytes state 64
     let text = Encoding.UTF8.GetString committed
-    Assert.Equal("line\n", text)
+    Assert.Equal("line\nmore", text)
 
 [<Fact>]
 let ``Hotfix — chunk-spanning CR followed by NOT-LF in next chunk fires tail-mask transition`` () =

--- a/tests/Tests.Unit/LinearTextStreamTests.fs
+++ b/tests/Tests.Unit/LinearTextStreamTests.fs
@@ -526,3 +526,105 @@ let ``Cycle 35b — hasOsc133Markers resets to false after finalizeHighWaterMark
     Assert.True(LinearTextStream.hasOsc133Markers state)
     let (_, state) = LinearTextStream.finalizeHighWaterMark state
     Assert.False(LinearTextStream.hasOsc133Markers state)
+
+// =====================================================================
+// HOTFIX — bare-CR vs CR-LF disambiguation (RFC §5.3 #3)
+// =====================================================================
+// Pre-existing 34a-era bug: classifyLiveRegion returned EnterTailMask
+// for `\r` unconditionally, but the deferred resolution promised by
+// the `previousEvent` parameter was never implemented in `append`.
+// Result: every cmd / PowerShell output line (`\r\n`-terminated) had
+// its content moved to TailMask on the `\r`, never flushed (cmd
+// doesn't emit OSC 133 sealed seams). NVDA heard nothing.
+//
+// Hotfix: defer the tail-mask transition on CR. Resolve at the next
+// event — LF → CRLF newline (no tail-mask), else → bare CR (perform
+// the deferred tail-mask transition before processing the new event).
+// State persists across chunks so a chunk-boundary `\r` resolves
+// correctly against the next chunk's first event.
+
+[<Fact>]
+let ``Hotfix — CRLF in same chunk commits content to Committed (the regression case)`` () =
+    let state = freshProducer ()
+    // Mimics cmd output: text followed by CR + LF.
+    let (_, state) = feed state t0 (ascii "hi\r\n")
+    // Without the fix: "hi" gets stuck in TailMask; only "\n" reaches
+    // Committed. With the fix: "hi\n" commits to Committed.
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    Assert.Equal("hi\n", text)
+
+[<Fact>]
+let ``Hotfix — bare CR (no LF after) moves Pending to TailMask`` () =
+    let state = freshProducer ()
+    // Spinner pattern: "frame1\rframe2" (no LF).
+    let (_, state) = feed state t0 (ascii "frame1")
+    // After feeding bare CR followed by Print, the bare-CR resolver
+    // should fire on the Print and move "frame1" → TailMask.
+    let (_, state) = feed state (after 5) (ascii "\rframe2")
+    // Committed has nothing (no seam crossed); TailMask holds "frame1".
+    let committed = LinearTextStream.getLastBytes state 64
+    Assert.Equal(0, committed.Length)
+    // Sealed drain (OSC 133 PromptStart) flushes TailMask LATEST into
+    // Committed. With LATEST semantics, "frame1" should appear.
+    let (_, state) = feed state (after 10) (osc133Prompt ())
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    Assert.Contains("frame1", text)
+
+[<Fact>]
+let ``Hotfix — chunk-spanning CR followed by LF in next chunk commits as CRLF newline`` () =
+    let state = freshProducer ()
+    // Chunk 1: ends with `\r` (CR deferred at chunk boundary).
+    let (_, state) = feed state t0 (ascii "line\r")
+    // Chunk 2: starts with `\n`. The deferred CR resolver should see
+    // LF and treat as CRLF (no tail-mask).
+    let (_, state) = feed state (after 5) (ascii "\nmore")
+    // After chunk 2, Pending has "more" (Print bytes since last seam).
+    // The `\n` in chunk 2 triggered drainPending which committed "line\n".
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    Assert.Equal("line\n", text)
+
+[<Fact>]
+let ``Hotfix — chunk-spanning CR followed by NOT-LF in next chunk fires tail-mask transition`` () =
+    let state = freshProducer ()
+    // Chunk 1: "frame1" ends with `\r`.
+    let (_, state) = feed state t0 (ascii "frame1\r")
+    // Chunk 2: starts with `frame2` (a Print, not LF). Deferred CR
+    // should resolve as bare CR → move "frame1" to TailMask.
+    let (_, state) = feed state (after 5) (ascii "frame2\n")
+    // After chunk 2: "frame2\n" committed (LF seam fired); TailMask
+    // has "frame1" awaiting a sealed drain.
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    Assert.Equal("frame2\n", text)
+    Assert.DoesNotContain("frame1", text)
+
+[<Fact>]
+let ``Hotfix — multiple CRLF lines all commit (cmd output regression)`` () =
+    let state = freshProducer ()
+    // Mimics a cmd `dir` output: multiple CRLF-terminated lines.
+    let cmdOutput = "  Volume in drive C\r\n  Directory of C:\\\r\n\r\n01/01/2026\r\n"
+    let (_, state) = feed state t0 (ascii cmdOutput)
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    // All four lines should have committed; the LFs become row
+    // boundaries. The CRs themselves are not in Committed (not
+    // added to Pending in any case).
+    Assert.Contains("Volume in drive C", text)
+    Assert.Contains("Directory of C:\\", text)
+    Assert.Contains("01/01/2026", text)
+
+[<Fact>]
+let ``Hotfix — empty chunk after deferred CR keeps the deferral pending`` () =
+    let state = freshProducer ()
+    let (_, state) = feed state t0 (ascii "x\r")
+    // Feeding an empty chunk: no events to resolve the deferred CR.
+    // PendingCRDeferred should still be true; Pending still holds "x".
+    let (_, state) = feed state (after 5) [||]
+    // Now feed LF — should resolve as CRLF, commit "x\n".
+    let (_, state) = feed state (after 10) (ascii "\n")
+    let committed = LinearTextStream.getLastBytes state 64
+    let text = Encoding.UTF8.GetString committed
+    Assert.Equal("x\n", text)


### PR DESCRIPTION
## Summary

Pre-existing **34a-era bug** that surfaced after Cycle 35b's `substrate_mode = "auto"` default flip routed Linear-substrate output for non-alt-screen frames. Fixes a **systemic regression** where NVDA hears no output across cmd / PowerShell / Claude (confirmed via diagnostic battery: `EVENTS (0)`, `FAIL — missing=StreamChunk`, empty linear-stream sibling file in `Ctrl+Shift+D` bundle).

## Root cause

[`src/Terminal.Core/LinearTextStream.fs`](src/Terminal.Core/LinearTextStream.fs) `classifyLiveRegion` (lines 318-351) returned `EnterTailMask` for `\r` unconditionally. The deferred resolution promised by the `previousEvent` parameter ("RFC §5.3 #3 — \\r alone is tail-mask; \\r\\n is just a newline") **was never implemented in `append`**. Every `\r` immediately moved `Pending` → `TailMask`.

For cmd / PowerShell output (always `\r\n`-terminated): the `\r` moved content into TailMask; the LF added 1 byte to a fresh Pending; end-of-walk drained 1 byte (`\n`) to Committed. The actual content stayed stuck in TailMask forever (cmd doesn't emit OSC 133 sealed seams that flush TailMask). `LinearTextStream.Committed` only ever held bare `\n` bytes; `assembleSuffixFromStream` decoded these to whitespace the sanitiser stripped; NVDA was silent.

The bug existed since Cycle 34a but was masked by Cycle 35a's default-off `screen-diff` substrate. Cycle 35b's flip to `auto` exposed it across all shells.

## Fix

Defer the tail-mask transition on `\r`. New `PendingCRDeferred: bool` field on producer State; set when CR arrives. The next event resolves:

- **CR + LF** → CRLF newline, no tail-mask. Clear flag; LF handler runs normally.
- **CR + anything else** (Print, CSI, OSC) → bare CR, overwrite-in-place. Perform the deferred `Pending` → `TailMask` transition before processing the new event.

Flag persists across chunks: a chunk ending with `\r` keeps the flag set so the FIRST event of the next chunk resolves the ambiguity.

## Tests

6 new facts in [`tests/Tests.Unit/LinearTextStreamTests.fs`](tests/Tests.Unit/LinearTextStreamTests.fs):

| # | Test | Pin |
|---|---|---|
| 1 | CRLF in same chunk commits content to Committed | The regression case — `"hi\r\n"` → `Committed = "hi\n"`. |
| 2 | Bare CR (no LF after) moves Pending to TailMask | Spinner-pattern preservation. |
| 3 | Chunk-spanning CR + LF in next chunk | CRLF resolves across chunk boundary. |
| 4 | Chunk-spanning CR + Print in next chunk | Bare CR resolves across chunk boundary. |
| 5 | Multiple CRLF lines all commit | The `dir` output regression case. |
| 6 | Empty chunk after deferred CR keeps deferral pending | Flag persists across no-event chunks. |

## Sequencing with PR #248

This hotfix lands **before** PR #248 (Cycle 37b — UIA listbox peer) per the maintainer's choice. After both merge, the maintainer can run the Cycle 37 NVDA validation matrix without needing the `substrate_mode = "screen-diff"` workaround.

## Test plan

- [ ] `Build and test (windows-latest)` green — 6 new LinearTextStreamTests facts + existing 935+ tests stay green.
- [ ] `Workflow lint`, `Portability lint`, `Markdown link check` green.
- [ ] **Maintainer dogfood post-merge**: rebuild release; press `Ctrl+Shift+D`; run `T1.Plain` battery; verify `Pass=1 Fail=0`. Run `dir` in cmd; verify NVDA announces output. Run a Claude prompt; verify NVDA announces response.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_