### PR TITLE
feat(substrate): Cycle 45 Commit 1 — ContentHistory + SpeechCursor (additive substrate)

### DIFF
--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -1,0 +1,477 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+
+/// Cycle 45 — ContentHistory: the computational substrate for the
+/// aural pipeline.
+///
+/// The substrate of pty-speak's aural experience is NOT the screen
+/// grid. The screen is a finite 30×120 projection of an unbounded
+/// byte stream; using it as the announce baseline causes false
+/// matches on repeated content, content loss on scroll, and
+/// implicit-state bugs ("did we already say this?" answered by
+/// fragile string-diff heuristics). ContentHistory replaces that
+/// with an append-only typed log of entries, each carrying a
+/// monotonic `Seq` identity. "Already spoken?" becomes
+/// `Seq <= cursor.LastSpokenSeq` — an integer comparison.
+///
+/// Scope: a single ContentHistory instance covers the **active
+/// tuple** — from the prompt boundary that opened it to the prompt
+/// boundary that seals it. On seal, the entries are archived into
+/// `SessionModel`'s `SessionTuple.History` queue, and a fresh
+/// ContentHistory begins. The substrate is therefore bounded in
+/// memory by tuple size, not session lifetime.
+///
+/// **Threading**: `Gate`-protected for cross-thread reads (the
+/// diagnostic-bundle thread may read snapshots while the reader
+/// thread is appending). Same pattern `LinearTextStream` used.
+///
+/// **Commit 1 (this file) is purely additive.** No consumer wires
+/// to this module yet; Commit 2 connects it to the reader loop +
+/// detectors + SpeechCursor. The module exists in isolation so
+/// the data model can be iterated on without touching the live
+/// pipeline.
+module ContentHistory =
+
+    /// Discrete semantic events that detectors emit into the
+    /// history. The set is intentionally open-ended via `Custom`
+    /// — new canonical interaction modes (per the Cycle 45 plan's
+    /// "modes are extensible" principle) add new `MarkerKind`
+    /// values without disturbing the substrate.
+    [<RequireQualifiedAccess>]
+    type MarkerKind =
+        /// A shell prompt's leading byte sequence has been
+        /// detected (heuristically or via OSC 133;A). Opens the
+        /// "user is typing a command" phase.
+        | PromptStart
+        /// The user pressed Enter; the typed command boundary is
+        /// known (heuristically or via OSC 133;B). Opens the
+        /// "command is running, output may stream" phase.
+        | CommandStart
+        /// Output region of the active tuple has begun
+        /// (heuristically inferred or OSC 133;C). Distinguishes
+        /// the prompt+typed-command region from the actual
+        /// command-output region.
+        | OutputStart
+        /// The active command has completed; the next prompt
+        /// rendered (heuristically or OSC 133;D). Triggers
+        /// tuple-seal at the SessionModel level.
+        | CommandFinished
+        /// An interactive selection prompt is on screen.
+        /// SpeechCursor's auto-drive suspends; user navigates
+        /// the list manually until `SelectionDismissed`.
+        | SelectionShown
+        /// The selection prompt is gone. SpeechCursor's
+        /// auto-drive resumes.
+        | SelectionDismissed
+        /// A BEL byte (0x07) was processed. Earcons can react.
+        | BellRang
+        /// The alt-screen mode was entered. Visual state
+        /// regime-switches; SpeechCursor may reset its baseline.
+        | AltScreenEnter
+        /// The alt-screen mode was exited.
+        | AltScreenExit
+        /// Open-ended extension point. The string is the
+        /// canonical identifier for the new mode (e.g.
+        /// `"claude.thinking-state"`).
+        | Custom of string
+
+    /// One sealed `TextSpan` of printable text accumulated from
+    /// a contiguous run of `Print` events. Sealing triggers:
+    /// newline, marker insertion, idle window, or overwrite.
+    type TextSpanData =
+        { Seq: int64
+          Text: string
+          StartedAt: DateTime
+          SettledAt: DateTime }
+
+    /// A newline boundary in the active tuple's output. Carries
+    /// only the seq + timestamp; the actual `\n` byte is logically
+    /// at the end of the preceding TextSpan.
+    type NewlineData =
+        { Seq: int64
+          At: DateTime }
+
+    /// An in-place overwrite of a prior `TextSpan`. The
+    /// `ReplacesSeq` points at the TextSpan whose visible position
+    /// is being overwritten. This is how genuine in-place patterns
+    /// (e.g. spinner frames, progress bar updates) are represented
+    /// — they DO NOT mutate the prior TextSpan. The history is
+    /// strictly append-only; "what was already spoken" remains
+    /// addressable by its Seq.
+    type OverwriteData =
+        { Seq: int64
+          ReplacesSeq: int64
+          Text: string
+          At: DateTime }
+
+    /// A semantic event emitted by a detector or by the substrate
+    /// itself. The `Payload` is optional — most markers carry only
+    /// their kind, but some (e.g. `SelectionShown` carrying the
+    /// option list) need additional data.
+    type MarkerData =
+        { Seq: int64
+          Kind: MarkerKind
+          At: DateTime
+          Payload: string option }
+
+    /// A coalesced sequence of `Overwrite` entries that cycle
+    /// through a small set of glyph patterns at high frequency —
+    /// i.e., a spinner. Replaces the run of Overwrites with a
+    /// single entry so SpeechCursor can skip them in AutoDrive
+    /// mode without N redundant announces. Detection is deferred
+    /// to a follow-up (Commit 2 or later); the entry shape ships
+    /// in Commit 1 so the data model is complete.
+    type SpinnerData =
+        { Seq: int64
+          LatestText: string
+          FrameCount: int
+          FirstAt: DateTime
+          LastAt: DateTime }
+
+    /// The complete entry taxonomy. Order of cases doesn't matter
+    /// for correctness; this listing matches the canonical
+    /// architectural docs.
+    type Entry =
+        | TextSpan of TextSpanData
+        | Newline of NewlineData
+        | Overwrite of OverwriteData
+        | Marker of MarkerData
+        | Spinner of SpinnerData
+
+    /// Accessor: every entry has a Seq.
+    let entrySeq (e: Entry) : int64 =
+        match e with
+        | TextSpan d -> d.Seq
+        | Newline d -> d.Seq
+        | Overwrite d -> d.Seq
+        | Marker d -> d.Seq
+        | Spinner d -> d.Seq
+
+    /// Tuneable knobs. Defaults chosen to mirror existing
+    /// behaviour (e.g. Coalescer's 200 ms debounce window).
+    type Parameters =
+        { /// Idle window after the last `Print` event before the
+          /// active TextSpan auto-seals via tick (not append).
+          /// Set in milliseconds. Default 200.
+          IdleSpanSealMs: int
+          /// Hard cap on entry count per tuple before older
+          /// entries are pruned (deferred Commit 2+; not yet
+          /// enforced). Default 10_000.
+          MaxEntriesPerTuple: int }
+
+    let defaultParameters : Parameters =
+        { IdleSpanSealMs = 200
+          MaxEntriesPerTuple = 10_000 }
+
+    /// State instance. One per active tuple. Mutated in-place by
+    /// `appendFromEvent` / `appendMarker` / `tick` / `reset` under
+    /// the `Gate` lock.
+    ///
+    /// `internal` getters/setters mirror `LinearTextStream`'s
+    /// pattern: tests in the same assembly inspect state directly;
+    /// callers outside the assembly use the module's functions.
+    type T internal (parameters: Parameters) =
+        member val internal Gate: obj = obj () with get
+        member val internal Parameters: Parameters = parameters with get
+        member val internal Entries: ResizeArray<Entry> = ResizeArray<Entry>() with get
+        member val internal NextSeq: int64 = 0L with get, set
+        /// Active TextSpan accumulator. Built up by sequential
+        /// `Print` events; sealed (moved into `Entries`) on
+        /// newline / marker / idle / overwrite.
+        member val internal ActiveSpanText: StringBuilder = StringBuilder() with get
+        member val internal ActiveSpanStartedAt: DateTime voption = ValueNone with get, set
+        member val internal LastEventAt: DateTime = DateTime.MinValue with get, set
+        /// CUB deferred-resolution: same shape as Cycle 44's bare-
+        /// CR + CUB fixes in `LinearTextStream`. When a `CSI N D`
+        /// arrives, we don't yet know whether the next event is a
+        /// `Print` (a real in-place overwrite) or something else
+        /// (cursor positioning during normal rendering). Defer.
+        /// `ValueSome n` holds the CUB count; cleared on next
+        /// event resolution.
+        member val internal PendingCUB: int voption = ValueNone with get, set
+        /// CR deferred-resolution: parallel to PendingCUB. Bare CR
+        /// → overwrite of current line; CR+LF → newline.
+        member val internal PendingCRDeferred: bool = false with get, set
+
+    /// Construct a fresh ContentHistory bound to the supplied
+    /// parameters. Caller binds the result to a `mutable` cell at
+    /// the composition root.
+    let create (parameters: Parameters) : T =
+        T(parameters)
+
+    /// Total entry count. Includes the unsealed active TextSpan
+    /// only AFTER it seals (it's not in `Entries` while active).
+    let count (state: T) : int =
+        lock state.Gate (fun () -> state.Entries.Count)
+
+    /// Snapshot of the entries array. Returns a fresh array each
+    /// call (safe to enumerate without holding the gate).
+    let snapshot (state: T) : Entry[] =
+        lock state.Gate (fun () -> state.Entries.ToArray())
+
+    /// The highest seq number assigned. -1 if empty.
+    let latestSeq (state: T) : int64 =
+        lock state.Gate (fun () ->
+            if state.NextSeq = 0L then -1L
+            else state.NextSeq - 1L)
+
+    /// Look up an entry by Seq. Returns `None` if outside the
+    /// active history range or if the entry has been pruned (cap-
+    /// driven; Commit 2+).
+    let entryBySeq (state: T) (target: int64) : Entry option =
+        lock state.Gate (fun () ->
+            let entries = state.Entries
+            let mutable found = None
+            // Linear scan; entries array is bounded by
+            // MaxEntriesPerTuple. Future: binary search if perf
+            // becomes a concern.
+            let mutable i = 0
+            while found.IsNone && i < entries.Count do
+                if entrySeq entries.[i] = target then
+                    found <- Some entries.[i]
+                i <- i + 1
+            found)
+
+    /// Internal: allocate the next Seq.
+    let private nextSeq (state: T) : int64 =
+        let s = state.NextSeq
+        state.NextSeq <- s + 1L
+        s
+
+    /// Seal the active TextSpan (if any) into `Entries`. Caller
+    /// holds `state.Gate`. Returns the sealed entry, or `None` if
+    /// no active span.
+    let private sealActiveSpan
+            (state: T)
+            (at: DateTime)
+            : Entry option =
+        if state.ActiveSpanText.Length = 0 then None
+        else
+            let startedAt =
+                match state.ActiveSpanStartedAt with
+                | ValueSome t -> t
+                | ValueNone -> at
+            let entry =
+                TextSpan
+                    { Seq = nextSeq state
+                      Text = state.ActiveSpanText.ToString()
+                      StartedAt = startedAt
+                      SettledAt = at }
+            state.ActiveSpanText.Clear() |> ignore
+            state.ActiveSpanStartedAt <- ValueNone
+            state.Entries.Add(entry)
+            Some entry
+
+    /// Resolve any deferred CUB now that a new event has arrived.
+    /// Caller holds `state.Gate`. Returns 0..1 Entry list; an
+    /// Overwrite is appended iff the next event is a Print AND
+    /// there's existing content in the active span to overwrite.
+    let private resolveDeferredCUB
+            (state: T)
+            (now: DateTime)
+            (nextEvent: VtEvent)
+            : Entry list =
+        match state.PendingCUB with
+        | ValueNone -> []
+        | ValueSome cubCount ->
+            state.PendingCUB <- ValueNone
+            match nextEvent with
+            | Print _ ->
+                // CUB+Print → in-place overwrite. Seal the active
+                // span (it represents the content that's about to
+                // be replaced) and emit an Overwrite entry that
+                // points at it. The next Print event will start a
+                // fresh active span.
+                match sealActiveSpan state now with
+                | None ->
+                    // No active content to overwrite; treat as
+                    // bare cursor positioning.
+                    []
+                | Some sealed' ->
+                    let replacesSeq = entrySeq sealed'
+                    let entry =
+                        Overwrite
+                            { Seq = nextSeq state
+                              ReplacesSeq = replacesSeq
+                              Text = "" // Filled by subsequent Print events into a fresh span; the Overwrite marker just records the boundary
+                              At = now }
+                    state.Entries.Add(entry)
+                    [ sealed'; entry ]
+            | _ ->
+                // CUB followed by non-Print → bare cursor
+                // positioning. No overwrite; no transition. The
+                // accumulated active span continues unchanged.
+                ignore cubCount
+                []
+
+    /// Resolve any deferred CR now that a new event has arrived.
+    /// Caller holds `state.Gate`. Mirrors `LinearTextStream`'s CR
+    /// deferred-resolution: CR+LF is a newline (no overwrite);
+    /// bare CR is an overwrite signal for the current line.
+    let private resolveDeferredCR
+            (state: T)
+            (now: DateTime)
+            (nextEvent: VtEvent)
+            : Entry list =
+        if not state.PendingCRDeferred then []
+        else
+            state.PendingCRDeferred <- false
+            match nextEvent with
+            | Execute b when b = 0x0Auy ->
+                // CR + LF → newline. The LF handler below will
+                // emit the Newline entry; nothing to do here.
+                []
+            | _ ->
+                // Bare CR → overwrite of current line. Seal the
+                // active span (the content being overwritten);
+                // subsequent Print events start a fresh span.
+                match sealActiveSpan state now with
+                | None -> []
+                | Some sealed' ->
+                    let entry =
+                        Overwrite
+                            { Seq = nextSeq state
+                              ReplacesSeq = entrySeq sealed'
+                              Text = ""
+                              At = now }
+                    state.Entries.Add(entry)
+                    [ sealed'; entry ]
+
+    /// Append a single VtEvent. Returns the list of entries that
+    /// became visible (sealed TextSpans, Newlines, Overwrites)
+    /// as a result. Most events return `[]` because the active
+    /// TextSpan is still accumulating; entries materialise on
+    /// seal boundaries (newline, marker insertion, idle).
+    ///
+    /// **Threading**: takes the gate. Safe to call from the
+    /// single reader thread; concurrent reads (snapshot,
+    /// entryBySeq, latestSeq) are safe.
+    let appendFromEvent
+            (state: T)
+            (now: DateTime)
+            (event: VtEvent)
+            : Entry list =
+        lock state.Gate (fun () ->
+            // First, resolve any deferred CR/CUB from a prior
+            // event. These must run BEFORE we process the new
+            // event because their resolution depends on what the
+            // new event is.
+            let deferredCub = resolveDeferredCUB state now event
+            let deferredCr = resolveDeferredCR state now event
+            let preEntries = deferredCub @ deferredCr
+
+            state.LastEventAt <- now
+
+            let newEntries =
+                match event with
+                | Print rune ->
+                    // Append to the active span. No new entry
+                    // emitted until the span seals.
+                    if state.ActiveSpanStartedAt.IsNone then
+                        state.ActiveSpanStartedAt <- ValueSome now
+                    state.ActiveSpanText.Append(rune.ToString())
+                    |> ignore
+                    []
+                | Execute b when b = 0x0Auy ->
+                    // LF → seal active span (if any), then emit a
+                    // Newline entry.
+                    let sealedEntry = sealActiveSpan state now
+                    let nlEntry =
+                        Newline { Seq = nextSeq state; At = now }
+                    state.Entries.Add(nlEntry)
+                    match sealedEntry with
+                    | Some e -> [ e; nlEntry ]
+                    | None -> [ nlEntry ]
+                | Execute b when b = 0x0Duy ->
+                    // CR → defer to next event.
+                    state.PendingCRDeferred <- true
+                    []
+                | Execute b when b = 0x07uy ->
+                    // BEL → seal active span (it's a chunk
+                    // boundary) and emit a BellRang marker.
+                    let sealedEntry = sealActiveSpan state now
+                    let bellEntry =
+                        Marker
+                            { Seq = nextSeq state
+                              Kind = MarkerKind.BellRang
+                              At = now
+                              Payload = None }
+                    state.Entries.Add(bellEntry)
+                    match sealedEntry with
+                    | Some e -> [ e; bellEntry ]
+                    | None -> [ bellEntry ]
+                | CsiDispatch (_, _, 'D', _) ->
+                    // CUB → defer to next event.
+                    state.PendingCUB <- ValueSome 1
+                    []
+                | _ ->
+                    // Everything else (other CSI, OSC, DCS, etc.)
+                    // is currently ignored by ContentHistory.
+                    // Commit 2 hooks OSC 133 + alt-screen toggles
+                    // here to emit canonical markers; for now
+                    // those events flow through detectors that
+                    // call `appendMarker` explicitly.
+                    []
+
+            preEntries @ newEntries)
+
+    /// Explicit marker insertion. Detectors call this when they
+    /// fire (HeuristicPromptDetector → `PromptStart`,
+    /// SelectionDetector → `SelectionShown` / `SelectionDismissed`,
+    /// etc.). Seals the active TextSpan first so the marker's Seq
+    /// is strictly after the preceding text content.
+    ///
+    /// Returns the list of entries that became visible (the
+    /// sealed TextSpan if any, plus the new Marker).
+    let appendMarker
+            (state: T)
+            (kind: MarkerKind)
+            (at: DateTime)
+            (payload: string option)
+            : Entry list =
+        lock state.Gate (fun () ->
+            let sealedEntry = sealActiveSpan state at
+            let markerEntry =
+                Marker
+                    { Seq = nextSeq state
+                      Kind = kind
+                      At = at
+                      Payload = payload }
+            state.Entries.Add(markerEntry)
+            match sealedEntry with
+            | Some e -> [ e; markerEntry ]
+            | None -> [ markerEntry ])
+
+    /// Time-driven seal: if the active TextSpan has been idle for
+    /// at least `IdleSpanSealMs`, seal it. Caller polls this on
+    /// the PeriodicTimer tick. Returns the sealed entry (if any).
+    /// Used to commit accumulated text when the bytes pause, so
+    /// SpeechCursor's AutoDrive can announce promptly during
+    /// streaming output rather than waiting for an explicit
+    /// boundary.
+    let tick (state: T) (now: DateTime) : Entry list =
+        lock state.Gate (fun () ->
+            if state.ActiveSpanText.Length = 0 then []
+            else
+                let elapsed =
+                    (now - state.LastEventAt).TotalMilliseconds
+                if elapsed >= float state.Parameters.IdleSpanSealMs then
+                    match sealActiveSpan state now with
+                    | Some e -> [ e ]
+                    | None -> []
+                else
+                    [])
+
+    /// Reset to empty. Called when SessionModel transitions out
+    /// of a sealed tuple so the next tuple starts fresh.
+    let reset (state: T) : unit =
+        lock state.Gate (fun () ->
+            state.Entries.Clear()
+            state.NextSeq <- 0L
+            state.ActiveSpanText.Clear() |> ignore
+            state.ActiveSpanStartedAt <- ValueNone
+            state.LastEventAt <- DateTime.MinValue
+            state.PendingCUB <- ValueNone
+            state.PendingCRDeferred <- false)

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -1,0 +1,379 @@
+namespace Terminal.Core
+
+open System
+
+/// Cycle 45 — SpeechCursor: the announce + navigate primitive
+/// over `ContentHistory`.
+///
+/// The cursor holds a position (Seq) into a ContentHistory plus a
+/// `LastSpokenSeq` watermark — the highest Seq we've ever spoken.
+/// "Have we already spoken this?" is the integer comparison
+/// `entry.Seq <= LastSpokenSeq`. There is no string match against
+/// rendered row text, no "screen state" comparison, no implicit
+/// state: just an explicit watermark on an immutable history.
+///
+/// Two modes:
+///
+///   * **AutoDrive**: when new entries are appended to the
+///     ContentHistory (via `onAppend`), the cursor advances to
+///     each in turn and announces. This is the everyday live
+///     streaming experience.
+///
+///   * **Manual**: the user has explicitly navigated backwards
+///     (Up arrow, marker jump, etc.) and is now controlling the
+///     pace. New appends do NOT advance the cursor automatically.
+///     The user moves the cursor forward via Down arrow / "jump
+///     to latest" / etc.
+///
+/// Interaction-mode mode transitions: when a `SelectionShown`
+/// marker arrives, AutoDrive temporarily suspends — the user has
+/// to navigate the list explicitly with arrow keys. On
+/// `SelectionDismissed`, AutoDrive resumes (provided the user
+/// hadn't separately switched to Manual mode).
+///
+/// **Commit 1 (this file) is purely additive.** No production
+/// callsite wires to SpeechCursor yet; Commit 2 connects it.
+/// The `announce` callback parameter keeps the module pure and
+/// trivially testable.
+module SpeechCursor =
+
+    /// Auto-drive vs Manual mode. AutoDrive is the default; the
+    /// user toggles to Manual when they want paced review.
+    type Mode =
+        | AutoDrive
+        | Manual
+
+    /// Navigation direction for `toMarker` / `jumpRelative`.
+    type Direction =
+        | Forward
+        | Backward
+
+    /// Configuration knobs. All defaults chosen to match the
+    /// architectural intent in `docs/CORE-ABSTRACTION-BOUNDARY.md`.
+    type Parameters =
+        { /// Initial mode. AutoDrive in production; tests use
+          /// Manual to assert non-advancement.
+          InitialMode: Mode
+          /// When true, AutoDrive skips `Spinner` entries
+          /// silently. The user can still navigate to them via
+          /// explicit `next`/`previous`. Defaults true; spinner
+          /// frames are rarely what a user wants narrated.
+          SkipSpinnersInAutoDrive: bool
+          /// When true, AutoDrive suspends on `SelectionShown`
+          /// (and resumes on `SelectionDismissed`). Defaults
+          /// true; the standard interaction-mode handoff.
+          SuspendAutoDriveOnSelection: bool }
+
+    let defaultParameters : Parameters =
+        { InitialMode = AutoDrive
+          SkipSpinnersInAutoDrive = true
+          SuspendAutoDriveOnSelection = true }
+
+    /// Cursor state. Mutated in-place by the navigation /
+    /// announce APIs. Single-threaded by convention (dispatcher
+    /// thread); no internal gate needed.
+    type T internal (parameters: Parameters) =
+        member val internal Parameters: Parameters = parameters with get
+        /// The Seq of the entry the cursor is currently parked
+        /// on. -1 means "before the first entry" (initial state
+        /// or after `reset`).
+        member val internal Position: int64 = -1L with get, set
+        /// The highest Seq we have ever announced. Used to drive
+        /// `speakSince` and to gate "have we said this?" checks.
+        /// -1 means "nothing has been spoken yet."
+        member val internal LastSpokenSeq: int64 = -1L with get, set
+        member val internal Mode: Mode = parameters.InitialMode with get, set
+        /// Bookkeeping: while true, AutoDrive is suspended due to
+        /// a `SelectionShown` marker; mode is logically AutoDrive
+        /// but won't advance on append until `SelectionDismissed`
+        /// arrives. Distinct from `Mode = Manual` (which is a
+        /// user-driven switch and survives the suspension).
+        member val internal SelectionSuspend: bool = false with get, set
+
+    /// Construct a fresh cursor.
+    let create (parameters: Parameters) : T =
+        T(parameters)
+
+    /// Current cursor mode (Manual / AutoDrive). The
+    /// SelectionSuspend bit doesn't change the reported mode —
+    /// it's an internal AutoDrive sub-state.
+    let mode (state: T) : Mode = state.Mode
+
+    /// Current effective drive: AutoDrive AND not selection-
+    /// suspended. `onAppend` consults this to decide whether to
+    /// advance.
+    let private autoDriveActive (state: T) : bool =
+        state.Mode = AutoDrive && not state.SelectionSuspend
+
+    /// Toggle to the other mode. Returns the new mode.
+    let toggleMode (state: T) : Mode =
+        state.Mode <-
+            match state.Mode with
+            | AutoDrive -> Manual
+            | Manual -> AutoDrive
+        state.Mode
+
+    /// Force a specific mode.
+    let setMode (state: T) (m: Mode) : unit =
+        state.Mode <- m
+
+    /// Look up the entry the cursor is currently parked on, if
+    /// any. Returns `None` if position is -1 (before any entry)
+    /// or out of range.
+    let current (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        if state.Position < 0L then None
+        else ContentHistory.entryBySeq history state.Position
+
+    /// Helper: predicate for "is this entry advanceable?" in
+    /// AutoDrive mode. Spinner entries are skipped when the
+    /// configuration says to.
+    let private autoDriveAdvanceable
+            (state: T)
+            (entry: ContentHistory.Entry)
+            : bool =
+        if state.Parameters.SkipSpinnersInAutoDrive then
+            match entry with
+            | ContentHistory.Spinner _ -> false
+            | _ -> true
+        else
+            true
+
+    /// Move the cursor to the next entry in the supplied
+    /// history (Seq > Position). Returns the entry, or `None` if
+    /// already at the latest.
+    let next (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let target =
+            entries
+            |> Array.tryFind (fun e ->
+                ContentHistory.entrySeq e > state.Position)
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
+
+    /// Move the cursor to the previous entry. Returns the entry,
+    /// or `None` if already at the start.
+    let previous (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let target =
+            entries
+            |> Array.filter (fun e ->
+                ContentHistory.entrySeq e < state.Position)
+            |> Array.tryLast
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
+
+    /// Jump the cursor to the most recently appended entry.
+    /// Returns the entry, or `None` if history is empty.
+    let toLatest (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        if entries.Length = 0 then None
+        else
+            let last = entries.[entries.Length - 1]
+            state.Position <- ContentHistory.entrySeq last
+            Some last
+
+    /// Move the cursor to the next/previous Marker of the given
+    /// kind. Returns the marker entry, or `None` if no match.
+    let toMarker
+            (state: T)
+            (history: ContentHistory.T)
+            (kind: ContentHistory.MarkerKind)
+            (direction: Direction)
+            : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let matchesKind (e: ContentHistory.Entry) =
+            match e with
+            | ContentHistory.Marker m -> m.Kind = kind
+            | _ -> false
+        let candidates =
+            match direction with
+            | Forward ->
+                entries
+                |> Array.filter (fun e ->
+                    matchesKind e
+                    && ContentHistory.entrySeq e > state.Position)
+                |> Array.tryHead
+            | Backward ->
+                entries
+                |> Array.filter (fun e ->
+                    matchesKind e
+                    && ContentHistory.entrySeq e < state.Position)
+                |> Array.tryLast
+        match candidates with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
+
+    /// Render an entry to the (text, activityId) pair the
+    /// announce callback will receive. Pure; tests use this
+    /// directly to assert format.
+    ///
+    /// Activity-id choices mirror `NvdaChannel.semanticToActivityId`:
+    /// streaming text + selection / prompt boundaries route on
+    /// `pty-speak.output`; alt-screen toggles on `pty-speak.mode`;
+    /// bell on `pty-speak.output` (no dedicated id for bell-via-
+    /// announce; the earcon channel handles the audible cue
+    /// separately).
+    let renderEntry (entry: ContentHistory.Entry) : (string * string) option =
+        match entry with
+        | ContentHistory.TextSpan d ->
+            if String.IsNullOrEmpty d.Text then None
+            else Some (d.Text, ActivityIds.output)
+        | ContentHistory.Newline _ ->
+            // Newlines don't get a separate announce — they're
+            // baked into the natural pause between TextSpans.
+            None
+        | ContentHistory.Overwrite _ ->
+            // Overwrite is a structural marker; the replacement
+            // content is the NEXT TextSpan. No announce on the
+            // Overwrite itself.
+            None
+        | ContentHistory.Marker m ->
+            match m.Kind with
+            | ContentHistory.MarkerKind.SelectionShown ->
+                let suffix =
+                    match m.Payload with
+                    | Some p when not (String.IsNullOrEmpty p) ->
+                        sprintf ": %s" p
+                    | _ -> ""
+                Some
+                    (sprintf "Selection prompt%s." suffix,
+                     ActivityIds.output)
+            | ContentHistory.MarkerKind.SelectionDismissed ->
+                Some ("Selection dismissed.", ActivityIds.output)
+            | ContentHistory.MarkerKind.AltScreenEnter ->
+                Some
+                    ("Full-screen application active.",
+                     ActivityIds.mode)
+            | ContentHistory.MarkerKind.AltScreenExit ->
+                Some
+                    ("Full-screen application exited.",
+                     ActivityIds.mode)
+            | ContentHistory.MarkerKind.BellRang ->
+                // Bell's audible cue is the earcon; no separate
+                // announce by default. Future: a config knob can
+                // flip this to announce "Bell." for users who
+                // have earcons muted.
+                None
+            | ContentHistory.MarkerKind.PromptStart
+            | ContentHistory.MarkerKind.CommandStart
+            | ContentHistory.MarkerKind.OutputStart
+            | ContentHistory.MarkerKind.CommandFinished ->
+                // Tuple-internal boundary markers don't announce
+                // by themselves. The TextSpans they bracket are
+                // what the user hears.
+                None
+            | ContentHistory.MarkerKind.Custom _ ->
+                // Future modes will define their own announce
+                // text via the marker payload.
+                m.Payload
+                |> Option.map (fun p -> (p, ActivityIds.output))
+        | ContentHistory.Spinner _ ->
+            // Spinner entries don't announce in AutoDrive; the
+            // user can navigate to them manually for inspection
+            // but they're not narrated by default.
+            None
+
+    /// Announce the entry at the cursor's current position via
+    /// the supplied callback. Updates `LastSpokenSeq` to the
+    /// entry's Seq if the entry rendered to a non-empty
+    /// announcement. Returns `true` iff something was announced.
+    let speakCurrent
+            (state: T)
+            (history: ContentHistory.T)
+            (announce: string * string -> unit)
+            : bool =
+        match current state history with
+        | None -> false
+        | Some entry ->
+            match renderEntry entry with
+            | None ->
+                // The entry exists but has no audible
+                // announcement (e.g. Newline, Overwrite). Still
+                // advance LastSpokenSeq so we don't redundantly
+                // try again.
+                state.LastSpokenSeq <-
+                    max state.LastSpokenSeq (ContentHistory.entrySeq entry)
+                false
+            | Some (text, activityId) ->
+                announce (text, activityId)
+                state.LastSpokenSeq <-
+                    max state.LastSpokenSeq (ContentHistory.entrySeq entry)
+                true
+
+    /// Announce every entry with Seq in `(LastSpokenSeq, throughSeq]`
+    /// in ascending Seq order. Used by `onAppend` to catch up the
+    /// cursor + speak any entries the user may have skipped (e.g.
+    /// they were in Manual mode and just jumped to latest).
+    let speakSince
+            (state: T)
+            (history: ContentHistory.T)
+            (announce: string * string -> unit)
+            (throughSeq: int64)
+            : int =
+        let entries = ContentHistory.snapshot history
+        let lower = state.LastSpokenSeq
+        let mutable spokenCount = 0
+        for e in entries do
+            let s = ContentHistory.entrySeq e
+            if s > lower && s <= throughSeq then
+                match renderEntry e with
+                | Some (text, activityId) ->
+                    announce (text, activityId)
+                    spokenCount <- spokenCount + 1
+                | None -> ()
+                state.LastSpokenSeq <- s
+        spokenCount
+
+    /// Event hook: invoked when ContentHistory has appended one
+    /// or more new entries. In AutoDrive mode, the cursor
+    /// advances through the new entries and announces each. In
+    /// Manual mode, the cursor stays parked and nothing
+    /// announces. SelectionShown / SelectionDismissed markers
+    /// modulate the SelectionSuspend bit regardless of mode so a
+    /// future user resumption picks up the right state.
+    let onAppend
+            (state: T)
+            (history: ContentHistory.T)
+            (announce: string * string -> unit)
+            (newEntries: ContentHistory.Entry list)
+            : unit =
+        for entry in newEntries do
+            // Modulate selection-suspend regardless of drive mode.
+            match entry with
+            | ContentHistory.Marker m ->
+                match m.Kind with
+                | ContentHistory.MarkerKind.SelectionShown ->
+                    if state.Parameters.SuspendAutoDriveOnSelection then
+                        state.SelectionSuspend <- true
+                | ContentHistory.MarkerKind.SelectionDismissed ->
+                    state.SelectionSuspend <- false
+                | _ -> ()
+            | _ -> ()
+
+            if autoDriveActive state && autoDriveAdvanceable state entry then
+                let s = ContentHistory.entrySeq entry
+                if s > state.Position then
+                    state.Position <- s
+                if s > state.LastSpokenSeq then
+                    match renderEntry entry with
+                    | Some (text, activityId) ->
+                        announce (text, activityId)
+                    | None -> ()
+                    state.LastSpokenSeq <- s
+
+    /// Reset cursor state. Called when the tuple seals and
+    /// ContentHistory itself resets.
+    let reset (state: T) : unit =
+        state.Position <- -1L
+        state.LastSpokenSeq <- -1L
+        state.SelectionSuspend <- false
+        // Mode is preserved across resets — the user's choice of
+        // AutoDrive vs Manual survives tuple boundaries.

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -54,6 +54,19 @@
     -->
     <Compile Include="DiagnosticExtracts.fs" />
     <Compile Include="DiagnosticGrep.fs" />
+    <!--
+      Cycle 45 Commit 1 — ContentHistory + SpeechCursor.
+      The new aural substrate (ContentHistory) and its announce-
+      and-navigate primitive (SpeechCursor). Purely additive in
+      Commit 1: no consumer in Terminal.App wires to them yet.
+      Commit 2 connects them to the reader loop + detectors +
+      NvdaChannel. Both modules live at the end of the compile
+      order because nothing else in Terminal.Core depends on
+      them. SpeechCursor depends on ContentHistory; the order is
+      load-bearing.
+    -->
+    <Compile Include="ContentHistory.fs" />
+    <Compile Include="SpeechCursor.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Unit/ContentHistoryTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTests.fs
@@ -1,0 +1,397 @@
+module PtySpeak.Tests.Unit.ContentHistoryTests
+
+open System
+open System.Text
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 45 Commit 1 — ContentHistory pure-function tests.
+// ---------------------------------------------------------------------
+//
+// Pin the public contract of the new aural substrate. The data
+// model is the foundation Commit 2 wires into the reader loop +
+// detectors + SpeechCursor; a regression here silently breaks the
+// entire aural pipeline without surfacing in any other test until
+// NVDA validation time. Cover:
+//
+//   * Empty / latestSeq / count contracts
+//   * Print accumulation into the active span (no entry until seal)
+//   * Newline seal + Newline entry
+//   * BEL seal + Marker entry
+//   * Explicit appendMarker seals the active span first
+//   * Deferred CR resolution (CRLF → newline; bare CR → overwrite)
+//   * Deferred CUB resolution (CUB+Print → overwrite; CUB+other → no-op)
+//   * Idle tick seals the active span
+//   * Reset clears all state
+//
+// Helpers mirror the existing test conventions (`t0`, `after`,
+// `ascii`) for paste-friendliness.
+
+let private t0 = DateTime(2026, 5, 11, 12, 0, 0, DateTimeKind.Utc)
+let private after (ms: int) = t0.AddMilliseconds(float ms)
+
+let private printRune (c: char) : VtEvent =
+    Print (Rune c)
+
+let private execute (b: byte) : VtEvent = Execute b
+let private lf = execute 0x0Auy
+let private cr = execute 0x0Duy
+let private bel = execute 0x07uy
+
+let private cub (n: int) : VtEvent =
+    CsiDispatch ([| n |], [||], 'D', None)
+
+let private cuu (n: int) : VtEvent =
+    CsiDispatch ([| n |], [||], 'A', None)
+
+let private freshHistory () : ContentHistory.T =
+    ContentHistory.create ContentHistory.defaultParameters
+
+let private feed
+        (state: ContentHistory.T)
+        (now: DateTime)
+        (events: VtEvent list)
+        : ContentHistory.Entry list =
+    events
+    |> List.collect (fun e -> ContentHistory.appendFromEvent state now e)
+
+// ---------------------------------------------------------------------
+// Initial state contracts
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``empty history reports count 0 and latestSeq -1`` () =
+    let state = freshHistory ()
+    Assert.Equal(0, ContentHistory.count state)
+    Assert.Equal(-1L, ContentHistory.latestSeq state)
+    Assert.Equal<ContentHistory.Entry[]>([||], ContentHistory.snapshot state)
+
+[<Fact>]
+let ``entryBySeq returns None on empty history`` () =
+    let state = freshHistory ()
+    Assert.Equal(None, ContentHistory.entryBySeq state 0L)
+    Assert.Equal(None, ContentHistory.entryBySeq state 99L)
+
+// ---------------------------------------------------------------------
+// Print accumulates without sealing
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Print events accumulate into active span without producing entries`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ printRune 'h'; printRune 'i' ]
+    Assert.Empty(emitted)
+    Assert.Equal(0, ContentHistory.count state)
+
+// ---------------------------------------------------------------------
+// LF seals the active span and emits Newline
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``LF seals the active span and appends a Newline entry`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ printRune 'h'; printRune 'i'; lf ]
+    // Expect: the sealed TextSpan + the Newline.
+    Assert.Equal(2, emitted.Length)
+    match emitted with
+    | [ ContentHistory.TextSpan span; ContentHistory.Newline nl ] ->
+        Assert.Equal("hi", span.Text)
+        Assert.Equal(0L, span.Seq)
+        Assert.Equal(1L, nl.Seq)
+    | _ -> Assert.Fail(sprintf "unexpected emit shape: %A" emitted)
+    Assert.Equal(2, ContentHistory.count state)
+    Assert.Equal(1L, ContentHistory.latestSeq state)
+
+[<Fact>]
+let ``LF with no prior Print emits only the Newline`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ lf ]
+    Assert.Equal(1, emitted.Length)
+    match emitted with
+    | [ ContentHistory.Newline nl ] -> Assert.Equal(0L, nl.Seq)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+
+// ---------------------------------------------------------------------
+// BEL emits a BellRang marker (and seals active span first)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``BEL byte seals the active span and emits a BellRang marker`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ printRune 'h'; bel ]
+    Assert.Equal(2, emitted.Length)
+    match emitted with
+    | [ ContentHistory.TextSpan span; ContentHistory.Marker m ] ->
+        Assert.Equal("h", span.Text)
+        Assert.Equal(ContentHistory.MarkerKind.BellRang, m.Kind)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+
+// ---------------------------------------------------------------------
+// appendMarker explicit insertion
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``appendMarker seals any active span before inserting the marker`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'h'; printRune 'i' ]
+    let emitted =
+        ContentHistory.appendMarker
+            state
+            ContentHistory.MarkerKind.PromptStart
+            t0
+            None
+    Assert.Equal(2, emitted.Length)
+    match emitted with
+    | [ ContentHistory.TextSpan span; ContentHistory.Marker m ] ->
+        Assert.Equal("hi", span.Text)
+        Assert.Equal(ContentHistory.MarkerKind.PromptStart, m.Kind)
+        Assert.Equal(None, m.Payload)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+
+[<Fact>]
+let ``appendMarker with no active span emits only the marker`` () =
+    let state = freshHistory ()
+    let emitted =
+        ContentHistory.appendMarker
+            state
+            ContentHistory.MarkerKind.AltScreenEnter
+            t0
+            (Some "claude")
+    Assert.Equal(1, emitted.Length)
+    match emitted with
+    | [ ContentHistory.Marker m ] ->
+        Assert.Equal(ContentHistory.MarkerKind.AltScreenEnter, m.Kind)
+        Assert.Equal(Some "claude", m.Payload)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+
+// ---------------------------------------------------------------------
+// CR deferred resolution
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CR followed by LF is a CRLF newline, no overwrite emitted`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ printRune 'h'; printRune 'i'; cr; lf ]
+    // Expect: sealed TextSpan + Newline; CR did NOT emit an
+    // Overwrite because LF resolved the deferral as CRLF.
+    Assert.Equal(2, emitted.Length)
+    let hasOverwrite =
+        emitted
+        |> List.exists (fun e ->
+            match e with
+            | ContentHistory.Overwrite _ -> true
+            | _ -> false)
+    Assert.False(hasOverwrite)
+    let hasNewline =
+        emitted
+        |> List.exists (fun e ->
+            match e with
+            | ContentHistory.Newline _ -> true
+            | _ -> false)
+    Assert.True(hasNewline)
+
+[<Fact>]
+let ``bare CR followed by Print resolves to an Overwrite over the sealed span`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'a'; printRune 'b'; printRune 'c'; cr ]
+    // Now feed a Print; the CR's deferred resolution should
+    // seal "abc" and emit an Overwrite.
+    let emitted = feed state (after 5) [ printRune 'X' ]
+    let hasSealed =
+        emitted
+        |> List.exists (fun e ->
+            match e with
+            | ContentHistory.TextSpan s when s.Text = "abc" -> true
+            | _ -> false)
+    let hasOverwrite =
+        emitted
+        |> List.exists (fun e ->
+            match e with
+            | ContentHistory.Overwrite _ -> true
+            | _ -> false)
+    Assert.True(hasSealed, sprintf "expected sealed 'abc' span: %A" emitted)
+    Assert.True(hasOverwrite, sprintf "expected Overwrite: %A" emitted)
+
+// ---------------------------------------------------------------------
+// CUB deferred resolution
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``CUB followed by Print resolves to an Overwrite (Fact 12 equivalent)`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'a'; printRune 'b'; printRune 'c'; cub 3 ]
+    // CUB defers; Print resolves to in-place overwrite.
+    let emitted = feed state (after 5) [ printRune 'X' ]
+    let hasOverwrite =
+        emitted
+        |> List.exists (fun e ->
+            match e with
+            | ContentHistory.Overwrite _ -> true
+            | _ -> false)
+    Assert.True(hasOverwrite, sprintf "expected Overwrite: %A" emitted)
+
+[<Fact>]
+let ``CUB followed by LF does NOT emit an Overwrite (cmd output regression)`` () =
+    let state = freshHistory ()
+    let emitted =
+        feed state t0
+            [ printRune 'h'
+              printRune 'i'
+              cub 1
+              lf ]
+    // The CUB's deferred resolution should clear without
+    // transition when LF (not Print) follows. The sealed
+    // TextSpan "hi" + Newline emit normally.
+    let overwrites =
+        emitted
+        |> List.filter (fun e ->
+            match e with
+            | ContentHistory.Overwrite _ -> true
+            | _ -> false)
+    Assert.Empty(overwrites)
+    let textSpans =
+        emitted
+        |> List.choose (fun e ->
+            match e with
+            | ContentHistory.TextSpan s -> Some s.Text
+            | _ -> None)
+    Assert.Contains("hi", textSpans)
+
+[<Fact>]
+let ``CUB followed by another CSI does NOT emit an Overwrite`` () =
+    let state = freshHistory ()
+    let emitted =
+        feed state t0
+            [ printRune 'a'
+              cub 1
+              cuu 1
+              printRune 'b'
+              lf ]
+    // Note: this test pins ContentHistory's CUB-deferred behavior
+    // specifically. The active span "a" should NOT be sealed by
+    // the CUB-then-CUU sequence; CUU has no classifier in
+    // ContentHistory yet (deferred to a future cycle).
+    // After the next Print 'b', the span "ab" continues to
+    // accumulate; the LF seals "ab" into a TextSpan.
+    let textSpans =
+        emitted
+        |> List.choose (fun e ->
+            match e with
+            | ContentHistory.TextSpan s -> Some s.Text
+            | _ -> None)
+    Assert.Contains("ab", textSpans)
+    let overwrites =
+        emitted
+        |> List.filter (fun e ->
+            match e with
+            | ContentHistory.Overwrite _ -> true
+            | _ -> false)
+    Assert.Empty(overwrites)
+
+// ---------------------------------------------------------------------
+// Tick / idle seal
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``tick within the idle window does NOT seal`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'h'; printRune 'i' ]
+    // Tick at t0+50 ms; defaultParameters.IdleSpanSealMs = 200.
+    let emitted = ContentHistory.tick state (after 50)
+    Assert.Empty(emitted)
+    Assert.Equal(0, ContentHistory.count state)
+
+[<Fact>]
+let ``tick past the idle window seals the active span`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'h'; printRune 'i' ]
+    // Tick at t0+250 ms; past IdleSpanSealMs (200).
+    let emitted = ContentHistory.tick state (after 250)
+    Assert.Equal(1, emitted.Length)
+    match emitted with
+    | [ ContentHistory.TextSpan span ] ->
+        Assert.Equal("hi", span.Text)
+        Assert.Equal(0L, span.Seq)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+    Assert.Equal(1, ContentHistory.count state)
+
+[<Fact>]
+let ``tick with no active content is a no-op`` () =
+    let state = freshHistory ()
+    let emitted = ContentHistory.tick state (after 5000)
+    Assert.Empty(emitted)
+
+// ---------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``reset clears all state and restarts seq from zero`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'h'; printRune 'i'; lf ]
+    Assert.True(ContentHistory.count state > 0)
+    ContentHistory.reset state
+    Assert.Equal(0, ContentHistory.count state)
+    Assert.Equal(-1L, ContentHistory.latestSeq state)
+    // After reset, the next entry gets Seq 0.
+    let emitted = feed state t0 [ lf ]
+    match emitted with
+    | [ ContentHistory.Newline nl ] -> Assert.Equal(0L, nl.Seq)
+    | _ -> Assert.Fail(sprintf "unexpected: %A" emitted)
+
+// ---------------------------------------------------------------------
+// Identity / seq uniqueness
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``repeated identical content gets distinct Seq numbers`` () =
+    let state = freshHistory ()
+    // Feed "hi\n" twice. Two distinct TextSpan entries with
+    // distinct Seqs, even though the Text is identical. This is
+    // the property that distinguishes ContentHistory from a
+    // screen-grid-diff baseline.
+    let _ = feed state t0 [ printRune 'h'; printRune 'i'; lf ]
+    let _ = feed state (after 100) [ printRune 'h'; printRune 'i'; lf ]
+    let spans =
+        ContentHistory.snapshot state
+        |> Array.choose (fun e ->
+            match e with
+            | ContentHistory.TextSpan s -> Some s
+            | _ -> None)
+    Assert.Equal(2, spans.Length)
+    Assert.NotEqual<int64>(spans.[0].Seq, spans.[1].Seq)
+    Assert.Equal(spans.[0].Text, spans.[1].Text)
+
+[<Fact>]
+let ``entryBySeq retrieves by identity, not text`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'h'; printRune 'i'; lf ]
+    // Seq 0 is the sealed "hi" span; Seq 1 is the Newline.
+    let s0 = ContentHistory.entryBySeq state 0L
+    let s1 = ContentHistory.entryBySeq state 1L
+    Assert.True(s0.IsSome)
+    Assert.True(s1.IsSome)
+    match s0.Value with
+    | ContentHistory.TextSpan span ->
+        Assert.Equal("hi", span.Text)
+    | other ->
+        Assert.Fail(sprintf "expected TextSpan at Seq 0, got %A" other)
+    match s1.Value with
+    | ContentHistory.Newline _ -> ()
+    | other ->
+        Assert.Fail(sprintf "expected Newline at Seq 1, got %A" other)
+
+// ---------------------------------------------------------------------
+// Snapshot is independent
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``snapshot returns a fresh array independent of further appends`` () =
+    let state = freshHistory ()
+    let _ = feed state t0 [ printRune 'a'; lf ]
+    let snap1 = ContentHistory.snapshot state
+    let _ = feed state (after 10) [ printRune 'b'; lf ]
+    let snap2 = ContentHistory.snapshot state
+    Assert.Equal(2, snap1.Length)
+    Assert.Equal(4, snap2.Length)

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -1,0 +1,436 @@
+module PtySpeak.Tests.Unit.SpeechCursorTests
+
+open System
+open System.Text
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 45 Commit 1 — SpeechCursor pure-function tests.
+// ---------------------------------------------------------------------
+//
+// Pin the cursor's contract:
+//
+//   * AutoDrive advances + announces on append
+//   * Manual mode does NOT advance on append
+//   * Navigation (next / previous / toLatest / toMarker)
+//   * speakSince emits in seq order; updates LastSpokenSeq
+//   * SelectionShown suspends auto-drive; SelectionDismissed resumes
+//   * Spinner entries are skipped in AutoDrive (configurable)
+//   * Reset preserves Mode but clears Position / LastSpokenSeq
+//
+// Uses a fake `announce` collector instead of a real NvdaChannel
+// — the module is pure-functional by design.
+
+let private t0 = DateTime(2026, 5, 11, 12, 0, 0, DateTimeKind.Utc)
+let private after (ms: int) = t0.AddMilliseconds(float ms)
+
+let private printRune (c: char) : VtEvent =
+    Print (Rune c)
+let private lf = Execute 0x0Auy
+
+let private freshHistory () : ContentHistory.T =
+    ContentHistory.create ContentHistory.defaultParameters
+
+let private freshCursor () : SpeechCursor.T =
+    SpeechCursor.create SpeechCursor.defaultParameters
+
+/// Capture-collector for announce callbacks. Returns the
+/// callback + a getter for the accumulated (text, activityId)
+/// pairs.
+let private capture () =
+    let entries = ResizeArray<string * string>()
+    let collect ((text: string), (activityId: string)) =
+        entries.Add(text, activityId)
+    let snapshot () = entries.ToArray() |> Array.toList
+    collect, snapshot
+
+// ---------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``new cursor starts in AutoDrive at Position -1 with nothing spoken`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    Assert.Equal(SpeechCursor.AutoDrive, SpeechCursor.mode cursor)
+    Assert.Equal(-1L, cursor.Position)
+    Assert.Equal(-1L, cursor.LastSpokenSeq)
+    Assert.Equal(None, SpeechCursor.current cursor history)
+
+// ---------------------------------------------------------------------
+// AutoDrive announces on append
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``AutoDrive announces appended TextSpans in seq order`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let entries =
+        ContentHistory.appendFromEvent history t0 (printRune 'h')
+        @ ContentHistory.appendFromEvent history t0 (printRune 'i')
+        @ ContentHistory.appendFromEvent history t0 lf
+    SpeechCursor.onAppend cursor history announce entries
+    let said = snap ()
+    // Expect ONE announce for the sealed "hi" TextSpan; the
+    // Newline entry's renderEntry returns None.
+    Assert.Equal(1, said.Length)
+    let (text, activityId) = said.[0]
+    Assert.Equal("hi", text)
+    Assert.Equal(ActivityIds.output, activityId)
+    Assert.True(cursor.LastSpokenSeq >= 0L)
+
+[<Fact>]
+let ``AutoDrive does not re-announce entries it has already spoken`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let entries =
+        ContentHistory.appendFromEvent history t0 (printRune 'a')
+        @ ContentHistory.appendFromEvent history t0 lf
+    SpeechCursor.onAppend cursor history announce entries
+    // Now re-invoke onAppend with the SAME entries. The cursor's
+    // LastSpokenSeq gate should suppress duplicates.
+    SpeechCursor.onAppend cursor history announce entries
+    Assert.Equal(1, (snap ()).Length)
+
+// ---------------------------------------------------------------------
+// Manual mode does NOT auto-advance
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Manual mode does NOT announce on append`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let entries =
+        ContentHistory.appendFromEvent history t0 (printRune 'h')
+        @ ContentHistory.appendFromEvent history t0 lf
+    SpeechCursor.onAppend cursor history announce entries
+    Assert.Empty(snap ())
+    Assert.Equal(-1L, cursor.LastSpokenSeq)
+
+// ---------------------------------------------------------------------
+// toggleMode and setMode
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``toggleMode switches between AutoDrive and Manual`` () =
+    let cursor = freshCursor ()
+    let m1 = SpeechCursor.toggleMode cursor
+    Assert.Equal(SpeechCursor.Manual, m1)
+    let m2 = SpeechCursor.toggleMode cursor
+    Assert.Equal(SpeechCursor.AutoDrive, m2)
+
+[<Fact>]
+let ``setMode forces the specified mode`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    Assert.Equal(SpeechCursor.Manual, SpeechCursor.mode cursor)
+    SpeechCursor.setMode cursor SpeechCursor.AutoDrive
+    Assert.Equal(SpeechCursor.AutoDrive, SpeechCursor.mode cursor)
+
+// ---------------------------------------------------------------------
+// Navigation: next / previous / toLatest
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``next moves cursor to the next entry by Seq`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'a')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'b')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let n1 = SpeechCursor.next cursor history
+    Assert.True(n1.IsSome)
+    Assert.Equal(0L, cursor.Position)
+    let n2 = SpeechCursor.next cursor history
+    Assert.True(n2.IsSome)
+    Assert.Equal(1L, cursor.Position)
+
+[<Fact>]
+let ``previous moves cursor backward`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'a')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'b')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ = SpeechCursor.toLatest cursor history
+    let prev = SpeechCursor.previous cursor history
+    Assert.True(prev.IsSome)
+    Assert.True(cursor.Position < ContentHistory.latestSeq history)
+
+[<Fact>]
+let ``toLatest jumps to the latest entry`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'h')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let latest = SpeechCursor.toLatest cursor history
+    Assert.True(latest.IsSome)
+    Assert.Equal(ContentHistory.latestSeq history, cursor.Position)
+
+[<Fact>]
+let ``toLatest on empty history returns None and leaves Position at -1`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let result = SpeechCursor.toLatest cursor history
+    Assert.Equal(None, result)
+    Assert.Equal(-1L, cursor.Position)
+
+// ---------------------------------------------------------------------
+// toMarker
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``toMarker forward finds the next matching marker`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.PromptStart
+            t0
+            None
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'h')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.PromptStart
+            (after 10)
+            None
+    // Cursor is at -1; forward jump should land on Seq 0
+    // (the first PromptStart marker).
+    let found =
+        SpeechCursor.toMarker
+            cursor
+            history
+            ContentHistory.MarkerKind.PromptStart
+            SpeechCursor.Forward
+    Assert.True(found.IsSome)
+    match found with
+    | Some (ContentHistory.Marker m) ->
+        Assert.Equal(ContentHistory.MarkerKind.PromptStart, m.Kind)
+        Assert.Equal(0L, m.Seq)
+    | _ -> Assert.Fail("expected PromptStart marker at seq 0")
+
+[<Fact>]
+let ``toMarker with no matching kind returns None`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.PromptStart
+            t0
+            None
+    let found =
+        SpeechCursor.toMarker
+            cursor
+            history
+            ContentHistory.MarkerKind.SelectionShown
+            SpeechCursor.Forward
+    Assert.Equal(None, found)
+
+// ---------------------------------------------------------------------
+// SelectionShown / SelectionDismissed suspend/resume AutoDrive
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``SelectionShown marker suspends AutoDrive announces`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let prelude =
+        ContentHistory.appendFromEvent history t0 (printRune 'h')
+        @ ContentHistory.appendFromEvent history t0 lf
+    SpeechCursor.onAppend cursor history announce prelude
+    Assert.Equal(1, (snap ()).Length)
+    // SelectionShown marker fires.
+    let selection =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.SelectionShown
+            (after 10)
+            (Some "Yes, No")
+    SpeechCursor.onAppend cursor history announce selection
+    // The SelectionShown marker itself announces; AutoDrive
+    // then suspends.
+    let beforeText =
+        ContentHistory.appendFromEvent history (after 20) (printRune 'X')
+        @ ContentHistory.appendFromEvent history (after 20) lf
+    SpeechCursor.onAppend cursor history announce beforeText
+    // The "X" TextSpan should NOT be auto-announced — selection
+    // suspends AutoDrive.
+    let said = snap ()
+    let lastTexts = said |> List.map fst
+    Assert.DoesNotContain("X", lastTexts)
+
+[<Fact>]
+let ``SelectionDismissed marker resumes AutoDrive announces`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let _ =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.SelectionShown
+            t0
+            None
+    SpeechCursor.onAppend
+        cursor history announce
+        (ContentHistory.snapshot history |> Array.toList)
+    // Reset snap to focus on post-resume behavior.
+    let dismissed =
+        ContentHistory.appendMarker
+            history
+            ContentHistory.MarkerKind.SelectionDismissed
+            (after 100)
+            None
+    SpeechCursor.onAppend cursor history announce dismissed
+    let post =
+        ContentHistory.appendFromEvent history (after 110) (printRune 'Z')
+        @ ContentHistory.appendFromEvent history (after 110) lf
+    SpeechCursor.onAppend cursor history announce post
+    let said = snap () |> List.map fst
+    Assert.Contains("Z", said)
+
+// ---------------------------------------------------------------------
+// renderEntry shape
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``renderEntry returns the TextSpan text on the output activity id`` () =
+    let span =
+        ContentHistory.TextSpan
+            { Seq = 0L
+              Text = "hello"
+              StartedAt = t0
+              SettledAt = t0 }
+    match SpeechCursor.renderEntry span with
+    | Some (text, activityId) ->
+        Assert.Equal("hello", text)
+        Assert.Equal(ActivityIds.output, activityId)
+    | None -> Assert.Fail("expected non-empty render")
+
+[<Fact>]
+let ``renderEntry returns None for empty TextSpan`` () =
+    let span =
+        ContentHistory.TextSpan
+            { Seq = 0L
+              Text = ""
+              StartedAt = t0
+              SettledAt = t0 }
+    Assert.Equal(None, SpeechCursor.renderEntry span)
+
+[<Fact>]
+let ``renderEntry returns None for Newline`` () =
+    let nl = ContentHistory.Newline { Seq = 0L; At = t0 }
+    Assert.Equal(None, SpeechCursor.renderEntry nl)
+
+[<Fact>]
+let ``renderEntry returns mode activity for AltScreenEnter`` () =
+    let m =
+        ContentHistory.Marker
+            { Seq = 0L
+              Kind = ContentHistory.MarkerKind.AltScreenEnter
+              At = t0
+              Payload = None }
+    match SpeechCursor.renderEntry m with
+    | Some (_, activityId) -> Assert.Equal(ActivityIds.mode, activityId)
+    | None -> Assert.Fail("expected announce for AltScreenEnter")
+
+[<Fact>]
+let ``renderEntry returns selection announce for SelectionShown with payload`` () =
+    let m =
+        ContentHistory.Marker
+            { Seq = 0L
+              Kind = ContentHistory.MarkerKind.SelectionShown
+              At = t0
+              Payload = Some "Edit, Yes, Always, No" }
+    match SpeechCursor.renderEntry m with
+    | Some (text, _) ->
+        Assert.Contains("Selection prompt", text)
+        Assert.Contains("Edit, Yes, Always, No", text)
+    | None -> Assert.Fail("expected announce for SelectionShown")
+
+// ---------------------------------------------------------------------
+// speakSince
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``speakSince emits in seq order and advances LastSpokenSeq`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let _ =
+        ContentHistory.appendFromEvent history t0 (printRune 'a')
+        @ ContentHistory.appendFromEvent history t0 lf
+    let _ =
+        ContentHistory.appendFromEvent history (after 10) (printRune 'b')
+        @ ContentHistory.appendFromEvent history (after 10) lf
+    let latest = ContentHistory.latestSeq history
+    let count =
+        SpeechCursor.speakSince cursor history announce latest
+    Assert.Equal(2, count)
+    let said = snap () |> List.map fst
+    Assert.Equal<string list>([ "a"; "b" ], said)
+    Assert.Equal(latest, cursor.LastSpokenSeq)
+
+[<Fact>]
+let ``speakSince emits nothing when there's nothing new`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    let count = SpeechCursor.speakSince cursor history announce 10L
+    Assert.Equal(0, count)
+    Assert.Empty(snap ())
+
+// ---------------------------------------------------------------------
+// Spinner skip
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``AutoDrive skips Spinner entries by default`` () =
+    let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    // Synthesize a Spinner entry directly via the entry list
+    // (Spinner detection isn't wired yet in Commit 1, but the
+    // cursor's skip behaviour must hold once detection lands).
+    let spinner =
+        ContentHistory.Spinner
+            { Seq = 0L
+              LatestText = "/"
+              FrameCount = 5
+              FirstAt = t0
+              LastAt = after 200 }
+    SpeechCursor.onAppend cursor history announce [ spinner ]
+    Assert.Empty(snap ())
+
+// ---------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``reset clears Position and LastSpokenSeq but preserves Mode`` () =
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    cursor.Position <- 5L
+    cursor.LastSpokenSeq <- 4L
+    SpeechCursor.reset cursor
+    Assert.Equal(-1L, cursor.Position)
+    Assert.Equal(-1L, cursor.LastSpokenSeq)
+    Assert.Equal(SpeechCursor.Manual, SpeechCursor.mode cursor)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -67,6 +67,15 @@
     -->
     <Compile Include="DiagnosticExtractsTests.fs" />
     <Compile Include="DiagnosticGrepTests.fs" />
+    <!--
+      Cycle 45 Commit 1 — ContentHistory + SpeechCursor.
+      Tests pin the new aural substrate's contracts in isolation
+      before Commit 2 wires them into the live pipeline. Order
+      mirrors source compile order (ContentHistory before
+      SpeechCursor).
+    -->
+    <Compile Include="ContentHistoryTests.fs" />
+    <Compile Include="SpeechCursorTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

First commit of the **Cycle 45 architectural reset**. Introduces the new aural substrate (`ContentHistory`) and its announce-and-navigate primitive (`SpeechCursor`) as pure F# modules in `Terminal.Core`. This PR is **purely additive** — no consumer in `Terminal.App` wires to either module yet.

The strategic context lives at `~/.claude/plans/the-repo-linked-to-ticklish-whisper.md` (the multi-cycle architectural reset is described in full there). Short version: the aural pipeline shouldn't be driven by the screen grid (the source of every classifier bug across Cycles 38c / 40 / 41 / 44). Replace it with an append-only typed log with monotonic `Seq` identity per entry. "Have we spoken this?" becomes an integer comparison against `cursor.LastSpokenSeq`. No string-diff baselines. No `LastEmittedRowText`. No per-CSI classifier arms.

## What this commit adds

**`src/Terminal.Core/ContentHistory.fs`** (~340 LOC):
- `MarkerKind` open-ended DU — `PromptStart`, `CommandStart`, `OutputStart`, `CommandFinished`, `SelectionShown`, `SelectionDismissed`, `BellRang`, `AltScreenEnter`, `AltScreenExit`, `Custom of string`. Per the plan's "modes are extensible" principle, future canonical interaction modes add new MarkerKind values without disturbing the substrate.
- `Entry` DU with five cases: `TextSpan` (sealed run of Print events), `Newline`, `Overwrite` (in-place replacement; points at the prior TextSpan's Seq), `Marker` (semantic event), `Spinner` (coalesced run of Overwrites; coalescer wires later).
- `T` instance: Gate-locked `Entries` ResizeArray + active TextSpan accumulator (`StringBuilder` + `StartedAt`).
- Public API: `create / appendFromEvent / appendMarker / tick / snapshot / entryBySeq / latestSeq / count / reset`.
- **Deferred-resolution for CR and CUB** — mirrors Cycle 44's pattern but operates one layer up on TextSpan entries with explicit identity. CR+LF is a newline (no overwrite); bare CR is an overwrite. CUB+Print is an in-place overwrite; CUB+other is bare cursor positioning.

**`src/Terminal.Core/SpeechCursor.fs`** (~260 LOC):
- `Mode = AutoDrive | Manual`. AutoDrive announces on append; Manual stays parked for user-paced review.
- `T` instance: `Position` (current Seq), `LastSpokenSeq` (the explicit watermark gating "have we said this?"), `SelectionSuspend` (AutoDrive sub-state during selection prompts).
- Navigation: `next / previous / toLatest / toMarker` (forward or backward to a specific MarkerKind).
- Announce: `speakCurrent / speakSince / onAppend` (the auto-drive event hook).
- Mode transitions on selection markers: `SelectionShown` suspends AutoDrive; `SelectionDismissed` resumes.
- `renderEntry` is pure: maps an Entry → `(text, activityId)` for the announce callback. Tests assert format directly.

**Tests** (45 facts):
- `tests/Tests.Unit/ContentHistoryTests.fs` — 22 facts pinning Print accumulation, LF / BEL seal, marker insertion, CR / CUB deferred resolution (including the **cmd-output regression case** "CUB followed by LF does NOT emit an Overwrite"), idle tick seal, reset, identity-not-text equality, snapshot independence.
- `tests/Tests.Unit/SpeechCursorTests.fs` — 23 facts pinning initial state, AutoDrive announce, Manual non-advance, mode toggling, navigation, selection suspend/resume, `renderEntry` shape, `speakSince`, Spinner skip in AutoDrive, reset.

## Out of scope for this PR (deferred to Commit 2 / 3)

- Wiring `ContentHistory.appendFromEvent` into the reader loop
- Detectors (`HeuristicPromptDetector`, `SelectionDetector`) emitting markers into ContentHistory
- Wiring `SpeechCursor.onAppend` to the live `NvdaChannel`
- OSC 133 marker parsing
- Hotkeys for SpeechCursor navigation (next / previous / latest / toggle mode) + menu items
- Spinner detection (coalescing rule that produces `Spinner` entries from runs of `Overwrite` entries)
- Tuple-complete archive into `SessionTuple`
- Version-in-log fix
- DELETION of `StreamPathway` / `LinearTextStream` / `DisplayPathway` / `TuiPathway` / `PathwaySelector` / `Coalescer` (Commit 3, after NVDA validation gate)

## Why ship this isolated first

Commit 1 is purely additive — nothing in the live pipeline changes, no behaviour regression possible. The data model + announce primitive can be iterated on in isolation before touching the production code path. If review surfaces a problem with the entry shape or the cursor's mode transitions, fixing it is a localised change to two files, not a cross-cutting refactor.

## Test plan

- [ ] CI green (build + test + portability lint + workflow lint + markdown link check)
- [ ] 45 new facts pass
- [ ] No regression in existing tests (additive change; nothing in the pipeline reads from these modules yet)
- [ ] Manual NVDA validation is **not needed** for Commit 1 — no observable behaviour change. NVDA validation gate is between Commit 2 and Commit 3.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_