### PR TITLE
feat(cycle-38a): canonical interaction-pair corpus + diagnostic battery integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,81 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 38a): Canonical interaction-pair corpus + diagnostic battery integration
+
+Regression scaffolding for the cmd / PowerShell / Claude per-shell
+parser-route refactors landing in Cycles 38b-e. The 35b regression
+went undetected for ~3 cycles (PR #249 hotfix); this cycle introduces
+a curated `(bytes-in, expected-NVDA-out)` corpus that the
+`Ctrl+Shift+D` battery loads and runs against the active shell so
+future substrate flips can't silently break announcement.
+
+**New module**:
+[`src/Terminal.Core/CanonicalCorpus.fs`](src/Terminal.Core/CanonicalCorpus.fs)
+defines the `Scenario` record + TOML parser. The schema is
+**tiered**: required v1 fields (id / shell / description / command /
+must_include / must_not_include / quiescence_ms / timeout_ms)
+match `Diagnostics.DiagnosticTest`'s shape exactly so the runner
+reuses `runOneTest`'s capture pipeline. Optional v2 extension
+fields (`setup_command`, `expected_payload_regex`,
+`expected_session_tuple`, `expected_pane_routing`, `notes`) are
+parsed but not yet enforced — subsequent sub-cycles promote each
+to load-bearing.
+
+**Seed corpus**:
+[`tests/fixtures/canonical-interactions.toml`](tests/fixtures/canonical-interactions.toml)
+ships 12 cmd scenarios drawn from real workflows + the existing
+Cycle 36 matrix:
+
+- `cmd.echo.plain`, `cmd.dir.simple`, `cmd.dir.large`
+- `cmd.exit.success`, `cmd.exit.failure`
+- `cmd.set.userprompt` (Read-Host equivalent)
+- `cmd.choice.yn` (selection prompt — currently fails because
+  `SelectionDetector` is shellKey-gated to claude; tagged for 38e)
+- `cmd.cls.alt`, `cmd.echo.color.benign`, `cmd.echo.color.error`
+- `cmd.multiline.continuation`, `cmd.tab.completion`
+
+Scenarios where current behaviour is wrong carry
+`notes = "Bug 2026-05-10: …; fixed in <sub-cycle>"`; the assertion
+lists what NVDA CURRENTLY hears so the corpus stays green at HEAD
+and the bug-fix sub-cycle has to update both code and assertion
+atomically.
+
+**Diagnostic battery integration**:
+[`src/Terminal.App/Diagnostics.fs`](src/Terminal.App/Diagnostics.fs)
+gains `runOneScenario` (mirrors `runOneTest` but with per-scenario
+`QuiescenceMs` / `TimeoutMs` rather than the hard-coded 200/1500),
+`runCorpus` (filters scenarios for active shell, runs each), and
+extends `formatDiagnosticBundle` with a new
+`--- CANONICAL CORPUS RESULTS ---` section. The corpus TOML is
+deployed next to `Terminal.App.exe` via Content + CopyToOutput in
+[`src/Terminal.App/Terminal.App.fsproj`](src/Terminal.App/Terminal.App.fsproj);
+runtime resolves it via `AppContext.BaseDirectory`. Failure to
+load the corpus (missing file, parse error) is non-fatal — the
+bundle just renders an explanatory section.
+
+**Tests**:
+[`tests/Tests.Unit/CanonicalCorpusTests.fs`](tests/Tests.Unit/CanonicalCorpusTests.fs)
+adds 12 facts pinning required-field round-trip, optional-field
+round-trip, missing-required-field error, unknown
+`SemanticCategory` error, unknown `expected_pane_routing` error,
+empty document, multiple-scenarios ordering, default
+`quiescence_ms` / `timeout_ms`, `formatScenarioResult` shape,
+`formatCorpusResultsForBundle` summary, empty-results summary.
+
+**Docs**:
+[`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+gains a `### Cycle 38a — Canonical interaction corpus baseline`
+section with schema reference, the sub-cycle promotion table, a
+5-row manual matrix for the dogfood loop, and the stopping gate.
+
+**What 38a does NOT do**: per-shell route table (38b);
+echo-suppression for cmd (38c); three-pane channel routing (38d);
+PowerShell or Claude scenarios (38b/e); NVDA verbatim-text matching
+(parsed but not yet evaluated by `runCorpus`); CI gating on corpus
+results (post-38e once the corpus is comprehensive enough that
+random regressions are noise rather than design).
+
 ### Fixed (Hotfix): LinearTextStream bare-CR vs CR-LF disambiguation regression
 
 Pre-existing 34a-era bug surfaced after Cycle 35b's `substrate_mode = "auto"`

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1235,6 +1235,72 @@ matrix's shrinking surface area over time.
   the producer side (pattern present + GetText returns a snapshot
   with the expected length floor) is now CI-pinned.
 
+### Cycle 38a — Canonical interaction corpus baseline
+
+Cycle 38a is the **regression scaffolding** for the cmd / PowerShell
+/ Claude per-shell parser-route work landing in 38b-e. It introduces
+a curated catalogue of `(bytes-in, expected-NVDA-out)` scenarios in
+[`tests/fixtures/canonical-interactions.toml`](../tests/fixtures/canonical-interactions.toml)
+that the `Ctrl+Shift+D` battery loads and runs against the active
+shell, reporting per-scenario PASS / FAIL in a new
+`--- CANONICAL CORPUS RESULTS ---` section in the bundle.
+
+**No behaviour change in 38a.** The corpus captures CURRENT
+behaviour as the baseline. Subsequent sub-cycles flip individual
+scenarios from FAIL → PASS as they fix the relevant pipeline
+behaviour:
+
+| Sub-cycle | Adds | Scenarios it makes load-bearing |
+|---|---|---|
+| 38b | Per-shell route table + PowerShell scenarios | `expected_session_tuple` (exit-code capture) |
+| 38c | Cmd input-echo suppression | `cmd.echo.plain`, `cmd.set.userprompt`, `expected_payload_regex` |
+| 38d | Three-sub-pane channel routing | `expected_pane_routing` (input / current_output / history) |
+| 38e | Claude scenarios + per-shell hardening | `cmd.choice.yn` (cross-shell SelectionShown) |
+
+**Corpus schema reference.** Each `[[scenario]]` table requires
+`id`, `shell`, `description`, `command`, `must_include`,
+`must_not_include`. Optional defaults: `quiescence_ms` (200),
+`timeout_ms` (1500). Optional v2 extensions parsed but not yet
+enforced in 38a: `setup_command`, `expected_payload_regex`,
+`expected_session_tuple`, `expected_pane_routing`, `notes`. Valid
+`SemanticCategory` values come from
+[`src/Terminal.Core/OutputEventTypes.fs`](../src/Terminal.Core/OutputEventTypes.fs)
+`type SemanticCategory` (lines 42-111).
+
+**Adding a scenario.** Edit the TOML file, rebuild, press
+`Ctrl+Shift+D`, look at the new section in the bundle. If the
+scenario reports PASS but the actual NVDA experience is wrong,
+the assertion is wrong — adjust `must_include` /
+`must_not_include` to reflect reality and add a `notes` field
+describing the gap.
+
+**Bug-tagged scenarios.** Scenarios where current behaviour is
+known-wrong carry `notes = "Bug 2026-05-XX: <gap>; fixed in
+<sub-cycle>"`. The assertion lists what NVDA CURRENTLY hears so
+the corpus stays green; the bug-fix sub-cycle has to update both
+the code and the assertion atomically.
+
+**Reading the bundle section.** The header `CORPUS: 9 PASS / 3
+FAIL / 12 total` summarises counts. Each scenario block shows id,
+elapsed ms, must_include / must_not_include sets, observed
+semantic categories, and notes (if present). FAIL scenarios get a
+reason after the elapsed time (`missing=…`, `unexpected=…`, or
+`no quiescence within Nms`).
+
+**Manual matrix row (Cycle 38a):**
+
+| Test | Procedure | Expected |
+|---|---|---|
+| 38a.1 — Corpus runs from Ctrl+Shift+D | Open cmd in pty-speak, press Ctrl+Shift+D, wait ~10 seconds | Bundle file in `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\` contains `--- CANONICAL CORPUS RESULTS ---` section. Section starts with `CORPUS: <P> PASS / <F> FAIL / 12 total`. |
+| 38a.2 — Per-scenario reporting | Read each of the 12 scenario blocks in the bundle | Each scenario block shows `[PASS]` or `[FAIL]` with elapsed ms; observed semantics line; notes line for `Bug:`-tagged scenarios. |
+| 38a.3 — PowerShell skip | Switch to PowerShell with Ctrl+Shift+2; press Ctrl+Shift+D | Bundle reports `CORPUS: 0 PASS / 0 FAIL / 0 total` (no PowerShell scenarios in 38a; these arrive in 38b). |
+| 38a.4 — Claude skip | Switch to Claude with Ctrl+Shift+3; press Ctrl+Shift+D | Same as 38a.3 — no Claude scenarios in 38a; these arrive in 38e. |
+| 38a.5 — Behavioural calibration | For each `cmd.*` scenario in the bundle, run the same command manually in cmd and confirm the reported PASS / FAIL matches what NVDA actually does | Discrepancies → fixup commit on the PR adjusting the scenario's assertions until baseline matches reality. |
+
+**Stopping gate for 38a.** Maintainer-acknowledged baseline + bundle
+integration working. Subsequent sub-cycles use this baseline as
+their regression net.
+
 ## Why this is manual
 
 CI tests run on a Windows runner with no logged-in interactive

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -879,6 +879,7 @@ module Diagnostics =
             (configPath: string)
             (sessionLogSummary: string)
             (linearStreamSection: string)
+            (corpusResultsSection: string)
             : string =
         let sb = StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
@@ -933,6 +934,16 @@ module Diagnostics =
         appendLine linearStreamSection
         appendLine ""
 
+        // Cycle 38a — canonical interaction-pair corpus results.
+        // The runner ran the active shell's scenarios from
+        // `canonical-interactions.toml` (deployed next to the .exe);
+        // this section reports per-scenario PASS / FAIL with the
+        // observed `SemanticCategory` events. Empty body if the
+        // corpus file is missing or no scenarios match the shell.
+        appendLine "--- CANONICAL CORPUS RESULTS ---"
+        appendLine corpusResultsSection
+        appendLine ""
+
         appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"
         appendLine (formatEnvironmentRedacted ())
         appendLine ""
@@ -968,6 +979,183 @@ module Diagnostics =
                 "Diagnostic snapshot file write failed at {Path}: {Message}",
                 path, ex.Message)
             None
+
+    // ---------------------------------------------------------------
+    // Cycle 38a — canonical interaction-pair corpus runner
+    // ---------------------------------------------------------------
+
+    /// Resolve the canonical-corpus TOML path. Lives next to the
+    /// Terminal.App.exe at runtime (Content + CopyToOutputDirectory
+    /// in `Terminal.App.fsproj`); the source-of-truth file lives at
+    /// `tests/fixtures/canonical-interactions.toml` in the repo and
+    /// is `<Link>`-flattened on copy. Returns `None` if the file
+    /// isn't present (e.g. running an older build where the corpus
+    /// hadn't shipped yet).
+    let private resolveCorpusPath () : string option =
+        let path =
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "canonical-interactions.toml")
+        if File.Exists(path) then Some path else None
+
+    /// Filter a Scenario array down to the entries matching the
+    /// active shell's identifier. Maps `ShellRegistry.ShellId`
+    /// values to the corpus's lower-case shell-key strings —
+    /// mirrors the `shellIdToConfigKey` pattern in `Program.fs:1141`.
+    let private filterScenariosForShell
+            (shellId: ShellRegistry.ShellId)
+            (scenarios: CanonicalCorpus.Scenario[])
+            : CanonicalCorpus.Scenario[] =
+        let shellKey =
+            match shellId with
+            | ShellRegistry.Cmd -> "cmd"
+            | ShellRegistry.PowerShell -> "powershell"
+            | ShellRegistry.Claude -> "claude"
+        scenarios
+        |> Array.filter (fun s -> s.Shell = shellKey)
+
+    /// Run one scenario. Mirrors `runOneTest`'s shape but takes the
+    /// per-scenario `QuiescenceMs` / `TimeoutMs` parameters from
+    /// the Scenario record rather than the hard-coded 200/1500
+    /// `runOneTest` uses. Returns a `ScenarioResult` (no Boolean —
+    /// the caller assembles the bundle).
+    let private runOneScenario
+            (writer: DiagnosticLogWriter)
+            (writeBytes: byte[] -> Task)
+            (resolveSeq: unit -> int64)
+            (scenario: CanonicalCorpus.Scenario)
+            : Task<CanonicalCorpus.ScenarioResult> =
+        task {
+            let cat = sprintf "Diagnostic.Corpus.%s" scenario.Id
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "BEGIN %s" scenario.Description)
+            let tap = DiagnosticEventTap()
+            // Setup phase (optional).
+            match scenario.SetupCommand with
+            | Some setupCmd ->
+                let setupBytes = commandBytes setupCmd
+                writer.WriteLine LogLevel.Information cat
+                    (sprintf "SETUP %s" (hexDump setupBytes))
+                tap.Enable()
+                do! writeBytes setupBytes
+                let! settled, elapsed =
+                    waitForQuiescence
+                        resolveSeq
+                        scenario.QuiescenceMs
+                        scenario.TimeoutMs
+                let setupEvents = tap.DisableAndDrain()
+                writer.WriteLine LogLevel.Information cat
+                    (sprintf "SETUP_RESULT settled=%b elapsedMs=%d events=%d"
+                         settled elapsed setupEvents.Length)
+            | None -> ()
+            // Main phase.
+            let mainBytes = commandBytes scenario.Command
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "WRITE %s" (hexDump mainBytes))
+            tap.Enable()
+            let started = DateTimeOffset.UtcNow
+            do! writeBytes mainBytes
+            let! settled, _ =
+                waitForQuiescence
+                    resolveSeq
+                    scenario.QuiescenceMs
+                    scenario.TimeoutMs
+            let events = tap.DisableAndDrain()
+            let elapsedMs =
+                int (DateTimeOffset.UtcNow - started).TotalMilliseconds
+            let semantics =
+                events |> Array.map (fun ev -> ev.Semantic)
+            let payloads =
+                events |> Array.map (fun ev -> ev.Payload)
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "WAIT settled=%b elapsedMs=%d" settled elapsedMs)
+            writer.WriteLine LogLevel.Information cat
+                (sprintf "EVENTS (%d): %s"
+                     events.Length
+                     (events
+                      |> Array.map formatEvent
+                      |> String.concat " | "))
+            // Evaluate must_include / must_not_include.
+            let missing =
+                scenario.MustInclude
+                |> Array.filter (fun s -> not (Array.contains s semantics))
+            let unexpected =
+                scenario.MustNotInclude
+                |> Array.filter (fun s -> Array.contains s semantics)
+            let outcome : CanonicalCorpus.ScenarioOutcome =
+                if not settled then
+                    CanonicalCorpus.Fail
+                        (sprintf "no quiescence within %dms" scenario.TimeoutMs)
+                elif not (Array.isEmpty missing) then
+                    let names =
+                        missing
+                        |> Array.map (sprintf "%A")
+                        |> String.concat ","
+                    CanonicalCorpus.Fail (sprintf "missing=%s" names)
+                elif not (Array.isEmpty unexpected) then
+                    let names =
+                        unexpected
+                        |> Array.map (sprintf "%A")
+                        |> String.concat ","
+                    CanonicalCorpus.Fail (sprintf "unexpected=%s" names)
+                else
+                    CanonicalCorpus.Pass
+            let outcomeMsg =
+                match outcome with
+                | CanonicalCorpus.Pass -> "PASS"
+                | CanonicalCorpus.Fail r -> sprintf "FAIL — %s" r
+            writer.WriteLine
+                (match outcome with
+                 | CanonicalCorpus.Pass -> LogLevel.Information
+                 | _ -> LogLevel.Warning)
+                cat outcomeMsg
+            return
+                { Scenario = scenario
+                  Outcome = outcome
+                  ObservedSemantics = semantics
+                  ObservedPayloads = payloads
+                  ElapsedMs = elapsedMs }
+        }
+
+    /// Run the canonical-corpus scenarios for the active shell.
+    /// Returns `Ok results` on success or `Error message` if the
+    /// corpus file is missing or malformed (the caller emits a
+    /// short bundle section in that case).
+    let private runCorpus
+            (writer: DiagnosticLogWriter)
+            (writeBytes: byte[] -> Task)
+            (resolveSeq: unit -> int64)
+            (shellId: ShellRegistry.ShellId)
+            : Task<Result<CanonicalCorpus.ScenarioResult[], string>> =
+        task {
+            match resolveCorpusPath () with
+            | None ->
+                writer.WriteLine LogLevel.Information "Diagnostic.Corpus"
+                    "Corpus file not found next to executable; section omitted."
+                return Error "canonical-interactions.toml not found"
+            | Some path ->
+                writer.WriteLine LogLevel.Information "Diagnostic.Corpus"
+                    (sprintf "Loading corpus from %s" path)
+                match CanonicalCorpus.loadCanonicalCorpus path with
+                | Error e ->
+                    writer.WriteLine LogLevel.Warning "Diagnostic.Corpus"
+                        (sprintf "Corpus parse error: %s" e)
+                    return Error e
+                | Ok scenarios ->
+                    let filtered =
+                        filterScenariosForShell shellId scenarios
+                    writer.WriteLine LogLevel.Information "Diagnostic.Corpus"
+                        (sprintf
+                            "Loaded %d scenarios; %d match active shell %A."
+                            scenarios.Length filtered.Length shellId)
+                    let results = ResizeArray<CanonicalCorpus.ScenarioResult>()
+                    for scenario in filtered do
+                        let! r =
+                            runOneScenario
+                                writer writeBytes resolveSeq scenario
+                        results.Add(r)
+                    return Ok (results.ToArray())
+        }
 
     // ---------------------------------------------------------------
     // Main entry — runFullBattery
@@ -1081,6 +1269,26 @@ module Diagnostics =
                     log.LogInformation(
                         "Diagnostic battery complete. Pass={Pass} Fail={Fail} Total={Total}",
                         pass, fail, total)
+
+                    // Cycle 38a — canonical interaction-pair corpus
+                    // run. Independent of the existing per-shell
+                    // `DiagnosticTest` battery: the corpus targets
+                    // a curated catalogue of (bytes-in,
+                    // expected-NVDA-out) scenarios that grow over
+                    // sub-cycles 38b-e. Failure to load the corpus
+                    // (missing file, parse error) is non-fatal —
+                    // the bundle just renders an explanatory
+                    // section rather than aborting the battery.
+                    let! corpusResultOuter =
+                        runCorpus writer writeBytes resolveSeq shell.Id
+                    let corpusResultsSection =
+                        match corpusResultOuter with
+                        | Ok results ->
+                            CanonicalCorpus.formatCorpusResultsForBundle results
+                        | Error msg ->
+                            sprintf
+                                "(corpus skipped: %s)"
+                                msg
                     // Close the writer BEFORE reading the file for clipboard.
                     (writer :> IDisposable).Dispose()
                     // Read the diagnostic log content for clipboard. Same
@@ -1199,6 +1407,7 @@ module Diagnostics =
                             configPath
                             sessionLogSummary
                             linearStreamSection
+                            corpusResultsSection
                     let writtenPath = writeSnapshotFile log snapshotPath bundle
                     let savedFragment =
                         match writtenPath with

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -1109,12 +1109,13 @@ module Diagnostics =
                  | CanonicalCorpus.Pass -> LogLevel.Information
                  | _ -> LogLevel.Warning)
                 cat outcomeMsg
-            return
+            let result : CanonicalCorpus.ScenarioResult =
                 { Scenario = scenario
                   Outcome = outcome
                   ObservedSemantics = semantics
                   ObservedPayloads = payloads
                   ElapsedMs = elapsedMs }
+            return result
         }
 
     /// Run the canonical-corpus scenarios for the active shell.

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -47,6 +47,19 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>test-process-cleanup.ps1</Link>
     </Content>
+    <!--
+      Cycle 38a — canonical interaction-pair corpus. The TOML
+      file lives in `tests/fixtures/` (alongside other planned
+      replay fixtures per `docs/ACCESSIBILITY-TESTING.md:50-69`)
+      and is copied flat next to Terminal.App.exe so the
+      Ctrl+Shift+D battery can resolve it via
+      `AppContext.BaseDirectory + canonical-interactions.toml`.
+      Velopack pack picks it up automatically.
+    -->
+    <Content Include="..\..\tests\fixtures\canonical-interactions.toml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>canonical-interactions.toml</Link>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Terminal.Core/CanonicalCorpus.fs
+++ b/src/Terminal.Core/CanonicalCorpus.fs
@@ -321,7 +321,7 @@ module CanonicalCorpus =
                                             id shell command
                                             mustInclude mustNotInclude
                                             regex tuple pane
-                                            table)))))))))
+                                            table))))))))
 
     // -----------------------------------------------------------
     // Public API

--- a/src/Terminal.Core/CanonicalCorpus.fs
+++ b/src/Terminal.Core/CanonicalCorpus.fs
@@ -1,0 +1,437 @@
+namespace Terminal.Core
+
+open System
+open System.IO
+open Tomlyn
+open Tomlyn.Model
+
+/// Cycle 38a — canonical interaction-pair corpus.
+///
+/// Loads a TOML file (typically
+/// `tests/fixtures/canonical-interactions.toml`) containing curated
+/// `(bytes-in, expected-NVDA-out)` scenarios used by the
+/// `Ctrl+Shift+D` diagnostic battery as a regression net for the
+/// per-shell parser-route refactors landing in Cycles 38b-e.
+///
+/// **Tiered schema** (per maintainer 2026-05-10). Required v1 fields
+/// match `Diagnostics.DiagnosticTest`'s shape exactly so the runner
+/// in `Diagnostics.fs` can reuse `runOneTest`'s capture pipeline
+/// without reshaping. Optional v2 extension fields are parsed but
+/// not yet enforced by `runCorpus` in Cycle 38a; subsequent sub-
+/// cycles promote each to load-bearing:
+///
+/// - `expected_payload_regex` — Cycle 38c (echo-suppression validation).
+/// - `expected_session_tuple` — Cycle 38b (per-shell route + tuple capture).
+/// - `expected_pane_routing` — Cycle 38d (three-sub-pane channel routing).
+///
+/// **Tomlyn API.** Mirrors `Config.fs:348-377` helper patterns. Uses
+/// `TomlTable` for sub-tables, `TomlArray` for value arrays,
+/// `TomlTableArray` for `[[scenario]]` array-of-tables.
+module CanonicalCorpus =
+
+    /// Cycle 38d extension — three-sub-pane channel routing
+    /// identifier. Parsed in 38a so corpus authors can annotate
+    /// scenarios; not yet honoured by `runCorpus` (the channel-
+    /// layer routing wires through in 38d).
+    type PaneRouting =
+        | Input
+        | CurrentOutput
+        | History
+
+    /// Cycle 38b extension — expected SessionModel tuple shape
+    /// after the scenario completes. Mirrors `RecentTupleView`
+    /// shape from `Diagnostics.fs:106-148`. Each field is optional
+    /// so a scenario can pin only the parts it cares about (e.g.
+    /// `cmd.exit.failure` pins `ExitCode = Some 1` and leaves the
+    /// text fields unbound).
+    type SessionTupleExpectation =
+        { CommandText: string option
+          OutputText: string option
+          ExitCode: int option }
+
+    /// One canonical interaction-pair scenario, parsed from a
+    /// `[[scenario]]` TOML table.
+    type Scenario =
+        { Id: string
+          Shell: string
+          Description: string
+          Command: string
+          MustInclude: SemanticCategory[]
+          MustNotInclude: SemanticCategory[]
+          QuiescenceMs: int
+          TimeoutMs: int
+          SetupCommand: string option
+          ExpectedPayloadRegex: string[]
+          ExpectedSessionTuple: SessionTupleExpectation option
+          ExpectedPaneRouting: PaneRouting option
+          Notes: string option }
+
+    /// Outcome of running one scenario.
+    type ScenarioOutcome =
+        | Pass
+        | Fail of reason: string
+
+    /// Result captured for one scenario after `runCorpus`. Even
+    /// on FAIL we capture the observed semantic categories +
+    /// payloads so the bundle output is diagnostically useful
+    /// (the maintainer can read what NVDA actually heard versus
+    /// what was expected).
+    type ScenarioResult =
+        { Scenario: Scenario
+          Outcome: ScenarioOutcome
+          ObservedSemantics: SemanticCategory[]
+          ObservedPayloads: string[]
+          ElapsedMs: int }
+
+    // -----------------------------------------------------------
+    // Internals — TOML helpers (mirror Config.fs:348-377)
+    // -----------------------------------------------------------
+
+    let private tryGetInt (table: TomlTable) (key: string) : int64 option =
+        match table.TryGetValue(key) with
+        | true, (:? int64 as i) -> Some i
+        | _ -> None
+
+    let private tryGetString (table: TomlTable) (key: string) : string option =
+        match table.TryGetValue(key) with
+        | true, (:? string as s) -> Some s
+        | _ -> None
+
+    let private tryGetTable (table: TomlTable) (key: string) : TomlTable option =
+        match table.TryGetValue(key) with
+        | true, (:? TomlTable as t) -> Some t
+        | _ -> None
+
+    /// Read a string array. Returns `Error` if the key is present
+    /// but ANY element is non-string, so the corpus author gets a
+    /// loud failure rather than a silently-truncated array.
+    let private tryGetStringArray
+            (table: TomlTable)
+            (key: string)
+            : Result<string[] option, string> =
+        match table.TryGetValue(key) with
+        | true, (:? TomlArray as arr) ->
+            let buf = ResizeArray<string>()
+            let mutable badIndex: int option = None
+            let mutable i = 0
+            for item in arr do
+                match item with
+                | :? string as s -> buf.Add(s)
+                | _ -> if badIndex.IsNone then badIndex <- Some i
+                i <- i + 1
+            match badIndex with
+            | Some idx ->
+                Error (sprintf "%s[%d]: expected string" key idx)
+            | None -> Ok (Some (buf.ToArray()))
+        | true, _ -> Error (sprintf "%s: expected array of strings" key)
+        | _ -> Ok None
+
+    /// Map a `SemanticCategory` string name to the DU value.
+    /// Returns `None` for unknown names so the caller can surface
+    /// a context-prefixed parse error. Catalog mirrors
+    /// `OutputEventTypes.fs:42-111`. `Custom of string` is
+    /// deliberately excluded — corpus scenarios should not target
+    /// user-extension categories in v1.
+    let private semanticCategoryFromString
+            (name: string)
+            : SemanticCategory option =
+        match name with
+        | "StreamChunk" -> Some SemanticCategory.StreamChunk
+        | "SelectionShown" -> Some SemanticCategory.SelectionShown
+        | "SelectionItem" -> Some SemanticCategory.SelectionItem
+        | "SelectionDismissed" -> Some SemanticCategory.SelectionDismissed
+        | "SpinnerTick" -> Some SemanticCategory.SpinnerTick
+        | "ErrorLine" -> Some SemanticCategory.ErrorLine
+        | "WarningLine" -> Some SemanticCategory.WarningLine
+        | "PromptDetected" -> Some SemanticCategory.PromptDetected
+        | "CommandSubmitted" -> Some SemanticCategory.CommandSubmitted
+        | "BellRang" -> Some SemanticCategory.BellRang
+        | "HyperlinkOpened" -> Some SemanticCategory.HyperlinkOpened
+        | "AltScreenEntered" -> Some SemanticCategory.AltScreenEntered
+        | "ModeBarrier" -> Some SemanticCategory.ModeBarrier
+        | "ParserError" -> Some SemanticCategory.ParserError
+        | _ -> None
+
+    let private parsePaneRouting (s: string) : PaneRouting option =
+        match s with
+        | "input" -> Some Input
+        | "current_output" -> Some CurrentOutput
+        | "history" -> Some History
+        | _ -> None
+
+    /// Parse a `must_include` / `must_not_include` array. Each
+    /// element must be a known `SemanticCategory` name. Returns
+    /// `Error` on first unknown name with a context-prefixed
+    /// message.
+    let private parseSemanticArray
+            (scenarioId: string)
+            (field: string)
+            (table: TomlTable)
+            : Result<SemanticCategory[], string> =
+        match tryGetStringArray table field with
+        | Error e -> Error (sprintf "scenario %s.%s" scenarioId e)
+        | Ok None -> Ok [||]
+        | Ok (Some names) ->
+            let mutable err: string option = None
+            let mapped =
+                names
+                |> Array.choose (fun name ->
+                    match semanticCategoryFromString name with
+                    | Some s -> Some s
+                    | None ->
+                        if err.IsNone then
+                            err <-
+                                Some
+                                    (sprintf
+                                        "scenario %s.%s: unknown SemanticCategory \"%s\""
+                                        scenarioId field name)
+                        None)
+            match err with
+            | Some e -> Error e
+            | None -> Ok mapped
+
+    let private parseSessionTuple
+            (scenarioId: string)
+            (table: TomlTable)
+            : Result<SessionTupleExpectation option, string> =
+        match tryGetTable table "expected_session_tuple" with
+        | None -> Ok None
+        | Some t ->
+            let exitCode =
+                tryGetInt t "exit_code"
+                |> Option.map int
+            let expectation =
+                { CommandText = tryGetString t "command_text"
+                  OutputText = tryGetString t "output_text"
+                  ExitCode = exitCode }
+            Ok (Some expectation)
+
+    /// Parse the optional `expected_pane_routing` field. Returns
+    /// `Ok None` if absent, `Ok (Some r)` if present with a known
+    /// value, `Error` for unknown values.
+    let private parseExpectedPaneRouting
+            (scenarioId: string)
+            (table: TomlTable)
+            : Result<PaneRouting option, string> =
+        match tryGetString table "expected_pane_routing" with
+        | None -> Ok None
+        | Some s ->
+            match parsePaneRouting s with
+            | Some r -> Ok (Some r)
+            | None ->
+                Error
+                    (sprintf
+                        "scenario %s.expected_pane_routing: unknown value \"%s\" (expected: input | current_output | history)"
+                        scenarioId s)
+
+    /// Parse the optional `expected_payload_regex` array. Returns
+    /// `Ok [||]` if absent, `Ok arr` if present and well-formed,
+    /// `Error` if the value is malformed (non-array or non-string
+    /// element).
+    let private parseExpectedPayloadRegex
+            (scenarioId: string)
+            (table: TomlTable)
+            : Result<string[], string> =
+        match tryGetStringArray table "expected_payload_regex" with
+        | Error e -> Error (sprintf "scenario %s.%s" scenarioId e)
+        | Ok None -> Ok [||]
+        | Ok (Some arr) -> Ok arr
+
+    /// Assemble the Scenario record from already-validated pieces.
+    /// Pure helper; never returns `Error`.
+    let private buildScenario
+            (id: string)
+            (shell: string)
+            (command: string)
+            (mustInclude: SemanticCategory[])
+            (mustNotInclude: SemanticCategory[])
+            (expectedPayloadRegex: string[])
+            (expectedSessionTuple: SessionTupleExpectation option)
+            (expectedPaneRouting: PaneRouting option)
+            (table: TomlTable)
+            : Scenario =
+        let description =
+            tryGetString table "description"
+            |> Option.defaultValue ""
+        let setupCommand = tryGetString table "setup_command"
+        let notes = tryGetString table "notes"
+        let quiescenceMs =
+            tryGetInt table "quiescence_ms"
+            |> Option.map int
+            |> Option.defaultValue 200
+        let timeoutMs =
+            tryGetInt table "timeout_ms"
+            |> Option.map int
+            |> Option.defaultValue 1500
+        { Id = id
+          Shell = shell
+          Description = description
+          Command = command
+          MustInclude = mustInclude
+          MustNotInclude = mustNotInclude
+          QuiescenceMs = quiescenceMs
+          TimeoutMs = timeoutMs
+          SetupCommand = setupCommand
+          ExpectedPayloadRegex = expectedPayloadRegex
+          ExpectedSessionTuple = expectedSessionTuple
+          ExpectedPaneRouting = expectedPaneRouting
+          Notes = notes }
+
+    /// Parse one `[[scenario]]` table into a Scenario record.
+    /// Returns `Error` on the first violation (missing required
+    /// field, unknown SemanticCategory, malformed sub-table, etc.).
+    /// Implementation uses `Result.bind` chain to avoid F# 9
+    /// offside-rule traps with deeply-chained match expressions
+    /// (per `CLAUDE.md` "Sequence-in-match-arm" gotcha).
+    let private parseScenario
+            (index: int)
+            (table: TomlTable)
+            : Result<Scenario, string> =
+        let positionalCtx field msg =
+            sprintf "scenario[%d].%s: %s" index field msg
+        let scenarioCtx (id: string) (field: string) (msg: string) : string =
+            sprintf "scenario %s.%s: %s" id field msg
+        let requireString (id: string option) (field: string)
+                : Result<string, string> =
+            match tryGetString table field with
+            | Some s -> Ok s
+            | None ->
+                let ctx =
+                    match id with
+                    | Some i -> scenarioCtx i field
+                    | None -> positionalCtx field
+                Error (ctx "required string field missing")
+        requireString None "id"
+        |> Result.bind (fun id ->
+            requireString (Some id) "shell"
+            |> Result.bind (fun shell ->
+                requireString (Some id) "command"
+                |> Result.bind (fun command ->
+                    parseSemanticArray id "must_include" table
+                    |> Result.bind (fun mustInclude ->
+                        parseSemanticArray id "must_not_include" table
+                        |> Result.bind (fun mustNotInclude ->
+                            parseExpectedPayloadRegex id table
+                            |> Result.bind (fun regex ->
+                                parseSessionTuple id table
+                                |> Result.bind (fun tuple ->
+                                    parseExpectedPaneRouting id table
+                                    |> Result.map (fun pane ->
+                                        buildScenario
+                                            id shell command
+                                            mustInclude mustNotInclude
+                                            regex tuple pane
+                                            table)))))))))
+
+    // -----------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------
+
+    /// Parse a TOML string into a Scenario array. Returns `Error`
+    /// on first malformed scenario. Empty document (no
+    /// `[[scenario]]` entries) is a valid Ok with an empty array.
+    let parseFromString (toml: string) : Result<Scenario[], string> =
+        try
+            let model = Toml.ToModel(toml)
+            match model.TryGetValue("scenario") with
+            | false, _ -> Ok [||]
+            | true, (:? TomlTableArray as arr) ->
+                let buf = ResizeArray<Scenario>()
+                let mutable err: string option = None
+                let mutable i = 0
+                for table in arr do
+                    if err.IsNone then
+                        match parseScenario i table with
+                        | Ok s -> buf.Add(s)
+                        | Error e -> err <- Some e
+                    i <- i + 1
+                match err with
+                | Some e -> Error e
+                | None -> Ok (buf.ToArray())
+            | true, _ ->
+                Error "scenario: expected [[scenario]] array-of-tables"
+        with ex ->
+            Error (sprintf "TOML parse error: %s" ex.Message)
+
+    /// Load a Scenario array from a file path. Returns `Error` on
+    /// I/O failure or malformed content. Missing file is `Error`
+    /// (caller decides whether to treat as warning or fatal).
+    let loadCanonicalCorpus
+            (path: string)
+            : Result<Scenario[], string> =
+        try
+            let content = File.ReadAllText(path)
+            parseFromString content
+        with ex ->
+            Error (sprintf "Failed to read %s: %s" path ex.Message)
+
+    /// Format a scenario's outcome for inclusion in the
+    /// `Ctrl+Shift+D` diagnostic bundle's
+    /// `--- CANONICAL CORPUS RESULTS ---` section. Stable,
+    /// lexicographic, screen-reader-friendly multi-line block.
+    let formatScenarioResult (result: ScenarioResult) : string =
+        let s = result.Scenario
+        let header =
+            match result.Outcome with
+            | Pass -> sprintf "[PASS] %s (%dms)" s.Id result.ElapsedMs
+            | Fail reason ->
+                sprintf "[FAIL] %s (%dms) — %s" s.Id result.ElapsedMs reason
+        let semanticsLine =
+            sprintf
+                "       observed: [%s]"
+                (result.ObservedSemantics
+                 |> Array.map (sprintf "%A")
+                 |> String.concat ", ")
+        let mustIncludeLine =
+            if Array.isEmpty s.MustInclude then None
+            else
+                Some
+                    (sprintf
+                        "       must_include: %s"
+                        (s.MustInclude
+                         |> Array.map (sprintf "%A")
+                         |> String.concat ", "))
+        let mustNotIncludeLine =
+            if Array.isEmpty s.MustNotInclude then None
+            else
+                Some
+                    (sprintf
+                        "       must_not_include: %s"
+                        (s.MustNotInclude
+                         |> Array.map (sprintf "%A")
+                         |> String.concat ", "))
+        let notesLine =
+            s.Notes
+            |> Option.map (fun n -> sprintf "       notes: %s" n)
+        [ Some header
+          mustIncludeLine
+          mustNotIncludeLine
+          Some semanticsLine
+          notesLine ]
+        |> List.choose id
+        |> String.concat "\n"
+
+    /// Format an array of scenario results as the bundle section
+    /// body. Includes a one-line summary header
+    /// ("CORPUS: 9 PASS / 3 FAIL / 12 total") followed by each
+    /// scenario result block separated by blank lines.
+    let formatCorpusResultsForBundle
+            (results: ScenarioResult[])
+            : string =
+        let total = results.Length
+        let passed =
+            results
+            |> Array.filter (fun r ->
+                match r.Outcome with Pass -> true | _ -> false)
+            |> Array.length
+        let failed = total - passed
+        let summary =
+            sprintf
+                "CORPUS: %d PASS / %d FAIL / %d total"
+                passed failed total
+        let bodies =
+            results
+            |> Array.map formatScenarioResult
+            |> String.concat "\n\n"
+        if total = 0 then summary
+        else summary + "\n\n" + bodies

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="Coalescer.fs" />
     <Compile Include="LinearTextStream.fs" />
     <Compile Include="OutputEventTypes.fs" />
+    <Compile Include="CanonicalCorpus.fs" />
     <Compile Include="OutputEventBuilder.fs" />
     <Compile Include="NvdaChannel.fs" />
     <Compile Include="FileLoggerChannel.fs" />

--- a/tests/Tests.Unit/CanonicalCorpusTests.fs
+++ b/tests/Tests.Unit/CanonicalCorpusTests.fs
@@ -1,0 +1,313 @@
+module PtySpeak.Tests.Unit.CanonicalCorpusTests
+
+open Xunit
+open Terminal.Core
+
+/// Cycle 38a — pins the CanonicalCorpus parser contract per
+/// `docs/PROJECT-PLAN-2026-05-09.md` Section 18.3.5.
+///
+/// The 10 facts cover required fields, optional v2 extensions,
+/// missing-field errors, unknown-SemanticCategory errors, the
+/// scenario-result formatter shape, and the empty-document edge
+/// case. Tests use `parseFromString` directly with inline TOML
+/// strings; the file-I/O `loadCanonicalCorpus` wrapper is exercised
+/// only indirectly (it's a thin `File.ReadAllText` over
+/// `parseFromString`).
+
+// =====================================================================
+// Required-field round-trip
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString preserves all required v1 fields round-trip`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.required"
+        shell = "cmd"
+        description = "narrative"
+        command = "echo hi"
+        must_include = ["StreamChunk"]
+        must_not_include = ["ErrorLine", "WarningLine"]
+        quiescence_ms = 250
+        timeout_ms = 2000
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Error e -> Assert.Fail(sprintf "expected Ok, got Error: %s" e)
+    | Ok scenarios ->
+        Assert.Equal(1, scenarios.Length)
+        let s = scenarios.[0]
+        Assert.Equal("test.required", s.Id)
+        Assert.Equal("cmd", s.Shell)
+        Assert.Equal("narrative", s.Description)
+        Assert.Equal("echo hi", s.Command)
+        Assert.Equal<SemanticCategory[]>(
+            [| SemanticCategory.StreamChunk |],
+            s.MustInclude)
+        Assert.Equal<SemanticCategory[]>(
+            [| SemanticCategory.ErrorLine; SemanticCategory.WarningLine |],
+            s.MustNotInclude)
+        Assert.Equal(250, s.QuiescenceMs)
+        Assert.Equal(2000, s.TimeoutMs)
+
+// =====================================================================
+// Optional-field round-trip
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString preserves all optional v2 extension fields`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.optional"
+        shell = "powershell"
+        command = "Write-Host hi"
+        must_include = ["StreamChunk"]
+        must_not_include = []
+        setup_command = "Write-Host setup"
+        expected_payload_regex = ["^hi", "trailing\\.dot$"]
+        expected_pane_routing = "current_output"
+        notes = "captures every optional field"
+
+        [scenario.expected_session_tuple]
+        command_text = "Write-Host hi"
+        output_text = "hi"
+        exit_code = 0
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Error e -> Assert.Fail(sprintf "expected Ok, got Error: %s" e)
+    | Ok scenarios ->
+        Assert.Equal(1, scenarios.Length)
+        let s = scenarios.[0]
+        Assert.Equal(Some "Write-Host setup", s.SetupCommand)
+        Assert.Equal<string[]>(
+            [| "^hi"; "trailing\\.dot$" |],
+            s.ExpectedPayloadRegex)
+        Assert.Equal(
+            Some CanonicalCorpus.CurrentOutput,
+            s.ExpectedPaneRouting)
+        Assert.Equal(Some "captures every optional field", s.Notes)
+        match s.ExpectedSessionTuple with
+        | None -> Assert.Fail("expected expected_session_tuple to parse")
+        | Some t ->
+            Assert.Equal(Some "Write-Host hi", t.CommandText)
+            Assert.Equal(Some "hi", t.OutputText)
+            Assert.Equal(Some 0, t.ExitCode)
+
+// =====================================================================
+// Missing-required-field errors
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString fails when required field id is missing`` () =
+    let toml =
+        """
+        [[scenario]]
+        shell = "cmd"
+        command = "echo"
+        must_include = ["StreamChunk"]
+        must_not_include = []
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Ok _ -> Assert.Fail("expected Error, got Ok")
+    | Error e -> Assert.Contains("id", e)
+
+[<Fact>]
+let ``parseFromString fails when required field command is missing`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.no.command"
+        shell = "cmd"
+        must_include = ["StreamChunk"]
+        must_not_include = []
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Ok _ -> Assert.Fail("expected Error, got Ok")
+    | Error e -> Assert.Contains("command", e)
+
+// =====================================================================
+// Unknown-SemanticCategory error
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString fails on unknown SemanticCategory name`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.bad.semantic"
+        shell = "cmd"
+        command = "echo"
+        must_include = ["NotARealCategory"]
+        must_not_include = []
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Ok _ -> Assert.Fail("expected Error, got Ok")
+    | Error e ->
+        Assert.Contains("NotARealCategory", e)
+        Assert.Contains("unknown SemanticCategory", e)
+
+// =====================================================================
+// Unknown pane-routing error
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString fails on unknown expected_pane_routing value`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.bad.pane"
+        shell = "cmd"
+        command = "echo"
+        must_include = []
+        must_not_include = []
+        expected_pane_routing = "sidebar"
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Ok _ -> Assert.Fail("expected Error, got Ok")
+    | Error e ->
+        Assert.Contains("sidebar", e)
+        Assert.Contains("expected_pane_routing", e)
+
+// =====================================================================
+// Empty document
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString returns empty array for document with no scenarios`` () =
+    match CanonicalCorpus.parseFromString "" with
+    | Error e -> Assert.Fail(sprintf "expected Ok empty, got Error: %s" e)
+    | Ok scenarios -> Assert.Empty(scenarios)
+
+[<Fact>]
+let ``parseFromString returns empty array for document with only comments`` () =
+    let toml = "# only a comment\n# nothing else\n"
+    match CanonicalCorpus.parseFromString toml with
+    | Error e -> Assert.Fail(sprintf "expected Ok empty, got Error: %s" e)
+    | Ok scenarios -> Assert.Empty(scenarios)
+
+// =====================================================================
+// Multiple scenarios
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString parses multiple scenarios in order`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "first"
+        shell = "cmd"
+        command = "echo a"
+        must_include = ["StreamChunk"]
+        must_not_include = []
+
+        [[scenario]]
+        id = "second"
+        shell = "powershell"
+        command = "Write-Host b"
+        must_include = ["StreamChunk"]
+        must_not_include = ["ErrorLine"]
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Error e -> Assert.Fail(sprintf "expected Ok, got Error: %s" e)
+    | Ok scenarios ->
+        Assert.Equal(2, scenarios.Length)
+        Assert.Equal("first", scenarios.[0].Id)
+        Assert.Equal("cmd", scenarios.[0].Shell)
+        Assert.Equal("second", scenarios.[1].Id)
+        Assert.Equal("powershell", scenarios.[1].Shell)
+
+// =====================================================================
+// Default values for missing optional integers
+// =====================================================================
+
+[<Fact>]
+let ``parseFromString applies default quiescence_ms and timeout_ms when omitted`` () =
+    let toml =
+        """
+        [[scenario]]
+        id = "test.defaults"
+        shell = "cmd"
+        command = "echo"
+        must_include = []
+        must_not_include = []
+        """
+    match CanonicalCorpus.parseFromString toml with
+    | Error e -> Assert.Fail(sprintf "expected Ok, got Error: %s" e)
+    | Ok scenarios ->
+        Assert.Equal(1, scenarios.Length)
+        Assert.Equal(200, scenarios.[0].QuiescenceMs)
+        Assert.Equal(1500, scenarios.[0].TimeoutMs)
+
+// =====================================================================
+// formatScenarioResult / formatCorpusResultsForBundle shape
+// =====================================================================
+
+[<Fact>]
+let ``formatScenarioResult renders PASS scenario with id, elapsed ms, and observed line`` () =
+    let scenario : CanonicalCorpus.Scenario =
+        { Id = "fixture.pass"
+          Shell = "cmd"
+          Description = ""
+          Command = "echo hi"
+          MustInclude = [| SemanticCategory.StreamChunk |]
+          MustNotInclude = [| SemanticCategory.ErrorLine |]
+          QuiescenceMs = 200
+          TimeoutMs = 1500
+          SetupCommand = None
+          ExpectedPayloadRegex = [||]
+          ExpectedSessionTuple = None
+          ExpectedPaneRouting = None
+          Notes = None }
+    let result : CanonicalCorpus.ScenarioResult =
+        { Scenario = scenario
+          Outcome = CanonicalCorpus.Pass
+          ObservedSemantics = [| SemanticCategory.StreamChunk |]
+          ObservedPayloads = [| "hi" |]
+          ElapsedMs = 147 }
+    let formatted = CanonicalCorpus.formatScenarioResult result
+    Assert.Contains("[PASS] fixture.pass (147ms)", formatted)
+    Assert.Contains("must_include: StreamChunk", formatted)
+    Assert.Contains("must_not_include: ErrorLine", formatted)
+    Assert.Contains("observed: [StreamChunk]", formatted)
+
+[<Fact>]
+let ``formatCorpusResultsForBundle includes the pass-fail summary header`` () =
+    let scenario : CanonicalCorpus.Scenario =
+        { Id = "summary.test"
+          Shell = "cmd"
+          Description = ""
+          Command = "echo"
+          MustInclude = [||]
+          MustNotInclude = [||]
+          QuiescenceMs = 200
+          TimeoutMs = 1500
+          SetupCommand = None
+          ExpectedPayloadRegex = [||]
+          ExpectedSessionTuple = None
+          ExpectedPaneRouting = None
+          Notes = None }
+    let pass : CanonicalCorpus.ScenarioResult =
+        { Scenario = scenario
+          Outcome = CanonicalCorpus.Pass
+          ObservedSemantics = [||]
+          ObservedPayloads = [||]
+          ElapsedMs = 50 }
+    let fail : CanonicalCorpus.ScenarioResult =
+        { Scenario = { scenario with Id = "summary.fail" }
+          Outcome = CanonicalCorpus.Fail "missing=StreamChunk"
+          ObservedSemantics = [||]
+          ObservedPayloads = [||]
+          ElapsedMs = 1500 }
+    let formatted =
+        CanonicalCorpus.formatCorpusResultsForBundle [| pass; fail |]
+    Assert.Contains("CORPUS: 1 PASS / 1 FAIL / 2 total", formatted)
+
+// =====================================================================
+// Empty results bundle
+// =====================================================================
+
+[<Fact>]
+let ``formatCorpusResultsForBundle on empty array reports zero counts`` () =
+    let formatted = CanonicalCorpus.formatCorpusResultsForBundle [||]
+    Assert.Equal("CORPUS: 0 PASS / 0 FAIL / 0 total", formatted)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -57,6 +57,7 @@
     <Compile Include="AppReservedHotkeysMirrorTests.fs" />
     <Compile Include="MultiStateRegistryTests.fs" />
     <Compile Include="LinearTextStreamTests.fs" />
+    <Compile Include="CanonicalCorpusTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/fixtures/canonical-interactions.toml
+++ b/tests/fixtures/canonical-interactions.toml
@@ -1,0 +1,170 @@
+# pty-speak — canonical interaction-pair corpus (Cycle 38a baseline)
+#
+# Curated catalogue of `(bytes-in, expected-NVDA-out)` scenarios.
+# The Ctrl+Shift+D diagnostic battery loads this file (deployed
+# next to Terminal.App.exe via Terminal.App.fsproj's Content + Link),
+# filters scenarios for the active shell, runs each, and reports
+# PASS / FAIL with the observed `SemanticCategory` events in the
+# bundle's `--- CANONICAL CORPUS RESULTS ---` section.
+#
+# # Schema
+#
+# Each `[[scenario]]` table requires:
+#   id                 string  Stable identifier (lower.dotted.case)
+#   shell              string  "cmd" / "powershell" / "claude"
+#   description        string  Narrative (what's being validated)
+#   command            string  Bytes to send (UTF-8; 0x0D CR appended)
+#   must_include       array   SemanticCategory names that MUST fire
+#   must_not_include   array   SemanticCategory names that MUST NOT fire
+#   quiescence_ms      int     Settling window after output stops (default 200)
+#   timeout_ms         int     Total scenario timeout (default 1500)
+#
+# Optional v2 extension fields (parsed but not yet enforced in 38a;
+# subsequent sub-cycles promote each to load-bearing):
+#   setup_command           string                Pre-test command
+#   expected_payload_regex  array of strings      Substrings the captured payload must match (38c)
+#   expected_session_tuple  table { command_text, output_text, exit_code }  (38b)
+#   expected_pane_routing   string  "input" / "current_output" / "history"  (38d)
+#   notes                   string                Free-form (especially "Bug: …; fixed in 38X")
+#
+# # Editing
+#
+# Scenarios should reflect CURRENT behaviour. Where current
+# behaviour is wrong, capture the regression with a `notes` field
+# explaining what the fix sub-cycle will flip; the assertion in
+# `must_include` / `must_not_include` should match what NVDA
+# CURRENTLY hears, so the corpus stays green at HEAD and the bug-
+# fix has to update the assertion alongside the code change.
+#
+# Valid SemanticCategory values (from
+# `src/Terminal.Core/OutputEventTypes.fs:42-111`):
+#   StreamChunk SelectionShown SelectionItem SelectionDismissed
+#   SpinnerTick ErrorLine WarningLine PromptDetected CommandSubmitted
+#   BellRang HyperlinkOpened AltScreenEntered ModeBarrier ParserError
+
+# ---------------------------------------------------------------
+# cmd seed (Cycle 38a; PowerShell extends in 38b, Claude in 38e)
+# ---------------------------------------------------------------
+
+[[scenario]]
+id = "cmd.echo.plain"
+shell = "cmd"
+description = "Plain `echo hello` should emit StreamChunk for the output 'hello' only."
+command = "echo PtySpeakDiagEchoPlain"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine", "WarningLine"]
+quiescence_ms = 200
+notes = "Bug 2026-05-10: input-echo + next prompt currently bleed into the StreamChunk. Cycle 38c separates input echo from output."
+
+[[scenario]]
+id = "cmd.dir.simple"
+shell = "cmd"
+description = "Plain `dir` lists the current directory; emits StreamChunk only."
+command = "dir"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine", "WarningLine"]
+quiescence_ms = 300
+timeout_ms = 2500
+
+[[scenario]]
+id = "cmd.dir.large"
+shell = "cmd"
+description = "Recursive `dir /s` against the Windows directory streams chunks at idle quanta."
+command = "dir /s /a-d C:\\Windows\\System32"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 500
+timeout_ms = 5000
+notes = "Cycle 36 row 36.2 — large output; no per-row ErrorLine spam."
+
+[[scenario]]
+id = "cmd.exit.success"
+shell = "cmd"
+description = "Sub-shell exiting with code 0 emits StreamChunk only."
+command = "cmd /c exit 0"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 200
+
+[[scenario]]
+id = "cmd.exit.failure"
+shell = "cmd"
+description = "Sub-shell exiting with code 1; ExitCode capture validates in 38b once tuple extension lands."
+command = "cmd /c exit 1"
+must_include = ["StreamChunk"]
+must_not_include = ["WarningLine"]
+quiescence_ms = 200
+notes = "Cycle 38b will add expected_session_tuple = { exit_code = 1 } once SessionModel exit-code capture is wired through the corpus runner."
+
+[[scenario]]
+id = "cmd.set.userprompt"
+shell = "cmd"
+description = "`set /P NAME=` is the cmd Read-Host equivalent; emits the prompt as a StreamChunk and waits for input."
+command = "set /P PtySpeakDiagName=Enter your name: "
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 300
+timeout_ms = 2000
+notes = "The prompt is currently announced as plain output; Cycle 38c marks input-prompt segments distinctly via expected_pane_routing = 'input'."
+
+[[scenario]]
+id = "cmd.choice.yn"
+shell = "cmd"
+description = "`choice /c YN /m \"Continue\"` is cmd's selection-prompt equivalent."
+command = "choice /c YN /m \"PtySpeakDiagContinue\""
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 300
+timeout_ms = 2000
+notes = "Bug 2026-05-10: SelectionDetector is shellKey-gated to claude (SelectionDetector.fs:81); choice fires StreamChunk but NOT SelectionShown. Cycle 38e generalises the detector to recognise cmd `choice` patterns."
+
+[[scenario]]
+id = "cmd.cls.alt"
+shell = "cmd"
+description = "`cls` is a full-screen erase; the linear-substrate live-region detector should classify it cleanly."
+command = "cls"
+must_include = []
+must_not_include = ["ErrorLine", "WarningLine"]
+quiescence_ms = 200
+notes = "cls produces minimal events post-cycle 35 substrate. May need adjustment after 38a baseline is captured by maintainer."
+
+[[scenario]]
+id = "cmd.echo.color.benign"
+shell = "cmd"
+description = "Cmd echoing benign text without ANSI red doesn't trigger ErrorLine."
+command = "echo PtySpeakDiagBenignColor"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine", "WarningLine"]
+quiescence_ms = 200
+notes = "cmd has minimal ANSI support; this row guards against the Phase A.2 colour-detector misfiring on monochrome output."
+
+[[scenario]]
+id = "cmd.echo.color.error"
+shell = "cmd"
+description = "Cmd echoing a red ANSI sequence should trigger ErrorLine alongside StreamChunk."
+command = "echo [31mPtySpeakDiagRedText[0m"
+must_include = ["StreamChunk", "ErrorLine"]
+must_not_include = ["WarningLine"]
+quiescence_ms = 200
+notes = "Regression guard mirroring T2.Red from the PowerShell battery — keeps the colour detector honest on cmd."
+
+[[scenario]]
+id = "cmd.multiline.continuation"
+shell = "cmd"
+description = "Multi-line input via `^` continuation; tests echo separation across the continuation line."
+command = "echo line1 ^\nline2"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 300
+timeout_ms = 2500
+notes = "Bug 2026-05-10: continuation echo is announced indistinguishably from output. Cycle 38d's three-pane routing puts the continuation prompt in input pane."
+
+[[scenario]]
+id = "cmd.tab.completion"
+shell = "cmd"
+description = "Partial command followed by Tab triggers cmd's completion; the completed text should announce ONCE."
+command = "ec\tho PtySpeakDiagTabComplete"
+must_include = ["StreamChunk"]
+must_not_include = ["ErrorLine"]
+quiescence_ms = 300
+notes = "Cycle 36 row 36.8 — completion announces once, not re-announced on Enter. 38d's pane routing makes this load-bearing."


### PR DESCRIPTION
## Summary

Cycle 38a — **regression scaffolding** for the cmd / PowerShell / Claude per-shell parser-route refactors landing in Cycles 38b-e. The 35b regression went undetected for ~3 cycles (PR #249 hotfix); this cycle introduces a curated `(bytes-in, expected-NVDA-out)` corpus the `Ctrl+Shift+D` battery loads and runs against the active shell so future substrate flips can't silently break announcement.

**Plan reference**: [`fluffy-simon.md`](https://example.com) Section 18 (private plan file; the substantive content is in this PR's CHANGELOG entry).

**Sub-cycle decomposition** (this PR is 38a):

| Sub-cycle | Scope | Status |
|---|---|---|
| **38a** | Corpus format + runner + 12 cmd seed scenarios + `Ctrl+Shift+D` integration. **NO routing changes.** | This PR |
| 38b | Per-shell route table + PowerShell scenarios | Next |
| 38c | Cmd echo-suppression (`echo hello` regression fix) | After 38b |
| 38d | Three-sub-pane channel routing | After 38c |
| 38e | Claude scenarios + per-shell hardening | After 38d |

## What ships in 38a

### New module: [`src/Terminal.Core/CanonicalCorpus.fs`](src/Terminal.Core/CanonicalCorpus.fs) (~310 lines)

`Scenario` record + TOML parser + bundle formatter. **Tiered schema** (per maintainer 2026-05-10): required v1 fields match `Diagnostics.DiagnosticTest`'s shape exactly. Optional v2 extension fields (`setup_command`, `expected_payload_regex`, `expected_session_tuple`, `expected_pane_routing`, `notes`) are parsed but not yet enforced — subsequent sub-cycles promote each to load-bearing.

### Seed corpus: [`tests/fixtures/canonical-interactions.toml`](tests/fixtures/canonical-interactions.toml) (~150 lines, 12 scenarios)

Drawn from real cmd workflows + the existing Cycle 36 matrix:

| Scenario | Validates |
|---|---|
| `cmd.echo.plain` | The maintainer's reported regression (input echo + next prompt bleed into StreamChunk) |
| `cmd.dir.simple`, `cmd.dir.large` | Multi-line output coalescing + streaming chunks |
| `cmd.exit.success`, `cmd.exit.failure` | Exit-code capture (38b extension) |
| `cmd.set.userprompt` | Read-Host equivalent (input prompt) |
| `cmd.choice.yn` | Selection-prompt for non-claude shell (currently fails — `SelectionDetector` shellKey-gated to claude; tagged for 38e) |
| `cmd.cls.alt` | Full-screen-erase live-region detection |
| `cmd.echo.color.benign`, `cmd.echo.color.error` | ANSI red triggers ErrorLine; benign monochrome doesn't |
| `cmd.multiline.continuation` | `^` continuation echo separation |
| `cmd.tab.completion` | Cycle 36 row 36.8 — completion announces ONCE |

Bug-tagged scenarios carry `notes = "Bug 2026-05-10: …; fixed in <sub-cycle>"`; the assertion lists what NVDA CURRENTLY hears so the corpus stays green at HEAD and the bug-fix sub-cycle has to update both code and assertion atomically.

### Diagnostic battery integration: [`src/Terminal.App/Diagnostics.fs`](src/Terminal.App/Diagnostics.fs) (+209 lines)

- `runOneScenario` mirrors `runOneTest` but takes per-scenario `QuiescenceMs` / `TimeoutMs` rather than the hard-coded 200/1500.
- `runCorpus` filters scenarios for active shell, runs each, returns `Result<ScenarioResult[], string>`.
- `formatDiagnosticBundle` extended with `--- CANONICAL CORPUS RESULTS ---` section.
- Corpus TOML deployed next to `Terminal.App.exe` via Content + CopyToOutput in [`Terminal.App.fsproj`](src/Terminal.App/Terminal.App.fsproj); runtime resolves via `AppContext.BaseDirectory`.
- Failure to load (missing file, parse error) is **non-fatal** — bundle just renders an explanatory section.

### Tests: [`tests/Tests.Unit/CanonicalCorpusTests.fs`](tests/Tests.Unit/CanonicalCorpusTests.fs) (12 facts)

Pin: required-field round-trip, optional-field round-trip, missing-required-field error, unknown `SemanticCategory` error, unknown `expected_pane_routing` error, empty document, comment-only document, multiple-scenarios ordering, default `quiescence_ms` / `timeout_ms`, `formatScenarioResult` shape, `formatCorpusResultsForBundle` summary header, empty-results summary.

### Docs: [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md) (+66 lines)

New `### Cycle 38a — Canonical interaction corpus baseline` section with schema reference, sub-cycle promotion table, **5-row manual matrix** for dogfood, stopping gate.

## What 38a does NOT do

- **No per-shell route table.** `OutputDispatcher.setActiveProfileSet` stays uniform. Deferred to 38b.
- **No echo-suppression.** `cmd.echo.plain` reports based on current behaviour; the regression is captured as a corpus row, not fixed.
- **No three-pane channel routing.** Deferred to 38d.
- **No PowerShell or Claude scenarios.** cmd-only seed in 38a; 38b/e expand.
- **No NVDA verbatim-text matching.** `expected_payload_regex` is parseable but not yet evaluated by `runCorpus`. Wired in 38c.
- **No automatic CI gating.** Corpus runs in the diagnostic battery only; CI gating waits for 38e.

## Test plan

- [ ] `Build and test (windows-latest)` green — 12 new `CanonicalCorpusTests` facts + existing 977+ tests stay green.
- [ ] `Workflow lint`, `Portability lint`, `Markdown link check` green.
- [ ] **Maintainer dogfood** (post-merge):
  - Rebuild from `main`. Open cmd. Press `Ctrl+Shift+D`.
  - Bundle file in `%LOCALAPPDATA%\PtySpeak\diagnostic-snapshots\` contains `--- CANONICAL CORPUS RESULTS ---` section.
  - Section starts with `CORPUS: <P> PASS / <F> FAIL / 12 total`.
  - For each cmd scenario, confirm reported PASS / FAIL matches actual NVDA behaviour. Discrepancies → fixup commits adjusting `must_include` / `must_not_include` until baseline matches reality.
  - Switch to PowerShell + Claude (Ctrl+Shift+2 / +3); verify those report `0 PASS / 0 FAIL / 0 total` (scenarios arrive in 38b / 38e).

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_