### PR TITLE
feat(diagnostics): Cycle 43a — diagnostic chunk extractors + grep dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,107 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 43a): Diagnostic chunk extractors + Grep dialog
+
+Closes the long-standing iOS-paste-crash failure mode for triage
+workflows. The `Ctrl+Shift+D` diagnostic bundle is comprehensive
+but routinely exceeds the paste-back limits of chat clients used
+in triage (the Cycle 29b NVDA test produced a multi-megabyte
+bundle that crashed the maintainer's iOS chat app on paste).
+CLAUDE.md previously codified "request chunks, not full bundles"
+but only as instructions to Claude; the app gave the maintainer
+no tools to actually produce chunks — every triage required
+shell-quoting `findstr` from cmd or `Select-String` from PowerShell,
+both of which are friction for keyboard-only / screen-reader
+usage. Cycle 43a converts that workflow from "unusable" to "the
+primary triage path."
+
+**Surface** — six new menu-only commands under `Diagnostics`:
+
+- `Copy Latest Bundle to Clipboard` — fast lightweight bundle
+  (~100 ms; FileLogger active log + config.toml + session log
+  summary + linear stream tail + redacted environment;
+  no diagnostic-battery run).
+- `Grep Diagnostics...` — modal dialog (pattern + case-sensitive
+  flag + regex flag + context-lines spinner); regenerates the
+  lightweight bundle in-memory and produces a formatted match
+  list; clipboard + extract file.
+- `Extract → By Recency → Last 50 Log Lines` — tail of the active
+  FileLogger log.
+- `Extract → By Event Type → Errors and Warnings` — log entries
+  with `Semantic=ErrorLine`, `WarningLine`, or `ParserError`.
+- `Extract → By Bundle Section → Active Config` — current
+  `config.toml` content.
+- `Extract → Snapshot → Version Header` — version + OS + .NET +
+  PID + active shell (small status snapshot).
+
+All extractors:
+
+- Copy the result to the Windows clipboard via the
+  STA-thread + 3 s-timeout pattern (mirrors
+  `runCopyHistoryToClipboard`).
+- Cap the clipboard payload at **60 KB** (the Cycle 29b
+  iOS-paste-crash safety ceiling) and append a
+  `[... truncated at <N> bytes; full results in extract file ...]`
+  footer if larger.
+- Write the **full untruncated** extract to
+  `%LOCALAPPDATA%\PtySpeak\extracts\<extractor>-<timestamp>.txt`
+  as paste-fallback for clipboard-unfriendly chat clients.
+- Announce result size + extract file path via NVDA
+  (`ActivityIds.diagnostic`).
+
+**Architecture** — two new pure F# modules in `Terminal.Core`:
+
+- [`src/Terminal.Core/DiagnosticExtracts.fs`](src/Terminal.Core/DiagnosticExtracts.fs):
+  `tailLogLines`, `filterLogLinesSince`, `filterLogBySemantic`,
+  `slugifyForFilename`, `extractFilePath`, `truncateForClipboard`,
+  `formatExtractHeader`, `formatBytesForAnnounce`. No WPF /
+  clipboard / logger dependencies.
+- [`src/Terminal.Core/DiagnosticGrep.fs`](src/Terminal.Core/DiagnosticGrep.fs):
+  `GrepOptions` record + `formatGrep` + `countMatches`. Pure
+  function over a string; orchestrator owns side effects.
+
+Orchestration in `Terminal.App/Program.fs` adds a shared
+`runExtractorClipboard` helper that every menu item delegates to;
+per-command logic reduces to "compute body string, hand to
+helper." `Diagnostics.fs` gains a new internal
+`formatLightweightBundle` that mirrors `formatDiagnosticBundle`'s
+section structure minus the battery + corpus sections; this is
+the source `Copy Latest Bundle` copies and `Grep Diagnostics`
+searches over.
+
+**Dialog** — new [`src/Views/GrepDialog.xaml`](src/Views/GrepDialog.xaml)
++ code-behind. UIA-labeled controls (`AutomationProperties.Name`
+on every focusable element); explicit tab order; Enter activates
+OK, Escape activates Cancel; LiveSetting=Assertive validation
+message for context-lines range errors.
+
+**Tests** — 22 new facts across
+[`tests/Tests.Unit/DiagnosticExtractsTests.fs`](tests/Tests.Unit/DiagnosticExtractsTests.fs)
+(slug shape, timestamp parsing, tail behaviour, time-filter,
+Semantic-filter, truncation budget, header format) and
+[`tests/Tests.Unit/DiagnosticGrepTests.fs`](tests/Tests.Unit/DiagnosticGrepTests.fs)
+(empty pattern, regex compile errors, case sensitivity, context
+clamping at file edges, summary footer, match marker).
+`HotkeyRegistryTests.allCommands contains exactly the documented
+commands (PR-O)` updated with the 6 new AppCommand cases.
+
+**Docs** — `CLAUDE.md` "Diagnostic logs — request chunks, not full
+bundles" section refreshed: shell-recipe `findstr` /
+`Select-String` examples replaced with "ask the maintainer to use
+`Diagnostics → Grep diagnostics...`" or
+"`Diagnostics → Extract → X`" as the new primary triage path.
+Shell recipes retained as fallback for the few cases where the
+extractor catalog doesn't cover the specific slice. New NVDA
+matrix rows in [`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)
+for the grep dialog + each proof-of-concept extractor.
+
+**Deferred to Cycle 43b** — the remaining ~16 extractors across
+the four sub-submenus per the
+[`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md) catalog.
+Cycle 43a ships one proof-of-concept extractor per sub-submenu
+to validate the pattern end-to-end before fan-out.
+
 ### Reverted (Cycle 39): Cycle 38c echo-suppression
 
 Cycle 38c (`EchoCorrelator` + `EchoSuppressorProfile`) was solving a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,33 +119,56 @@ user isn't around, queue the question and wait. **Do not push
 speculative fixups** — the cost of one wrong fix is multiple
 minutes of wasted CI cycle plus a noisier git history.
 
-### Diagnostic logs — request chunks, not full bundles
+### Diagnostic logs — request chunks via the in-app menu
 
-`Ctrl+Shift+D`'s diagnostic snapshot is comprehensive: FileLogger
-log + config.toml + redacted env + session-log summary +
-diagnostic-battery log, all combined. **The full bundle can be
-multi-megabyte, especially after a Claude session.** Cycle 29b
-NVDA validation 2026-05-09 produced a bundle that crashed the
-maintainer's iOS chat app on paste. Sharing the whole thing back
-is sometimes infeasible.
+`Ctrl+Shift+D`'s full diagnostic snapshot is comprehensive but
+can be multi-megabyte after a Claude session. Cycle 29b NVDA
+validation 2026-05-09 produced a bundle that crashed the
+maintainer's iOS chat app on paste. Cycle 43a (2026-05-11)
+shipped in-app chunking infrastructure so the maintainer can
+produce paste-safe focused slices without shell-quoting `findstr`
+or `Select-String` — both of which are friction for keyboard-only
+/ screen-reader usage. **Default to the menu items**:
 
-**Default to chunk-first requests.** Tell the maintainer the
-specific strings or sections you need:
+- **`Diagnostics → Grep diagnostics...`** — opens a dialog
+  (pattern, case-sensitive checkbox, regex checkbox,
+  context-lines spinner). Greps the lightweight diagnostic
+  bundle in-memory; clipboard payload is capped at 60 KB with
+  full untruncated text written to
+  `%LOCALAPPDATA%\PtySpeak\extracts\grep-<slug>-<timestamp>.txt`.
+  Use this whenever you want a pattern match — replaces every
+  `findstr` recipe.
+- **`Diagnostics → Copy Latest Bundle to Clipboard`** — fast
+  current-state snapshot (~100 ms; skips the diagnostic battery,
+  so much faster than `Ctrl+Shift+D`'s ~10 s). Use when you want
+  the broad picture without running test commands.
+- **`Diagnostics → Extract → By Recency → Last 50 Log Lines`** —
+  tail of the active FileLogger log.
+- **`Diagnostics → Extract → By Event Type → Errors and Warnings`** —
+  log entries with `Semantic=ErrorLine`, `WarningLine`, or
+  `ParserError`.
+- **`Diagnostics → Extract → By Bundle Section → Active Config`** —
+  current `config.toml` content.
+- **`Diagnostics → Extract → Snapshot → Version Header`** —
+  version + OS + .NET + PID + active shell (< 1 KB).
 
-- Specific Semantic categories — `findstr "Semantic=SelectionShown" "<bundle>"` from cmd
-  or `Select-String -Pattern "Semantic=SelectionShown" "<bundle>"` from PowerShell.
-- Time-bounded windows — "the lines around 18:52 when the prompt
-  appeared" with ±10 lines of context.
-- Specific log sections — `--- DIAGNOSTIC BATTERY LOG ---` /
-  `--- FILELOGGER ACTIVE LOG ---` / `--- CONFIG.TOML ---` /
-  `--- ENVIRONMENT ---` are clearly delimited; ask for one
-  section by name rather than the whole snapshot.
-- Single-line counts — "how many `Earcon play started` lines
-  with `error-tone` in the last minute?" is a one-line answer
-  that often tells you what you need.
+**Asking the maintainer for an extract.** Replace
+"please paste me the FileLogger log filtered for Semantic=ErrorLine"
+with "press `Alt`, arrow to Diagnostics → Extract → By Event Type
+→ Errors and Warnings, press Enter, paste me the clipboard." The
+NVDA announce confirms size + extract-file path, so if iOS chat
+chokes on the paste the maintainer can navigate to the extract
+file path the announce mentioned and share that instead.
 
-When you DO need a wider grep, push the heavy lifting onto the
-maintainer's shell rather than the chat:
+**Asking for a custom pattern.** Replace any `findstr`/
+`Select-String` recipe with: "press `Alt`, arrow to Diagnostics →
+Grep Diagnostics, press Enter, type `<pattern>` and press Enter,
+paste me the result." If the pattern needs regex semantics, tell
+the maintainer to tick the "Treat pattern as regex" checkbox
+before pressing Enter.
+
+**Shell-script fallback (deprecated; use only if the menu items
+are unavailable, e.g. on a build before Cycle 43a):**
 
 ```
 :: cmd
@@ -159,10 +182,12 @@ Select-String -Pattern "Color=red" -Path "$env:LOCALAPPDATA\PtySpeak\logs\<file>
     Out-File excerpt.txt -Encoding utf8
 ```
 
-If the bundle is genuinely needed in full, ask whether the
-maintainer can share via a different channel (gist, file
-attachment, paste service) rather than inline chat — paste-into-chat
-is the failure mode.
+If the bundle is genuinely needed in full and even the extract
+file is too large for the chat channel, ask whether the
+maintainer can share via gist / file attachment / paste service
+— paste-into-chat is the long-standing failure mode the Cycle 43a
+extractors are designed to sidestep but cannot eliminate for
+truly enormous artifacts.
 
 ### PR creation and webhook subscription
 

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1151,6 +1151,47 @@ Select-String -Pattern "Semantic=SelectionShown" -Path "$env:LOCALAPPDATA\PtySpe
 Select-String -Pattern "AnnounceRawPayload received unexpected" -Path "$env:LOCALAPPDATA\PtySpeak\diagnostic-snapshots\snapshot-*.txt"
 ```
 
+<!-- DOGFOOD -->
+### Cycle 43a — Diagnostic chunk extractors + Grep dialog
+
+Cycle 43a converts diagnostic triage from "press `Ctrl+Shift+D`,
+hope the multi-megabyte bundle doesn't crash iOS chat on paste"
+to "press a menu item, get a paste-safe focused chunk." The new
+surface lives entirely under `Diagnostics`: two top-level items
+(`Copy Latest Bundle to Clipboard`, `Grep Diagnostics...`) plus a
+4-way `Extract` submenu (By Recency / By Event Type / By Bundle
+Section / Snapshot) with one proof-of-concept item each in 43a.
+
+Every extractor copies a clipboard payload (capped at **60 KB**
+to dodge the Cycle 29b iOS-paste-crash failure mode), writes the
+full untruncated text to
+`%LOCALAPPDATA%\PtySpeak\extracts\<extractor>-<timestamp>.txt` as
+paste-fallback, and announces "<extractor> copied to clipboard:
+<size>. Extract file at <path>." via NVDA.
+
+| Test | Steps | Expected |
+|---|---|---|
+| Top-level item: Copy Latest Bundle | Press Alt, arrow to Diagnostics → Copy Latest Bundle to Clipboard, press Enter. Wait for the NVDA announce. Paste clipboard into any text editor. | NVDA announces "CopyLatestBundle copied to clipboard: <N> kilobytes. Extract file at <path>." within ~1 second (lightweight bundle skips the diagnostic battery so it's much faster than Ctrl+Shift+D's ~10s). Pasted text starts with `pty-speak diagnostic snapshot (Cycle 43a lightweight)` and contains all five sections (`--- FILELOGGER ACTIVE LOG ---`, `--- CONFIG.TOML ---`, `--- SESSION LOG ---`, `--- LINEAR STREAM ---`, `--- ENVIRONMENT ---`). |
+| Top-level item: Grep Diagnostics dialog | Press Alt, arrow to Diagnostics → Grep Diagnostics..., press Enter. NVDA reads the dialog title. Tab through controls — pattern textbox, case-sensitive checkbox, regex checkbox, context-lines textbox, OK button, Cancel button. | Dialog opens centred on the main window. Initial focus is on the pattern textbox (NVDA reads "Search pattern, edit"). Tabbing reads each label: "Case sensitive, checkbox, not checked"; "Treat pattern as regex, checkbox, not checked"; "Lines of context around each match, edit, 5"; "OK, button"; "Cancel, button". |
+| Grep dialog default-OK round trip | Type `Heartbeat` in the pattern textbox, press Enter (default OK). | Dialog closes. NVDA announces "grep-Heartbeat copied to clipboard: <N> bytes. Extract file at <path>." Pasted clipboard begins with `pty-speak grep — pattern: Heartbeat (regex=false, case=false, context=5)` and contains one `--- Match N of M (line L) ---` block per matched line. |
+| Grep dialog Cancel / Escape | Open the dialog, press Escape. | Dialog closes silently. No NVDA announce. No clipboard write. |
+| Grep dialog invalid context lines | Open dialog, type `abc` into the context-lines textbox, press Enter. | Dialog stays open. Inline error message reads "Context lines must be a whole number between 0 and 20." Focus moves back to the context-lines textbox. NVDA reads the error via the `LiveSetting=Assertive` automation property. |
+| Grep clipboard truncation | Open dialog, type `Heartbeat` with context = 20, press Enter. The lightweight bundle has many heartbeat lines so result exceeds 60 KB. | NVDA announce contains "(clipboard truncated)" suffix. Pasted clipboard ends with `[... truncated at 60-something bytes; full results in extract file ...]`. Extract file at the announced path contains the full untruncated result. |
+| Extract → By Recency → Last 50 Log Lines | Press Alt → Diagnostics → Extract → By Recency → Last 50 Log Lines → Enter. | NVDA announces "ExtractLast50LogLines copied to clipboard: <N> kilobytes." Pasted text contains 50 log lines (or fewer if the active log is shorter), each prefixed by an ISO-8601 timestamp like `2026-05-11T14:32:17.456Z`. |
+| Extract → By Event Type → Errors and Warnings | Open the menu chain, select Errors and Warnings. | NVDA announces successfully. Pasted text contains only lines with `Semantic=ErrorLine`, `Semantic=WarningLine`, or `Semantic=ParserError`. If the current session has no such events, the body reads as empty (just the header). |
+| Extract → By Bundle Section → Active Config | Open the menu chain, select Active Config. | NVDA announces successfully. Pasted text is the verbatim content of `%LOCALAPPDATA%\PtySpeak\config.toml`. If the file is missing, the body reads `(file not present: <path>)`. |
+| Extract → Snapshot → Version Header | Open the menu chain, select Version Header. | NVDA announces successfully. Pasted text contains 5 short lines: `Version: 0.0.x.y`, `OS: <OS string>`, `.NET: <runtime version>`, `Process ID: <pid>`, `Active shell: cmd` (or whichever shell is current). Total size under 1 KB. |
+| Extract file fallback for clipboard contention | With pty-speak open, open another app that holds the clipboard (e.g., a clipboard-manager utility). Press Diagnostics → Extract → Snapshot → Version Header. | NVDA may announce "ExtractVersionHeader clipboard copy timed out. Extract file at <path>." Even on clipboard timeout, the extract file is written with the full content — the user can navigate to `%LOCALAPPDATA%\PtySpeak\extracts\` and open the latest file. |
+| Menu item announces with no InputGestureText | Focus any of the 6 new menu items via arrow keys. | NVDA reads only the item name (e.g., "Grep Diagnostics, ellipsis"). No keyboard shortcut is announced — all 6 commands are menu-only by canon (`Key = None`, `Modifiers = None` in `HotkeyRegistry.builtIns`). |
+
+**Diagnostic decoder.** If a clipboard copy fails repeatedly with
+"clipboard copy timed out": likely NVDA's clipboard hook
+contention. Pull the extract file directly from
+`%LOCALAPPDATA%\PtySpeak\extracts\`. If the extract file write
+fails: check `%LOCALAPPDATA%\PtySpeak\` disk space / permissions
+— the error path will report "Extract file write failed" but
+clipboard copy still works.
+
 ## Recording results
 
 For each release tag:

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -801,7 +801,12 @@ module Diagnostics =
     /// throwing — the bundle should always include something for
     /// each section so the maintainer can see "config not
     /// present" vs "config read failed".
-    let private readFileSafe (path: string) : string =
+    ///
+    /// Cycle 43a — bumped from `private` to `internal` so the new
+    /// `formatLightweightBundle` (consumed by `CopyLatestBundle`
+    /// and `GrepDiagnostics` from Program.fs) can reuse the same
+    /// FileShare.ReadWrite + missing-file fallback semantics.
+    let internal readFileSafe (path: string) : string =
         try
             if not (File.Exists path) then
                 sprintf "(file not present: %s)" path
@@ -841,7 +846,12 @@ module Diagnostics =
     /// Snapshot the current process environment, sorted by name,
     /// with sensitive values redacted. Format: one `NAME=value`
     /// line per variable.
-    let private formatEnvironmentRedacted () : string =
+    ///
+    /// Cycle 43a — bumped from `private` to `internal` so the
+    /// `formatLightweightBundle` orchestrator + future
+    /// extractors can reuse the redaction logic without
+    /// duplicating the deny-list.
+    let internal formatEnvironmentRedacted () : string =
         let table = Environment.GetEnvironmentVariables()
         let names = ResizeArray<string>()
         for entry in table do
@@ -942,6 +952,81 @@ module Diagnostics =
         // corpus file is missing or no scenarios match the shell.
         appendLine "--- CANONICAL CORPUS RESULTS ---"
         appendLine corpusResultsSection
+        appendLine ""
+
+        appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"
+        appendLine (formatEnvironmentRedacted ())
+        appendLine ""
+
+        appendLine "--- END OF SNAPSHOT ---"
+        sb.ToString()
+
+    /// Cycle 43a — assemble a "lightweight" bundle: the same
+    /// section structure as `formatDiagnosticBundle` minus the
+    /// `--- DIAGNOSTIC BATTERY LOG ---` and
+    /// `--- CANONICAL CORPUS RESULTS ---` sections that require
+    /// running test commands against the live shell (~10 seconds
+    /// of wall time + an externally-visible side effect on the
+    /// shell). The lightweight variant assembles in ~100 ms from
+    /// already-on-disk artifacts and is what the new top-level
+    /// `Diagnostics → Copy latest diagnostic bundle to clipboard`
+    /// item produces, plus the corpus the
+    /// `Diagnostics → Grep diagnostics...` dialog searches over.
+    ///
+    /// The bundle banner reads "lightweight" so paste-back
+    /// consumers know which variant they got — distinguishes
+    /// "you got a full battery run" from "you got a fast
+    /// current-state snapshot".
+    ///
+    /// `internal` rather than `public`: Program.fs (same
+    /// assembly) is the only intended caller.
+    let internal formatLightweightBundle
+            (now: DateTime)
+            (fileLoggerLogPath: string option)
+            (configPath: string)
+            (sessionLogSummary: string)
+            (linearStreamSection: string)
+            : string =
+        let sb = StringBuilder()
+        let appendLine (s: string) = sb.AppendLine(s) |> ignore
+        let separator = "========================================================="
+        appendLine separator
+        appendLine "pty-speak diagnostic snapshot (Cycle 43a lightweight)"
+        appendLine (sprintf "Captured: %s UTC" (now.ToString("yyyy-MM-dd HH:mm:ss")))
+        let version =
+            try
+                let asm = System.Reflection.Assembly.GetExecutingAssembly()
+                let v = asm.GetName().Version
+                if isNull v then "unknown" else string v
+            with _ -> "unknown"
+        appendLine (sprintf "Version: %s" version)
+        appendLine (sprintf "OS: %s" (Environment.OSVersion.VersionString))
+        appendLine (sprintf ".NET: %s" (Environment.Version.ToString()))
+        appendLine (sprintf "Process ID: %d" (System.Diagnostics.Process.GetCurrentProcess().Id))
+        appendLine "Variant: lightweight (no diagnostic battery; no canonical corpus)"
+        appendLine separator
+        appendLine ""
+
+        appendLine "--- FILELOGGER ACTIVE LOG ---"
+        match fileLoggerLogPath with
+        | Some path ->
+            appendLine (sprintf "(source: %s)" path)
+            appendLine (readFileSafe path)
+        | None ->
+            appendLine "(FileLogger not configured)"
+        appendLine ""
+
+        appendLine "--- CONFIG.TOML ---"
+        appendLine (sprintf "(source: %s)" configPath)
+        appendLine (readFileSafe configPath)
+        appendLine ""
+
+        appendLine "--- SESSION LOG ---"
+        appendLine sessionLogSummary
+        appendLine ""
+
+        appendLine "--- LINEAR STREAM (last 64KB) ---"
+        appendLine linearStreamSection
         appendLine ""
 
         appendLine "--- ENVIRONMENT (deny-listed values redacted) ---"

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2335,6 +2335,313 @@ module Program =
                         safe,
                     ActivityIds.error)
 
+        // ---------------------------------------------------------------
+        // Cycle 43a — Diagnostics → Extract submenu + Grep dialog
+        // ---------------------------------------------------------------
+        //
+        // Six new menu-only commands (no keyboard accelerators):
+        //   * `CopyLatestBundle`     — Diagnostics → Copy latest diagnostic bundle
+        //   * `GrepDiagnostics`      — Diagnostics → Grep diagnostics...
+        //   * `ExtractLast50LogLines` — Diagnostics → Extract → By Recency
+        //   * `ExtractErrorsAndWarnings` — Diagnostics → Extract → By Event Type
+        //   * `ExtractActiveConfig`     — Diagnostics → Extract → By Bundle Section
+        //   * `ExtractVersionHeader`    — Diagnostics → Extract → Snapshot
+        //
+        // All six follow the same shape: compute a body string,
+        // wrap it with a header, cap clipboard payload at 60 KB
+        // (Cycle 29b iOS-paste-crash ceiling), write the full
+        // untruncated text to `%LOCALAPPDATA%\PtySpeak\extracts\`
+        // as a paste-fallback, copy the (possibly-truncated)
+        // clipboard view via the STA-thread + 3s-timeout pattern
+        // shared by `runCopyHistoryToClipboard`, and announce the
+        // size + file path via NVDA. The shared shape lives in
+        // `runExtractorClipboard` below; the per-command logic
+        // is a single closure passed as `computeBody`.
+
+        // Shared building block for the lightweight diagnostic
+        // bundle that `CopyLatestBundle` copies and that
+        // `GrepDiagnostics` searches over. Resolvers run at
+        // press-time so a hot-switch between presses is picked up
+        // correctly. Skips the diagnostic-battery + canonical-
+        // corpus sections that `Ctrl+Shift+D` includes (those
+        // require running test commands against the live shell,
+        // adding ~10 seconds of wall time); the lightweight
+        // assembly is current-state-only and completes in ~100 ms.
+        let buildLightweightBundle () : string =
+            let now = DateTime.UtcNow
+            let configPath = Config.defaultConfigFilePath ()
+            let sessionLogSummary = buildSessionLogSummary ()
+            let fileLoggerPath =
+                loggerSink |> Option.map (fun s -> s.ActiveLogPath)
+            let tailBytes =
+                LinearTextStream.getLastBytes linearStream 64
+            let tailText =
+                try
+                    System.Text.Encoding.UTF8.GetString(tailBytes)
+                    |> AnnounceSanitiser.sanitise
+                with _ -> "(UTF-8 decode failed)"
+            Diagnostics.formatLightweightBundle
+                now
+                fileLoggerPath
+                configPath
+                sessionLogSummary
+                tailText
+
+        // Cycle 43a — the canonical "extractor → clipboard + file
+        // + announce" pipeline. Captures `window` from compose-
+        // local scope; otherwise pure (delegates body production
+        // to the caller-supplied closure). Mirrors the STA + 3s
+        // pattern of `runCopyHistoryToClipboard`; the difference
+        // is the file-write step ahead of the clipboard hand-off
+        // so paste-back consumers who can't paste from clipboard
+        // (e.g. iOS chat clients on huge content) have the
+        // untruncated text on disk.
+        let runExtractorClipboard
+                (extractorName: string)
+                (sourceDescription: string)
+                (computeBody: unit -> string)
+                : unit =
+            let log =
+                Logger.get
+                    (sprintf
+                        "Terminal.App.Program.runExtractor.%s"
+                        extractorName)
+            log.LogInformation(
+                "Extractor pressed: {Name}", extractorName)
+            let _ =
+                task {
+                    try
+                        let now = DateTimeOffset.UtcNow
+                        let body = computeBody ()
+                        let fullContent =
+                            DiagnosticExtracts.formatExtractHeader
+                                now
+                                extractorName
+                                sourceDescription
+                                body
+                        let (clipboardContent, truncated) =
+                            DiagnosticExtracts.truncateForClipboard
+                                DiagnosticExtracts.clipboardSafetyCeilingBytes
+                                fullContent
+                        let extractPath =
+                            DiagnosticExtracts.extractFilePath
+                                now
+                                extractorName
+                        let mutable extractWritten = false
+                        try
+                            DiagnosticExtracts.writeExtractFile
+                                extractPath
+                                fullContent
+                            extractWritten <- true
+                        with ex ->
+                            log.LogWarning(
+                                ex,
+                                "Extract file write failed at {Path}",
+                                extractPath)
+                        let setOk = TaskCompletionSource<bool>()
+                        let staBody = ThreadStart(fun () ->
+                            try
+                                System.Windows.Clipboard.SetText(clipboardContent)
+                                setOk.TrySetResult(true) |> ignore
+                            with ex ->
+                                log.LogWarning(
+                                    ex,
+                                    "Extractor clipboard SetText threw: {Message}",
+                                    ex.Message)
+                                setOk.TrySetResult(false) |> ignore)
+                        let staThread = new Thread(staBody)
+                        staThread.SetApartmentState(ApartmentState.STA)
+                        staThread.IsBackground <- true
+                        staThread.Start()
+                        let! winner =
+                            Task.WhenAny(
+                                setOk.Task :> Task,
+                                Task.Delay(3000))
+                        let copied =
+                            obj.ReferenceEquals(winner, setOk.Task)
+                            && setOk.Task.Result
+                        let bytes =
+                            System.Text.Encoding.UTF8.GetByteCount(clipboardContent)
+                        let sizeStr =
+                            DiagnosticExtracts.formatBytesForAnnounce bytes
+                        let truncSuffix =
+                            if truncated then " (clipboard truncated)"
+                            else ""
+                        let fileSuffix =
+                            if extractWritten then
+                                sprintf
+                                    " Extract file at %s."
+                                    extractPath
+                            else
+                                " Extract file write failed."
+                        let msg, activityId =
+                            if copied then
+                                log.LogInformation(
+                                    "Extractor {Name} copied. Bytes={Bytes} Truncated={Truncated} ExtractPath={Path}",
+                                    extractorName,
+                                    bytes,
+                                    truncated,
+                                    extractPath)
+                                sprintf
+                                    "%s copied to clipboard: %s%s.%s"
+                                    extractorName
+                                    sizeStr
+                                    truncSuffix
+                                    fileSuffix,
+                                ActivityIds.diagnostic
+                            else
+                                log.LogWarning(
+                                    "Extractor {Name} clipboard timed out.",
+                                    extractorName)
+                                sprintf
+                                    "%s clipboard copy timed out.%s"
+                                    extractorName
+                                    fileSuffix,
+                                ActivityIds.error
+                        let action () =
+                            window.TerminalSurface.Announce(msg, activityId)
+                        do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        log.LogError(
+                            ex,
+                            "Extractor {Name} failed.",
+                            extractorName)
+                        let action () =
+                            window.TerminalSurface.Announce(
+                                sprintf "%s failed: %s" extractorName safe,
+                                ActivityIds.error)
+                        try
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                        with _ -> ()
+                }
+            ()
+
+        // --- Top-level: Copy latest diagnostic bundle (no battery) ---
+        let runCopyLatestBundle () : unit =
+            runExtractorClipboard
+                "CopyLatestBundle"
+                "lightweight diagnostic bundle (FileLogger active log + config + session log summary + linear stream tail + redacted environment)"
+                buildLightweightBundle
+
+        // --- Top-level: Grep diagnostics... (modal dialog) ---
+        //
+        // Runs on the dispatcher (hotkey handler is dispatcher-bound
+        // by `bindHotkey`'s contract). Dialog is modal-with-owner
+        // so NVDA's focus model reads the dialog as a child of the
+        // main window and Alt+F4 / Escape close it cleanly. After
+        // the dialog returns, the grep + clipboard + announce
+        // pipeline runs through `runExtractorClipboard` so the
+        // size-cap / file-write / NVDA-announce behaviour is
+        // identical to the other extractors.
+        let runGrepDiagnostics () : unit =
+            let log =
+                Logger.get "Terminal.App.Program.runGrepDiagnostics"
+            try
+                let dialog = GrepDialog()
+                dialog.Owner <- window
+                let result = dialog.ShowDialog()
+                if result.HasValue && result.Value then
+                    let opts : DiagnosticGrep.GrepOptions =
+                        { Pattern = dialog.Pattern
+                          CaseSensitive = dialog.CaseSensitive
+                          TreatAsRegex = dialog.TreatAsRegex
+                          ContextLines = dialog.ContextLines }
+                    let extractorName =
+                        sprintf "grep-%s" dialog.Pattern
+                    let source =
+                        sprintf
+                            "lightweight diagnostic bundle; grep pattern=%s regex=%b case=%b context=%d"
+                            dialog.Pattern
+                            dialog.TreatAsRegex
+                            dialog.CaseSensitive
+                            dialog.ContextLines
+                    let computeBody () =
+                        let bundle = buildLightweightBundle ()
+                        DiagnosticGrep.formatGrep opts bundle
+                    runExtractorClipboard
+                        extractorName
+                        source
+                        computeBody
+                else
+                    log.LogInformation(
+                        "Grep dialog cancelled.")
+            with ex ->
+                let safe = AnnounceSanitiser.sanitise ex.Message
+                log.LogError(ex, "Grep dialog failed to open.")
+                window.TerminalSurface.Announce(
+                    sprintf "Grep dialog failed: %s" safe,
+                    ActivityIds.error)
+
+        // --- Extract → By Recency → Last 50 log lines ---
+        let runExtractLast50LogLines () : unit =
+            runExtractorClipboard
+                "ExtractLast50LogLines"
+                "FileLogger active log; last 50 lines"
+                (fun () ->
+                    match loggerSink with
+                    | None -> "(FileLogger not configured)"
+                    | Some sink ->
+                        DiagnosticExtracts.tailLogLines
+                            sink.ActiveLogPath
+                            50)
+
+        // --- Extract → By Event Type → Errors and warnings ---
+        let runExtractErrorsAndWarnings () : unit =
+            runExtractorClipboard
+                "ExtractErrorsAndWarnings"
+                "FileLogger active log; entries with Semantic=ErrorLine, WarningLine, or ParserError"
+                (fun () ->
+                    match loggerSink with
+                    | None -> "(FileLogger not configured)"
+                    | Some sink ->
+                        DiagnosticExtracts.filterLogBySemantic
+                            sink.ActiveLogPath
+                            [ "ErrorLine"; "WarningLine"; "ParserError" ])
+
+        // --- Extract → By Bundle Section → Active config.toml ---
+        let runExtractActiveConfig () : unit =
+            runExtractorClipboard
+                "ExtractActiveConfig"
+                (sprintf
+                    "config.toml at %s"
+                    (Config.defaultConfigFilePath ()))
+                (fun () ->
+                    let path = Config.defaultConfigFilePath ()
+                    Diagnostics.readFileSafe path)
+
+        // --- Extract → Snapshot → Version + environment header ---
+        let runExtractVersionHeader () : unit =
+            runExtractorClipboard
+                "ExtractVersionHeader"
+                "process version + OS + .NET + PID (small status snapshot)"
+                (fun () ->
+                    let version =
+                        try
+                            let asm =
+                                System.Reflection.Assembly.GetExecutingAssembly()
+                            let v = asm.GetName().Version
+                            if isNull v then "unknown" else string v
+                        with _ -> "unknown"
+                    let pid =
+                        System.Diagnostics.Process.GetCurrentProcess().Id
+                    let sb = System.Text.StringBuilder()
+                    sb.AppendLine(sprintf "Version: %s" version) |> ignore
+                    sb.AppendLine(
+                        sprintf
+                            "OS: %s"
+                            (Environment.OSVersion.VersionString)) |> ignore
+                    sb.AppendLine(
+                        sprintf
+                            ".NET: %s"
+                            (Environment.Version.ToString())) |> ignore
+                    sb.AppendLine(sprintf "Process ID: %d" pid) |> ignore
+                    sb.AppendLine(
+                        sprintf
+                            "Active shell: %s"
+                            currentShell.DisplayName) |> ignore
+                    sb.ToString())
+
         // Stage 7-followup PR-F — wire Ctrl+Shift+H and Ctrl+Shift+B
         // through the unified `bindHotkey` helper (PR-O). Both
         // closures capture compose-local state (lastReadUtc,
@@ -2346,6 +2653,16 @@ module Program =
         bind HotkeyRegistry.RunDiagnostic runDiagnostic
         bind HotkeyRegistry.CopyHistoryToClipboard runCopyHistoryToClipboard
         bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
+        // Cycle 43a — diagnostic chunk extractors + grep dialog.
+        // All menu-only (no keyboard accelerator); `bindHotkey`
+        // skips the KeyBinding installation but still registers
+        // the CommandBinding so MenuItem.Command dispatch works.
+        bind HotkeyRegistry.CopyLatestBundle runCopyLatestBundle
+        bind HotkeyRegistry.GrepDiagnostics runGrepDiagnostics
+        bind HotkeyRegistry.ExtractLast50LogLines runExtractLast50LogLines
+        bind HotkeyRegistry.ExtractErrorsAndWarnings runExtractErrorsAndWarnings
+        bind HotkeyRegistry.ExtractActiveConfig runExtractActiveConfig
+        bind HotkeyRegistry.ExtractVersionHeader runExtractVersionHeader
 
         // Stage 7-followup PR-F — background heartbeat. Every 5
         // seconds, log a single Information-level "Heartbeat" line

--- a/src/Terminal.Core/DiagnosticExtracts.fs
+++ b/src/Terminal.Core/DiagnosticExtracts.fs
@@ -1,0 +1,380 @@
+namespace Terminal.Core
+
+open System
+open System.Globalization
+open System.IO
+open System.Text
+
+/// Cycle 43a — pure helpers backing the new "Diagnostics → Extract"
+/// submenu and the "Diagnostics → Grep diagnostics..." dialog.
+///
+/// Background: pty-speak's existing `Ctrl+Shift+D` diagnostic bundle
+/// is comprehensive but routinely exceeds the paste-back limits of
+/// chat clients used in triage workflows (the Cycle 29b NVDA test
+/// produced a multi-megabyte bundle that crashed the maintainer's
+/// iOS chat app on paste). CLAUDE.md codifies "request chunks, not
+/// full bundles" but until Cycle 43 the app exposed no way for a
+/// screen-reader user to actually produce chunks — every triage
+/// required shell-quoting `findstr` from cmd or `Select-String` from
+/// PowerShell, both of which are friction for keyboard-only usage.
+///
+/// This module is the pure F# substrate the new menu items call
+/// into. Each function is deterministic, testable in isolation, and
+/// avoids any WPF / logging / clipboard dependencies — those live at
+/// the orchestration layer in `Terminal.App/Program.fs`.
+///
+/// Outputs from these helpers are sized for the 60 KB clipboard
+/// ceiling (`clipboardSafetyCeilingBytes`); orchestrators are
+/// responsible for calling `truncateForClipboard` before clipboard
+/// hand-off, and for falling back to an on-disk extract file when
+/// truncation fires.
+module DiagnosticExtracts =
+
+    /// Conservative clipboard ceiling. The Cycle 29b iOS-paste-crash
+    /// incident motivated the 64 KB cap on the bundle's
+    /// `--- LINEAR STREAM ---` section; the same ceiling applies
+    /// here. 60 KB leaves headroom for an `[... truncated ...]`
+    /// footer plus any user-visible framing the orchestrator adds.
+    let clipboardSafetyCeilingBytes : int = 60 * 1024
+
+    /// Root folder for on-disk extract files. Created on demand by
+    /// `ensureExtractsRoot`. Lives alongside `logs\` and
+    /// `diagnostic-snapshots\` under `%LOCALAPPDATA%\PtySpeak\`.
+    let extractsRoot () : string =
+        let local =
+            Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData)
+        Path.Combine(local, "PtySpeak", "extracts")
+
+    /// Ensure the extracts root exists. Returns the path.
+    /// Best-effort — a permissions failure or disk-full surfaces as
+    /// the exception from `Directory.CreateDirectory`, propagating
+    /// to the caller for a single "could not write extract file"
+    /// announce rather than a silent failure.
+    let ensureExtractsRoot () : string =
+        let root = extractsRoot ()
+        Directory.CreateDirectory(root) |> ignore
+        root
+
+    /// Reduce an arbitrary user-supplied string (e.g. a grep
+    /// pattern) to a filename-safe slug. Alphanumeric + dashes
+    /// only; consecutive non-alnum runs collapse to a single dash;
+    /// leading/trailing dashes trimmed; truncated to `maxLen`
+    /// characters; falls back to `"untitled"` when the input
+    /// produces an empty slug.
+    let slugifyForFilename (maxLen: int) (input: string) : string =
+        if String.IsNullOrEmpty input then "untitled"
+        else
+            let sb = StringBuilder(input.Length)
+            let mutable lastWasDash = false
+            for ch in input do
+                if Char.IsLetterOrDigit(ch) then
+                    sb.Append(Char.ToLowerInvariant(ch)) |> ignore
+                    lastWasDash <- false
+                elif not lastWasDash && sb.Length > 0 then
+                    sb.Append('-') |> ignore
+                    lastWasDash <- true
+            let raw = sb.ToString().Trim('-')
+            let capped =
+                if raw.Length > maxLen then raw.Substring(0, maxLen)
+                else raw
+            if String.IsNullOrEmpty capped then "untitled" else capped
+
+    /// Build the on-disk path for an extract file. Format:
+    /// `<extractsRoot>\<extractorName>-<timestamp>.txt`.
+    /// `extractorName` is slugified; `timestamp` uses the same
+    /// `yyyy-MM-dd-HH-mm-ss-fff` shape as `FileLogger.pathsForLaunch`
+    /// and `Diagnostics.resolveSnapshotPath`, so a sort-by-name in
+    /// the extracts folder is also a sort-by-time.
+    let extractFilePath
+            (now: DateTimeOffset)
+            (extractorName: string)
+            : string =
+        let slug = slugifyForFilename 40 extractorName
+        let stamp = now.UtcDateTime.ToString("yyyy-MM-dd-HH-mm-ss-fff")
+        let fileName = sprintf "%s-%s.txt" slug stamp
+        Path.Combine(extractsRoot (), fileName)
+
+    /// Read an entire file's content while tolerating concurrent
+    /// writers (the active FileLogger log is the canonical case —
+    /// pty-speak is still writing as we read). Returns `None` if
+    /// the file is missing; throws on any other IO error so the
+    /// orchestrator can surface a single "could not read X" message
+    /// rather than silently returning empty.
+    let private readFileShared (path: string) : string option =
+        if not (File.Exists path) then None
+        else
+            use stream =
+                new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite)
+            use reader = new StreamReader(stream, Encoding.UTF8)
+            Some (reader.ReadToEnd())
+
+    /// Read the last `n` lines of a UTF-8 text file. Returns the
+    /// joined lines (without a trailing newline) plus a header note
+    /// indicating the source path and the line count actually
+    /// returned. Returns a placeholder string if the file is
+    /// missing rather than throwing — for diagnostic surfacing the
+    /// caller should always get a renderable result.
+    ///
+    /// Implementation reads the entire file into memory then takes
+    /// the tail. For pty-speak's bounded log sizes (a few MB per
+    /// daily file) this is O(file-size) but simple and avoids
+    /// reverse-stream tricks. If log files ever grow large enough
+    /// to make this measurably slow, swap in a reverse-line reader;
+    /// the public signature is stable.
+    let tailLogLines (path: string) (n: int) : string =
+        match readFileShared path with
+        | None ->
+            sprintf "(file not present: %s)" path
+        | Some content ->
+            let lines =
+                content.Split([| '\n' |], StringSplitOptions.None)
+            let lineCount = lines.Length
+            let takeCount = if n < 0 then 0 else min n lineCount
+            let startIdx = lineCount - takeCount
+            let tail =
+                if startIdx <= 0 then lines
+                else lines |> Array.skip startIdx
+            // Strip the trailing empty element that always appears
+            // when the file ends with a newline (Split returns one
+            // empty string after the final `\n`). Keep interior
+            // blank lines.
+            let tail =
+                if tail.Length > 0 && tail.[tail.Length - 1] = "" then
+                    tail |> Array.take (tail.Length - 1)
+                else
+                    tail
+            // Also strip embedded \r so paste targets render cleanly
+            // on platforms that surface CR as a visible glyph.
+            let cleaned =
+                tail
+                |> Array.map (fun line -> line.TrimEnd('\r'))
+            String.Join("\n", cleaned)
+
+    /// Try to parse the leading ISO-8601 timestamp emitted by
+    /// `FileLogger.formatEntry`: `yyyy-MM-ddTHH:mm:ss.fffZ`. Returns
+    /// `None` for lines that don't carry a parseable timestamp
+    /// (continuation lines from a multi-line stack trace, blank
+    /// lines, etc.) — caller-policy whether to retain or drop those.
+    let parseLogTimestamp (line: string) : DateTimeOffset option =
+        if String.IsNullOrEmpty line || line.Length < 24 then None
+        else
+            let prefix = line.Substring(0, 24)
+            let mutable result = DateTimeOffset.MinValue
+            let ok =
+                DateTimeOffset.TryParseExact(
+                    prefix,
+                    "yyyy-MM-ddTHH:mm:ss.fffZ",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal
+                        ||| DateTimeStyles.AdjustToUniversal,
+                    &result)
+            if ok then Some result else None
+
+    /// Filter log lines whose timestamp is at or after `cutoff`.
+    /// Lines without a parseable timestamp (continuation lines of
+    /// multi-line entries) are retained when they immediately
+    /// follow a kept timestamped line, so stack traces stay
+    /// attached to their parent entry. Lines without a timestamp
+    /// that appear at the start of the file are dropped (no
+    /// parent to attach to).
+    let filterLogLinesSince
+            (path: string)
+            (cutoff: DateTimeOffset)
+            : string =
+        match readFileShared path with
+        | None ->
+            sprintf "(file not present: %s)" path
+        | Some content ->
+            let lines =
+                content.Split([| '\n' |], StringSplitOptions.None)
+            let kept = ResizeArray<string>()
+            let mutable retainContinuations = false
+            for rawLine in lines do
+                let line = rawLine.TrimEnd('\r')
+                match parseLogTimestamp line with
+                | Some ts when ts >= cutoff ->
+                    kept.Add(line)
+                    retainContinuations <- true
+                | Some _ ->
+                    retainContinuations <- false
+                | None ->
+                    if retainContinuations then kept.Add(line)
+            String.Join("\n", kept)
+
+    /// Filter log lines containing any of the supplied
+    /// `Semantic=<token>` substrings. Matching is case-sensitive
+    /// (the producer emits the SemanticCategory case names in their
+    /// canonical casing — `Semantic=ErrorLine`, not
+    /// `Semantic=errorline`). Continuation lines of multi-line
+    /// entries (stack traces) are kept when they immediately
+    /// follow a kept timestamped line, mirroring
+    /// `filterLogLinesSince`'s policy.
+    let filterLogBySemantic
+            (path: string)
+            (semanticTokens: string list)
+            : string =
+        if List.isEmpty semanticTokens then ""
+        else
+            match readFileShared path with
+            | None ->
+                sprintf "(file not present: %s)" path
+            | Some content ->
+                let needles =
+                    semanticTokens
+                    |> List.map (fun t -> sprintf "Semantic=%s" t)
+                let lineMatches (line: string) : bool =
+                    needles
+                    |> List.exists (fun n -> line.Contains(n))
+                let lines =
+                    content.Split(
+                        [| '\n' |], StringSplitOptions.None)
+                let kept = ResizeArray<string>()
+                let mutable retainContinuations = false
+                for rawLine in lines do
+                    let line = rawLine.TrimEnd('\r')
+                    match parseLogTimestamp line with
+                    | Some _ ->
+                        if lineMatches line then
+                            kept.Add(line)
+                            retainContinuations <- true
+                        else
+                            retainContinuations <- false
+                    | None ->
+                        if retainContinuations then kept.Add(line)
+                String.Join("\n", kept)
+
+    /// Cap `content` at `maxBytes` UTF-8 bytes. Returns the
+    /// (possibly-truncated) content and a `wasTruncated` flag the
+    /// orchestrator uses to decide whether to surface a truncation
+    /// notice in the NVDA announce. Truncation happens at a UTF-8
+    /// byte boundary (no partial code points) and appends a single-
+    /// line footer `[... truncated at <N> bytes; full results in
+    /// extract file ...]` so paste-back consumers know they're
+    /// looking at a head-only view.
+    ///
+    /// Implementation: encode the entire content to UTF-8 once,
+    /// scan for the largest prefix whose byte count fits the budget
+    /// minus the footer length, then decode that prefix back. This
+    /// is O(content-size) but simple and correct.
+    let truncateForClipboard
+            (maxBytes: int)
+            (content: string)
+            : string * bool =
+        let encoding = Encoding.UTF8
+        let totalBytes = encoding.GetByteCount(content)
+        if totalBytes <= maxBytes then content, false
+        else
+            let footer =
+                sprintf
+                    "\n[... truncated at %d bytes; full results in extract file ...]"
+                    maxBytes
+            let footerBytes = encoding.GetByteCount(footer)
+            let budget = maxBytes - footerBytes
+            if budget <= 0 then "", true
+            else
+                // Find the largest substring whose UTF-8 encoding
+                // fits the budget. Char-by-char scan from the
+                // start avoids the surrogate-pair-split problem
+                // that a naive byte-substring would hit.
+                let sb = StringBuilder(content.Length)
+                let mutable running = 0
+                let mutable idx = 0
+                let mutable stopped = false
+                while not stopped && idx < content.Length do
+                    let ch = content.[idx]
+                    let segLen =
+                        if Char.IsHighSurrogate(ch)
+                           && idx + 1 < content.Length
+                           && Char.IsLowSurrogate(content.[idx + 1]) then
+                            encoding.GetByteCount(content, idx, 2)
+                        else
+                            encoding.GetByteCount(content, idx, 1)
+                    if running + segLen > budget then
+                        stopped <- true
+                    else
+                        if Char.IsHighSurrogate(ch)
+                           && idx + 1 < content.Length
+                           && Char.IsLowSurrogate(content.[idx + 1]) then
+                            sb.Append(ch) |> ignore
+                            sb.Append(content.[idx + 1]) |> ignore
+                            idx <- idx + 2
+                        else
+                            sb.Append(ch) |> ignore
+                            idx <- idx + 1
+                        running <- running + segLen
+                sb.Append(footer) |> ignore
+                sb.ToString(), true
+
+    /// Compose the standard extract-file header. Format:
+    /// ```
+    /// pty-speak extract — <extractorName>
+    /// Captured: <timestamp> UTC
+    /// Source: <description>
+    /// Size: <bytes> bytes (<lineCount> lines)
+    /// =========================================================
+    /// ```
+    /// Used as the prefix for every extract file. Stable shape so
+    /// future tooling can parse extract files by header (mirrors
+    /// the `formatDiagnosticBundle` separator convention).
+    let formatExtractHeader
+            (now: DateTimeOffset)
+            (extractorName: string)
+            (sourceDescription: string)
+            (body: string)
+            : string =
+        let separator = "========================================================="
+        let bytes = Encoding.UTF8.GetByteCount(body)
+        let lineCount =
+            if String.IsNullOrEmpty body then 0
+            else
+                let mutable count = 1
+                for ch in body do
+                    if ch = '\n' then count <- count + 1
+                count
+        let sb = StringBuilder()
+        sb.AppendLine(sprintf "pty-speak extract — %s" extractorName) |> ignore
+        sb.AppendLine(
+            sprintf
+                "Captured: %s UTC"
+                (now.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss"))) |> ignore
+        sb.AppendLine(sprintf "Source: %s" sourceDescription) |> ignore
+        sb.AppendLine(
+            sprintf "Size: %d bytes (%d lines)" bytes lineCount) |> ignore
+        sb.AppendLine(separator) |> ignore
+        sb.AppendLine("") |> ignore
+        sb.Append(body) |> ignore
+        sb.ToString()
+
+    /// Write `content` to `path`, creating parent directories as
+    /// needed. Best-effort — exceptions propagate so the
+    /// orchestrator can surface a single "could not write extract
+    /// file" announce.
+    ///
+    /// F# 9 nullness: `Path.GetDirectoryName` returns
+    /// `string | null` (null for root paths or empty input).
+    /// Pattern-match on the result rather than `if not (isNull …)`
+    /// so the narrowing is explicit per `Diagnostics.writeSnapshotFile`'s
+    /// convention (`Diagnostics.fs:970-974`).
+    let writeExtractFile (path: string) (content: string) : unit =
+        match Path.GetDirectoryName(path) with
+        | null -> ()
+        | "" -> ()
+        | dir -> Directory.CreateDirectory(dir) |> ignore
+        File.WriteAllText(path, content, Encoding.UTF8)
+
+    /// Format a size-bytes value as a human-readable string. Used
+    /// in NVDA announces ("3.4 kilobytes"). Mirrors NVDA's own
+    /// pronunciation conventions: "bytes" / "kilobytes" /
+    /// "megabytes"; no abbreviations (NVDA would spell "KB" as
+    /// "kay bee" which is not what we want).
+    let formatBytesForAnnounce (bytes: int) : string =
+        if bytes < 1024 then sprintf "%d bytes" bytes
+        elif bytes < 1024 * 1024 then
+            sprintf "%.1f kilobytes" (float bytes / 1024.0)
+        else
+            sprintf "%.1f megabytes" (float bytes / 1024.0 / 1024.0)

--- a/src/Terminal.Core/DiagnosticExtracts.fs
+++ b/src/Terminal.Core/DiagnosticExtracts.fs
@@ -113,6 +113,20 @@ module DiagnosticExtracts =
             use reader = new StreamReader(stream, Encoding.UTF8)
             Some (reader.ReadToEnd())
 
+    /// Split a UTF-8 text body into lines, stripping the single
+    /// trailing empty element that `String.Split('\n')` produces
+    /// when the source ends with a newline. Keeps interior blank
+    /// lines (a blank line BETWEEN log entries is content; the
+    /// trailing empty AFTER the final newline is not). Centralised
+    /// here so `tailLogLines`, `filterLogLinesSince`, and
+    /// `filterLogBySemantic` share the same line-count semantics.
+    let private splitLinesStripTrailing (content: string) : string[] =
+        let lines = content.Split([| '\n' |], StringSplitOptions.None)
+        if lines.Length > 0 && lines.[lines.Length - 1] = "" then
+            lines |> Array.take (lines.Length - 1)
+        else
+            lines
+
     /// Read the last `n` lines of a UTF-8 text file. Returns the
     /// joined lines (without a trailing newline) plus a header note
     /// indicating the source path and the line count actually
@@ -131,25 +145,20 @@ module DiagnosticExtracts =
         | None ->
             sprintf "(file not present: %s)" path
         | Some content ->
-            let lines =
-                content.Split([| '\n' |], StringSplitOptions.None)
+            // Strip the trailing empty BEFORE computing the tail
+            // window so `lineCount` reflects real-line count, not
+            // the Split-artifact count. Without this strip the
+            // window includes the trailing-empty slot, eats one
+            // real line, and returns N-1 lines instead of N.
+            let lines = splitLinesStripTrailing content
             let lineCount = lines.Length
             let takeCount = if n < 0 then 0 else min n lineCount
             let startIdx = lineCount - takeCount
             let tail =
                 if startIdx <= 0 then lines
                 else lines |> Array.skip startIdx
-            // Strip the trailing empty element that always appears
-            // when the file ends with a newline (Split returns one
-            // empty string after the final `\n`). Keep interior
-            // blank lines.
-            let tail =
-                if tail.Length > 0 && tail.[tail.Length - 1] = "" then
-                    tail |> Array.take (tail.Length - 1)
-                else
-                    tail
-            // Also strip embedded \r so paste targets render cleanly
-            // on platforms that surface CR as a visible glyph.
+            // Strip embedded \r so paste targets render cleanly on
+            // platforms that surface CR as a visible glyph.
             let cleaned =
                 tail
                 |> Array.map (fun line -> line.TrimEnd('\r'))
@@ -190,8 +199,7 @@ module DiagnosticExtracts =
         | None ->
             sprintf "(file not present: %s)" path
         | Some content ->
-            let lines =
-                content.Split([| '\n' |], StringSplitOptions.None)
+            let lines = splitLinesStripTrailing content
             let kept = ResizeArray<string>()
             let mutable retainContinuations = false
             for rawLine in lines do
@@ -230,9 +238,7 @@ module DiagnosticExtracts =
                 let lineMatches (line: string) : bool =
                     needles
                     |> List.exists (fun n -> line.Contains(n))
-                let lines =
-                    content.Split(
-                        [| '\n' |], StringSplitOptions.None)
+                let lines = splitLinesStripTrailing content
                 let kept = ResizeArray<string>()
                 let mutable retainContinuations = false
                 for rawLine in lines do

--- a/src/Terminal.Core/DiagnosticGrep.fs
+++ b/src/Terminal.Core/DiagnosticGrep.fs
@@ -1,0 +1,217 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+open System.Text.RegularExpressions
+
+/// Cycle 43a — pure F# grep over the in-memory diagnostic bundle.
+/// Backs the `Diagnostics → Grep diagnostics...` top-level menu
+/// command (`HotkeyRegistry.AppCommand.GrepDiagnostics`).
+///
+/// The orchestrator in `Terminal.App/Program.fs` opens a modal
+/// `Views/GrepDialog.xaml` window, collects a pattern + options,
+/// regenerates a lightweight bundle via
+/// `Terminal.App.Diagnostics.formatLightweightBundle`, then calls
+/// into this module to produce the formatted match list. The
+/// orchestrator caps the output via
+/// `DiagnosticExtracts.truncateForClipboard` and writes the full
+/// untruncated content to an extract file as paste-fallback.
+///
+/// Substrate rule: this module is pure. No file I/O, no clipboard,
+/// no logger, no clock. Caller passes the search-target string;
+/// this module returns the formatted output string. The orchestrator
+/// owns side effects.
+module DiagnosticGrep =
+
+    /// Match-mode options collected from the dialog.
+    type GrepOptions =
+        { /// Pattern to search for. Empty pattern produces a
+          /// single-line error result rather than matching every
+          /// line.
+          Pattern: string
+          /// Case sensitivity flag. Default: false (case-insensitive
+          /// substring match is the friendliest default for users
+          /// who think of grep as "find this word, however it's
+          /// spelled").
+          CaseSensitive: bool
+          /// When true, `Pattern` is interpreted as a .NET regex.
+          /// When false, it's a literal substring. Regex errors
+          /// produce a single-line error result rather than
+          /// throwing.
+          TreatAsRegex: bool
+          /// Number of context lines emitted before AND after each
+          /// matched line. Clamped to [0, 20] by the orchestrator
+          /// per the dialog's spinner range.
+          ContextLines: int }
+
+    let defaultOptions : GrepOptions =
+        { Pattern = ""
+          CaseSensitive = false
+          TreatAsRegex = false
+          ContextLines = 5 }
+
+    /// Result of compiling a pattern. Encapsulates the per-line
+    /// match predicate so the actual matching loop stays simple.
+    type private CompiledMatcher =
+        /// Pattern compiled successfully; carries the predicate.
+        | Compiled of (string -> bool)
+        /// Pattern was empty.
+        | EmptyPattern
+        /// Regex compile failed with the given message.
+        | RegexError of string
+
+    let private compile (opts: GrepOptions) : CompiledMatcher =
+        if String.IsNullOrEmpty opts.Pattern then EmptyPattern
+        elif opts.TreatAsRegex then
+            try
+                let regexOpts =
+                    if opts.CaseSensitive then RegexOptions.None
+                    else RegexOptions.IgnoreCase
+                let rx =
+                    Regex(
+                        opts.Pattern,
+                        regexOpts ||| RegexOptions.CultureInvariant,
+                        TimeSpan.FromSeconds(1.0))
+                Compiled (fun line -> rx.IsMatch(line))
+            with
+            | :? RegexParseException as ex -> RegexError ex.Message
+            | :? ArgumentException as ex -> RegexError ex.Message
+        else
+            let comparison =
+                if opts.CaseSensitive then StringComparison.Ordinal
+                else StringComparison.OrdinalIgnoreCase
+            let pattern = opts.Pattern
+            Compiled (fun line -> line.IndexOf(pattern, comparison) >= 0)
+
+    /// Count matches without producing the full output. Used by
+    /// the orchestrator for the NVDA pre-announce ("Found N
+    /// matches.") so the user knows the result size before the
+    /// clipboard copy completes.
+    let countMatches (opts: GrepOptions) (source: string) : int =
+        match compile opts with
+        | EmptyPattern -> 0
+        | RegexError _ -> 0
+        | Compiled predicate ->
+            if String.IsNullOrEmpty source then 0
+            else
+                let lines = source.Split([| '\n' |], StringSplitOptions.None)
+                let mutable count = 0
+                for rawLine in lines do
+                    let line = rawLine.TrimEnd('\r')
+                    if predicate line then count <- count + 1
+                count
+
+    /// Format the full grep output: a per-match block carrying
+    /// context lines and the matched line marked with a `>>>`
+    /// prefix, followed by a one-line summary footer.
+    ///
+    /// Output shape (stable; future tooling can index by header
+    /// format):
+    /// ```
+    /// pty-speak grep — pattern: <pattern> (regex=<bool>, case=<bool>)
+    /// Source size: <bytes> bytes (<lines> lines)
+    /// =========================================================
+    ///
+    /// --- Match 1 of 12 (line 42) ---
+    /// line 40
+    /// line 41
+    /// >>> line 42 with pattern hit
+    /// line 43
+    /// line 44
+    ///
+    /// --- Match 2 of 12 (line 48) ---
+    /// ...
+    ///
+    /// --- Summary: 12 matches; <N> bytes of output ---
+    /// ```
+    ///
+    /// Special cases:
+    /// - Empty pattern → `pty-speak grep — empty pattern` banner.
+    /// - Regex error → `pty-speak grep — regex error: <msg>` banner.
+    /// - Zero matches → banner + `No matches for <pattern>.` line.
+    let formatGrep (opts: GrepOptions) (source: string) : string =
+        let sb = StringBuilder()
+        let separator = "========================================================="
+        let appendLine (s: string) = sb.AppendLine(s) |> ignore
+
+        // Banner — always present so the consumer can read the
+        // search parameters back without scrolling.
+        appendLine
+            (sprintf
+                "pty-speak grep — pattern: %s (regex=%b, case=%b, context=%d)"
+                opts.Pattern
+                opts.TreatAsRegex
+                opts.CaseSensitive
+                opts.ContextLines)
+
+        // Compile + validate before computing source statistics so
+        // an empty / invalid pattern returns quickly without
+        // scanning the source.
+        match compile opts with
+        | EmptyPattern ->
+            appendLine separator
+            appendLine ""
+            appendLine "(empty pattern — nothing to match)"
+            sb.ToString()
+        | RegexError msg ->
+            appendLine separator
+            appendLine ""
+            appendLine (sprintf "(regex error: %s)" msg)
+            sb.ToString()
+        | Compiled predicate ->
+            let sourceBytes = Encoding.UTF8.GetByteCount(source)
+            let lines =
+                if String.IsNullOrEmpty source then [||]
+                else source.Split([| '\n' |], StringSplitOptions.None)
+            appendLine
+                (sprintf
+                    "Source size: %d bytes (%d lines)"
+                    sourceBytes
+                    lines.Length)
+            appendLine separator
+            appendLine ""
+
+            // Scan once, collect matching indexes.
+            let matchIndexes = ResizeArray<int>()
+            for i in 0 .. lines.Length - 1 do
+                let line = lines.[i].TrimEnd('\r')
+                if predicate line then matchIndexes.Add(i)
+
+            if matchIndexes.Count = 0 then
+                appendLine (sprintf "No matches for %s." opts.Pattern)
+                sb.ToString()
+            else
+                let total = matchIndexes.Count
+                let ctx = max 0 opts.ContextLines
+
+                // Emit one block per match. Adjacent matches will
+                // produce overlapping context windows — that's
+                // intentional: each match is independently labelled
+                // with its line number, which is the field the
+                // consumer reads to navigate. Deduplicating the
+                // body would obscure that.
+                for matchOrdinal in 0 .. total - 1 do
+                    let idx = matchIndexes.[matchOrdinal]
+                    let lineNum = idx + 1
+                    appendLine
+                        (sprintf
+                            "--- Match %d of %d (line %d) ---"
+                            (matchOrdinal + 1)
+                            total
+                            lineNum)
+                    let startIdx = max 0 (idx - ctx)
+                    let endIdx = min (lines.Length - 1) (idx + ctx)
+                    for k in startIdx .. endIdx do
+                        let line = lines.[k].TrimEnd('\r')
+                        if k = idx then
+                            appendLine (sprintf ">>> %s" line)
+                        else
+                            appendLine line
+                    appendLine ""
+
+                appendLine
+                    (sprintf
+                        "--- Summary: %d matches; pattern=%s ---"
+                        total
+                        opts.Pattern)
+                sb.ToString()

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -122,6 +122,26 @@ module HotkeyRegistry =
         // and opens it in the default browser. NVDA browse-mode H
         // key jumps headings; D key jumps the `<main>` landmark.
         | OpenManualTests
+        // Cycle 43a — diagnostic chunk extractors. All menu-only;
+        // no keyboard accelerators (accelerator budget is saturated
+        // per the maintainer's hotkey-count working-memory ceiling,
+        // and chunking is power-user enough that menu access is the
+        // right shape). The full catalog lives under
+        // `Diagnostics → Extract → {Recency | Event Type | Bundle
+        // Section | Snapshot}` with first-cut representatives in
+        // 43a; subsequent extractors plug into the same shape in
+        // 43b. The two top-level items
+        // (`CopyLatestBundle` and `GrepDiagnostics`) bypass the
+        // submenu hierarchy because they're the load-bearing
+        // triage tools — every chunking session starts by either
+        // copying the current state in one keystroke or grepping
+        // it with a pattern.
+        | CopyLatestBundle
+        | GrepDiagnostics
+        | ExtractLast50LogLines
+        | ExtractErrorsAndWarnings
+        | ExtractActiveConfig
+        | ExtractVersionHeader
 
     /// Stable string name for a command, used as the
     /// `RoutedCommand` name passed to WPF and as a TOML key
@@ -146,6 +166,12 @@ module HotkeyRegistry =
         | CloseWindow -> "CloseWindow"
         | ExitApp -> "ExitApp"
         | OpenManualTests -> "OpenManualTests"
+        | CopyLatestBundle -> "CopyLatestBundle"
+        | GrepDiagnostics -> "GrepDiagnostics"
+        | ExtractLast50LogLines -> "ExtractLast50LogLines"
+        | ExtractErrorsAndWarnings -> "ExtractErrorsAndWarnings"
+        | ExtractActiveConfig -> "ExtractActiveConfig"
+        | ExtractVersionHeader -> "ExtractVersionHeader"
 
     /// Default key binding for a command. Mirrors the
     /// `AppReservedHotkeys` table in
@@ -254,7 +280,37 @@ module HotkeyRegistry =
           { Command = OpenManualTests
             Key = None
             Modifiers = None
-            Description = "Open the dogfood-filtered manual-tests HTML quickref in the default browser (Cycle 38a-followup)" } ]
+            Description = "Open the dogfood-filtered manual-tests HTML quickref in the default browser (Cycle 38a-followup)" }
+          // Cycle 43a — diagnostic chunk extractors. All menu-only.
+          // The two top-level items live under Diagnostics directly;
+          // the four `Extract*` items live under
+          // Diagnostics → Extract → {Recency | Event Type | Bundle
+          // Section | Snapshot} (one representative per sub-submenu
+          // in 43a; the remaining catalog ships in 43b).
+          { Command = CopyLatestBundle
+            Key = None
+            Modifiers = None
+            Description = "Copy the latest lightweight diagnostic bundle to the clipboard (Cycle 43a; no battery run, no test commands — fast current-state snapshot)" }
+          { Command = GrepDiagnostics
+            Key = None
+            Modifiers = None
+            Description = "Open a dialog to grep the lightweight diagnostic bundle for a pattern; copies matches to the clipboard (Cycle 43a)" }
+          { Command = ExtractLast50LogLines
+            Key = None
+            Modifiers = None
+            Description = "Extract the last 50 lines of the active FileLogger log to the clipboard (Cycle 43a; Recency)" }
+          { Command = ExtractErrorsAndWarnings
+            Key = None
+            Modifiers = None
+            Description = "Extract FileLogger entries with Semantic=ErrorLine, WarningLine, or ParserError (Cycle 43a; Event Type)" }
+          { Command = ExtractActiveConfig
+            Key = None
+            Modifiers = None
+            Description = "Extract the active config.toml to the clipboard (Cycle 43a; Bundle Section)" }
+          { Command = ExtractVersionHeader
+            Key = None
+            Modifiers = None
+            Description = "Extract the version + environment header (version, OS, .NET, PID) to the clipboard (Cycle 43a; Snapshot)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —
@@ -334,7 +390,13 @@ module HotkeyRegistry =
           RunProcessCleanupScript
           CloseWindow
           ExitApp
-          OpenManualTests ]
+          OpenManualTests
+          CopyLatestBundle
+          GrepDiagnostics
+          ExtractLast50LogLines
+          ExtractErrorsAndWarnings
+          ExtractActiveConfig
+          ExtractVersionHeader ]
 
     // ---------------------------------------------------------------
     // Cycle 27 — Multi-state command paradigm

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -43,6 +43,17 @@
     <Compile Include="Channels/IHotkeyTranslator.fs" />
     <Compile Include="Channels/IDisplayBuffer.fs" />
     <Compile Include="ManualTestsHtml.fs" />
+    <!--
+      Cycle 43a — diagnostic chunk extractors + grep substrate.
+      Pure F# helpers backing the new `Diagnostics → Extract` and
+      `Diagnostics → Grep diagnostics...` menu commands. No
+      WPF / clipboard / logger dependencies; orchestrator in
+      `Terminal.App/Program.fs` owns side effects. The two
+      modules live at the end of the compile order because
+      nothing else in `Terminal.Core` depends on them.
+    -->
+    <Compile Include="DiagnosticExtracts.fs" />
+    <Compile Include="DiagnosticGrep.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Views/GrepDialog.xaml
+++ b/src/Views/GrepDialog.xaml
@@ -1,0 +1,136 @@
+<!--
+  Cycle 43a — Grep diagnostics dialog. Modal WPF window opened
+  from the `Diagnostics → Grep diagnostics...` menu item. The user
+  enters a search pattern + options; the orchestrator in
+  `Terminal.App/Program.fs` calls `Terminal.Core.DiagnosticGrep`
+  to produce a formatted match list and copy it to the clipboard.
+
+  Accessibility-first conventions:
+  - Every interactive control has an explicit
+    `AutomationProperties.Name` so NVDA reads a clear label on tab
+    focus rather than the WPF default (which often reads "edit"
+    or "checkbox" with no field name).
+  - `FocusManager.FocusedElement` points at the pattern textbox so
+    the user can start typing immediately on dialog open.
+  - The OK button is `IsDefault="True"` (Enter activates) and
+    Cancel is `IsCancel="True"` (Escape activates), per WPF
+    standard modal-dialog conventions; this means the user can
+    type a pattern + hit Enter without leaving the textbox.
+  - Tab order is explicit (TabIndex on every focusable control)
+    so the screen-reader walks: pattern → case-sensitive →
+    regex → context-lines → OK → Cancel.
+  - Window is small (480 × 280), modal, non-resizable, centered
+    on the owner. SizeToContent="Height" lets the inline error
+    message expand the dialog vertically when validation fires.
+-->
+<Window x:Class="PtySpeak.Views.GrepDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Grep diagnostics"
+        Width="480"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        AutomationProperties.Name="Grep diagnostics dialog"
+        AutomationProperties.AutomationId="pty-speak.GrepDialog"
+        FocusManager.FocusedElement="{Binding ElementName=PatternTextBox}">
+    <Grid Margin="16">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Row 0: pattern textbox + label. -->
+        <Label Grid.Row="0" Grid.Column="0"
+               Target="{Binding ElementName=PatternTextBox}"
+               Content="Search _pattern:"
+               Margin="0,0,8,4"
+               VerticalAlignment="Center" />
+        <TextBox x:Name="PatternTextBox"
+                 Grid.Row="0" Grid.Column="1"
+                 Margin="0,0,0,4"
+                 TabIndex="0"
+                 AutomationProperties.Name="Search pattern"
+                 AutomationProperties.HelpText="Pattern to search for. Empty pattern returns no matches." />
+
+        <!-- Row 1: case-sensitive checkbox. -->
+        <CheckBox x:Name="CaseSensitiveCheckBox"
+                  Grid.Row="1" Grid.Column="1"
+                  Margin="0,8,0,4"
+                  TabIndex="1"
+                  Content="_Case sensitive"
+                  AutomationProperties.Name="Case sensitive"
+                  AutomationProperties.HelpText="When unchecked, the pattern matches regardless of letter case (default)." />
+
+        <!-- Row 2: regex checkbox. -->
+        <CheckBox x:Name="RegexCheckBox"
+                  Grid.Row="2" Grid.Column="1"
+                  Margin="0,4,0,4"
+                  TabIndex="2"
+                  Content="Treat pattern as _regex"
+                  AutomationProperties.Name="Treat pattern as regex"
+                  AutomationProperties.HelpText="When unchecked, the pattern is a literal substring (default). When checked, the pattern is a .NET regular expression." />
+
+        <!-- Row 3: context-lines textbox + label. -->
+        <Label Grid.Row="3" Grid.Column="0"
+               Target="{Binding ElementName=ContextLinesTextBox}"
+               Content="_Lines of context:"
+               Margin="0,8,8,4"
+               VerticalAlignment="Center" />
+        <TextBox x:Name="ContextLinesTextBox"
+                 Grid.Row="3" Grid.Column="1"
+                 Margin="0,8,0,4"
+                 TabIndex="3"
+                 Text="5"
+                 AutomationProperties.Name="Lines of context around each match"
+                 AutomationProperties.HelpText="Integer between zero and twenty. Default five. Sets the number of lines of surrounding context emitted before and after each matched line." />
+
+        <!-- Row 4: validation error message (hidden by default). -->
+        <TextBlock x:Name="ValidationMessage"
+                   Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                   Margin="0,8,0,0"
+                   Foreground="DarkRed"
+                   TextWrapping="Wrap"
+                   Visibility="Collapsed"
+                   AutomationProperties.Name="Validation error"
+                   AutomationProperties.LiveSetting="Assertive" />
+
+        <!-- Row 5: spacer. -->
+        <Border Grid.Row="5" Grid.ColumnSpan="2" Height="8" />
+
+        <!-- Row 6: OK + Cancel buttons. Right-aligned, OK is
+             default so Enter from any field activates it; Cancel
+             is the IsCancel button so Escape closes the dialog. -->
+        <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+            <Button x:Name="OkButton"
+                    Content="_OK"
+                    IsDefault="True"
+                    Width="80"
+                    Height="28"
+                    Margin="0,0,8,0"
+                    TabIndex="4"
+                    AutomationProperties.Name="OK; run grep and copy results to clipboard"
+                    Click="OkButton_Click" />
+            <Button x:Name="CancelButton"
+                    Content="_Cancel"
+                    IsCancel="True"
+                    Width="80"
+                    Height="28"
+                    TabIndex="5"
+                    AutomationProperties.Name="Cancel; close dialog without running grep" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Views/GrepDialog.xaml.cs
+++ b/src/Views/GrepDialog.xaml.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using System.Windows;
+
+namespace PtySpeak.Views;
+
+/// <summary>
+/// Cycle 43a — code-behind for the Grep diagnostics dialog.
+/// <para>
+/// The dialog collects four inputs (pattern, case-sensitive flag,
+/// regex flag, context lines) and exposes them as read-only
+/// properties after the user clicks OK. The orchestrator in
+/// <c>Terminal.App/Program.fs</c> opens this dialog modally,
+/// inspects the properties when <c>DialogResult == true</c>, and
+/// hands them off to the F# <c>Terminal.Core.DiagnosticGrep</c>
+/// module along with the assembled lightweight bundle.
+/// </para>
+/// <para>
+/// Validation: context-lines must parse as an integer in
+/// <c>[0, 20]</c>. Invalid input keeps the dialog open with an
+/// inline error message; the validation TextBlock has
+/// <c>LiveSetting="Assertive"</c> so NVDA reads the error
+/// immediately when it becomes visible.
+/// </para>
+/// </summary>
+public partial class GrepDialog : Window
+{
+    private const int MinContextLines = 0;
+    private const int MaxContextLines = 20;
+
+    public GrepDialog()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>The pattern the user entered in the textbox.</summary>
+    public string Pattern { get; private set; } = string.Empty;
+
+    /// <summary>Whether the case-sensitive checkbox was ticked.</summary>
+    public bool CaseSensitive { get; private set; }
+
+    /// <summary>Whether the regex checkbox was ticked.</summary>
+    public bool TreatAsRegex { get; private set; }
+
+    /// <summary>
+    /// Number of context lines requested. Guaranteed to be in
+    /// <c>[0, 20]</c> when the dialog returns <c>true</c>.
+    /// </summary>
+    public int ContextLines { get; private set; } = 5;
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        // Validate context-lines first; keep the dialog open
+        // with an inline error if invalid. Pattern is allowed to
+        // be empty — the grep module returns a clean "empty
+        // pattern" banner rather than throwing, and the
+        // orchestrator surfaces a "no matches" announce. That
+        // way a user who accidentally hits Enter on an empty
+        // pattern gets feedback (an empty clipboard slot rather
+        // than a 60KB log dump) without an in-dialog error.
+        var contextText = ContextLinesTextBox.Text ?? string.Empty;
+        if (!int.TryParse(
+                contextText.Trim(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var context)
+            || context < MinContextLines
+            || context > MaxContextLines)
+        {
+            ValidationMessage.Text =
+                $"Context lines must be a whole number between {MinContextLines} and {MaxContextLines}.";
+            ValidationMessage.Visibility = Visibility.Visible;
+            ContextLinesTextBox.Focus();
+            ContextLinesTextBox.SelectAll();
+            return;
+        }
+
+        Pattern = PatternTextBox.Text ?? string.Empty;
+        CaseSensitive = CaseSensitiveCheckBox.IsChecked == true;
+        TreatAsRegex = RegexCheckBox.IsChecked == true;
+        ContextLines = context;
+
+        DialogResult = true;
+        Close();
+    }
+}

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -133,6 +133,45 @@
                 <MenuItem x:Name="MenuItem_OpenManualTests"
                           x:FieldModifier="public"
                           Header="Open Manual _Tests" />
+                <Separator />
+                <!-- Cycle 43a — diagnostic chunking. Top-level
+                     `Copy Latest Bundle` and `Grep Diagnostics`
+                     are the load-bearing triage tools; the
+                     `Extract` submenu tree provides the catalog of
+                     small targeted slices. All six items are
+                     menu-only (no keyboard accelerators) per the
+                     hotkey-count working-memory ceiling — the
+                     existing Ctrl+Shift+D path stays for users
+                     who want the full battery + clipboard copy
+                     in one keystroke. -->
+                <MenuItem x:Name="MenuItem_CopyLatestBundle"
+                          x:FieldModifier="public"
+                          Header="Copy Latest Bun_dle to Clipboard" />
+                <MenuItem x:Name="MenuItem_GrepDiagnostics"
+                          x:FieldModifier="public"
+                          Header="_Grep Diagnostics..." />
+                <MenuItem Header="E_xtract">
+                    <MenuItem Header="By _Recency">
+                        <MenuItem x:Name="MenuItem_ExtractLast50LogLines"
+                                  x:FieldModifier="public"
+                                  Header="Last 50 _Log Lines" />
+                    </MenuItem>
+                    <MenuItem Header="By _Event Type">
+                        <MenuItem x:Name="MenuItem_ExtractErrorsAndWarnings"
+                                  x:FieldModifier="public"
+                                  Header="_Errors and Warnings" />
+                    </MenuItem>
+                    <MenuItem Header="By _Bundle Section">
+                        <MenuItem x:Name="MenuItem_ExtractActiveConfig"
+                                  x:FieldModifier="public"
+                                  Header="Active _Config" />
+                    </MenuItem>
+                    <MenuItem Header="_Snapshot">
+                        <MenuItem x:Name="MenuItem_ExtractVersionHeader"
+                                  x:FieldModifier="public"
+                                  Header="_Version Header" />
+                    </MenuItem>
+                </MenuItem>
             </MenuItem>
             <!-- Cycle 28 — Window menu. Both items are menu-only
                  commands (no keyboard accelerator registered with

--- a/tests/Tests.Unit/DiagnosticExtractsTests.fs
+++ b/tests/Tests.Unit/DiagnosticExtractsTests.fs
@@ -1,0 +1,269 @@
+module PtySpeak.Tests.Unit.DiagnosticExtractsTests
+
+open System
+open System.IO
+open System.Text
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 43a — DiagnosticExtracts pure-helper tests.
+// ---------------------------------------------------------------------
+//
+// Pins the public contract of every helper exposed by
+// `Terminal.Core/DiagnosticExtracts.fs`. The orchestrator in
+// `Terminal.App/Program.fs` depends on these contracts for the
+// new `Diagnostics → Copy latest diagnostic bundle`,
+// `Diagnostics → Grep diagnostics...`, and `Diagnostics → Extract`
+// menu items; a regression here can silently break the chunking
+// workflow without surfacing in any NVDA test until the
+// maintainer tries to copy a chunk and gets the wrong content.
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+/// Build a deterministic UTF-8 log file in a unique temp directory
+/// so concurrent tests don't trip on each other. Returns the path;
+/// caller is responsible for deleting (xunit's per-fact isolation
+/// + IDisposable would be cleaner but the test surface is small
+/// enough that explicit File.Delete works).
+let private writeTempLog (content: string) : string =
+    let dir =
+        Path.Combine(
+            Path.GetTempPath(),
+            sprintf "pty-speak-extracts-test-%s" (Guid.NewGuid().ToString("N")))
+    Directory.CreateDirectory(dir) |> ignore
+    let path = Path.Combine(dir, "active.log")
+    File.WriteAllText(path, content, Encoding.UTF8)
+    path
+
+let private fixedNow : DateTimeOffset =
+    DateTimeOffset(2026, 5, 11, 14, 32, 17, 456, TimeSpan.Zero)
+
+// ---------------------------------------------------------------------
+// slugifyForFilename
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``slugifyForFilename collapses non-alnum runs to single dashes`` () =
+    let slug = DiagnosticExtracts.slugifyForFilename 40 "Hello, world!  foo"
+    Assert.Equal("hello-world-foo", slug)
+
+[<Fact>]
+let ``slugifyForFilename trims leading and trailing dashes`` () =
+    let slug = DiagnosticExtracts.slugifyForFilename 40 "   ?? bang ??   "
+    Assert.Equal("bang", slug)
+
+[<Fact>]
+let ``slugifyForFilename caps length and produces untitled for empty input`` () =
+    let long = String.replicate 200 "a"
+    let slug = DiagnosticExtracts.slugifyForFilename 10 long
+    Assert.Equal(10, slug.Length)
+    Assert.Equal("untitled", DiagnosticExtracts.slugifyForFilename 40 "")
+    Assert.Equal("untitled", DiagnosticExtracts.slugifyForFilename 40 "!!!!")
+
+[<Fact>]
+let ``slugifyForFilename lowercases letters`` () =
+    let slug = DiagnosticExtracts.slugifyForFilename 40 "MixedCASE"
+    Assert.Equal("mixedcase", slug)
+
+// ---------------------------------------------------------------------
+// extractFilePath
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``extractFilePath embeds slugged name and yyyy-MM-dd timestamp`` () =
+    let path = DiagnosticExtracts.extractFilePath fixedNow "MyExtractor"
+    let leaf = Path.GetFileName(path)
+    Assert.Equal("myextractor-2026-05-11-14-32-17-456.txt", leaf)
+    Assert.EndsWith(".txt", path)
+    Assert.Contains("extracts", path)
+
+// ---------------------------------------------------------------------
+// parseLogTimestamp
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``parseLogTimestamp accepts the exact FileLogger ISO format`` () =
+    let line = "2026-05-11T14:32:17.456Z [INF] [Category] message body"
+    let parsed = DiagnosticExtracts.parseLogTimestamp line
+    Assert.True(parsed.IsSome)
+    let dt = parsed.Value
+    Assert.Equal(2026, dt.Year)
+    Assert.Equal(5, dt.Month)
+    Assert.Equal(11, dt.Day)
+    Assert.Equal(14, dt.Hour)
+    Assert.Equal(456, dt.Millisecond)
+
+[<Fact>]
+let ``parseLogTimestamp returns None for short or malformed lines`` () =
+    Assert.Equal(None, DiagnosticExtracts.parseLogTimestamp "")
+    Assert.Equal(None, DiagnosticExtracts.parseLogTimestamp "short")
+    Assert.Equal(None, DiagnosticExtracts.parseLogTimestamp "not-a-timestamp line continuation")
+    Assert.Equal(None, DiagnosticExtracts.parseLogTimestamp "2026-99-99T99:99:99.999Z bad date")
+
+// ---------------------------------------------------------------------
+// tailLogLines
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``tailLogLines returns the last N lines in order`` () =
+    let body =
+        seq { for i in 1 .. 10 -> sprintf "line-%d" i }
+        |> String.concat "\n"
+    let path = writeTempLog (body + "\n")
+    try
+        let tail = DiagnosticExtracts.tailLogLines path 3
+        Assert.Equal("line-8\nline-9\nline-10", tail)
+    finally
+        File.Delete(path)
+
+[<Fact>]
+let ``tailLogLines tolerates fewer lines than requested`` () =
+    let path = writeTempLog "only-one\n"
+    try
+        let tail = DiagnosticExtracts.tailLogLines path 10
+        Assert.Equal("only-one", tail)
+    finally
+        File.Delete(path)
+
+[<Fact>]
+let ``tailLogLines returns a placeholder for missing files`` () =
+    let path =
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".log")
+    let tail = DiagnosticExtracts.tailLogLines path 5
+    Assert.StartsWith("(file not present:", tail)
+
+// ---------------------------------------------------------------------
+// filterLogLinesSince
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``filterLogLinesSince keeps timestamped lines at or after cutoff`` () =
+    let body =
+        String.Join(
+            "\n",
+            [| "2026-05-11T14:00:00.000Z [INF] [Cat] before cutoff"
+               "2026-05-11T14:30:00.000Z [INF] [Cat] at cutoff"
+               "2026-05-11T14:45:00.000Z [INF] [Cat] after cutoff" |])
+    let path = writeTempLog body
+    try
+        let cutoff =
+            DateTimeOffset(2026, 5, 11, 14, 30, 0, TimeSpan.Zero)
+        let result = DiagnosticExtracts.filterLogLinesSince path cutoff
+        Assert.Contains("at cutoff", result)
+        Assert.Contains("after cutoff", result)
+        Assert.DoesNotContain("before cutoff", result)
+    finally
+        File.Delete(path)
+
+[<Fact>]
+let ``filterLogLinesSince keeps continuation lines for retained entries`` () =
+    let body =
+        String.Join(
+            "\n",
+            [| "2026-05-11T14:00:00.000Z [INF] [Cat] before cutoff"
+               "  stack frame for before — should be dropped"
+               "2026-05-11T14:45:00.000Z [ERR] [Cat] after cutoff"
+               "  stack frame for after — should be kept" |])
+    let path = writeTempLog body
+    try
+        let cutoff =
+            DateTimeOffset(2026, 5, 11, 14, 30, 0, TimeSpan.Zero)
+        let result = DiagnosticExtracts.filterLogLinesSince path cutoff
+        Assert.Contains("after cutoff", result)
+        Assert.Contains("stack frame for after", result)
+        Assert.DoesNotContain("stack frame for before", result)
+    finally
+        File.Delete(path)
+
+// ---------------------------------------------------------------------
+// filterLogBySemantic
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``filterLogBySemantic matches any token in the supplied list`` () =
+    let body =
+        String.Join(
+            "\n",
+            [| "2026-05-11T14:00:00.000Z [INF] [Cat] OutputEvent. Semantic=StreamChunk Payload=hello"
+               "2026-05-11T14:00:01.000Z [INF] [Cat] OutputEvent. Semantic=ErrorLine Payload=oops"
+               "2026-05-11T14:00:02.000Z [INF] [Cat] OutputEvent. Semantic=WarningLine Payload=warn"
+               "2026-05-11T14:00:03.000Z [INF] [Cat] OutputEvent. Semantic=SpinnerTick Payload=spin" |])
+    let path = writeTempLog body
+    try
+        let result =
+            DiagnosticExtracts.filterLogBySemantic
+                path
+                [ "ErrorLine"; "WarningLine" ]
+        Assert.Contains("Semantic=ErrorLine", result)
+        Assert.Contains("Semantic=WarningLine", result)
+        Assert.DoesNotContain("Semantic=StreamChunk", result)
+        Assert.DoesNotContain("Semantic=SpinnerTick", result)
+    finally
+        File.Delete(path)
+
+[<Fact>]
+let ``filterLogBySemantic returns empty string for empty token list`` () =
+    let path = writeTempLog "anything"
+    try
+        let result = DiagnosticExtracts.filterLogBySemantic path []
+        Assert.Equal("", result)
+    finally
+        File.Delete(path)
+
+// ---------------------------------------------------------------------
+// truncateForClipboard
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``truncateForClipboard returns content unchanged when within budget`` () =
+    let content = "short content"
+    let (out, truncated) = DiagnosticExtracts.truncateForClipboard 1000 content
+    Assert.Equal(content, out)
+    Assert.False(truncated)
+
+[<Fact>]
+let ``truncateForClipboard caps oversize content with footer`` () =
+    let big = String.replicate 200 "x"
+    let (out, truncated) = DiagnosticExtracts.truncateForClipboard 100 big
+    Assert.True(truncated)
+    Assert.True(Encoding.UTF8.GetByteCount(out) <= 100)
+    Assert.Contains("truncated", out)
+
+[<Fact>]
+let ``truncateForClipboard handles maxBytes smaller than footer gracefully`` () =
+    let (out, truncated) = DiagnosticExtracts.truncateForClipboard 5 "anything"
+    Assert.True(truncated)
+    Assert.Equal("", out)
+
+// ---------------------------------------------------------------------
+// formatBytesForAnnounce
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``formatBytesForAnnounce uses bytes-kilobytes-megabytes scales`` () =
+    Assert.Equal("0 bytes", DiagnosticExtracts.formatBytesForAnnounce 0)
+    Assert.Equal("512 bytes", DiagnosticExtracts.formatBytesForAnnounce 512)
+    Assert.Contains("kilobytes", DiagnosticExtracts.formatBytesForAnnounce 2048)
+    Assert.Contains("megabytes", DiagnosticExtracts.formatBytesForAnnounce (3 * 1024 * 1024))
+
+// ---------------------------------------------------------------------
+// formatExtractHeader
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``formatExtractHeader carries extractor name, source, and body`` () =
+    let header =
+        DiagnosticExtracts.formatExtractHeader
+            fixedNow
+            "MyExtractor"
+            "the source description"
+            "body line 1\nbody line 2"
+    Assert.Contains("pty-speak extract — MyExtractor", header)
+    Assert.Contains("Source: the source description", header)
+    Assert.Contains("Captured: 2026-05-11 14:32:17 UTC", header)
+    Assert.Contains("body line 1", header)
+    Assert.Contains("body line 2", header)
+    Assert.Contains("2 lines", header)

--- a/tests/Tests.Unit/DiagnosticGrepTests.fs
+++ b/tests/Tests.Unit/DiagnosticGrepTests.fs
@@ -1,0 +1,185 @@
+module PtySpeak.Tests.Unit.DiagnosticGrepTests
+
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 43a — DiagnosticGrep pure-function tests.
+// ---------------------------------------------------------------------
+//
+// Pin the formatter shape, regex compile behaviour, and edge cases
+// for `Terminal.Core/DiagnosticGrep.fs`. The grep dialog
+// (`Views/GrepDialog.xaml`) collects options + pattern from the
+// user, then the orchestrator in `Terminal.App/Program.fs`
+// regenerates a lightweight bundle in-memory and calls
+// `DiagnosticGrep.formatGrep` to produce the clipboard payload.
+// The contracts below are what that wiring depends on.
+
+let private sampleSource : string =
+    String.concat "\n"
+        [ "line 0: alpha"
+          "line 1: beta"
+          "line 2: GAMMA UPPERCASE"
+          "line 3: gamma lowercase"
+          "line 4: delta"
+          "line 5: epsilon"
+          "line 6: zeta"
+          "line 7: eta"
+          "line 8: theta"
+          "line 9: iota"
+          "line 10: kappa" ]
+
+// ---------------------------------------------------------------------
+// countMatches
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``countMatches returns zero for an empty pattern`` () =
+    let opts = { DiagnosticGrep.defaultOptions with Pattern = "" }
+    Assert.Equal(0, DiagnosticGrep.countMatches opts sampleSource)
+
+[<Fact>]
+let ``countMatches is case-insensitive by default`` () =
+    let opts = { DiagnosticGrep.defaultOptions with Pattern = "gamma" }
+    // Lines 2 (UPPERCASE) and 3 (lowercase) both match when
+    // case-insensitive (default).
+    Assert.Equal(2, DiagnosticGrep.countMatches opts sampleSource)
+
+[<Fact>]
+let ``countMatches respects the case-sensitive flag`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "gamma"
+            CaseSensitive = true }
+    // Only line 3 matches the lowercase pattern when case-sensitive.
+    Assert.Equal(1, DiagnosticGrep.countMatches opts sampleSource)
+
+[<Fact>]
+let ``countMatches handles regex mode`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "^line [0-2]:"
+            TreatAsRegex = true }
+    Assert.Equal(3, DiagnosticGrep.countMatches opts sampleSource)
+
+[<Fact>]
+let ``countMatches returns zero on a bad regex`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "(unclosed"
+            TreatAsRegex = true }
+    Assert.Equal(0, DiagnosticGrep.countMatches opts sampleSource)
+
+// ---------------------------------------------------------------------
+// formatGrep
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``formatGrep banner reports the pattern and options`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "alpha"
+            CaseSensitive = true
+            TreatAsRegex = false
+            ContextLines = 2 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("pty-speak grep — pattern: alpha", result)
+    Assert.Contains("regex=false", result)
+    Assert.Contains("case=true", result)
+    Assert.Contains("context=2", result)
+
+[<Fact>]
+let ``formatGrep emits a banner and footer for an empty pattern`` () =
+    let opts = { DiagnosticGrep.defaultOptions with Pattern = "" }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("empty pattern", result)
+
+[<Fact>]
+let ``formatGrep emits a banner with the regex error message`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "(unclosed"
+            TreatAsRegex = true }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("regex error", result)
+
+[<Fact>]
+let ``formatGrep reports zero matches with a clear no-matches line`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with Pattern = "no-such-pattern" }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("No matches for no-such-pattern", result)
+
+[<Fact>]
+let ``formatGrep marks matched lines with the >>> prefix`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "kappa"
+            ContextLines = 1 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains(">>> line 10: kappa", result)
+
+[<Fact>]
+let ``formatGrep emits one block per match with sequential numbering`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "gamma"
+            ContextLines = 0 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("Match 1 of 2", result)
+    Assert.Contains("Match 2 of 2", result)
+
+[<Fact>]
+let ``formatGrep emits the right context-line count above and below`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "delta"
+            ContextLines = 2 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    // delta is on line 4 (1-indexed: line 5). Context = 2 means
+    // we should see lines 2, 3, the match, 5, 6.
+    Assert.Contains("line 2: GAMMA UPPERCASE", result)
+    Assert.Contains("line 3: gamma lowercase", result)
+    Assert.Contains(">>> line 4: delta", result)
+    Assert.Contains("line 5: epsilon", result)
+    Assert.Contains("line 6: zeta", result)
+
+[<Fact>]
+let ``formatGrep clamps context at the start of the source`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "alpha"
+            ContextLines = 5 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    // alpha is line 1 (1-indexed). Context window asks for 5
+    // lines before but only 0 exist; formatter should handle the
+    // clamp without throwing or going negative.
+    Assert.Contains(">>> line 0: alpha", result)
+
+[<Fact>]
+let ``formatGrep summary footer reports the total match count`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with Pattern = "line" }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("Summary: 11 matches", result)
+
+[<Fact>]
+let ``formatGrep regex mode honours anchors`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "^line 5:"
+            TreatAsRegex = true
+            ContextLines = 0 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains(">>> line 5: epsilon", result)
+    Assert.Contains("Summary: 1 matches", result)
+
+[<Fact>]
+let ``formatGrep regex mode respects case-insensitive default`` () =
+    let opts =
+        { DiagnosticGrep.defaultOptions with
+            Pattern = "GAMMA"
+            TreatAsRegex = true
+            ContextLines = 0 }
+    let result = DiagnosticGrep.formatGrep opts sampleSource
+    Assert.Contains("Summary: 2 matches", result)

--- a/tests/Tests.Unit/FileLoggerTests.fs
+++ b/tests/Tests.Unit/FileLoggerTests.fs
@@ -432,6 +432,15 @@ let ``Logger module returns the configured factory's logger after configure`` ()
     let logger = Logger.get "Configured.Category"
     Assert.True(logger.IsEnabled(LogLevel.Information))
     logger.LogInformation("via configured factory")
+    // Same flake-fix pattern PR #213 applied to the
+    // `day-folder-creation` test in this file (lines 213-223):
+    // `Dispose`'s implicit drain-wait is racy under CI load, so
+    // an explicit `FlushPending` call is required before reading
+    // the log back. Without it, this test intermittently sees an
+    // empty log file because the async drain task hasn't yet
+    // written the LogInformation entry. Caught on Cycle 43a CI
+    // run; the race pre-dates this PR.
+    sink.FlushPending(5000).Wait() |> ignore
     (provider :> IDisposable).Dispose()
     let content = readActiveLog sink
     Assert.Contains("[Configured.Category]", content)

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -90,7 +90,18 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               HotkeyRegistry.ExitApp
               // Cycle 38a-followup — second menu-only command;
               // Diagnostics → Open Manual Tests.
-              HotkeyRegistry.OpenManualTests ]
+              HotkeyRegistry.OpenManualTests
+              // Cycle 43a — diagnostic chunk extractors. All
+              // menu-only (no keyboard accelerators). Two top-level
+              // items under Diagnostics + 4 proof-of-concept
+              // extractors under Diagnostics → Extract → {Recency
+              // | Event Type | Bundle Section | Snapshot}.
+              HotkeyRegistry.CopyLatestBundle
+              HotkeyRegistry.GrepDiagnostics
+              HotkeyRegistry.ExtractLast50LogLines
+              HotkeyRegistry.ExtractErrorsAndWarnings
+              HotkeyRegistry.ExtractActiveConfig
+              HotkeyRegistry.ExtractVersionHeader ]
     let actual = Set.ofList HotkeyRegistry.allCommands
     Assert.Equal<Set<HotkeyRegistry.AppCommand>>(expected, actual)
 

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -59,6 +59,14 @@
     <Compile Include="LinearTextStreamTests.fs" />
     <Compile Include="CanonicalCorpusTests.fs" />
     <Compile Include="ManualTestsHtmlTests.fs" />
+    <!--
+      Cycle 43a — DiagnosticExtracts + DiagnosticGrep tests.
+      Slot after `ManualTestsHtmlTests` so the test compile
+      order mirrors the source compile order in
+      `Terminal.Core/Terminal.Core.fsproj`.
+    -->
+    <Compile Include="DiagnosticExtractsTests.fs" />
+    <Compile Include="DiagnosticGrepTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Closes the iOS-paste-crash failure mode for triage workflows. Adds in-app chunking infrastructure so the maintainer can produce paste-safe focused slices of the diagnostic bundle without shell-quoting `findstr` / `Select-String` from cmd / PowerShell (both of which are friction for keyboard-only / screen-reader usage). Converts the chunking workflow documented in CLAUDE.md from "unusable from the maintainer's side" to "the primary triage path."

## What's new

Six new menu-only commands under `Diagnostics`:

- **`Diagnostics → Copy Latest Bundle to Clipboard`** — fast lightweight bundle (~100 ms; skips the ~10 s diagnostic-battery run). FileLogger active log + config.toml + session log summary + linear stream tail + redacted environment.
- **`Diagnostics → Grep Diagnostics...`** — modal dialog: pattern, case-sensitive checkbox, regex checkbox, context-lines spinner. Regenerates the lightweight bundle in-memory and produces a formatted match list.
- **`Diagnostics → Extract → By Recency → Last 50 Log Lines`** — tail of the active FileLogger log.
- **`Diagnostics → Extract → By Event Type → Errors and Warnings`** — entries with `Semantic=ErrorLine`, `WarningLine`, or `ParserError`.
- **`Diagnostics → Extract → By Bundle Section → Active Config`** — current `config.toml`.
- **`Diagnostics → Extract → Snapshot → Version Header`** — version + OS + .NET + PID + active shell (< 1 KB).

Every extractor:
- Caps the clipboard payload at **60 KB** (the Cycle 29b iOS-paste-crash ceiling) with a `[... truncated ... full results in extract file ...]` footer if larger.
- Writes the full untruncated text to `%LOCALAPPDATA%\PtySpeak\extracts\<extractor>-<timestamp>.txt` as paste-fallback.
- Announces result size + extract file path via NVDA (`ActivityIds.diagnostic`).

## Architecture

Two new pure F# modules in `Terminal.Core`:

- **`src/Terminal.Core/DiagnosticExtracts.fs`** — `tailLogLines`, `filterLogLinesSince`, `filterLogBySemantic`, `slugifyForFilename`, `extractFilePath`, `truncateForClipboard`, `formatExtractHeader`, `formatBytesForAnnounce`. No WPF / clipboard / logger dependencies.
- **`src/Terminal.Core/DiagnosticGrep.fs`** — `GrepOptions` record + `formatGrep` + `countMatches`. Pure function over a string; orchestrator owns side effects.

Orchestration in `Terminal.App/Program.fs` adds a shared `runExtractorClipboard` helper (mirrors the STA + 3 s timeout pattern of `runCopyHistoryToClipboard`). Per-command closures reduce to "compute body string, hand to helper." `Diagnostics.fs` gains internal `formatLightweightBundle` (battery-free bundle), with `readFileSafe` and `formatEnvironmentRedacted` bumped from `private` to `internal` for reuse.

WPF dialog: `src/Views/GrepDialog.xaml` + code-behind. UIA-labeled controls on every focusable element, explicit tab order, Enter activates OK, Escape activates Cancel, `LiveSetting=Assertive` validation message for context-lines range errors.

## Tests

22 new facts across:
- `tests/Tests.Unit/DiagnosticExtractsTests.fs` — slug shape, timestamp parsing, tail behaviour, time-filter, Semantic-filter, truncation budget, header format.
- `tests/Tests.Unit/DiagnosticGrepTests.fs` — empty pattern, regex compile errors, case sensitivity, context clamping at file edges, summary footer, match marker.

`HotkeyRegistryTests.allCommands contains exactly the documented commands (PR-O)` updated with the 6 new AppCommand cases. All commands are menu-only (`Key = None`, `Modifiers = None`) so `AppReservedHotkeysMirrorTests` (which only pins gesture-bearing commands) is unaffected.

## Docs

- `CLAUDE.md` "Diagnostic logs — request chunks, not full bundles" section refreshed: shell-recipe `findstr` / `Select-String` examples replaced with menu-item references as the new primary triage path. Shell recipes retained as deprecated fallback for builds before Cycle 43a.
- `docs/ACCESSIBILITY-TESTING.md` — new Cycle 43a section with 11 NVDA matrix rows covering dialog navigation, default-OK round trip, Cancel/Escape, invalid input handling, clipboard truncation, each extractor's expected announce + paste shape, and the extract-file fallback when clipboard times out.
- `CHANGELOG.md` `[Unreleased]` — comprehensive entry above the Cycle 39 revert block.

## Deferred to Cycle 43b

The remaining ~16 extractors across the four sub-submenus per the SESSION-HANDOFF catalog. 43a ships one proof-of-concept extractor per sub-submenu to validate the pattern end-to-end before fan-out.

## Test plan

- [ ] CI green on Windows-latest (build + test + portability lint + workflow lint + markdown link check)
- [ ] Manual NVDA validation per the 11 new matrix rows in `docs/ACCESSIBILITY-TESTING.md` "Cycle 43a" section
- [ ] Confirm `%LOCALAPPDATA%\PtySpeak\extracts\` is created on first extract press
- [ ] Confirm grep dialog reads each control label correctly under NVDA on tab
- [ ] Confirm clipboard truncation footer fires on a large pattern (e.g., `Heartbeat` with context = 20)
- [ ] Confirm extract file fallback works when clipboard contention causes a timeout

## Context note

The maintainer is currently running pre-revert preview.87 which has the Cycle 41 OSC 133 injection that wedges cmd output. A separate release cut from current `main` (`2d18a02`) is needed to restore cmd / PowerShell / key-echo announces; that's tracked separately from this PR. The chunking infrastructure shipped here becomes unblocking for diagnosing the broader regression once a new build is installed.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_