### PR TITLE
fix(speech-cursor): preserve history across tuple boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 45 Commit 2 follow-up): SpeechCursor history persists across tuple boundaries
+
+Maintainer NVDA dogfood on preview.92 (the Commit 2 build)
+surfaced that `Display → Speech Cursor → Next Entry` and
+`Previous Entry` always reported "Already at the latest entry"
+/ "Already at the first entry" even after several commands.
+Root cause: `handlePromptBoundary` reset both `ContentHistory`
+and `SpeechCursor` every time a SessionModel tuple finalised
+— on the (wrong) assumption that the cursor's scope is "the
+active tuple." With that scope, every completed command
+emptied the history, leaving the cursor with nothing to
+navigate.
+
+Corrected scope: **the shell session.** ContentHistory entries
+now accumulate across tuple boundaries; the user can Speech-
+Cursor backwards through completed-command output. Reset on
+shell-switch (`switchToShell`) still fires — that's a
+legitimate fresh-slate boundary. Tuple-archive into
+`SessionTuple` is deferred to Cycle 45e (the visual-surface
+cycle that needs structured per-tuple history anyway).
+
+One-file change (`src/Terminal.App/Program.fs` — the
+`boundaryAction` closure inside `handlePromptBoundary`). The
+removed `if tupleFinalised then …` block + accompanying
+comment updates.
+
 ### Added (Cycle 45 Commit 2): ContentHistory + SpeechCursor wired into the live pipeline
 
 Second commit of the Cycle 45 architectural reset (Commit 1

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -895,14 +895,16 @@ module Program =
 
         // Cycle 45 Commit 2 — ContentHistory + SpeechCursor are the
         // new aural substrate (parallel to the screen-grid + UIA
-        // surface). ContentHistory holds the active tuple's
-        // append-only typed log; SpeechCursor announces from it.
-        // Both are bounded by tuple lifetime — `ContentHistory.reset`
-        // fires when SessionModel finalises a tuple AND when the
-        // shell hot-switches (a new shell session starts fresh).
-        // LinearTextStream is kept in parallel through Commit 2 so
-        // the existing pump path stays functional; Commit 3 deletes
-        // it after the NVDA validation gate.
+        // surface). ContentHistory holds the shell session's
+        // append-only typed log; SpeechCursor announces from it
+        // (AutoDrive) and lets the user navigate it (Manual).
+        // Scope is the shell session (NOT individual tuples) so
+        // the user can Speech-Cursor backwards through completed
+        // commands — `ContentHistory.reset` fires only when the
+        // shell hot-switches, which is a legitimate fresh-slate
+        // boundary. LinearTextStream is kept in parallel through
+        // Commit 2 so the existing pump path stays functional;
+        // Commit 3 deletes it after the NVDA validation gate.
         let mutable contentHistory =
             ContentHistory.create ContentHistory.defaultParameters
         let mutable speechCursor =
@@ -1553,15 +1555,23 @@ module Program =
             | None -> ()
 
             // Cycle 45 Commit 2 — ContentHistory + SpeechCursor
-            // boundary handling. Mirrors the SessionModel state
-            // machine: on tuple finalise (Some), the previous
-            // tuple's history is no longer needed, so we reset
-            // both ContentHistory and SpeechCursor before the
-            // new tuple's boundary marker is emitted. The reset
-            // + appendMarker + SpeechCursor.onAppend are bundled
-            // into a single dispatcher action so they serialise
-            // with reader-thread-driven appends and hotkey-
-            // driven cursor moves (both also on the dispatcher).
+            // boundary handling. Emit a `MarkerKind` matching the
+            // SessionModel state-transition kind so SpeechCursor
+            // can navigate the prompt-boundary structure of the
+            // shell session.
+            //
+            // Cycle 45 Commit 2 follow-up (2026-05-11): the
+            // original wiring ALSO reset ContentHistory +
+            // SpeechCursor on tuple seal, on the assumption that
+            // a tuple boundary closed out the addressable history.
+            // User dogfood surfaced that this leaves the cursor
+            // with nothing to navigate — every Next/Previous
+            // gesture after a completed command returns "already
+            // at first/latest entry" because the history is
+            // empty post-reset. The corrected scope is "the
+            // shell session": entries accumulate across tuple
+            // boundaries; reset only on shell-switch (handled in
+            // `switchToShell` further below).
             let markerKind =
                 match augmented.Kind with
                 | BoundaryKind.PromptStart ->
@@ -1572,11 +1582,21 @@ module Program =
                     Some ContentHistory.MarkerKind.OutputStart
                 | BoundaryKind.CommandFinished _ ->
                     Some ContentHistory.MarkerKind.CommandFinished
-            let tupleFinalised = finalisedOpt.IsSome
+            // Cycle 45 Commit 2 follow-up — do NOT reset
+            // ContentHistory + SpeechCursor on tuple seal.
+            // Original Commit 2 reset here on the assumption that
+            // ContentHistory's scope is "the active tuple"; user
+            // dogfood (2026-05-11) surfaced that this leaves the
+            // SpeechCursor with nothing to navigate the moment a
+            // command completes — every Next / Previous gesture
+            // returns "Already at the first/latest entry" because
+            // the history is empty post-reset. The right scope is
+            // "the shell session" — entries accumulate across
+            // tuple boundaries; the user can Speech-Cursor back
+            // through completed commands. Reset on shell-switch
+            // (in `switchToShell` below) still fires; that's a
+            // legitimate fresh-slate boundary.
             let boundaryAction () =
-                if tupleFinalised then
-                    ContentHistory.reset contentHistory
-                    SpeechCursor.reset speechCursor
                 match markerKind with
                 | Some k ->
                     ContentHistory.appendMarker


### PR DESCRIPTION
## Summary

Bug fix from maintainer NVDA dogfood on preview.92 (Cycle 45 Commit 2 build): `Display → Speech Cursor → Next Entry` / `Previous Entry` always report "Already at the latest entry" / "Already at the first entry" even after multiple commands have completed.

## Root cause

`handlePromptBoundary` in `Program.fs` reset both `ContentHistory` AND `SpeechCursor` every time a SessionModel tuple finalised. I had wired this on the assumption that the Speech Cursor's scope is "the active tuple" — so on tuple seal, the previous tuple's entries are no longer relevant. With that scope, every completed command emptied the history, leaving the cursor with nothing to navigate.

## Fix

Corrected scope: **the shell session**, not the active tuple. ContentHistory entries accumulate across tuple boundaries; the user can Speech-Cursor backwards through completed-command output. Reset on shell-switch (`switchToShell`) still fires — that IS a legitimate fresh-slate boundary.

Tuple-archive into `SessionTuple` is deferred to Cycle 45e (the visual-surface cycle that needs structured per-tuple history anyway). For now, in-memory accumulation within a shell session is fine.

## Surface

- `src/Terminal.App/Program.fs` — remove `if tupleFinalised then ContentHistory.reset/SpeechCursor.reset` block in `boundaryAction`; update adjacent comments to reflect corrected scope.
- `CHANGELOG.md` — `[Unreleased]` entry under "Fixed (Cycle 45 Commit 2 follow-up)".

Net: +67 / -21 lines.

## What this does NOT fix

The other gaps from the same dogfood session remain open:

- **No per-keystroke announces** — pre-existing (StreamPathway suppressed them too); the user explicitly accepted this.
- **No backspace announces** — likely NVDA-keyboard-echo setting, not pty-speak; not yet investigated.
- **Diagnostic battery `PASS=0 FAIL=1`** — cosmetic; the battery tests for `Semantic=StreamChunk` `OutputEvent`s which now come through SpeechCursor → NvdaChannel directly. Resolves naturally in Commit 3 when StreamPathway is deleted.
- **"echo hello" double-read (typed echo + command output)** — correct cmd behavior; not a bug.

## Test plan

- [ ] CI green
- [ ] Manual: install build, run `echo 1`, `echo 2`, `dir`. Then `Display → Speech Cursor → Previous Entry` should announce earlier output (e.g., "1" then "echo 1" then the prompt boundary marker). `Next Entry` should advance forward through them.
- [ ] `Ctrl+Shift+1/2/3` shell switch resets the history — first Next/Previous after switch announces "Already at first/latest entry."

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_