### PR TITLE
feat(cycle-40): three-panel channel routing (announce-clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,98 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 40): Three-panel channel routing (announce-clarity)
+
+Closes the maintainer's actual 2026-05-11 reported regression:
+`echo hello` no longer reads the next prompt inline with the
+output. Cycle 40 introduces a channel-level three-panel split —
+output, input, and history-panel `ActivityIds` — and wires the
+StreamPathway to emit separate `StreamChunk` (current-output
+panel) + `PromptDetected` (input panel) events when the cached
+prompt boundary matches the payload's tail.
+
+**Behavioural pipeline**:
+1. `HeuristicPromptDetector` detects the prompt boundary
+   (existing; Cycle 21+).
+2. `Program.fs.handlePromptBoundary` calls
+   `activePathway.OnPromptBoundary boundaryData` (existing).
+3. NEW: `StreamPathway.OnPromptBoundary` caches the boundary
+   in `state.LastPromptBoundary` (was a no-op).
+4. NEW: `StreamPathway`'s next emit (leading-edge, trailing-edge
+   tick, or mode-barrier flush) consults the cache via the new
+   `splitAtPromptBoundary` helper. If the boundary's
+   `MatchedRowText` is a tail-suffix of the payload, the
+   payload splits into output portion + prompt portion.
+5. NEW: Two events emit: `StreamChunk` (output portion) +
+   `PromptDetected` (empty Payload + prompt text in
+   `Extensions["prompt.text"]`).
+6. NEW: `NvdaChannel.semanticToActivityId` routes
+   `PromptDetected → ActivityIds.inputPanel`. The empty Payload
+   triggers the existing `RenderText "" -> ()` skip — silent
+   auto-announce by design. Prompt remains on-screen via UIA
+   TextProvider, navigable in NVDA browse mode.
+
+**Cache lifecycle**: single-shot. `LastPromptBoundary` is set by
+`OnPromptBoundary` and cleared by the next emit that consumes it.
+`resetState` (shell-switch, alt-screen toggle) clears the cache
+so a stale boundary from the prior shell can't trigger a split
+on the new shell.
+
+**New module additions**:
+
+- [`src/Terminal.Core/Types.fs`](src/Terminal.Core/Types.fs)
+  `ActivityIds` gains three new constants:
+  - `currentOutputPanel = "pty-speak.current-output-panel"`
+    (reserved; not yet load-bearing — Cycle 40 keeps StreamChunk
+    on `output` for back-compat).
+  - `inputPanel = "pty-speak.input-panel"` (load-bearing; where
+    `PromptDetected` routes).
+  - `historyPanel = "pty-speak.history-panel"` (reserved for
+    Cycle 41 history-panel surfacing).
+- [`src/Terminal.Core/NvdaChannel.fs`](src/Terminal.Core/NvdaChannel.fs)
+  `semanticToActivityId` routes `PromptDetected → inputPanel`.
+- [`src/Terminal.Core/StreamPathway.fs`](src/Terminal.Core/StreamPathway.fs)
+  - `State.LastPromptBoundary: PromptBoundaryData voption`.
+  - `splitAtPromptBoundary` (internal helper).
+  - `promptDetectedFromText` (builds the `PromptDetected` event).
+  - `buildEmittedEvents` (centralises the split logic; used by
+    all three emit sites: leading-edge, trailing-edge tick,
+    mode-barrier flush).
+  - `OnPromptBoundary` (both production + test-only factory)
+    caches the boundary.
+  - `resetState` clears the cache.
+
+**Tests** (~150 LOC):
+- 6 new facts in
+  [`tests/Tests.Unit/StreamPathwayTests.fs`](tests/Tests.Unit/StreamPathwayTests.fs):
+  splitAtPromptBoundary happy path; trims trailing whitespace;
+  returns no-split when prompt not a suffix; whole-prompt
+  empty-output case; no-split when boundary has no
+  MatchedRowText; OnPromptBoundary caches.
+- 2 new facts in
+  [`tests/Tests.Unit/NvdaChannelTests.fs`](tests/Tests.Unit/NvdaChannelTests.fs):
+  PromptDetected routes to `inputPanel`; empty-payload skip.
+
+**Corpus update**: `cmd.echo.plain` row updates
+`must_include = ["StreamChunk", "PromptDetected"]` (both events
+fire post-split). `notes` field flips to "Fixed in Cycle 40."
+
+**Docs**: `ACCESSIBILITY-TESTING.md` gains a Cycle 40 matrix
+section (6 manual rows) plus DOGFOOD marker.
+
+**What this PR does NOT do**:
+- No visual WPF split of `MainWindow` into 3 regions (Cycle 42).
+- No History panel surfacing as a UIA peer (Cycle 41).
+- No keyboard accelerator for panel navigation (NVDA browse mode
+  is the navigation path).
+- No `expected_payload_regex` enforcement in `runCorpus` (still
+  parsed-only).
+- No prompt-stripping for prompts the
+  `HeuristicPromptDetector` doesn't catch (e.g. custom `PROMPT`
+  env-var on cmd, oh-my-posh on PowerShell). Fallback:
+  single-StreamChunk behaviour preserved when no boundary is
+  cached.
+
 ### Reverted (Cycle 39): Cycle 38c echo-suppression
 
 Cycle 38c (`EchoCorrelator` + `EchoSuppressorProfile`) was solving a

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1263,6 +1263,38 @@ matrix's shrinking surface area over time.
   with the expected length floor) is now CI-pinned.
 
 <!-- DOGFOOD -->
+### Cycle 40 — Three-panel channel routing (announce-clarity)
+
+Cycle 40 splits the StreamChunk emitted by `StreamPathway` at the
+prompt boundary. The output portion stays in the StreamChunk (routes
+to NVDA at `ActivityIds.output`); the prompt portion lifts into a
+`PromptDetected` event with empty Payload + the prompt text in
+`Extensions["prompt.text"]`. `NvdaChannel` routes `PromptDetected`
+to `ActivityIds.inputPanel`; the empty-payload skip means no auto-
+announce of the prompt. Maintainer hears the command output and
+stops — the prompt is on-screen and navigable via NVDA browse mode.
+
+**Behavioural rule**: `StreamPathway.OnPromptBoundary` caches the
+boundary; the NEXT emit consults the cache. If the boundary's
+`MatchedRowText` is a suffix of the payload, the pathway splits.
+Cache is single-shot (cleared after consumption) so a stale
+boundary can't trigger a split on a later unrelated chunk.
+
+**Manual matrix rows**:
+
+| Test | Procedure | Expected |
+|---|---|---|
+| 40.1 — `echo` clarity on cmd | In cmd, type `echo hello` + Enter. | NVDA announces "hello" and STOPS. No reading of `C:\path>`. Pressing NVDA browse-mode down arrow / End reaches the prompt text on screen. |
+| 40.2 — `echo` clarity on PowerShell | Switch to PowerShell (Ctrl+Shift+2). Type `Write-Host hello` + Enter. | NVDA announces "hello" and stops. The PowerShell prompt does NOT auto-announce. |
+| 40.3 — Claude unaffected | Switch to Claude. Send a short message. | Claude behaviour unchanged (its OSC 133 boundaries also flow through `OnPromptBoundary` but the typical Claude payload pattern doesn't have a trailing prompt-row that triggers the split). |
+| 40.4 — Audit trail | After 40.1, press Ctrl+Shift+D. Inspect bundle's `--- FILELOGGER ACTIVE LOG ---` section. | Should find a `PromptDetected` event entry alongside the `StreamChunk` event for the output portion. |
+| 40.5 — Shell-switch cache clear | Type `echo hello` in cmd (without pressing Enter). Switch to PowerShell. Press Enter. | The `LastPromptBoundary` cache should clear on shell-switch (via `resetState`); the PowerShell session shouldn't reuse the cmd prompt to split. |
+| 40.6 — Corpus `cmd.echo.plain` | Press Ctrl+Shift+D. Inspect the `--- CANONICAL CORPUS RESULTS ---` section. | `cmd.echo.plain` should PASS with `must_include = ["StreamChunk", "PromptDetected"]` (both events fire post-split). |
+
+**Stopping gate for Cycle 40**: `echo hello` no longer reads the
+prompt inline. The reported regression is closed.
+
+<!-- DOGFOOD -->
 ### Cycle 38b + 38c — Per-shell route table + cmd/PowerShell echo-suppression
 
 Cycle 38b introduces a per-shell profile-set TOML override

--- a/src/Terminal.Core/NvdaChannel.fs
+++ b/src/Terminal.Core/NvdaChannel.fs
@@ -82,8 +82,16 @@ module NvdaChannel =
         | SemanticCategory.SpinnerTick
         | SemanticCategory.BellRang
         | SemanticCategory.HyperlinkOpened
-        | SemanticCategory.PromptDetected
         | SemanticCategory.CommandSubmitted -> ActivityIds.output
+        // Cycle 40 — PromptDetected routes to the input panel.
+        // Events arrive with empty Payload by convention (the
+        // empty-payload trick from Cycle 8d.2 / 29b); NvdaChannel's
+        // existing `RenderText "" -> ()` skip means no auto-
+        // announce. The prompt text lives in
+        // `Extensions["prompt.text"]` and on the screen for
+        // browse-mode navigation. FileLogger logs the structured
+        // event for the audit trail.
+        | SemanticCategory.PromptDetected -> ActivityIds.inputPanel
         | SemanticCategory.Custom _ -> ActivityIds.output
 
     /// Construct a Channel that announces via the supplied

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -489,9 +489,15 @@ module StreamPathway =
                 Priority.Polite
                 id
                 ""
+        // F# 9 strict-nullness: `box` returns `obj | null`, but the
+        // Extensions map's value type is `obj` (non-nullable).
+        // Mirrors the `boxNN` helper pattern from SelectionDetector
+        // / SelectionProfile (Cycle 29a/b) per CLAUDE.md's "FS3261
+        // is the canonical CI failure" gotcha.
         { baseEvt with
             Extensions =
-                Map.ofList [ "prompt.text", box promptText ] }
+                Map.ofList
+                    [ "prompt.text", nonNull (box promptText) ] }
 
     /// Cycle 40 — split a StreamChunk payload at the prompt
     /// boundary, when a boundary is cached and its

--- a/src/Terminal.Core/StreamPathway.fs
+++ b/src/Terminal.Core/StreamPathway.fs
@@ -256,6 +256,17 @@ module StreamPathway =
           /// reads `LinearTextStream.suffixSince` from this
           /// watermark and updates it on emit.
           mutable LastLinearWatermark: int64
+          /// Cycle 40 — the most-recent `PromptBoundaryData`
+          /// received via `OnPromptBoundary`. Consumed at the
+          /// next StreamChunk emit: if the boundary's
+          /// `MatchedRowText` appears at the tail of the
+          /// payload, the pathway splits the payload into an
+          /// output portion (StreamChunk → output panel) and a
+          /// prompt portion (PromptDetected → input panel).
+          /// Cleared after consumption (single-shot per
+          /// boundary detection). `ValueNone` is the steady
+          /// state.
+          mutable LastPromptBoundary: PromptBoundaryData voption
           PerRowHistory: Dictionary<SpinnerKey, ResizeArray<DateTimeOffset>>
           HashHistory: Dictionary<uint64, ResizeArray<DateTimeOffset>> }
 
@@ -270,6 +281,7 @@ module StreamPathway =
           PendingSnapshot = ValueNone
           LastRowHashes = ValueNone
           LastLinearWatermark = 0L
+          LastPromptBoundary = ValueNone
           PerRowHistory = Dictionary()
           HashHistory = Dictionary() }
 
@@ -461,6 +473,97 @@ module StreamPathway =
             Priority.Polite
             id
             text
+
+    /// Cycle 40 — build a PromptDetected event carrying the
+    /// prompt-row text in `Extensions["prompt.text"]`. The
+    /// event's Payload is EMPTY by convention (the empty-
+    /// payload trick from Cycle 8d.2 / 29b) so `NvdaChannel`
+    /// skips the auto-announce. FileLogger logs the
+    /// structured payload (with the prompt text in
+    /// Extensions) for the audit trail. Routed to
+    /// `ActivityIds.inputPanel` per `NvdaChannel`'s mapping.
+    let private promptDetectedFromText (promptText: string) : OutputEvent =
+        let baseEvt =
+            OutputEvent.create
+                SemanticCategory.PromptDetected
+                Priority.Polite
+                id
+                ""
+        { baseEvt with
+            Extensions =
+                Map.ofList [ "prompt.text", box promptText ] }
+
+    /// Cycle 40 — split a StreamChunk payload at the prompt
+    /// boundary, when a boundary is cached and its
+    /// `MatchedRowText` is a SUFFIX of the payload. Returns
+    /// `(outputPortion, promptPortion)` where `promptPortion`
+    /// is `None` when no split applies (the caller emits the
+    /// payload as a single StreamChunk).
+    ///
+    /// **Match rule.** The boundary's `MatchedRowText` (e.g.
+    /// `"C:\\path>"`) must appear at the END of the payload,
+    /// possibly preceded by whitespace / CRLF. The pathway
+    /// strips trailing whitespace after `MatchedRowText` when
+    /// computing the split point so a payload like
+    /// `"hello\r\nC:\\path>"` splits at the line break.
+    let internal splitAtPromptBoundary
+            (payload: string)
+            (boundary: PromptBoundaryData)
+            : string * string option =
+        match boundary.MatchedRowText with
+        | None -> payload, None
+        | Some promptText when promptText.Length = 0 ->
+            payload, None
+        | Some promptText ->
+            // Look for the prompt text near the tail. Trim
+            // trailing whitespace from the payload first so a
+            // payload like "hello\r\nC:\\path> " still splits
+            // at the prompt's start.
+            let trimmedPayload = payload.TrimEnd()
+            if trimmedPayload.EndsWith(promptText) then
+                let splitIdx = trimmedPayload.Length - promptText.Length
+                let outputPortion =
+                    if splitIdx <= 0 then ""
+                    else trimmedPayload.Substring(0, splitIdx).TrimEnd()
+                outputPortion, Some promptText
+            else
+                payload, None
+
+    /// Cycle 40 — build the OutputEvent array for an emitted
+    /// payload, accounting for the cached prompt boundary and
+    /// any dominant-colour event. Centralises the split logic
+    /// used by all three emit sites (leading-edge, trailing-
+    /// edge tick, mode-barrier flush).
+    ///
+    /// **Order of events** matters for FileLogger ordering:
+    /// `[streamChunk; promptDetected; color]`. NVDA dispatches
+    /// each independently; the order is purely for the audit
+    /// trail.
+    let private buildEmittedEvents
+            (state: State)
+            (capped: string)
+            (dominantColor: OutputEvent option)
+            : OutputEvent[] =
+        let outputPortion, promptPortion =
+            match state.LastPromptBoundary with
+            | ValueSome boundary ->
+                let result = splitAtPromptBoundary capped boundary
+                // Single-shot consumption: clear the cache so
+                // a later StreamChunk that doesn't contain the
+                // prompt doesn't accidentally trigger a split.
+                state.LastPromptBoundary <- ValueNone
+                result
+            | ValueNone -> capped, None
+        let events = ResizeArray<OutputEvent>()
+        if not (String.IsNullOrEmpty outputPortion) then
+            events.Add(streamOutputEvent outputPortion)
+        match promptPortion with
+        | Some promptText -> events.Add(promptDetectedFromText promptText)
+        | None -> ()
+        match dominantColor with
+        | Some evt -> events.Add(evt)
+        | None -> ()
+        events.ToArray()
 
     // -------------------------------------------------------------
     // Sub-row suffix-diff (PR #166).
@@ -894,9 +997,18 @@ module StreamPathway =
                             // EarconProfile claims it semantically;
                             // NvdaChannel skips the empty payload so no
                             // double-announce.
-                            match dominantColor |> Option.bind colorOutputEvent with
-                            | Some colorEvt -> [| streamOutputEvent capped; colorEvt |]
-                            | None -> [| streamOutputEvent capped |]
+                            //
+                            // Cycle 40 — buildEmittedEvents also
+                            // consults `state.LastPromptBoundary`:
+                            // if a prompt boundary is cached and
+                            // its MatchedRowText is a suffix of the
+                            // payload, the StreamChunk is split into
+                            // output portion + PromptDetected event.
+                            // PromptDetected routes to inputPanel
+                            // (empty payload → silent auto-announce).
+                            let colorEvt =
+                                dominantColor |> Option.bind colorOutputEvent
+                            buildEmittedEvents state capped colorEvt
                 else
                     // Within debounce: accumulate the diff;
                     // trailing edge will flush. Stash the dominant
@@ -1034,9 +1146,10 @@ module StreamPathway =
                             "Emit StreamChunk (trailing-edge). FrameHash=0x{Hash:X16} ChangedRows={Rows} TextLen={Len} Color={Color}",
                             hash, diff.ChangedRows.Length, capped.Length,
                             (match pendingColor with ValueSome c -> c | ValueNone -> "none"))
-                        match colorEvt with
-                        | Some evt -> [| streamOutputEvent capped; evt |]
-                        | None -> [| streamOutputEvent capped |]
+                        // Cycle 40 — consult cached prompt boundary
+                        // and split if applicable (see leading-edge
+                        // emit site at line ~898 for context).
+                        buildEmittedEvents state capped colorEvt
             else
                 [||]
         | _ -> [||]
@@ -1071,7 +1184,13 @@ module StreamPathway =
             | Verbose ->
                 match state.PendingDiff with
                 | ValueSome diff when diff.ChangedRows.Length > 0 ->
-                    [| streamOutputEvent diff.ChangedText |]
+                    // Cycle 40 — buildEmittedEvents consults
+                    // the cached prompt boundary for split, then
+                    // emits the StreamChunk (with no
+                    // color event at mode-barrier flushes per
+                    // the existing PendingColor-clear semantics
+                    // documented just below).
+                    buildEmittedEvents state diff.ChangedText None
                 | _ -> [||]
             | SummaryOnly | Suppressed ->
                 [||]
@@ -1145,6 +1264,10 @@ module StreamPathway =
         // treats the producer's entire committed buffer as
         // unreceived suffix.
         state.LastLinearWatermark <- 0L
+        // Cycle 40 — clear cached prompt boundary so a stale
+        // entry from the prior shell can't trigger a split on
+        // the new shell's first chunk.
+        state.LastPromptBoundary <- ValueNone
         state.PerRowHistory.Clear()
         state.HashHistory.Clear()
 
@@ -1210,11 +1333,17 @@ module StreamPathway =
           SetBaseline =
             fun canonical -> seedBaseline state canonical
           OnPromptBoundary =
-            // SessionModel Tier 1.A: no-op default. StreamPathway
-            // doesn't yet integrate SessionModel data; future
-            // pathways (ReplPathway, ClaudeCodePathway) override
-            // with non-trivial implementations.
-            fun _boundary -> [||] }
+            // Cycle 40 — cache the boundary so the NEXT
+            // `processCanonicalState` / `onTimerTick` /
+            // `onModeBarrier` emit can split the StreamChunk
+            // payload at the prompt boundary. Single-shot: the
+            // cache clears after the next emit consumes it
+            // (see `buildEmittedEvents`). Until consumed, the
+            // boundary's `MatchedRowText` is the suffix the
+            // pathway looks for in the upcoming payload.
+            fun boundary ->
+                state.LastPromptBoundary <- ValueSome boundary
+                [||] }
 
     /// Test-only — expose the state for direct manipulation in
     /// the test harness. Production code never calls this.
@@ -1250,7 +1379,10 @@ module StreamPathway =
               SetBaseline =
                 fun canonical -> seedBaseline state canonical
               OnPromptBoundary =
-                // SessionModel Tier 1.A: no-op default (mirrors
-                // the production `create` factory above).
-                fun _boundary -> [||] }
+                // Cycle 40 — cache the boundary for the next
+                // emit's payload split (mirrors the production
+                // `create` factory above).
+                fun boundary ->
+                    state.LastPromptBoundary <- ValueSome boundary
+                    [||] }
         pathway, state

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -502,3 +502,42 @@ module ActivityIds =
     /// ActivityId so consecutive presses dedupe at the
     /// NVDA-channel layer.
     let processCleanup = "pty-speak.process-cleanup"
+
+    /// Cycle 40 — three-panel channel routing. Distinct
+    /// ActivityIds for the current-output, input, and history
+    /// panels. Each panel routes its events through NVDA with
+    /// its own tag so user-side NVDA notification-processing
+    /// config can silence / amplify / re-prioritise per panel.
+    ///
+    /// The `output` ActivityId above remains as the catch-all
+    /// for events that don't have a panel-specific routing
+    /// (BellRang, SpinnerTick, HyperlinkOpened, etc.).
+    /// `StreamChunk` events ALSO continue to route through
+    /// `output` for backward compatibility — the maintainer's
+    /// existing NVDA config that filters on `pty-speak.output`
+    /// stays intact post-Cycle-40.
+    ///
+    /// `inputPanel` is where prompts land (Cycle 40). Events
+    /// arrive with EMPTY Payload + the prompt text in
+    /// `Extensions["prompt.text"]`; NvdaChannel skips the
+    /// empty payload (silent auto-announce by design) but the
+    /// FileLogger preserves the structured payload for audit
+    /// + future panel-specific UIA peers can read the
+    /// extension data.
+
+    /// Current-output panel — where the running command's
+    /// output lands. Cycle 40 reserves this ActivityId for
+    /// future use; StreamChunk still routes through `output`
+    /// for backward compat.
+    let currentOutputPanel = "pty-speak.current-output-panel"
+
+    /// Input panel — where prompts land (Cycle 40). NVDA
+    /// announces nothing by default (empty payload trick);
+    /// user navigates to the on-screen prompt text via NVDA
+    /// browse-mode arrow keys.
+    let inputPanel = "pty-speak.input-panel"
+
+    /// History panel — where completed `(prompt, command,
+    /// output)` tuples land (Cycle 41 reserved; not yet
+    /// wired). Stage 10 review-mode + quick-nav surfaces this.
+    let historyPanel = "pty-speak.history-panel"

--- a/tests/Tests.Unit/NvdaChannelTests.fs
+++ b/tests/Tests.Unit/NvdaChannelTests.fs
@@ -60,6 +60,29 @@ let ``StreamChunk routes to ActivityIds.output`` () =
     Assert.Equal(1, calls.Count)
     Assert.Equal(("ls", ActivityIds.output), calls.[0])
 
+// Cycle 40 — PromptDetected routes to the input panel. The
+// empty-payload trick (Payload = "") means NvdaChannel's
+// existing skip-empty-RenderText guard fires and no announce
+// is recorded. The ActivityId mapping itself is exercised when
+// a non-empty payload is sent (rare for PromptDetected, but
+// tested here for completeness so the routing arm is pinned).
+[<Fact>]
+let ``Cycle 40 — PromptDetected routes to ActivityIds.inputPanel`` () =
+    let calls, recorder = makeRecorder ()
+    let channel = NvdaChannel.create recorder noOpRawRecorder
+    let event = buildEvent SemanticCategory.PromptDetected "C:\\path>"
+    channel.Send event (RenderText event.Payload)
+    Assert.Equal(1, calls.Count)
+    Assert.Equal(("C:\\path>", ActivityIds.inputPanel), calls.[0])
+
+[<Fact>]
+let ``Cycle 40 — PromptDetected with empty payload is skipped (silent auto-announce)`` () =
+    let calls, recorder = makeRecorder ()
+    let channel = NvdaChannel.create recorder noOpRawRecorder
+    let event = buildEvent SemanticCategory.PromptDetected ""
+    channel.Send event (RenderText event.Payload)
+    Assert.Empty(calls)
+
 [<Fact>]
 let ``ParserError routes to ActivityIds.error`` () =
     let calls, recorder = makeRecorder ()

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -1797,7 +1797,7 @@ let ``Cycle 35c — SubstrateMode=ScreenDiff still gates spinners (regression)``
 
 let private fakeBoundary (matchedRowText: string) : PromptBoundaryData =
     { Kind = BoundaryKind.PromptStart
-      Source = BoundarySource.Heuristic
+      Source = BoundarySource.HeuristicPromptRegex
       DetectedAt = DateTime.UtcNow
       CommandId = None
       ExtraParams = Map.empty
@@ -1845,7 +1845,7 @@ let ``Cycle 40 — splitAtPromptBoundary returns no-split when boundary has no M
     let payload = "hello\r\nC:\\path>"
     let boundary =
         { Kind = BoundaryKind.PromptStart
-          Source = BoundarySource.Heuristic
+          Source = BoundarySource.HeuristicPromptRegex
           DetectedAt = DateTime.UtcNow
           CommandId = None
           ExtraParams = Map.empty

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -1790,3 +1790,83 @@ let ``Cycle 35c — SubstrateMode=ScreenDiff still gates spinners (regression)``
             suppressedCount emittedCount)
     // Sanity: the gate's state machine WAS engaged on this path.
     Assert.NotEmpty(state.PerRowHistory)
+
+// =====================================================================
+// Cycle 40 — Three-panel channel routing: splitAtPromptBoundary
+// =====================================================================
+
+let private fakeBoundary (matchedRowText: string) : PromptBoundaryData =
+    { Kind = BoundaryKind.PromptStart
+      Source = BoundarySource.Heuristic
+      DetectedAt = DateTime.UtcNow
+      CommandId = None
+      ExtraParams = Map.empty
+      MatchedRowText = Some matchedRowText
+      MatchedRowIndex = Some 0 }
+
+[<Fact>]
+let ``Cycle 40 — splitAtPromptBoundary splits when prompt is a suffix of the payload`` () =
+    let payload = "hello\r\nC:\\path>"
+    let boundary = fakeBoundary "C:\\path>"
+    let outputPortion, promptPortion =
+        StreamPathway.splitAtPromptBoundary payload boundary
+    Assert.Equal("hello", outputPortion)
+    Assert.Equal(Some "C:\\path>", promptPortion)
+
+[<Fact>]
+let ``Cycle 40 — splitAtPromptBoundary trims trailing whitespace after prompt`` () =
+    let payload = "hello\r\nC:\\path>   "
+    let boundary = fakeBoundary "C:\\path>"
+    let outputPortion, promptPortion =
+        StreamPathway.splitAtPromptBoundary payload boundary
+    Assert.Equal("hello", outputPortion)
+    Assert.Equal(Some "C:\\path>", promptPortion)
+
+[<Fact>]
+let ``Cycle 40 — splitAtPromptBoundary returns None when prompt is not a tail suffix`` () =
+    let payload = "hello world"
+    let boundary = fakeBoundary "C:\\path>"
+    let outputPortion, promptPortion =
+        StreamPathway.splitAtPromptBoundary payload boundary
+    Assert.Equal("hello world", outputPortion)
+    Assert.Equal(None, promptPortion)
+
+[<Fact>]
+let ``Cycle 40 — splitAtPromptBoundary returns whole-prompt + empty-output when entire payload is the prompt`` () =
+    let payload = "C:\\path>"
+    let boundary = fakeBoundary "C:\\path>"
+    let outputPortion, promptPortion =
+        StreamPathway.splitAtPromptBoundary payload boundary
+    Assert.Equal("", outputPortion)
+    Assert.Equal(Some "C:\\path>", promptPortion)
+
+[<Fact>]
+let ``Cycle 40 — splitAtPromptBoundary returns no-split when boundary has no MatchedRowText`` () =
+    let payload = "hello\r\nC:\\path>"
+    let boundary =
+        { Kind = BoundaryKind.PromptStart
+          Source = BoundarySource.Heuristic
+          DetectedAt = DateTime.UtcNow
+          CommandId = None
+          ExtraParams = Map.empty
+          MatchedRowText = None
+          MatchedRowIndex = None }
+    let outputPortion, promptPortion =
+        StreamPathway.splitAtPromptBoundary payload boundary
+    Assert.Equal("hello\r\nC:\\path>", outputPortion)
+    Assert.Equal(None, promptPortion)
+
+[<Fact>]
+let ``Cycle 40 — OnPromptBoundary caches the boundary on the pathway state`` () =
+    let pathway, exposedState =
+        StreamPathway.createWithExposedState
+            StreamPathway.defaultParameters
+            (LinearTextStream.create LinearTextStream.defaultParameters)
+    let boundary = fakeBoundary "C:\\path>"
+    let result = pathway.OnPromptBoundary boundary
+    Assert.Empty(result)
+    match exposedState.LastPromptBoundary with
+    | ValueSome cached ->
+        Assert.Equal(Some "C:\\path>", cached.MatchedRowText)
+    | ValueNone ->
+        Assert.Fail("expected LastPromptBoundary to be cached after OnPromptBoundary")

--- a/tests/Tests.Unit/StreamPathwayTests.fs
+++ b/tests/Tests.Unit/StreamPathwayTests.fs
@@ -1797,7 +1797,7 @@ let ``Cycle 35c — SubstrateMode=ScreenDiff still gates spinners (regression)``
 
 let private fakeBoundary (matchedRowText: string) : PromptBoundaryData =
     { Kind = BoundaryKind.PromptStart
-      Source = BoundarySource.HeuristicPromptRegex
+      Source = BoundarySource.HeuristicPromptRegex 100
       DetectedAt = DateTime.UtcNow
       CommandId = None
       ExtraParams = Map.empty
@@ -1845,7 +1845,7 @@ let ``Cycle 40 — splitAtPromptBoundary returns no-split when boundary has no M
     let payload = "hello\r\nC:\\path>"
     let boundary =
         { Kind = BoundaryKind.PromptStart
-          Source = BoundarySource.HeuristicPromptRegex
+          Source = BoundarySource.HeuristicPromptRegex 100
           DetectedAt = DateTime.UtcNow
           CommandId = None
           ExtraParams = Map.empty

--- a/tests/fixtures/canonical-interactions.toml
+++ b/tests/fixtures/canonical-interactions.toml
@@ -49,13 +49,13 @@
 [[scenario]]
 id = "cmd.echo.plain"
 shell = "cmd"
-description = "Plain `echo hello` should emit StreamChunk for the output 'hello' only. The next prompt should NOT bleed into the same announce as the output."
+description = "Plain `echo hello` should emit StreamChunk for the output 'hello' only. The next prompt should split into a PromptDetected event that routes to the input panel (silent auto-announce; navigable via NVDA browse mode)."
 command = "echo PtySpeakDiagEchoPlain"
-must_include = ["StreamChunk"]
+must_include = ["StreamChunk", "PromptDetected"]
 must_not_include = ["ErrorLine", "WarningLine"]
 quiescence_ms = 200
 expected_payload_regex = ["PtySpeakDiagEchoPlain"]
-notes = "Bug 2026-05-11: output and next prompt currently bleed into the StreamChunk. Cycle 40 (three-panel channel routing) splits StreamChunk at the prompt boundary so the prompt portion routes to the input panel. Cycle 39 reverted the unrelated Cycle 38c echo-suppression."
+notes = "Fixed in Cycle 40. StreamPathway splits the chunk at the cached prompt-boundary: output portion (e.g. PtySpeakDiagEchoPlain) emits as StreamChunk; prompt portion (e.g. C:\\>) emits as PromptDetected with empty Payload + prompt text in Extensions['prompt.text']. NvdaChannel routes PromptDetected to ActivityIds.inputPanel; empty payload means no auto-announce."
 
 [[scenario]]
 id = "cmd.dir.simple"


### PR DESCRIPTION
## Summary

**Closes the maintainer's 2026-05-11 actual reported regression**: `echo hello` no longer reads the next prompt inline with the output. NVDA announces "hello" and stops; the prompt sits on-screen, navigable via NVDA browse mode.

Cycle 40 is the **first slice of three-panel channel routing**. Output portion of a StreamChunk keeps routing to NVDA at `ActivityIds.output` (back-compat). Prompt portion lifts into a `PromptDetected` event with empty Payload + prompt text in `Extensions["prompt.text"]`; `NvdaChannel` routes it to the new `ActivityIds.inputPanel`. Empty Payload triggers the existing skip — silent auto-announce by design.

**Plan reference**: `fluffy-simon.md` Section 21.

## Pipeline change

1. `HeuristicPromptDetector` detects prompt boundary (existing).
2. `Program.fs.handlePromptBoundary` → `activePathway.OnPromptBoundary boundaryData` (existing).
3. **NEW**: `StreamPathway.OnPromptBoundary` caches the boundary in `state.LastPromptBoundary` (was a no-op).
4. **NEW**: StreamPathway's next emit (leading-edge / trailing-edge tick / mode-barrier flush) consults the cache via the new `splitAtPromptBoundary` helper. If the boundary's `MatchedRowText` is a tail-suffix of the payload, the payload splits.
5. **NEW**: Two events emit: `StreamChunk` (output portion) + `PromptDetected` (empty Payload + prompt text in Extensions).
6. **NEW**: `NvdaChannel.semanticToActivityId` routes `PromptDetected → ActivityIds.inputPanel`. Empty Payload triggers existing `RenderText "" -> ()` skip → silent auto-announce.

## New ActivityIds

| ID | String | Status |
|---|---|---|
| `currentOutputPanel` | `pty-speak.current-output-panel` | Reserved (Cycle 40 keeps StreamChunk on `output` for back-compat) |
| `inputPanel` | `pty-speak.input-panel` | Load-bearing (PromptDetected routes here) |
| `historyPanel` | `pty-speak.history-panel` | Reserved for Cycle 41 |

## Cache lifecycle

**Single-shot.** `LastPromptBoundary` is set by `OnPromptBoundary`; cleared by the next emit that consumes it. `resetState` (shell-switch, alt-screen toggle) clears so a stale boundary from the prior shell can't trigger a split on the new shell.

## Tests

- 6 new facts in [`tests/Tests.Unit/StreamPathwayTests.fs`](tests/Tests.Unit/StreamPathwayTests.fs): split happy path, trim trailing whitespace, no-split when prompt not a suffix, whole-prompt empty-output case, None MatchedRowText, OnPromptBoundary caches.
- 2 new facts in [`tests/Tests.Unit/NvdaChannelTests.fs`](tests/Tests.Unit/NvdaChannelTests.fs): `PromptDetected → inputPanel`; empty-payload skip.

## Corpus

[`tests/fixtures/canonical-interactions.toml`](tests/fixtures/canonical-interactions.toml) — `cmd.echo.plain` row's `must_include = ["StreamChunk", "PromptDetected"]` (both events fire post-split). `notes` field flips to "Fixed in Cycle 40."

## Docs

[`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md) gains a Cycle 40 matrix section (6 manual rows) + DOGFOOD marker.

## What this PR does NOT do

- **No visual WPF split** of `MainWindow` into 3 regions (deferred to Cycle 42).
- **No History panel** UIA surfacing (Cycle 41).
- **No keyboard accelerator** for panel navigation (NVDA browse mode is the nav path).
- **No `expected_payload_regex` enforcement** in `runCorpus` (still parsed-only).
- **No prompt-stripping for prompts the `HeuristicPromptDetector` doesn't catch.** Fallback: single-StreamChunk behaviour preserved when no boundary is cached.

## Test plan

- [ ] `Build and test (windows-latest)` green — 8 new facts + ~1020 existing tests stay green.
- [ ] `Workflow lint`, `Portability lint`, `Markdown link check` green.
- [ ] **Maintainer dogfood post-merge**: rebuild from main. Type `echo hello` in cmd + Enter. NVDA should announce "hello" and stop. The prompt does NOT auto-announce. NVDA browse-mode down-arrow / End / etc. reaches the on-screen prompt text. Same for PowerShell. Claude unchanged.

https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5SxHV5T4KPVFLySyCBB4)_