### PR TITLE
feat(cycle-38b-38c): per-shell route table + cmd/PowerShell echo-suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,105 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 38b + 38c): Per-shell route table + cmd/PowerShell echo-suppression
+
+Closes the maintainer's 2026-05-10 dogfood regression: `echo hello`
+in cmd no longer causes NVDA to read the typed-input echo prefix.
+Two related changes ship as one PR per maintainer's "stable
+functional position" directive.
+
+**Cycle 38b — Per-shell profile-set route table** (~150 LOC):
+
+- [`src/Terminal.Core/Config.fs`](src/Terminal.Core/Config.fs)
+  extends `ShellPathwayConfig` with `Profiles: string[] option`
+  and grows `parseShellOverrides` to read
+  `[shell.<key>] profiles = [...]` alongside the existing
+  `pathway` field. New `tryGetStringArray` helper. New
+  `resolveShellProfiles` resolver.
+- [`src/Terminal.App/Program.fs`](src/Terminal.App/Program.fs)
+  adds `resolveProfilesForShell : ShellId -> Profile list`
+  (defined after `chosenShell` is known) and calls
+  `OutputDispatcher.ProfileRegistry.setActiveProfileSet` at
+  startup AND on every shell-switch (alongside the existing
+  detector resets). The setActiveProfileSet surface was planned
+  at `OutputDispatcher.fs:80-83` ("Stage 8f wires this") but
+  wasn't wired until now.
+- Built-in defaults when TOML doesn't override:
+  cmd / powershell → `["echo-suppressor", "earcon", "selection"]`
+  claude → `["passthrough", "earcon", "selection"]`
+- Unknown profile IDs in TOML are logged + dropped (warning, not
+  fatal) so a typo doesn't crash startup.
+- `defaultsTemplate` in Config.fs gains a commented example block
+  documenting the override syntax.
+
+**Cycle 38c — Echo-suppression for cmd / PowerShell** (~300 LOC):
+
+- New module
+  [`src/Terminal.Core/EchoCorrelator.fs`](src/Terminal.Core/EchoCorrelator.fs)
+  holds a bounded, time-bounded buffer of bytes written to
+  `ConPtyHost.WriteBytes`. `matchAndConsumeEchoPrefix` returns
+  how many leading payload bytes match the recent input, with
+  CR→CRLF normalisation for cmd's echo behaviour. Atomic
+  match-then-consume so an input byte echoes exactly once.
+  Lock-per-instance for thread safety (WriteBytes runs on UI
+  thread; matching runs on dispatcher pump thread).
+- New module
+  [`src/Terminal.Core/EchoSuppressorProfile.fs`](src/Terminal.Core/EchoSuppressorProfile.fs)
+  registers as `ProfileId = "echo-suppressor"`. For StreamChunk
+  events: consults the shared correlator; strips matched prefix
+  from the NVDA payload; emits FileLogger with the FULL original
+  (or `(suppressed echo: ...)` annotation when fully echoed).
+  For non-StreamChunk events: behaves identically to
+  PassThroughProfile.
+- `Program.fs` wires:
+  - One `EchoCorrelator` instance at composition root.
+  - One `EchoSuppressorProfile` instance, registered with
+    `ProfileRegistry`.
+  - `ConPtyHost.WriteBytes` is wrapped to feed the correlator
+    BEFORE the PTY write (so a fast shell can't echo before we
+    tracked the typed bytes).
+  - `EchoCorrelator.reset` is called on shell-switch alongside
+    the existing prompt / selection detector resets.
+
+**Tests** (~250 LOC):
+
+- 9 facts in
+  [`tests/Tests.Unit/EchoCorrelatorTests.fs`](tests/Tests.Unit/EchoCorrelatorTests.fs)
+  pin: empty-buffer baseline; exact-match prefix; payload
+  divergence; CR-LF normalisation; match-then-consume invariant;
+  partial-match leaves remainder; age-based expiry; buffer
+  overflow eviction; reset.
+- 7 facts in
+  [`tests/Tests.Unit/EchoSuppressorProfileTests.fs`](tests/Tests.Unit/EchoSuppressorProfileTests.fs)
+  pin: full-echo NVDA-drop; partial-echo strip; no-match
+  pass-through; payload divergence pass-through; non-StreamChunk
+  pass-through; module identity.
+- 5 new facts in
+  [`tests/Tests.Unit/ConfigTests.fs`](tests/Tests.Unit/ConfigTests.fs)
+  pin: profiles array parse; absent profiles returns None;
+  pathway + profiles together; profiles without pathway; absent
+  shell section.
+
+**Corpus update**:
+[`tests/fixtures/canonical-interactions.toml`](tests/fixtures/canonical-interactions.toml)
+`cmd.echo.plain` row's `notes` field flips FAIL→PASS: bug-tag
+becomes "Fixed in Cycle 38c." `expected_payload_regex` field
+populated (parsed today but enforced from Cycle 38d).
+
+**What this PR does NOT do**:
+- No three-pane channel routing (input vs current_output vs
+  history pane). Echo is SUPPRESSED in 38c, not ROUTED. Deferred
+  to Cycle 38d.
+- No `expected_payload_regex` enforcement in `runCorpus`. Still
+  parsed-only; 38d wires it.
+- No PowerShell / Claude scenarios in the corpus. 38e adds those.
+- No NVDA verbatim-text matching. Same as above.
+- No prompt-stripping (cmd's next prompt `C:\>` still flows
+  through). Separate concern (heuristic prompt detector).
+- No timing-parameter exposure via TOML. EchoCorrelator
+  parameters are hardcoded; future cycle exposes via
+  `[profile.echo-suppressor]` if dogfood reveals timing issues.
+
 ### Changed (Cycle 38a-followup): Post-dogfood UX refresh
 
 Five UX/ergonomics fixes from the 2026-05-10 dogfood session of

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1263,6 +1263,49 @@ matrix's shrinking surface area over time.
   with the expected length floor) is now CI-pinned.
 
 <!-- DOGFOOD -->
+### Cycle 38b + 38c — Per-shell route table + cmd/PowerShell echo-suppression
+
+Cycle 38b introduces a per-shell profile-set TOML override
+(`[shell.<key>] profiles = [...]` in `config.toml`); Cycle 38c
+ships the first profile that uses it — `EchoSuppressorProfile`,
+which strips the user's typed-input echo from NVDA announcements
+on cmd / PowerShell.
+
+**Built-in default active sets** (when TOML doesn't override):
+- cmd, powershell → `["echo-suppressor", "earcon", "selection"]`
+- claude → `["passthrough", "earcon", "selection"]`
+
+**EchoSuppressorProfile behaviour**:
+- For `StreamChunk` events with non-empty payload, consult
+  `EchoCorrelator` (which has been recording bytes written via
+  `ConPtyHost.WriteBytes`). If a leading prefix of the payload
+  matches recent input (with CR→CRLF normalisation for cmd's
+  echo-translation behaviour), strip that prefix from the NVDA
+  announce.
+- If the entire payload was echo: NVDA decision is DROPPED; the
+  FileLogger gets a `(suppressed echo: ...)` annotation in its
+  audit trail.
+- If a partial match: NVDA gets the stripped payload; FileLogger
+  gets the full original.
+- Non-StreamChunk events behave identically to PassThrough.
+
+**Manual matrix rows**:
+
+| Test | Procedure | Expected |
+|---|---|---|
+| 38b.1 — Active profile set per shell | Switch between cmd / PowerShell / Claude via Ctrl+Shift+1/2/3. After each switch, type a short command. | Cmd / PowerShell: no echoed-input bleed in NVDA announce. Claude: behaves as today (passthrough). |
+| 38c.1 — `echo` suppression on cmd | In cmd, type `echo hello` + Enter. | NVDA announces "hello" (or near-equivalent). The typed `echo hello` echo is NOT in the announce. |
+| 38c.2 — Suppression audit trail | After 38c.1, press Ctrl+Shift+D. Open the bundle's `--- FILELOGGER ACTIVE LOG ---` section. Search for `(suppressed echo:`. | The annotation appears with the echo-prefix payload. |
+| 38c.3 — Partial-echo case | In cmd, type `set` + Enter (cmd lists env vars with `set` as the first echoed word). | NVDA announces the env-var list. The leading `set\r\n` echo is stripped; the rest is announced. |
+| 38c.4 — Claude unaffected | Switch to Claude. Send a short message. | Claude behaviour is unchanged (still uses passthrough; selection-list peer still fires for tool-use prompts). |
+| 38c.5 — Per-shell override via TOML | Edit `config.toml`. Add `[shell.cmd] profiles = ["passthrough", "earcon"]` (no echo-suppressor). Restart pty-speak (or hot-switch to a different shell and back to cmd). Type `echo hello` + Enter. | Echo is NO LONGER suppressed (because TOML overrode the default and dropped echo-suppressor). |
+
+**Stopping gate for 38b+c**: NVDA hears only the output of
+`echo hello` on cmd (no input echo). FileLogger preserves the
+suppression annotation for forensics. Per-shell TOML override
+respected.
+
+<!-- DOGFOOD -->
 ### Cycle 38a — Canonical interaction corpus baseline
 
 Cycle 38a is the **regression scaffolding** for the cmd / PowerShell

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1068,12 +1068,30 @@ module Program =
         // user-facing text and emit a NVDA + FileLogger pair.
         let selectionProfile = SelectionProfile.create ()
         OutputDispatcher.ProfileRegistry.register selectionProfile
-        // Active set: [ passThroughProfile; earconProfile;
-        // selectionProfile ]. PassThrough fans non-empty
-        // payloads to NVDA + FileLogger; Earcon claims
-        // BellRang / ErrorLine / WarningLine; Selection claims
-        // SelectionShown / SelectionItem / SelectionDismissed
-        // and emits the user-facing text rendering for them.
+        // Cycle 38c — EchoCorrelator + EchoSuppressorProfile.
+        // The correlator tracks bytes written to PTY-stdin via
+        // the wrapped WriteBytes call below; EchoSuppressorProfile
+        // consults the correlator on each StreamChunk to strip
+        // the echoed input prefix from NVDA announcements. The
+        // FileLogger audit trail preserves the full payload (with
+        // a `(suppressed echo: ...)` annotation for fully-echoed
+        // chunks) so `Ctrl+Shift+D` bundles can verify suppression
+        // behaviour post-hoc. For shells where echo isn't an issue
+        // (Claude uses OSC 133), this profile is omitted from the
+        // active set via the per-shell route table (Cycle 38b).
+        let echoCorrelator =
+            EchoCorrelator.create EchoCorrelator.defaultParameters
+        let echoSuppressorProfile =
+            EchoSuppressorProfile.create echoCorrelator
+        OutputDispatcher.ProfileRegistry.register echoSuppressorProfile
+        // Cycle 38b — startup active set uses the legacy
+        // PassThrough-based list as a placeholder until
+        // `chosenShell` is resolved later in composition. The
+        // dispatcher doesn't see events until after the PTY
+        // starts producing, so the placeholder window is
+        // dispatch-event-free. `setActiveProfileSet` is
+        // re-called once `chosenShell` is known (line ~1962)
+        // and again on every shell-switch.
         OutputDispatcher.ProfileRegistry.setActiveProfileSet
             [ passThroughProfile; earconProfile; selectionProfile ]
 
@@ -1925,6 +1943,41 @@ module Program =
         // shell.
         currentShellId <- chosenShell.Id
 
+        // Cycle 38b — resolve the active profile set for the
+        // chosen shell. Defined here (after `chosenShell` is
+        // known) so the resolver can read the shell key. Used
+        // both at startup (this call) and on every shell-switch
+        // (later in `switchToShell`). Built-in defaults give
+        // cmd / PowerShell the EchoSuppressor (Cycle 38c) and
+        // Claude the legacy PassThrough; TOML
+        // `[shell.<key>] profiles = [...]` overrides per shell.
+        let shellIdToProfileKey (id: ShellRegistry.ShellId) : string =
+            match id with
+            | ShellRegistry.Cmd -> "cmd"
+            | ShellRegistry.PowerShell -> "powershell"
+            | ShellRegistry.Claude -> "claude"
+        let resolveProfilesForShell (shellId: ShellRegistry.ShellId) : Profile list =
+            let shellKey = shellIdToProfileKey shellId
+            let defaultSet =
+                match shellKey with
+                | "claude" -> [ "passthrough"; "earcon"; "selection" ]
+                | _ -> [ "echo-suppressor"; "earcon"; "selection" ]
+            let configured =
+                Config.resolveShellProfiles config shellKey
+                |> Option.map Array.toList
+                |> Option.defaultValue defaultSet
+            configured
+            |> List.choose (fun pid ->
+                match OutputDispatcher.ProfileRegistry.lookup pid with
+                | Some p -> Some p
+                | None ->
+                    log.LogWarning(
+                        "Config: profile id '{Id}' for shell '{Shell}' is not registered; dropped from active set.",
+                        pid, shellKey)
+                    None)
+        OutputDispatcher.ProfileRegistry.setActiveProfileSet
+            (resolveProfilesForShell chosenShell.Id)
+
         // SessionModel Tier 1.C — re-create with the resolved
         // startup shell key. The placeholder declared above
         // (with `cmd` key) is replaced here once `chosenShell`
@@ -2414,7 +2467,15 @@ module Program =
                     (fun _ -> lastReadUtc <- DateTimeOffset.UtcNow)
                     cts.Token
             window.TerminalSurface.SetPtyHost(
-                Action<byte[]>(fun bytes -> host.WriteBytes(bytes)),
+                // Cycle 38c — record bytes into the EchoCorrelator
+                // BEFORE the PTY write so a fast shell can't echo
+                // back before we tracked the typed bytes. The
+                // correlator is shared with EchoSuppressorProfile,
+                // which strips matched prefixes from StreamChunk
+                // payloads at dispatch time.
+                Action<byte[]>(fun bytes ->
+                    EchoCorrelator.recordWrite echoCorrelator (DateTime.UtcNow) bytes
+                    host.WriteBytes(bytes)),
                 Action<int, int>(fun cols rows ->
                     // Resize is best-effort: a transient failure
                     // (e.g. the child has just exited) shouldn't
@@ -2694,6 +2755,24 @@ module Program =
                                         selectionDetector <-
                                             SelectionDetector.reset
                                                 selectionDetector
+                                        // Cycle 38c — clear the
+                                        // EchoCorrelator's pending
+                                        // input buffer so bytes
+                                        // typed at the prior shell
+                                        // can't match early output
+                                        // on the new shell.
+                                        EchoCorrelator.reset
+                                            echoCorrelator
+                                        // Cycle 38b — re-resolve
+                                        // the active profile set
+                                        // for the new shell so its
+                                        // TOML `[shell.<key>] profiles`
+                                        // takes effect (cmd /
+                                        // PowerShell get
+                                        // EchoSuppressor; Claude
+                                        // gets PassThrough).
+                                        OutputDispatcher.ProfileRegistry.setActiveProfileSet
+                                            (resolveProfilesForShell shell.Id)
                                         // Phase A — swap the active
                                         // pathway for the new shell.
                                         // `Reset` clears any pending

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -76,7 +76,17 @@ module Config =
     /// stays free of `StreamPathway` / `TuiPathway` direct
     /// references on the SHELL side so adding a new pathway in
     /// Phase 2 doesn't require a Config-module change.
-    type ShellPathwayConfig = { PathwayId: string }
+    type ShellPathwayConfig =
+        { PathwayId: string
+          /// Cycle 38b — per-shell profile-set override. `None`
+          /// means the shell uses the composition-root default
+          /// (`["passthrough", "earcon", "selection"]` for Claude;
+          /// `["echo-suppressor", "earcon", "selection"]` for
+          /// cmd / PowerShell). `Some [|...|]` overrides with the
+          /// listed profile IDs (validated against the registered
+          /// `ProfileId`s at composition time; unknown IDs are
+          /// logged + dropped).
+          Profiles: string[] option }
 
     /// Optional overrides for `StreamPathway.Parameters`. Each
     /// field is `int option` so the resolver can merge with
@@ -294,6 +304,20 @@ module Config =
             "# current session only; doesn't persist."
             "min_level = \"Information\""
             ""
+            "# Cycle 38b — per-shell profile-set overrides."
+            "# Each [shell.<key>] table may specify `profiles = [...]`"
+            "# to override the composition-root default. Profile IDs:"
+            "#   \"passthrough\"     — fan every OutputEvent to NVDA + FileLogger."
+            "#   \"echo-suppressor\" — strip cmd / PowerShell input echo before NVDA."
+            "#   \"earcon\"          — bell-ping / error-tone / warning-tone."
+            "#   \"selection\"       — Claude tool-use prompts as ControlType.List."
+            "# Defaults (applied when `profiles` is unset):"
+            "#   cmd / powershell  → [\"echo-suppressor\", \"earcon\", \"selection\"]"
+            "#   claude            → [\"passthrough\", \"earcon\", \"selection\"]"
+            "# Uncomment + edit to override."
+            "# [shell.cmd]"
+            "# profiles = [\"echo-suppressor\", \"earcon\", \"selection\"]"
+            ""
         ]
 
     /// Cycle 25a — write `defaultsTemplate` to `filePath` if no
@@ -374,6 +398,26 @@ module Config =
     let private tryGetBool (table: TomlTable) (key: string) : bool option =
         match table.TryGetValue(key) with
         | true, (:? bool as b) -> Some b
+        | _ -> None
+
+    /// Cycle 38b — try to read a string-array value from a
+    /// TomlTable by key. Returns `None` if absent OR if the
+    /// value is non-array OR if any element is non-string.
+    /// (Strict so a malformed `profiles = [42, "x"]` doesn't
+    /// silently truncate; caller logs the situation.)
+    let private tryGetStringArray
+            (table: TomlTable)
+            (key: string)
+            : string[] option =
+        match table.TryGetValue(key) with
+        | true, (:? TomlArray as arr) ->
+            let buf = ResizeArray<string>()
+            let mutable ok = true
+            for item in arr do
+                match item with
+                | :? string as s -> buf.Add(s)
+                | _ -> ok <- false
+            if ok then Some (buf.ToArray()) else None
         | _ -> None
 
     /// Internal — known parameter keys for `[pathway.stream]`.
@@ -667,12 +711,42 @@ module Config =
                             "Config: [shell.{Key}] is not a table; ignored.",
                             key)
                     | Some shellTable ->
-                        match tryGetString shellTable "pathway" with
-                        | None -> ()
-                        | Some pathwayId ->
+                        // Cycle 38b — `profiles = [...]` is OPTIONAL
+                        // and orthogonal to `pathway`. A shell may
+                        // override one, the other, both, or neither.
+                        // We materialise an entry in `result` if
+                        // EITHER field is set; if only `profiles`
+                        // is set, `PathwayId` falls through to the
+                        // default `"stream"` (matching the prior
+                        // behaviour for a shell that omitted
+                        // `pathway`).
+                        let pathwayId =
+                            tryGetString shellTable "pathway"
+                            |> Option.defaultValue "stream"
+                        let profiles =
+                            match tryGetStringArray shellTable "profiles" with
+                            | Some arr -> Some arr
+                            | None ->
+                                // Distinguish "key absent" (None ok)
+                                // from "key present but malformed"
+                                // (warn so the maintainer notices).
+                                match shellTable.TryGetValue("profiles") with
+                                | true, _ ->
+                                    logger.LogWarning(
+                                        "Config: [shell.{Key}] `profiles` is not a string array; ignored.",
+                                        key)
+                                    None
+                                | _ -> None
+                        let hasOverride =
+                            tryGetString shellTable "pathway" |> Option.isSome
+                            || profiles |> Option.isSome
+                        if hasOverride then
                             result <-
                                 result
-                                |> Map.add key { PathwayId = pathwayId }
+                                |> Map.add
+                                    key
+                                    { PathwayId = pathwayId
+                                      Profiles = profiles }
             result
 
     /// Cycle 19 — parse `[startup]` table. Recognises only
@@ -997,6 +1071,22 @@ module Config =
         match Map.tryFind shellKey config.ShellOverrides with
         | Some entry -> entry.PathwayId
         | None -> "stream"
+
+    /// Cycle 38b — resolve the per-shell profile-set override.
+    /// Returns `Some` when `[shell.<key>] profiles = [...]` is
+    /// set in `config.toml`; `None` otherwise (composition root
+    /// falls back to its built-in default for the shell).
+    /// Caller (`resolveProfilesForShell` in `Program.fs`)
+    /// translates the string IDs into `Profile` instances via
+    /// `OutputDispatcher.ProfileRegistry.lookup`; unknown IDs
+    /// are logged + dropped, never crash.
+    let resolveShellProfiles
+            (config: Config)
+            (shellKey: string)
+            : string[] option =
+        match Map.tryFind shellKey config.ShellOverrides with
+        | Some entry -> entry.Profiles
+        | None -> None
 
     /// Resolve the StreamPathway parameters from a Config.
     /// Each field that's `None` in `StreamOverrides` falls

--- a/src/Terminal.Core/EchoCorrelator.fs
+++ b/src/Terminal.Core/EchoCorrelator.fs
@@ -1,0 +1,178 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+open System.Collections.Generic
+
+/// Cycle 38c — input-echo correlator for cmd / PowerShell.
+///
+/// **Problem.** Cmd (and PowerShell with default `Set-PSReadLineOption`
+/// echo) writes the user's typed bytes back through PTY-stdout as
+/// the user types — `echo hello\r` produces 11 echoed bytes followed
+/// by the command output `hello\r\n` followed by the next prompt.
+/// Without correlation, NVDA reads ALL of this as one announce.
+///
+/// **Solution.** This module tracks bytes written to PTY-stdin via
+/// `ConPtyHost.WriteBytes` (wired at `Program.fs:2417`). When a
+/// `StreamChunk` `OutputEvent` arrives at `EchoSuppressorProfile`,
+/// the profile asks this correlator how many leading bytes of the
+/// payload match the recently-typed input. Matched bytes are
+/// stripped from the announce text but preserved in the FileLogger
+/// audit trail so post-hoc debugging via the `Ctrl+Shift+D` bundle
+/// can verify suppression behaviour.
+///
+/// **CR-LF normalisation.** Cmd translates a `\r` (0x0D, the Enter
+/// keystroke per `KeyEncoding.fs`) input byte to `\r\n` (0x0D 0x0A)
+/// in the echo. The matcher detects this and consumes both
+/// payload bytes against the single correlator byte. Without
+/// normalisation, `echo hello\r` would match against `echo hello\r`
+/// but fail at the trailing `\n` cmd appends.
+///
+/// **Time-bounded.** Entries older than `Parameters.MaxAgeMs`
+/// (default 5 seconds) are skipped during matching and dropped from
+/// the buffer. Without this, a stale typed byte from minutes ago
+/// could spuriously match a fresh output. 5 seconds is generous —
+/// even a slow shell start-up usually echoes within 200ms.
+///
+/// **Bounded buffer.** `Parameters.MaxBufferSize` (default 4096
+/// bytes) caps memory. When a `recordWrite` would exceed the cap,
+/// the oldest entries are dropped to make room.
+///
+/// **Thread safety.** All mutating operations take a per-instance
+/// lock. WriteBytes is called from the WPF UI thread; matching is
+/// called from the OutputDispatcher pump thread; the lock keeps the
+/// buffer consistent across both.
+module EchoCorrelator =
+
+    /// Configuration parameters. Mutable for unit-test
+    /// scenarios; production composition uses `defaultParameters`.
+    type Parameters =
+        { MaxBufferSize: int
+          MaxAgeMs: int }
+
+    let defaultParameters: Parameters =
+        { MaxBufferSize = 4096
+          MaxAgeMs = 5000 }
+
+    /// Internal per-byte record. Each byte the user types is
+    /// stored alongside the timestamp at which it was written
+    /// to PTY-stdin.
+    type private TimedByte =
+        { Byte: byte
+          RecordedAt: DateTime }
+
+    /// Producer state. Mutable class — the composition root
+    /// holds one instance, wires `recordWrite` into the WriteBytes
+    /// path, and passes the instance to `EchoSuppressorProfile`
+    /// for matching at dispatch time.
+    type T(parameters: Parameters) =
+        let gate: obj = obj ()
+        let pending: LinkedList<TimedByte> = LinkedList<TimedByte>()
+        member val internal Parameters: Parameters = parameters with get
+        member internal _.Gate = gate
+        member internal _.Pending = pending
+
+    /// Create a fresh correlator with the supplied parameters.
+    let create (parameters: Parameters) : T = T(parameters)
+
+    /// Drop entries older than `MaxAgeMs` from the FRONT of the
+    /// pending buffer (the head is the oldest). Called internally
+    /// before any matching or recording operation so callers don't
+    /// have to worry about stale entries.
+    let private expireOld (state: T) (now: DateTime) : unit =
+        let maxAge = TimeSpan.FromMilliseconds(float state.Parameters.MaxAgeMs)
+        let mutable continueLoop = true
+        while continueLoop do
+            match state.Pending.First with
+            | null -> continueLoop <- false
+            | head ->
+                if (now - head.Value.RecordedAt) > maxAge then
+                    state.Pending.RemoveFirst()
+                else
+                    continueLoop <- false
+
+    /// Record a chunk of bytes written to PTY-stdin. Each byte
+    /// is tagged with `now`. Buffer is capped at
+    /// `MaxBufferSize`; over-cap pushes evict the oldest entries.
+    let recordWrite (state: T) (now: DateTime) (bytes: byte[]) : unit =
+        if bytes.Length > 0 then
+            lock state.Gate (fun () ->
+                expireOld state now
+                for b in bytes do
+                    state.Pending.AddLast(
+                        { Byte = b; RecordedAt = now })
+                    |> ignore
+                while state.Pending.Count > state.Parameters.MaxBufferSize do
+                    state.Pending.RemoveFirst())
+
+    /// Try to match a leading prefix of `payload` against the
+    /// pending buffer. CR-LF normalisation: when the correlator
+    /// has `\r` (0x0D) and the payload has `\r\n` (0x0D 0x0A) at
+    /// the same position, both payload bytes are consumed against
+    /// the one correlator byte.
+    ///
+    /// **Side effect**: if any bytes matched, the corresponding
+    /// correlator entries are CONSUMED (removed from pending).
+    /// This is the atomic match-then-consume operation
+    /// `EchoSuppressorProfile` calls per StreamChunk so a given
+    /// input byte echoes exactly once.
+    ///
+    /// Returns the count of PAYLOAD bytes matched (which, with
+    /// CR-LF normalisation, may exceed the count of correlator
+    /// bytes consumed).
+    let matchAndConsumeEchoPrefix
+            (state: T)
+            (now: DateTime)
+            (payload: string)
+            : int =
+        if String.IsNullOrEmpty payload then 0
+        else
+            lock state.Gate (fun () ->
+                expireOld state now
+                let payloadBytes = Encoding.UTF8.GetBytes(payload)
+                let mutable payloadIdx = 0
+                let mutable currentNode = state.Pending.First
+                let mutable stop = false
+                while not stop
+                      && payloadIdx < payloadBytes.Length
+                      && not (isNull currentNode) do
+                    let cByte = currentNode.Value.Byte
+                    let pByte = payloadBytes.[payloadIdx]
+                    if cByte = pByte then
+                        payloadIdx <- payloadIdx + 1
+                        currentNode <- currentNode.Next
+                        // CR-LF expansion: cmd translates a typed
+                        // `\r` (the Enter keystroke per
+                        // `KeyEncoding`) into `\r\n` on the
+                        // echo path. After matching the `\r` in
+                        // both, look ahead one byte in the
+                        // payload — if it's `\n`, consume it
+                        // too without advancing the correlator.
+                        // Handles both "correlator ends at \r"
+                        // (e.g. user typed `echo` + Enter) and
+                        // "correlator has more after \r" (queued
+                        // additional input).
+                        if cByte = 0x0Duy
+                           && payloadIdx < payloadBytes.Length
+                           && payloadBytes.[payloadIdx] = 0x0Auy then
+                            payloadIdx <- payloadIdx + 1
+                    else
+                        stop <- true
+                // Consume the matched correlator entries.
+                let mutable head = state.Pending.First
+                while not (isNull head)
+                      && not (obj.ReferenceEquals(head, currentNode)) do
+                    state.Pending.RemoveFirst()
+                    head <- state.Pending.First
+                payloadIdx)
+
+    /// Clear all pending bytes. Called on shell-switch (alongside
+    /// the existing `HeuristicPromptDetector` / `SelectionDetector`
+    /// resets in `Program.fs`) so a stale byte from the prior shell
+    /// can't match a fresh output on the new shell.
+    let reset (state: T) : unit =
+        lock state.Gate (fun () -> state.Pending.Clear())
+
+    /// Test-only — read pending byte count without consuming.
+    let internal pendingCount (state: T) : int =
+        lock state.Gate (fun () -> state.Pending.Count)

--- a/src/Terminal.Core/EchoCorrelator.fs
+++ b/src/Terminal.Core/EchoCorrelator.fs
@@ -131,16 +131,25 @@ module EchoCorrelator =
                 expireOld state now
                 let payloadBytes = Encoding.UTF8.GetBytes(payload)
                 let mutable payloadIdx = 0
-                let mutable currentNode = state.Pending.First
+                // F# 9 strict-nullness: `LinkedList<T>.First` and
+                // `LinkedListNode<T>.Next` both return
+                // `LinkedListNode<T> | null`. Annotate the cell
+                // explicitly and `nonNull`-coerce inside the loop
+                // body where the guard ensures non-null. Mirrors
+                // the F# 9 nullness pattern called out in
+                // `CLAUDE.md` ("FS3261 is the canonical CI failure").
+                let mutable currentNode : LinkedListNode<TimedByte> | null =
+                    state.Pending.First
                 let mutable stop = false
                 while not stop
                       && payloadIdx < payloadBytes.Length
                       && not (isNull currentNode) do
-                    let cByte = currentNode.Value.Byte
+                    let nodeNN = nonNull currentNode
+                    let cByte = nodeNN.Value.Byte
                     let pByte = payloadBytes.[payloadIdx]
                     if cByte = pByte then
                         payloadIdx <- payloadIdx + 1
-                        currentNode <- currentNode.Next
+                        currentNode <- nodeNN.Next
                         // CR-LF expansion: cmd translates a typed
                         // `\r` (the Enter keystroke per
                         // `KeyEncoding`) into `\r\n` on the
@@ -159,7 +168,8 @@ module EchoCorrelator =
                     else
                         stop <- true
                 // Consume the matched correlator entries.
-                let mutable head = state.Pending.First
+                let mutable head : LinkedListNode<TimedByte> | null =
+                    state.Pending.First
                 while not (isNull head)
                       && not (obj.ReferenceEquals(head, currentNode)) do
                     state.Pending.RemoveFirst()

--- a/src/Terminal.Core/EchoCorrelator.fs
+++ b/src/Terminal.Core/EchoCorrelator.fs
@@ -56,8 +56,11 @@ module EchoCorrelator =
 
     /// Internal per-byte record. Each byte the user types is
     /// stored alongside the timestamp at which it was written
-    /// to PTY-stdin.
-    type private TimedByte =
+    /// to PTY-stdin. `internal` (not `private`) because the
+    /// `T.Pending` member is `internal` and F# requires the
+    /// element type be at least as accessible as the member
+    /// that exposes it.
+    type internal TimedByte =
         { Byte: byte
           RecordedAt: DateTime }
 

--- a/src/Terminal.Core/EchoSuppressorProfile.fs
+++ b/src/Terminal.Core/EchoSuppressorProfile.fs
@@ -1,0 +1,98 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+
+/// Cycle 38c — strips cmd / PowerShell input echo from NVDA
+/// announcements while preserving the full payload in the
+/// FileLogger audit trail.
+///
+/// **Active set role.** Replaces `PassThroughProfile` in cmd /
+/// PowerShell's active profile set (per Cycle 38b's per-shell
+/// route table). For `StreamChunk` events, consults the shared
+/// `EchoCorrelator` to find the echo prefix and strips it before
+/// fanning the announce. For all other events, behaves
+/// IDENTICALLY to `PassThroughProfile` (NVDA + FileLogger
+/// RenderText). Other profiles in the active set
+/// (`EarconProfile`, `SelectionProfile`) run normally.
+///
+/// **Per-shell gating** is at the active-set level, not inside
+/// this profile. Claude's active set still uses
+/// `PassThroughProfile` (no echo issue; OSC 133 marks input
+/// versus output explicitly). If this profile ends up in Claude's
+/// set by mistake, the correlator simply doesn't have matching
+/// bytes (Claude's user input goes through different keystroke
+/// translation) and the profile degrades gracefully to
+/// PassThrough behaviour.
+///
+/// **FileLogger audit annotation.** When a payload is FULLY
+/// echo, the NVDA decision is dropped but the FileLogger gets a
+/// `(suppressed echo: ...)` annotation so `Ctrl+Shift+D` bundles
+/// preserve the suppression trail for post-hoc debugging. For
+/// PARTIAL echoes, FileLogger gets the full original payload
+/// (so the audit trail matches what the shell actually wrote).
+module EchoSuppressorProfile =
+
+    [<Literal>]
+    let id: ProfileId = "echo-suppressor"
+
+    let private nvdaTextDecision (text: string) : ChannelDecision =
+        { Channel = NvdaChannel.id
+          Render = RenderText text }
+
+    let private fileLoggerTextDecision (text: string) : ChannelDecision =
+        { Channel = FileLoggerChannel.id
+          Render = RenderText text }
+
+    /// Build the profile wrapping a specific `EchoCorrelator`
+    /// instance. The composition root constructs ONE correlator
+    /// per process, wires its `recordWrite` into the WriteBytes
+    /// path, and passes the same instance here.
+    let create (correlator: EchoCorrelator.T) : Profile =
+        let apply (event: OutputEvent) : (OutputEvent * ChannelDecision[])[] =
+            match event.Semantic with
+            | SemanticCategory.StreamChunk
+              when not (String.IsNullOrEmpty event.Payload) ->
+                let now = DateTime.UtcNow
+                let matchedBytes =
+                    EchoCorrelator.matchAndConsumeEchoPrefix
+                        correlator now event.Payload
+                let payloadBytes = Encoding.UTF8.GetBytes(event.Payload)
+                if matchedBytes = 0 then
+                    // No echo prefix; behave as PassThrough catch-all.
+                    [| event,
+                       [| nvdaTextDecision event.Payload
+                          fileLoggerTextDecision event.Payload |] |]
+                elif matchedBytes >= payloadBytes.Length then
+                    // Entire payload is echo. Drop NVDA decision;
+                    // emit FileLogger with audit annotation.
+                    [| event,
+                       [| fileLoggerTextDecision
+                            (sprintf "(suppressed echo: %s)" event.Payload) |] |]
+                else
+                    // Partial echo. Strip prefix from NVDA
+                    // payload; FileLogger gets the full original.
+                    let strippedPayload =
+                        try
+                            Encoding.UTF8.GetString(
+                                payloadBytes,
+                                matchedBytes,
+                                payloadBytes.Length - matchedBytes)
+                        with _ ->
+                            // UTF-8 multi-byte char split: fall
+                            // back to character-index slice.
+                            event.Payload.Substring(
+                                min matchedBytes event.Payload.Length)
+                    [| event,
+                       [| nvdaTextDecision strippedPayload
+                          fileLoggerTextDecision event.Payload |] |]
+            | _ ->
+                // Non-StreamChunk or empty-payload: behave as
+                // PassThrough catch-all.
+                [| event,
+                   [| nvdaTextDecision event.Payload
+                      fileLoggerTextDecision event.Payload |] |]
+        { Id = id
+          Apply = apply
+          Tick = fun _ -> [||]
+          Reset = fun () -> () }

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -36,6 +36,8 @@
     <Compile Include="EarconProfile.fs" />
     <Compile Include="SelectionProfile.fs" />
     <Compile Include="PassThroughProfile.fs" />
+    <Compile Include="EchoCorrelator.fs" />
+    <Compile Include="EchoSuppressorProfile.fs" />
     <Compile Include="OutputDispatcher.fs" />
     <Compile Include="KeyEncoding.fs" />
     <Compile Include="HotkeyRegistry.fs" />

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -128,6 +128,53 @@ let ``[shell.claude] pathway = "tui" parses correctly`` () =
     // Other shells fall back to default
     Assert.Equal("stream", Config.resolveShellPathway config "cmd")
 
+// ---- Cycle 38b — per-shell profile-set override -------------------
+
+[<Fact>]
+let ``[shell.cmd] profiles = [...] resolves to the string array`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nprofiles = [\"echo-suppressor\", \"earcon\"]\n"
+    let config, _ = loadFromText toml
+    let result = Config.resolveShellProfiles config "cmd"
+    Assert.True(result.IsSome)
+    Assert.Equal<string[]>(
+        [| "echo-suppressor"; "earcon" |],
+        result.Value)
+
+[<Fact>]
+let ``[shell.cmd] without profiles returns None for resolveShellProfiles`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\npathway = \"stream\"\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(None, Config.resolveShellProfiles config "cmd")
+
+[<Fact>]
+let ``[shell.cmd] with both pathway and profiles preserves both`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\npathway = \"tui\"\nprofiles = [\"passthrough\"]\n"
+    let config, _ = loadFromText toml
+    Assert.Equal("tui", Config.resolveShellPathway config "cmd")
+    let profiles = Config.resolveShellProfiles config "cmd"
+    Assert.True(profiles.IsSome)
+    Assert.Equal<string[]>([| "passthrough" |], profiles.Value)
+
+[<Fact>]
+let ``[shell.cmd] with only profiles (no pathway) defaults pathway to stream`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nprofiles = [\"echo-suppressor\"]\n"
+    let config, _ = loadFromText toml
+    // pathway field absent → resolver returns the "stream" default.
+    Assert.Equal("stream", Config.resolveShellPathway config "cmd")
+    let profiles = Config.resolveShellProfiles config "cmd"
+    Assert.True(profiles.IsSome)
+    Assert.Equal<string[]>([| "echo-suppressor" |], profiles.Value)
+
+[<Fact>]
+let ``resolveShellProfiles returns None for a shell with no override section`` () =
+    let toml = "schema_version = 1\n"
+    let config, _ = loadFromText toml
+    Assert.Equal(None, Config.resolveShellProfiles config "cmd")
+
 // ---- Per-pathway parameter override --------------------------------
 
 [<Fact>]

--- a/tests/Tests.Unit/EchoCorrelatorTests.fs
+++ b/tests/Tests.Unit/EchoCorrelatorTests.fs
@@ -1,0 +1,120 @@
+module PtySpeak.Tests.Unit.EchoCorrelatorTests
+
+open System
+open Xunit
+open Terminal.Core
+
+/// Cycle 38c — pins the EchoCorrelator contract per
+/// `fluffy-simon.md` Section 20.5.
+
+let private t0 = DateTime(2026, 5, 10, 12, 0, 0, DateTimeKind.Utc)
+let private after (ms: int) = t0.AddMilliseconds(float ms)
+
+let private fresh () : EchoCorrelator.T =
+    EchoCorrelator.create EchoCorrelator.defaultParameters
+
+let private bytes (s: string) : byte[] =
+    System.Text.Encoding.UTF8.GetBytes(s)
+
+// =====================================================================
+// Baseline + exact-match
+// =====================================================================
+
+[<Fact>]
+let ``matchAndConsumeEchoPrefix returns 0 when buffer is empty`` () =
+    let c = fresh ()
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c t0 "anything"
+    Assert.Equal(0, n)
+
+[<Fact>]
+let ``matchAndConsumeEchoPrefix returns N when payload starts with recent input`` () =
+    let c = fresh ()
+    EchoCorrelator.recordWrite c t0 (bytes "echo")
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "echo hello"
+    Assert.Equal(4, n)
+
+[<Fact>]
+let ``matchAndConsumeEchoPrefix returns 0 when payload diverges from input`` () =
+    let c = fresh ()
+    EchoCorrelator.recordWrite c t0 (bytes "echo")
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "hello world"
+    Assert.Equal(0, n)
+
+// =====================================================================
+// CR-LF normalisation (load-bearing for cmd)
+// =====================================================================
+
+[<Fact>]
+let ``CR in correlator matches CR-LF in payload (cmd echo behaviour)`` () =
+    let c = fresh ()
+    // User types "echo" + Enter. KeyEncoding sends "echo\r".
+    EchoCorrelator.recordWrite c t0 (bytes "echo\r")
+    // Cmd echoes "echo\r\n" before running the command.
+    let n =
+        EchoCorrelator.matchAndConsumeEchoPrefix
+            c (after 5) "echo\r\nhello\r\n"
+    // 5 input bytes consumed (e,c,h,o,\r); 6 payload bytes
+    // matched (echo\r\n) because the \n piggybacks on the \r.
+    Assert.Equal(6, n)
+
+// =====================================================================
+// Consumption invariant
+// =====================================================================
+
+[<Fact>]
+let ``matchAndConsumeEchoPrefix consumes matched bytes so a second call returns 0`` () =
+    let c = fresh ()
+    EchoCorrelator.recordWrite c t0 (bytes "abc")
+    let first =
+        EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "abc"
+    Assert.Equal(3, first)
+    let second =
+        EchoCorrelator.matchAndConsumeEchoPrefix c (after 10) "abc"
+    Assert.Equal(0, second)
+
+[<Fact>]
+let ``partial match leaves remaining bytes available for next call`` () =
+    let c = fresh ()
+    EchoCorrelator.recordWrite c t0 (bytes "abcdef")
+    let first =
+        EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "abcXYZ"
+    Assert.Equal(3, first)
+    let second =
+        EchoCorrelator.matchAndConsumeEchoPrefix c (after 10) "def"
+    Assert.Equal(3, second)
+
+// =====================================================================
+// Time bounds + buffer bounds
+// =====================================================================
+
+[<Fact>]
+let ``entries older than MaxAgeMs are expired`` () =
+    let parameters : EchoCorrelator.Parameters =
+        { MaxBufferSize = 1024
+          MaxAgeMs = 100 }
+    let c = EchoCorrelator.create parameters
+    EchoCorrelator.recordWrite c t0 (bytes "echo")
+    // 200ms later, bytes are too old to match.
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c (after 200) "echo"
+    Assert.Equal(0, n)
+
+[<Fact>]
+let ``recordWrite drops oldest entries when buffer exceeds MaxBufferSize`` () =
+    let parameters : EchoCorrelator.Parameters =
+        { MaxBufferSize = 4
+          MaxAgeMs = 10000 }
+    let c = EchoCorrelator.create parameters
+    EchoCorrelator.recordWrite c t0 (bytes "abcdef")
+    // Buffer should hold only the last 4 bytes: "cdef".
+    Assert.Equal(4, EchoCorrelator.pendingCount c)
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "cdef"
+    Assert.Equal(4, n)
+
+[<Fact>]
+let ``reset clears all pending bytes`` () =
+    let c = fresh ()
+    EchoCorrelator.recordWrite c t0 (bytes "abc")
+    EchoCorrelator.reset c
+    Assert.Equal(0, EchoCorrelator.pendingCount c)
+    let n = EchoCorrelator.matchAndConsumeEchoPrefix c (after 5) "abc"
+    Assert.Equal(0, n)

--- a/tests/Tests.Unit/EchoSuppressorProfileTests.fs
+++ b/tests/Tests.Unit/EchoSuppressorProfileTests.fs
@@ -1,0 +1,137 @@
+module PtySpeak.Tests.Unit.EchoSuppressorProfileTests
+
+open System
+open Xunit
+open Terminal.Core
+
+/// Cycle 38c — pins the EchoSuppressorProfile contract per
+/// `fluffy-simon.md` Section 20.5.2.
+
+let private bytes (s: string) : byte[] =
+    System.Text.Encoding.UTF8.GetBytes(s)
+
+let private streamChunk (payload: string) : OutputEvent =
+    OutputEvent.create
+        SemanticCategory.StreamChunk
+        Priority.Polite
+        "echo-suppressor-tests"
+        payload
+
+let private renderText (decision: ChannelDecision) : string =
+    match decision.Render with
+    | RenderText t -> t
+    | other ->
+        Assert.Fail(sprintf "expected RenderText, got %A" other)
+        ""
+
+// =====================================================================
+// Full-echo suppression
+// =====================================================================
+
+[<Fact>]
+let ``Apply drops NVDA decision when entire StreamChunk payload is echo`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    EchoCorrelator.recordWrite correlator DateTime.UtcNow (bytes "hi\r")
+    let profile = EchoSuppressorProfile.create correlator
+    let event = streamChunk "hi\r\n"
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    // Only FileLogger decision (no NVDA) because the whole
+    // payload was echo.
+    Assert.Equal(1, decisions.Length)
+    Assert.Equal(FileLoggerChannel.id, decisions.[0].Channel)
+    let text = renderText decisions.[0]
+    Assert.Contains("suppressed echo", text)
+    Assert.Contains("hi", text)
+
+// =====================================================================
+// Partial-echo strip
+// =====================================================================
+
+[<Fact>]
+let ``Apply emits stripped NVDA payload when partial echo`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    EchoCorrelator.recordWrite correlator DateTime.UtcNow (bytes "echo\r")
+    let profile = EchoSuppressorProfile.create correlator
+    let event = streamChunk "echo\r\nhello"
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    Assert.Equal(2, decisions.Length)
+    // First decision: NVDA with stripped payload.
+    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
+    Assert.Equal("hello", renderText decisions.[0])
+    // Second decision: FileLogger with full original payload.
+    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+    Assert.Equal("echo\r\nhello", renderText decisions.[1])
+
+// =====================================================================
+// No-match pass-through
+// =====================================================================
+
+[<Fact>]
+let ``Apply behaves as PassThrough when no echo match (empty buffer)`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    let profile = EchoSuppressorProfile.create correlator
+    let event = streamChunk "hello"
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    Assert.Equal(2, decisions.Length)
+    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
+    Assert.Equal("hello", renderText decisions.[0])
+    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+    Assert.Equal("hello", renderText decisions.[1])
+
+[<Fact>]
+let ``Apply behaves as PassThrough when payload diverges from buffer`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    EchoCorrelator.recordWrite correlator DateTime.UtcNow (bytes "abc")
+    let profile = EchoSuppressorProfile.create correlator
+    let event = streamChunk "hello"
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    // No prefix match → emit NVDA + FileLogger with the original
+    // payload.
+    Assert.Equal("hello", renderText decisions.[0])
+    Assert.Equal("hello", renderText decisions.[1])
+
+// =====================================================================
+// Non-StreamChunk events untouched
+// =====================================================================
+
+[<Fact>]
+let ``Apply behaves as PassThrough for non-StreamChunk events`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    EchoCorrelator.recordWrite correlator DateTime.UtcNow (bytes "anything")
+    let profile = EchoSuppressorProfile.create correlator
+    let event =
+        OutputEvent.create
+            SemanticCategory.BellRang
+            Priority.Polite
+            "test"
+            ""
+    let pairs = profile.Apply event
+    let _, decisions = pairs.[0]
+    Assert.Equal(2, decisions.Length)
+    Assert.Equal(NvdaChannel.id, decisions.[0].Channel)
+    Assert.Equal(FileLoggerChannel.id, decisions.[1].Channel)
+
+// =====================================================================
+// Profile identity
+// =====================================================================
+
+[<Fact>]
+let ``EchoSuppressorProfile.id is "echo-suppressor"`` () =
+    Assert.Equal("echo-suppressor", EchoSuppressorProfile.id)
+
+[<Fact>]
+let ``create returns a Profile whose Id matches the module id`` () =
+    let correlator =
+        EchoCorrelator.create EchoCorrelator.defaultParameters
+    let profile = EchoSuppressorProfile.create correlator
+    Assert.Equal(EchoSuppressorProfile.id, profile.Id)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -59,6 +59,8 @@
     <Compile Include="LinearTextStreamTests.fs" />
     <Compile Include="CanonicalCorpusTests.fs" />
     <Compile Include="ManualTestsHtmlTests.fs" />
+    <Compile Include="EchoCorrelatorTests.fs" />
+    <Compile Include="EchoSuppressorProfileTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/fixtures/canonical-interactions.toml
+++ b/tests/fixtures/canonical-interactions.toml
@@ -49,12 +49,13 @@
 [[scenario]]
 id = "cmd.echo.plain"
 shell = "cmd"
-description = "Plain `echo hello` should emit StreamChunk for the output 'hello' only."
+description = "Plain `echo hello` should emit StreamChunk for the output 'hello' only. EchoSuppressor (Cycle 38c) strips the typed-input prefix from the NVDA announce; FileLogger audit trail preserves the suppression via a `(suppressed echo: ...)` annotation."
 command = "echo PtySpeakDiagEchoPlain"
 must_include = ["StreamChunk"]
 must_not_include = ["ErrorLine", "WarningLine"]
 quiescence_ms = 200
-notes = "Bug 2026-05-10: input-echo + next prompt currently bleed into the StreamChunk. Cycle 38c separates input echo from output."
+expected_payload_regex = ["PtySpeakDiagEchoPlain"]
+notes = "Fixed in Cycle 38c. To verify suppression: open Ctrl+Shift+D bundle, search the --- FILELOGGER ACTIVE LOG --- section for `(suppressed echo: echo PtySpeakDiagEchoPlain`. expected_payload_regex enforcement lands in Cycle 38d."
 
 [[scenario]]
 id = "cmd.dir.simple"


### PR DESCRIPTION
## Summary

Closes the maintainer's 2026-05-10 regression: `echo hello` in cmd no longer reads the typed-input echo through NVDA. Cycle 38b + 38c combined per maintainer's "stable functional position" choice.

**Plan reference**: `fluffy-simon.md` Section 20.

## What ships

### Cycle 38b — Per-shell profile-set route table

- **`Config.fs`** extends `ShellPathwayConfig` with `Profiles: string[] option`; `parseShellOverrides` reads `[shell.<key>] profiles = [...]` alongside `pathway`. New `tryGetStringArray` helper; new `resolveShellProfiles` resolver.
- **`Program.fs`** new `resolveProfilesForShell : ShellId -> Profile list` (defined after `chosenShell` is known); calls `OutputDispatcher.ProfileRegistry.setActiveProfileSet` at startup **and on every shell-switch** alongside the existing prompt/selection detector resets. Wires the previously-planned-but-unwired "Stage 8f" surface at `OutputDispatcher.fs:80-83`.
- **Built-in defaults** (when TOML doesn't override):
  - cmd / powershell → `["echo-suppressor", "earcon", "selection"]`
  - claude → `["passthrough", "earcon", "selection"]`

### Cycle 38c — Echo-suppression

- **NEW [`EchoCorrelator.fs`](src/Terminal.Core/EchoCorrelator.fs)** — bounded, time-bounded byte buffer recording bytes written via `ConPtyHost.WriteBytes`. Atomic `matchAndConsumeEchoPrefix` with **CR→CRLF normalisation** for cmd's echo-translation behaviour. Lock-per-instance for the UI-thread writer vs pump-thread reader race.
- **NEW [`EchoSuppressorProfile.fs`](src/Terminal.Core/EchoSuppressorProfile.fs)** — `ProfileId = "echo-suppressor"`. For `StreamChunk` events: consults correlator; strips matched prefix from NVDA payload; emits FileLogger with the **FULL original** (or `(suppressed echo: ...)` annotation when fully echoed). For non-StreamChunk events: behaves identically to PassThrough.
- **`Program.fs`** instantiates one correlator + one profile at composition; wraps `WriteBytes` (line 2417) to feed correlator **BEFORE** the PTY write; resets correlator on shell-switch.

## Tests (~250 LOC)

- 9 facts in [`EchoCorrelatorTests.fs`](tests/Tests.Unit/EchoCorrelatorTests.fs): empty buffer baseline, exact-match prefix, payload divergence, CR-LF normalisation (cmd `\r` → payload `\r\n`), consumption invariant, partial-match, age-based expiry, buffer overflow eviction, reset.
- 7 facts in [`EchoSuppressorProfileTests.fs`](tests/Tests.Unit/EchoSuppressorProfileTests.fs): full-echo NVDA-drop, partial-echo strip, no-match pass-through, divergence pass-through, non-StreamChunk pass-through, module identity.
- 5 new facts in [`ConfigTests.fs`](tests/Tests.Unit/ConfigTests.fs): profiles array parse, absent → None, pathway+profiles together, profiles without pathway, absent shell section.

## Corpus update

[`tests/fixtures/canonical-interactions.toml`](tests/fixtures/canonical-interactions.toml) — `cmd.echo.plain` row's `notes` field flips: bug-tag becomes **"Fixed in Cycle 38c."** `expected_payload_regex` populated (parsed today; enforced from Cycle 38d).

## What this PR does NOT do (deferred)

- **No three-pane channel routing** — echo is SUPPRESSED, not ROUTED. Deferred to Cycle 38d.
- **No `expected_payload_regex` enforcement** in `runCorpus`. Still parsed-only.
- **No PowerShell or Claude scenarios** in the corpus.
- **No NVDA verbatim-text matching**.
- **No prompt-stripping** (cmd's next prompt `C:\>` still flows through; separate heuristic-prompt-detector concern).
- **No timing-parameter exposure via TOML**.

## Test plan

- [ ] `Build and test (windows-latest)` green — 21 new test facts + 1004+ existing tests stay green.
- [ ] `Workflow lint`, `Portability lint`, `Markdown link check` green.
- [ ] **Maintainer dogfood** post-merge:
  - Rebuild from `main`.
  - Open cmd; type `echo hello` + Enter. NVDA should announce "hello" without the leading "echo hello" echo.
  - Press `Ctrl+Shift+D`. Inspect bundle's `--- FILELOGGER ACTIVE LOG ---` for `(suppressed echo: ...)` lines confirming suppression.
  - Switch to PowerShell; same test.
  - Switch to Claude; verify behaviour unchanged.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_