### PR TITLE
feat(cycle-38a-followup): post-dogfood UX refresh (5 fixes in one PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,73 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 38a-followup): Post-dogfood UX refresh
+
+Five UX/ergonomics fixes from the 2026-05-10 dogfood session of
+Cycle 38a:
+
+1. **Truncation suffix references an existing shortcut.**
+   [`src/Terminal.Core/StreamPathway.fs:346`](src/Terminal.Core/StreamPathway.fs)
+   previously told the user to press `Ctrl+Shift+;` to copy the
+   full log — but that hotkey was retired in Cycle 25b-1a.
+   Replaced with `Ctrl+Shift+D` (the diagnostic bundle carries
+   the untruncated payload in its `--- FILELOGGER ACTIVE LOG ---`
+   section).
+
+2. **Spoken diagnostic summary now includes corpus results.**
+   The `Ctrl+Shift+D` end-of-battery announce previously said
+   only `"Diagnostic complete. {pass} of {total} passed.{substrate fragment}"`.
+   Corpus results (Cycle 38a) were in the bundle but not spoken.
+   Now the announce includes `"Corpus: {p} of {t} passed; failing: {ids}."`
+   when scenarios fail, or `"Corpus: all {N} passed."` when none
+   do, or no addition when no scenarios match the active shell.
+   The maintainer hears which canonical-interaction rows
+   misbehaved without opening the file.
+
+3. **New `Diagnostics → Open Manual Tests` menu item.**
+   Filters
+   [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+   to sections marked with an `<!-- DOGFOOD -->` HTML comment,
+   renders Markdig HTML wrapped in an HTML5 document with a
+   `<main>` landmark, writes to
+   `%LOCALAPPDATA%\PtySpeak\manual-tests.html`, and opens it in
+   the default browser via `ShellExecute`. NVDA browse-mode H
+   key jumps section headings; D key jumps the `<main>`
+   landmark. Maintainer can grow / prune the quickref by adding
+   / removing markers in the source markdown — no code change
+   required. Initial markers cover Cycle 38a / 37 / 36 / 29b /
+   28 sections plus the always-run "Artifact integrity" and
+   "Launch and process hygiene" matrices.
+
+   - New module:
+     [`src/Terminal.Core/ManualTestsHtml.fs`](src/Terminal.Core/ManualTestsHtml.fs)
+     (pure `filterAndConvert : markdown -> html`).
+   - New dependency: Markdig 0.38.0 (BSD 2-Clause).
+   - New menu-only AppCommand:
+     `HotkeyRegistry.OpenManualTests` (mirrors
+     `RunProcessCleanupScript`'s Cycle 26c pattern: `Key = None,
+     Modifiers = None`).
+   - Handler: `openManualTests` in
+     [`src/Terminal.App/Program.fs`](src/Terminal.App/Program.fs).
+   - Tests: 8 new facts in
+     [`tests/Tests.Unit/ManualTestsHtmlTests.fs`](tests/Tests.Unit/ManualTestsHtmlTests.fs)
+     pinning the filter + Markdig conversion + HTML wrapper
+     shape; 1 new fact in
+     [`tests/Tests.Unit/HotkeyRegistryTests.fs`](tests/Tests.Unit/HotkeyRegistryTests.fs)
+     pinning the menu-only shape.
+
+4. **Top-level "View" menu renamed to "Display".** Matches
+   maintainer's mental model;
+   [`src/Views/MainWindow.xaml`](src/Views/MainWindow.xaml)
+   line 66.
+
+5. **"Logging Level" multi-state item moved to Diagnostics.**
+   It's a diagnostic verbosity control, not a display setting.
+   Now first in the Diagnostics menu (so it's reachable without
+   arrow-scrolling); the `MultiStateRegistry` registration
+   itself is unchanged. Display now hosts only the Earcons
+   multi-state.
+
 ### Added (Cycle 38a): Canonical interaction-pair corpus + diagnostic battery integration
 
 Regression scaffolding for the cmd / PowerShell / Claude per-shell

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,14 @@
       the chosen library; this is its first appearance.
     -->
     <PackageVersion Include="Tomlyn" Version="0.18.0" />
+    <!--
+      Cycle 38a-followup — Markdig (BSD 2-Clause) for runtime
+      conversion of `docs/ACCESSIBILITY-TESTING.md` to HTML for
+      the `Diagnostics → Open Manual Tests` menu item. Pure
+      markdown→HTML; no JS, no DOM. `ManualTestsHtml.fs` is the
+      only consumer.
+    -->
+    <PackageVersion Include="Markdig" Version="0.38.0" />
 
     <!-- Test -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -15,6 +15,27 @@ of the matrix, but the scope is **all manual checks every release
 must pass**: artifact integrity, process-launch hygiene, UIA, NVDA,
 earcons, auto-update.
 
+## DOGFOOD markers
+
+Sub-sections preceded by an `<!-- DOGFOOD -->` HTML comment are
+surfaced in the runtime `Diagnostics → Open Manual Tests` quickref
+(Cycle 38a-followup). The menu item reads this file from the
+deployed location next to `Terminal.App.exe`, filters to marked
+`### `-level sub-sections via
+[`src/Terminal.Core/ManualTestsHtml.fs`](../src/Terminal.Core/ManualTestsHtml.fs),
+renders Markdig HTML, and opens it in the default browser for
+NVDA browse-mode heading navigation. Add or remove the marker on a
+per-section basis to grow or prune the quickref — no code change
+required. The marker is a normal HTML comment so it stays invisible
+in any rendered markdown view.
+
+The initial set marks the most-recently-relevant sections: Cycle
+38a (canonical interaction corpus baseline), Cycle 37 (UIA listbox
+peer), Cycle 36 (substrate-inversion arc matrix backfill), Cycle
+29b (SelectionProfile), Cycle 28 (Window menu), plus the standing
+"Artifact integrity" and "Launch and process hygiene" sections that
+run on every release.
+
 ## How to use this document
 
 1. Cut the release per
@@ -74,6 +95,7 @@ These two sections run on every release regardless of stage, because
 they catch regressions in things that don't have a "stage" but break
 loudly when wrong.
 
+<!-- DOGFOOD -->
 ### Artifact integrity (run before installing)
 
 | Test                              | Procedure                                       | Expected                                                          |
@@ -101,6 +123,7 @@ loudly when wrong.
   back per `docs/RELEASE-PROCESS.md` "Workflow changes when signing
   returns".
 
+<!-- DOGFOOD -->
 ### Launch and process hygiene (run on every install)
 
 | Test                              | Procedure                                       | Expected                                                          |
@@ -820,6 +843,7 @@ expected behavioural side-effect.
   immediate-update logic is possible but adds complexity for no
   user-visible benefit since the menu has already closed.)
 
+<!-- DOGFOOD -->
 ### Cycle 28 — Window menu
 
 Cycle 28 adds the top-level `Window` menu with two children:
@@ -858,6 +882,7 @@ natively.
   `AppReservedHotkeys` rows; existing behaviour should be
   unchanged.
 
+<!-- DOGFOOD -->
 ### Cycle 29b — SelectionProfile (NVDA reads selection prompts as text)
 
 Cycle 29b wires `SelectionDetector` (shipped in 29a) into the
@@ -910,6 +935,7 @@ short-circuit the detector entirely.
   thresholds; 29c lets the maintainer tune them via
   `Ctrl+Shift+E` (open config.toml).
 
+<!-- DOGFOOD -->
 ### Cycle 36 — Substrate-inversion arc matrix backfill
 
 Cycles 33-35c shipped the substrate-inversion arc: the canonical
@@ -1034,6 +1060,7 @@ findstr /C:"--- LINEAR STREAM" "<bundle-path>"
 These recipes lean on the existing diagnostic-bundle infrastructure
 shipped in Cycle 34b; no new logging is required.
 
+<!-- DOGFOOD -->
 ### Cycle 37 — UIA listbox peer (interactive-list canonical-display)
 
 Cycle 37 (37a + 37b) replaces SelectionProfile's Cycle 29b
@@ -1235,6 +1262,7 @@ matrix's shrinking surface area over time.
   the producer side (pattern present + GetText returns a snapshot
   with the expected length floor) is now CI-pinned.
 
+<!-- DOGFOOD -->
 ### Cycle 38a — Canonical interaction corpus baseline
 
 Cycle 38a is the **regression scaffolding** for the cmd / PowerShell

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -1334,17 +1334,58 @@ module Diagnostics =
                                 " SessionModel: %d of %d command history entries, no active state."
                                 sessionSnapshot.HistoryCount
                                 sessionSnapshot.MaxHistorySize
+                    // Cycle 38a-followup — corpus pass/fail counts +
+                    // names of failing scenarios in the spoken
+                    // summary so the maintainer hears which
+                    // canonical-interaction rows misbehaved without
+                    // opening the bundle file. Empty string for
+                    // `Error` (corpus missing/malformed; bundle
+                    // section already explains) and for
+                    // zero-scenarios (e.g. PowerShell/Claude with no
+                    // 38a-baseline rows yet — avoids "Corpus: all 0
+                    // passed.").
+                    let corpusSpoken =
+                        match corpusResultOuter with
+                        | Ok results when results.Length > 0 ->
+                            let passed =
+                                results
+                                |> Array.filter (fun r ->
+                                    match r.Outcome with
+                                    | CanonicalCorpus.Pass -> true
+                                    | _ -> false)
+                                |> Array.length
+                            let scenarioTotal = results.Length
+                            let scenarioFailed = scenarioTotal - passed
+                            if scenarioFailed = 0 then
+                                sprintf
+                                    " Corpus: all %d passed."
+                                    scenarioTotal
+                            else
+                                let failingIds =
+                                    results
+                                    |> Array.choose (fun r ->
+                                        match r.Outcome with
+                                        | CanonicalCorpus.Fail _ ->
+                                            Some r.Scenario.Id
+                                        | _ -> None)
+                                    |> String.concat ", "
+                                sprintf
+                                    " Corpus: %d of %d passed; failing: %s."
+                                    passed scenarioTotal failingIds
+                        | _ -> ""
                     let summaryLine =
                         if total = 0 then
                             sprintf
-                                "Diagnostic complete. Snapshot and earcons logged. Shell %s skipped command battery.%s"
+                                "Diagnostic complete. Snapshot and earcons logged. Shell %s skipped command battery.%s%s"
                                 shell.DisplayName
                                 substrateFragment
+                                corpusSpoken
                         else
                             sprintf
-                                "Diagnostic complete. %d of %d passed.%s"
+                                "Diagnostic complete. %d of %d passed.%s%s"
                                 pass total
                                 substrateFragment
+                                corpusSpoken
                     // Cycle 25b — assemble the combined dump
                     // bundle: diagnostic-battery log + FileLogger
                     // active log + config.toml + redacted env.

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -622,6 +622,80 @@ module Program =
             }
         ()
 
+    /// Cycle 38a-followup — Diagnostics → Open Manual Tests.
+    /// Reads `ACCESSIBILITY-TESTING.md` (deployed alongside
+    /// Terminal.App.exe via Content + CopyToOutput in
+    /// `Terminal.App.fsproj`), filters to sections marked
+    /// `<!-- DOGFOOD -->`, renders Markdig HTML wrapped in an
+    /// HTML5 document with a `<main>` landmark, writes to
+    /// `%LOCALAPPDATA%\PtySpeak\manual-tests.html`, and opens
+    /// in the default browser via `ShellExecute`. NVDA browse-
+    /// mode H key jumps section headings; D key jumps the
+    /// `<main>` landmark.
+    let private openManualTests (window: MainWindow) : unit =
+        let log = Logger.get "Terminal.App.Program.openManualTests"
+        // Forward-looking announce BEFORE the browser launch so
+        // NVDA has time to speak before focus changes. Mirrors
+        // `runTestProcessCleanup`'s announce-then-Task.Delay-then-
+        // launch pattern.
+        window.TerminalSurface.Announce(
+            "Opening manual tests in default browser.",
+            ActivityIds.diagnostic)
+        let _ =
+            task {
+                do! Task.Delay(700)
+                let action () =
+                    try
+                        let mdPath =
+                            System.IO.Path.Combine(
+                                System.AppContext.BaseDirectory,
+                                "ACCESSIBILITY-TESTING.md")
+                        if not (System.IO.File.Exists mdPath) then
+                            log.LogWarning(
+                                "Manual-tests source markdown not found at {Path}",
+                                mdPath)
+                            window.TerminalSurface.Announce(
+                                "Manual tests source file not found in install directory.",
+                                ActivityIds.error)
+                        else
+                            let mdContent =
+                                System.IO.File.ReadAllText(mdPath)
+                            let html =
+                                ManualTestsHtml.filterAndConvert mdContent
+                            let outDir =
+                                System.IO.Path.Combine(
+                                    System.Environment.GetFolderPath(
+                                        System.Environment.SpecialFolder.LocalApplicationData),
+                                    "PtySpeak")
+                            System.IO.Directory.CreateDirectory(outDir)
+                            |> ignore
+                            let htmlPath =
+                                System.IO.Path.Combine(
+                                    outDir,
+                                    "manual-tests.html")
+                            System.IO.File.WriteAllText(
+                                htmlPath, html, System.Text.Encoding.UTF8)
+                            let psi = System.Diagnostics.ProcessStartInfo()
+                            psi.FileName <- htmlPath
+                            psi.UseShellExecute <- true
+                            System.Diagnostics.Process.Start(psi) |> ignore
+                            log.LogInformation(
+                                "Manual-tests HTML written and opened. Path={Path}",
+                                htmlPath)
+                    with ex ->
+                        log.LogWarning(
+                            ex,
+                            "openManualTests failed: {Message}",
+                            ex.Message)
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        window.TerminalSurface.Announce(
+                            sprintf "Could not open manual tests: %s" safe,
+                            ActivityIds.error)
+                do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                ()
+            }
+        ()
+
     /// Cycle 28 — Window menu: close the main window. Mirrors
     /// the OS-level `Alt+F4` gesture, which WPF Window already
     /// handles natively via `SystemCommands.CloseWindow`. The
@@ -825,6 +899,8 @@ module Program =
         // hardcoded XAML values for None-key commands alone).
         bind HotkeyRegistry.CloseWindow (fun () -> runCloseWindow window)
         bind HotkeyRegistry.ExitApp (fun () -> runExitApp window)
+        // Cycle 38a-followup — menu-only; Diagnostics → Open Manual Tests.
+        bind HotkeyRegistry.OpenManualTests (fun () -> openManualTests window)
 
         // Cycle 25b-1a — `SetCopyLogToClipboardHandler` defense-in-
         // depth wiring removed alongside the Ctrl+Shift+L hotkey

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -60,6 +60,19 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>canonical-interactions.toml</Link>
     </Content>
+    <!--
+      Cycle 38a-followup — `Diagnostics → Open Manual Tests`
+      reads the matrix source file at runtime, filters to
+      DOGFOOD-marked sections, and renders Markdig HTML. The
+      markdown is deployed next to Terminal.App.exe and
+      resolved via `AppContext.BaseDirectory`. Maintainer can
+      grow / prune the quickref by editing markers in the
+      source markdown — no code change required.
+    -->
+    <Content Include="..\..\docs\ACCESSIBILITY-TESTING.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>ACCESSIBILITY-TESTING.md</Link>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -115,6 +115,13 @@ module HotkeyRegistry =
         // plans where Close-Window-vs-Exit-App becomes meaningful).
         | CloseWindow
         | ExitApp
+        // Cycle 38a-followup — second menu-only command.
+        // Filters `docs/ACCESSIBILITY-TESTING.md` to sections
+        // marked `<!-- DOGFOOD -->` via `ManualTestsHtml.filterAndConvert`,
+        // writes the HTML to `%LOCALAPPDATA%\PtySpeak\manual-tests.html`,
+        // and opens it in the default browser. NVDA browse-mode H
+        // key jumps headings; D key jumps the `<main>` landmark.
+        | OpenManualTests
 
     /// Stable string name for a command, used as the
     /// `RoutedCommand` name passed to WPF and as a TOML key
@@ -138,6 +145,7 @@ module HotkeyRegistry =
         | RunProcessCleanupScript -> "RunProcessCleanupScript"
         | CloseWindow -> "CloseWindow"
         | ExitApp -> "ExitApp"
+        | OpenManualTests -> "OpenManualTests"
 
     /// Default key binding for a command. Mirrors the
     /// `AppReservedHotkeys` table in
@@ -239,7 +247,14 @@ module HotkeyRegistry =
           { Command = ExitApp
             Key = None
             Modifiers = None
-            Description = "Exit pty-speak (Cycle 28; Application.Current.Shutdown)" } ]
+            Description = "Exit pty-speak (Cycle 28; Application.Current.Shutdown)" }
+          // Cycle 38a-followup — second menu-only command after
+          // RunProcessCleanupScript. Surfaced as Diagnostics →
+          // Open Manual Tests.
+          { Command = OpenManualTests
+            Key = None
+            Modifiers = None
+            Description = "Open the dogfood-filtered manual-tests HTML quickref in the default browser (Cycle 38a-followup)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —
@@ -318,7 +333,8 @@ module HotkeyRegistry =
           AnnounceSessionLogPath
           RunProcessCleanupScript
           CloseWindow
-          ExitApp ]
+          ExitApp
+          OpenManualTests ]
 
     // ---------------------------------------------------------------
     // Cycle 27 — Multi-state command paradigm

--- a/src/Terminal.Core/ManualTestsHtml.fs
+++ b/src/Terminal.Core/ManualTestsHtml.fs
@@ -1,0 +1,139 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+open Markdig
+
+/// Cycle 38a-followup — runtime markdown→HTML conversion for the
+/// `Diagnostics → Open Manual Tests` menu item.
+///
+/// **Source of truth.** [`docs/ACCESSIBILITY-TESTING.md`](../../docs/ACCESSIBILITY-TESTING.md)
+/// is the canonical manual-test matrix. It's deployed next to
+/// `Terminal.App.exe` via Content + CopyToOutput in
+/// `Terminal.App.fsproj`; the menu handler reads it via
+/// `AppContext.BaseDirectory + ACCESSIBILITY-TESTING.md`.
+///
+/// **DOGFOOD filter.** Many sections in the matrix are historical
+/// (shipped-stage validation done long ago) and would clutter the
+/// quickref. The filter convention: sub-sections preceded by an
+/// `<!-- DOGFOOD -->` HTML comment are included in the quickref;
+/// unmarked sub-sections are dropped. Maintainer can grow / prune
+/// the quickref by adding / removing markers — no code change
+/// required.
+///
+/// **Output HTML.** Standalone HTML5 with screen-reader-friendly
+/// markup: `<main>` landmark for NVDA D-key jump; semantic
+/// heading hierarchy from Markdig's `UseAutoIdentifiers` for H-key
+/// jumps; `<table>` rendered from Markdown pipe tables; CSS kept
+/// minimal so the page renders cleanly with NVDA browse mode.
+module ManualTestsHtml =
+
+    /// HTML-comment marker indicating a sub-section should appear
+    /// in the dogfood quickref. Maintained as a constant so any
+    /// future renaming touches exactly one file.
+    [<Literal>]
+    let DogfoodMarker = "<!-- DOGFOOD -->"
+
+    /// Split the markdown into chunks at `### ` heading
+    /// boundaries. Returns an array of `(markerFound, sectionText)`
+    /// tuples. `sectionText` is the heading line + body up to
+    /// (but not including) the next `### ` heading.
+    /// `markerFound` is true if the `<!-- DOGFOOD -->` marker
+    /// appeared in the lines BEFORE the heading (either in the
+    /// previous section's body or in the file's top-matter
+    /// immediately preceding the heading).
+    ///
+    /// Internal to allow unit-tests to pin the filter behaviour
+    /// independently of Markdig conversion.
+    let internal splitAndMark
+            (markdown: string)
+            : (bool * string)[] =
+        let lines = markdown.Split([| '\n' |])
+        let chunks = ResizeArray<bool * string>()
+        let currentLines = ResizeArray<string>()
+        let mutable markerForCurrent = false
+        let mutable markerPendingForNext = false
+        let mutable insideSection = false
+        let flushCurrent () =
+            if currentLines.Count > 0 then
+                let text =
+                    String.concat "\n" (currentLines |> Seq.toList)
+                chunks.Add((markerForCurrent, text))
+            currentLines.Clear()
+        for line in lines do
+            let trimmed = line.TrimStart()
+            if trimmed.StartsWith("### ") then
+                if insideSection then
+                    flushCurrent ()
+                else
+                    // Pre-matter (intro before first heading) is
+                    // discarded — it's not a test instruction
+                    // even if the maintainer placed a marker
+                    // there by accident.
+                    currentLines.Clear()
+                    insideSection <- true
+                markerForCurrent <- markerPendingForNext
+                markerPendingForNext <- false
+                currentLines.Add(line)
+            else
+                if line.Contains(DogfoodMarker) then
+                    markerPendingForNext <- true
+                currentLines.Add(line)
+        if insideSection then flushCurrent ()
+        chunks.ToArray()
+
+    /// HTML5 document head + body wrapper applied around the
+    /// Markdig-rendered body. Minimal CSS keeps the page readable
+    /// in any browser while staying out of NVDA's way.
+    let private renderDocument (bodyHtml: string) : string =
+        let sb = StringBuilder()
+        sb.AppendLine("<!DOCTYPE html>") |> ignore
+        sb.AppendLine("<html lang=\"en\">") |> ignore
+        sb.AppendLine("<head>") |> ignore
+        sb.AppendLine("  <meta charset=\"utf-8\">") |> ignore
+        sb.AppendLine("  <title>pty-speak Manual Tests Quickref</title>") |> ignore
+        sb.AppendLine("  <style>") |> ignore
+        sb.AppendLine("    body { font-family: -apple-system, Segoe UI, sans-serif; max-width: 80ch; margin: 2em auto; padding: 0 1em; line-height: 1.5; }") |> ignore
+        sb.AppendLine("    h1, h2, h3 { line-height: 1.2; }") |> ignore
+        sb.AppendLine("    table { border-collapse: collapse; margin: 0.5em 0; }") |> ignore
+        sb.AppendLine("    th, td { border: 1px solid #ccc; padding: 0.4em 0.6em; text-align: left; vertical-align: top; }") |> ignore
+        sb.AppendLine("    code { background: #f4f4f4; padding: 0.1em 0.3em; }") |> ignore
+        sb.AppendLine("    pre { background: #f4f4f4; padding: 0.5em; overflow-x: auto; }") |> ignore
+        sb.AppendLine("    pre code { background: transparent; padding: 0; }") |> ignore
+        sb.AppendLine("  </style>") |> ignore
+        sb.AppendLine("</head>") |> ignore
+        sb.AppendLine("<body>") |> ignore
+        sb.AppendLine("  <h1>pty-speak Manual Tests Quickref</h1>") |> ignore
+        sb.AppendLine("  <p><em>Generated from docs/ACCESSIBILITY-TESTING.md; filtered to sections marked <code>&lt;!-- DOGFOOD --&gt;</code>. Use NVDA browse mode H key to jump between test sections.</em></p>") |> ignore
+        sb.AppendLine("  <main>") |> ignore
+        sb.AppendLine(bodyHtml) |> ignore
+        sb.AppendLine("  </main>") |> ignore
+        sb.AppendLine("</body>") |> ignore
+        sb.AppendLine("</html>") |> ignore
+        sb.ToString()
+
+    /// Build the Markdig pipeline used by `filterAndConvert`.
+    /// `UseAutoIdentifiers` adds `id` attributes to headings so
+    /// in-page anchors work; `UsePipeTables` handles the matrix
+    /// rows formatted as `| col | col |` markdown tables.
+    let private buildPipeline () : MarkdownPipeline =
+        MarkdownPipelineBuilder()
+            .UseAutoIdentifiers()
+            .UseAutoLinks()
+            .UsePipeTables()
+            .Build()
+
+    /// Filter the markdown to sections marked with the DOGFOOD
+    /// comment and render the result as a standalone HTML5
+    /// document. Empty input or input with no marked sections
+    /// returns a valid HTML5 document with an empty `<main>`.
+    let filterAndConvert (markdown: string) : string =
+        let chunks = splitAndMark markdown
+        let keptMarkdown =
+            chunks
+            |> Array.filter fst
+            |> Array.map snd
+            |> String.concat "\n\n"
+        let pipeline = buildPipeline ()
+        let bodyHtml = Markdown.ToHtml(keptMarkdown, pipeline)
+        renderDocument bodyHtml

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -342,8 +342,15 @@ module StreamPathway =
         else
             let head = text.Substring(0, limit)
             let extra = text.Length - limit
+            // Cycle 38a-followup — `Ctrl+Shift+;` was retired in
+            // Cycle 25b-1a. `Ctrl+Shift+D` bundles the diagnostic
+            // snapshot, whose `--- FILELOGGER ACTIVE LOG ---`
+            // section carries the UNTRUNCATED payload via
+            // `FileLoggerChannel` (the announce layer's truncation
+            // doesn't gate the log layer). The bundle is copied to
+            // clipboard for paste-back to triage chat.
             sprintf
-                "%s ...announcement truncated; %d more characters available — press Ctrl+Shift+; to copy full log."
+                "%s ...announcement truncated; %d more characters available — press Ctrl+Shift+D to copy the diagnostic bundle (full payload in the FileLogger log section)."
                 head
                 extra
 

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -42,10 +42,12 @@
     <Compile Include="Channels/IClipboardProvider.fs" />
     <Compile Include="Channels/IHotkeyTranslator.fs" />
     <Compile Include="Channels/IDisplayBuffer.fs" />
+    <Compile Include="ManualTestsHtml.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Tomlyn" />
   </ItemGroup>

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -63,17 +63,12 @@
                  option, matching `multiStateNameOf` and the
                  stable `OptionId`s in
                  `HotkeyRegistry.multiStateBuiltIns`. -->
-            <MenuItem Header="_View">
-                <MenuItem x:Name="MenuItem_LoggingLevel"
-                          x:FieldModifier="public"
-                          Header="Logging _Level">
-                    <MenuItem x:Name="MenuItem_LoggingLevel_information"
-                              x:FieldModifier="public"
-                              Header="_Information" />
-                    <MenuItem x:Name="MenuItem_LoggingLevel_debug"
-                              x:FieldModifier="public"
-                              Header="_Debug" />
-                </MenuItem>
+            <!-- Cycle 38a-followup — renamed from "View" to
+                 "Display"; Logging Level moved to Diagnostics
+                 (it's a diagnostic-relevant control, not a
+                 display setting). Display now hosts only the
+                 Earcons multi-state. -->
+            <MenuItem Header="_Display">
                 <MenuItem x:Name="MenuItem_EarconsMode"
                           x:FieldModifier="public"
                           Header="_Earcons">
@@ -100,6 +95,20 @@
                           Header="Announce _Session Log Path" />
             </MenuItem>
             <MenuItem Header="Dia_gnostics">
+                <!-- Cycle 38a-followup — Logging Level moved here
+                     from Display (formerly View). It's a diagnostic
+                     verbosity control, not a display setting. First
+                     item so it's reachable without arrow-scrolling. -->
+                <MenuItem x:Name="MenuItem_LoggingLevel"
+                          x:FieldModifier="public"
+                          Header="Logging _Level">
+                    <MenuItem x:Name="MenuItem_LoggingLevel_information"
+                              x:FieldModifier="public"
+                              Header="_Information" />
+                    <MenuItem x:Name="MenuItem_LoggingLevel_debug"
+                              x:FieldModifier="public"
+                              Header="_Debug" />
+                </MenuItem>
                 <MenuItem x:Name="MenuItem_HealthCheck"
                           x:FieldModifier="public"
                           Header="_Health Check" />
@@ -116,6 +125,14 @@
                 <MenuItem x:Name="MenuItem_RunProcessCleanupScript"
                           x:FieldModifier="public"
                           Header="Test Process _Cleanup" />
+                <!-- Cycle 38a-followup — second menu-only command.
+                     Filters ACCESSIBILITY-TESTING.md to sections
+                     marked `<!-- DOGFOOD -->`, renders Markdig HTML,
+                     and opens in the default browser for NVDA
+                     browse-mode H-key heading navigation. -->
+                <MenuItem x:Name="MenuItem_OpenManualTests"
+                          x:FieldModifier="public"
+                          Header="Open Manual _Tests" />
             </MenuItem>
             <!-- Cycle 28 — Window menu. Both items are menu-only
                  commands (no keyboard accelerator registered with

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -127,9 +127,9 @@
                           Header="Test Process _Cleanup" />
                 <!-- Cycle 38a-followup — second menu-only command.
                      Filters ACCESSIBILITY-TESTING.md to sections
-                     marked `<!-- DOGFOOD -->`, renders Markdig HTML,
-                     and opens in the default browser for NVDA
-                     browse-mode H-key heading navigation. -->
+                     marked with the DOGFOOD HTML comment, renders
+                     Markdig HTML, and opens in the default browser
+                     for NVDA browse-mode H-key heading navigation. -->
                 <MenuItem x:Name="MenuItem_OpenManualTests"
                           x:FieldModifier="public"
                           Header="Open Manual _Tests" />

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -87,7 +87,10 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               HotkeyRegistry.RunProcessCleanupScript
               // Cycle 28 — Window menu commands (menu-only).
               HotkeyRegistry.CloseWindow
-              HotkeyRegistry.ExitApp ]
+              HotkeyRegistry.ExitApp
+              // Cycle 38a-followup — second menu-only command;
+              // Diagnostics → Open Manual Tests.
+              HotkeyRegistry.OpenManualTests ]
     let actual = Set.ofList HotkeyRegistry.allCommands
     Assert.Equal<Set<HotkeyRegistry.AppCommand>>(expected, actual)
 
@@ -405,6 +408,19 @@ let ``ExitApp is menu-only (Cycle 28 — None Key, None Modifiers)`` () =
     Assert.Equal(None, hk.Key)
     Assert.Equal<Set<HotkeyRegistry.Modifier> option>(None, hk.Modifiers)
     Assert.Equal("ExitApp", HotkeyRegistry.nameOf HotkeyRegistry.ExitApp)
+    Assert.Equal(None, HotkeyRegistry.gestureText hk)
+
+[<Fact>]
+let ``OpenManualTests is menu-only (Cycle 38a-followup — None Key, None Modifiers)`` () =
+    // Cycle 38a-followup — second menu-only AppCommand after
+    // RunProcessCleanupScript. Surfaced via Diagnostics → Open
+    // Manual Tests. Mirrors the (None, None) shape pin so a
+    // future PR doesn't accidentally promote it to a gesture-
+    // bearing command without an explicit decision.
+    let hk = HotkeyRegistry.hotkeyOf HotkeyRegistry.OpenManualTests
+    Assert.Equal(None, hk.Key)
+    Assert.Equal<Set<HotkeyRegistry.Modifier> option>(None, hk.Modifiers)
+    Assert.Equal("OpenManualTests", HotkeyRegistry.nameOf HotkeyRegistry.OpenManualTests)
     Assert.Equal(None, HotkeyRegistry.gestureText hk)
 
 [<Fact>]

--- a/tests/Tests.Unit/ManualTestsHtmlTests.fs
+++ b/tests/Tests.Unit/ManualTestsHtmlTests.fs
@@ -1,0 +1,95 @@
+module PtySpeak.Tests.Unit.ManualTestsHtmlTests
+
+open Xunit
+open Terminal.Core
+
+/// Cycle 38a-followup — pins the ManualTestsHtml filter +
+/// conversion contract. Tests use inline markdown strings rather
+/// than the real `ACCESSIBILITY-TESTING.md` fixture so they stay
+/// stable as that file grows.
+
+// =====================================================================
+// splitAndMark — DOGFOOD filter behaviour
+// =====================================================================
+
+[<Fact>]
+let ``splitAndMark keeps sections preceded by DOGFOOD marker`` () =
+    let md =
+        "# Title\n\nintro\n\n<!-- DOGFOOD -->\n### Marked Section\nbody A\n"
+    let chunks = ManualTestsHtml.splitAndMark md
+    Assert.Equal(1, chunks.Length)
+    let (markerFound, text) = chunks.[0]
+    Assert.True(markerFound)
+    Assert.Contains("### Marked Section", text)
+    Assert.Contains("body A", text)
+
+[<Fact>]
+let ``splitAndMark drops sections without preceding DOGFOOD marker`` () =
+    let md =
+        "# Title\n\nintro\n\n### Unmarked\nbody A\n\n<!-- DOGFOOD -->\n### Marked\nbody B\n"
+    let chunks = ManualTestsHtml.splitAndMark md
+    Assert.Equal(2, chunks.Length)
+    let (firstMarker, firstText) = chunks.[0]
+    let (secondMarker, secondText) = chunks.[1]
+    Assert.False(firstMarker)
+    Assert.Contains("### Unmarked", firstText)
+    Assert.True(secondMarker)
+    Assert.Contains("### Marked", secondText)
+
+[<Fact>]
+let ``splitAndMark resets the marker between sections so it does not bleed forward`` () =
+    let md =
+        "<!-- DOGFOOD -->\n### First\nbody A\n\n### Second\nbody B\n"
+    let chunks = ManualTestsHtml.splitAndMark md
+    Assert.Equal(2, chunks.Length)
+    let (firstMarker, _) = chunks.[0]
+    let (secondMarker, _) = chunks.[1]
+    Assert.True(firstMarker)
+    Assert.False(secondMarker)
+
+[<Fact>]
+let ``splitAndMark returns empty array for markdown with no level-3 headings`` () =
+    let md = "# Title\n\nSome intro text with no sub-sections.\n"
+    let chunks = ManualTestsHtml.splitAndMark md
+    Assert.Empty(chunks)
+
+// =====================================================================
+// filterAndConvert — end-to-end (filter + Markdig conversion)
+// =====================================================================
+
+[<Fact>]
+let ``filterAndConvert produces a complete HTML5 document with main landmark`` () =
+    let md = "<!-- DOGFOOD -->\n### Test\nbody\n"
+    let html = ManualTestsHtml.filterAndConvert md
+    Assert.StartsWith("<!DOCTYPE html>", html)
+    Assert.Contains("<html lang=\"en\">", html)
+    Assert.Contains("<main>", html)
+    Assert.Contains("</main>", html)
+    Assert.Contains("</html>", html)
+
+[<Fact>]
+let ``filterAndConvert includes content from marked section but not unmarked`` () =
+    let md =
+        "<!-- DOGFOOD -->\n### Dogfood Section\nbody KEEP\n\n### Hidden Section\nbody SKIP\n"
+    let html = ManualTestsHtml.filterAndConvert md
+    Assert.Contains("Dogfood Section", html)
+    Assert.Contains("KEEP", html)
+    Assert.DoesNotContain("Hidden Section", html)
+    Assert.DoesNotContain("SKIP", html)
+
+[<Fact>]
+let ``filterAndConvert renders pipe tables as HTML tables`` () =
+    let md =
+        "<!-- DOGFOOD -->\n### Table Section\n\n| col1 | col2 |\n| --- | --- |\n| a | b |\n"
+    let html = ManualTestsHtml.filterAndConvert md
+    Assert.Contains("<table>", html)
+    Assert.Contains("<th>col1</th>", html)
+    Assert.Contains("<td>a</td>", html)
+
+[<Fact>]
+let ``filterAndConvert on empty input returns a valid HTML5 shell with empty main`` () =
+    let html = ManualTestsHtml.filterAndConvert ""
+    Assert.StartsWith("<!DOCTYPE html>", html)
+    Assert.Contains("<main>", html)
+    Assert.Contains("</main>", html)
+    Assert.Contains("</html>", html)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="MultiStateRegistryTests.fs" />
     <Compile Include="LinearTextStreamTests.fs" />
     <Compile Include="CanonicalCorpusTests.fs" />
+    <Compile Include="ManualTestsHtmlTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Five UX/ergonomics fixes from the 2026-05-10 dogfood session of Cycle 38a. Bundled in one PR because they're small, related (all menu/announce/feedback surfaces), and the maintainer asked for them together.

**Plan reference**: `fluffy-simon.md` Section 19.

## The five fixes

### 1. Truncation suffix references an existing shortcut

[`src/Terminal.Core/StreamPathway.fs:346`](src/Terminal.Core/StreamPathway.fs) previously told the user to press `Ctrl+Shift+;` to copy the full log — but that hotkey was retired in Cycle 25b-1a. Replaced with `Ctrl+Shift+D` (the diagnostic bundle carries the untruncated payload in its `--- FILELOGGER ACTIVE LOG ---` section).

### 2. Spoken diagnostic summary enriched

The `Ctrl+Shift+D` end-of-battery announce previously said only `"Diagnostic complete. {pass} of {total} passed.{substrate fragment}"`. Corpus results (Cycle 38a) were in the bundle but not spoken. Now the announce includes:

- `" Corpus: {P} of {T} passed; failing: {ids}."` when scenarios fail
- `" Corpus: all {N} passed."` when none do
- nothing when no scenarios match the active shell

Maintainer hears which canonical-interaction rows misbehaved without opening the file.

### 3. New `Diagnostics → Open Manual Tests` menu item

- Filters [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md) to sub-sections marked with `<!-- DOGFOOD -->` HTML comment.
- Renders Markdig HTML wrapped in an HTML5 document with a `<main>` landmark.
- Writes to `%LOCALAPPDATA%\PtySpeak\manual-tests.html` and opens it in the default browser via `ShellExecute`.
- NVDA browse-mode H key jumps section headings; D key jumps the `<main>` landmark.
- Maintainer can grow / prune the quickref by adding / removing markers in the source markdown — no code change required.

**Implementation**:
- New module: [`src/Terminal.Core/ManualTestsHtml.fs`](src/Terminal.Core/ManualTestsHtml.fs) (pure `filterAndConvert : markdown -> html`).
- New dependency: Markdig 0.38.0 (BSD 2-Clause).
- New menu-only AppCommand: `HotkeyRegistry.OpenManualTests` (mirrors `RunProcessCleanupScript`'s Cycle 26c pattern: `Key = None, Modifiers = None`).
- Handler: `openManualTests` in [`src/Terminal.App/Program.fs`](src/Terminal.App/Program.fs).
- Initial DOGFOOD markers: Cycle 38a, 37, 36, 29b, 28 + the always-run "Artifact integrity" and "Launch and process hygiene" matrices.

### 4. View → Display rename

Top-level menu header rename. Matches maintainer's mental model. [`src/Views/MainWindow.xaml`](src/Views/MainWindow.xaml) line 66.

### 5. Logging Level moved Display → Diagnostics

It's a diagnostic verbosity control, not a display setting. Now first in the Diagnostics menu (reachable without arrow-scrolling). `MultiStateRegistry` registration unchanged; pure XAML move. Display now hosts only the Earcons multi-state.

## Tests

- 8 new facts in [`tests/Tests.Unit/ManualTestsHtmlTests.fs`](tests/Tests.Unit/ManualTestsHtmlTests.fs) pinning the `splitAndMark` filter + `filterAndConvert` end-to-end contract (DOGFOOD inclusion / exclusion, marker reset between sections, empty input, HTML5 shell, pipe-table rendering).
- 1 new fact in [`tests/Tests.Unit/HotkeyRegistryTests.fs`](tests/Tests.Unit/HotkeyRegistryTests.fs) pinning `OpenManualTests` menu-only shape.
- `AppReservedHotkeysMirrorTests` not touched (menu-only items excluded by definition).

## What this PR does NOT do

- **No Cycle 38b work.** Per-shell route table + PowerShell scenarios still deferred to its own PR.
- **No Bug-tagged-state-change tracking, explicit SessionModel sentence, or explicit bundle-path sentence in the spoken summary.** Maintainer didn't tick those.
- **No keyboard accelerator for `OpenManualTests`.** Menu-only per hotkey-count working-memory ceiling.
- **No automated comparison of `manual-tests.html` against the source markdown.** Filter is unit-tested; browser/NVDA behaviour is dogfood-validated.
- **No backport of DOGFOOD markers to the historical 1000+ lines of `ACCESSIBILITY-TESTING.md`.** Only 7 initial markers; maintainer adds others as needed.

## Test plan

- [ ] `Build and test (windows-latest)` green — 9 new test facts + 989+ existing tests stay green.
- [ ] `Workflow lint`, `Portability lint`, `Markdown link check` green.
- [ ] **Maintainer dogfood** post-merge:
  - Rebuild from `main`.
  - Top-level menu reads "Display" (not "View").
  - Display menu → only Earcons (Logging Level no longer there).
  - Diagnostics menu → Logging Level first; Open Manual Tests last.
  - Click Diagnostics → Open Manual Tests → default browser opens an HTML page with the 7 marked sections; NVDA H key jumps headings; D key jumps `<main>` landmark.
  - Trigger a truncated announcement (long output); listen for the suffix referencing `Ctrl+Shift+D`.
  - Press `Ctrl+Shift+D`; listen for `"Corpus: …"` in the spoken summary.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_