### PR TITLE
feat(nav-echo): announce screen-cell char on Backspace / arrow / Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 45 follow-up): Navigation-key echo for backspace + arrows
+
+Maintainer NVDA dogfood surfaced that Backspace / Left arrow /
+Right arrow / Home keys produce NO audible echo in pty-speak,
+even though the same keys announce the relevant character via
+NVDA's keyboard echo in Notepad and other text controls.
+
+Root cause: in any text-input control (Notepad, web forms,
+IDEs), the control fires a UIA `TextSelectionChangedEvent`
+when the caret moves, and NVDA reads the character at the new
+caret position. pty-speak's `TerminalAutomationPeer` exposes
+a Text pattern for review-cursor navigation but does NOT fire
+caret-change events when cmd's cursor moves in response to
+these keys — so NVDA's keyboard echo has nothing to react to.
+
+Fix: in `TerminalView.OnPreviewKeyDown`, before encoding the
+keystroke for the PTY, read the screen cell at the relevant
+position and call `Announce` directly with the new
+`ActivityIds.navigation` activity id (MostRecent processing
+so rapid keystrokes supersede rather than queue).
+
+Per-key mapping:
+- **Backspace** — char that will be deleted (cell at
+  `(Cursor.Row, Cursor.Col - 1)`). Skipped at column 0.
+- **Left arrow** — char the cursor will move onto (same
+  cell as Backspace). Skipped at column 0.
+- **Right arrow** — char the cursor will move past
+  (cell at `(Cursor.Row, Cursor.Col)`). Skipped at the last
+  column.
+- **Home** — char at `(Cursor.Row, 0)`.
+
+Not handled in this commit (semantics need design):
+- **Up / Down** — cmd recalls command history; the screen
+  rewrites after cmd responds, and SpeechCursor picks the
+  recalled line up via the normal append path. No
+  pre-emptive announce.
+- **End** — requires scanning for the last non-blank cell;
+  unclear semantics for cmd's prompt-line edit buffer.
+- **Delete** — behaviour varies by shell.
+
+Read-only helper; doesn't suppress the keystroke. PTY-side
+processing continues unaffected.
+
 ### Fixed (Cycle 45 Commit 2 follow-up): SpeechCursor history persists across tuple boundaries
 
 Maintainer NVDA dogfood on preview.92 (the Commit 2 build)

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -493,6 +493,25 @@ module ActivityIds =
     /// focus.
     let openConfig = "pty-speak.open-config"
 
+    /// Cycle 45 follow-up — navigation-key echo. Fired when the
+    /// user presses Backspace / Left / Right / Home and the
+    /// terminal-view handler announces the screen-cell char at
+    /// the cursor's effective destination. Uses MostRecent
+    /// processing so rapid keystrokes (held-down Backspace,
+    /// arrow-spamming) supersede rather than queue.
+    ///
+    /// Background: in any other text-input control (Notepad, a
+    /// web form, an IDE), NVDA reads the character at the
+    /// caret's new position after Backspace / arrow key presses
+    /// via the UIA `TextSelectionChangedEvent` the control
+    /// fires. pty-speak's `TerminalAutomationPeer` exposes a
+    /// Text pattern for review-cursor navigation but does NOT
+    /// fire caret-change events when cmd's cursor moves in
+    /// response to those keys, so NVDA's keyboard echo has no
+    /// signal to react to. This activity id is the explicit
+    /// announce path for those keys.
+    let navigation = "pty-speak.navigation"
+
     /// Process-cleanup-script launch announcements (Cycle 26c
     /// Diagnostics → Test Process Cleanup menu item — no
     /// keyboard accelerator). Emits "Launching process-cleanup

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -665,6 +665,23 @@ public class TerminalView : FrameworkElement
             return;
         }
 
+        // 4.5. Cycle 45 follow-up — navigation-key echo for
+        // screen-reader users. Backspace / Left / Right / Home
+        // don't fire UIA TextSelectionChangedEvent on our
+        // TerminalAutomationPeer the way Notepad's text-edit
+        // does, so NVDA's keyboard-echo path has no signal to
+        // react to. We bridge the gap by announcing the
+        // screen-cell character at the destination/source
+        // position BEFORE forwarding the keystroke to the PTY.
+        // Read-only — doesn't suppress the key event; the
+        // encoder + writeBytes step below still runs.
+        if (_screen is not null &&
+            !ctrlOrAltHeld &&
+            !pressedModifiers.HasFlag(ModifierKeys.Shift))
+        {
+            AnnounceNavigationEcho(e.Key);
+        }
+
         // 5. Encode and write. If the screen isn't attached yet
         // (very early init / teardown) drop the key gracefully —
         // there's nowhere meaningful to send it. _screen is set
@@ -682,6 +699,77 @@ public class TerminalView : FrameworkElement
         }
         _writeBytes(bytes);
         e.Handled = true;
+    }
+
+    /// <summary>
+    /// Cycle 45 follow-up — read-only helper that announces the
+    /// screen-cell character at the navigation key's destination
+    /// position. Called from <see cref="OnPreviewKeyDown"/> for
+    /// Backspace / Left / Right / Home before the keystroke is
+    /// encoded and forwarded to the PTY. The PTY-side processing
+    /// continues unaffected; this is purely an additional NVDA
+    /// signal to fill the gap left by our UIA peer not firing
+    /// caret-change events.
+    /// </summary>
+    /// <remarks>
+    /// Per-key mapping:
+    /// <list type="bullet">
+    ///   <item><description><see cref="Key.Back"/> — char that will be
+    ///   deleted (cell at <c>(Cursor.Row, Cursor.Col - 1)</c>). Skipped
+    ///   when cursor is already at column 0.</description></item>
+    ///   <item><description><see cref="Key.Left"/> — char the cursor
+    ///   will move onto (cell at <c>(Cursor.Row, Cursor.Col - 1)</c>).
+    ///   Skipped at column 0.</description></item>
+    ///   <item><description><see cref="Key.Right"/> — char the cursor
+    ///   will move PAST (current cell, <c>(Cursor.Row, Cursor.Col)</c>).
+    ///   Skipped at the last column.</description></item>
+    ///   <item><description><see cref="Key.Home"/> — char at
+    ///   <c>(Cursor.Row, 0)</c>.</description></item>
+    /// </list>
+    /// Up / Down / End / PgUp / PgDn / Delete are intentionally NOT
+    /// handled here. Up/Down in cmd recall history (the screen
+    /// rewrites after cmd responds; SpeechCursor picks that up
+    /// via the normal append path). End requires scanning for the
+    /// last non-blank cell which has unclear semantics for cmd's
+    /// prompt-line edit buffer. Delete's behaviour varies by shell.
+    /// All five can be added in a follow-up once their specific
+    /// announcement semantics are nailed down.
+    /// </remarks>
+    private void AnnounceNavigationEcho(Key key)
+    {
+        if (_screen is null)
+        {
+            return;
+        }
+        var cursor = _screen.Cursor;
+        var row = cursor.Row;
+        var col = cursor.Col;
+        int? targetCol = key switch
+        {
+            Key.Back => col > 0 ? col - 1 : (int?)null,
+            Key.Left => col > 0 ? col - 1 : (int?)null,
+            Key.Right => col < _screen.Cols - 1 ? col : (int?)null,
+            Key.Home => 0,
+            _ => null,
+        };
+        if (targetCol is null)
+        {
+            return;
+        }
+        if (row < 0 || row >= _screen.Rows)
+        {
+            return;
+        }
+        var cell = _screen.GetCell(row, targetCol.Value);
+        var text = cell.Ch.ToString();
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+        // NVDA itself substitutes "space" / "blank" for ASCII 0x20
+        // on review-cursor reads; we forward the raw character and
+        // let NVDA's TTS handle the substitution.
+        Announce(text, ActivityIds.navigation);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Maintainer NVDA dogfood on the post-Cycle-45-Commit-2 build surfaced that **Backspace / Left arrow / Right arrow / Home** keys produce no audible echo in pty-speak, while the same keys announce the relevant character via NVDA's keyboard echo in Notepad and other text-input controls.

## Root cause

Text-input controls (Notepad, web forms, IDEs) fire UIA `TextSelectionChangedEvent` when the caret moves. NVDA reads the character at the new caret position. pty-speak's `TerminalAutomationPeer` exposes a Text pattern for review-cursor navigation but does **not** fire caret-change events when cmd's cursor moves in response to these keys — so NVDA's keyboard echo has nothing to react to.

## Fix

Read-only helper in `TerminalView.OnPreviewKeyDown`: before encoding the keystroke for the PTY, look up the screen cell at the relevant position and call `Announce` with a new `ActivityIds.navigation` id (MostRecent processing so rapid keystrokes supersede rather than queue).

Per-key mapping:
| Key | Cell read |
|---|---|
| Backspace | `(Cursor.Row, Cursor.Col − 1)` — char that'll be deleted |
| Left | `(Cursor.Row, Cursor.Col − 1)` — char the cursor moves onto |
| Right | `(Cursor.Row, Cursor.Col)` — char the cursor moves past |
| Home | `(Cursor.Row, 0)` |

## What this PR does NOT handle

- **Up / Down** — cmd recalls command history; the screen rewrites after cmd responds, and SpeechCursor picks the recalled line up via the normal append path. No pre-emptive announce needed.
- **End** — requires scanning for the last non-blank cell; semantics for cmd's prompt-line edit buffer are unclear (does End jump to the visible end of the prompt's input, or the last cell?). Needs design.
- **Delete** — behaviour varies across shells. Skipped.

All four can be added in a follow-up once their specific announce semantics are nailed down. Out of scope for this PR.

## What this PR does NOT fix (still on the backlog)

- **"echo hi … hi … C:\\Users" verbosity** — user wants typed-command-echo and next-prompt-line suppressed by default, with per-shell config knobs. Design-heavier; deferred to a separate cycle that introduces the per-shell verbosity-rules registry.
- **Cycle 45 Commit 3 (deletions)** — still gated on NVDA validation per the strategic plan.

## Test plan

- [ ] CI green
- [ ] Manual NVDA: type `hello`, press Backspace 5 times — should hear "o", "l", "l", "e", "h" (or NVDA's equivalent rendering).
- [ ] Manual NVDA: type `hello`, press Left arrow 3 times — should hear "l", "l", "e".
- [ ] Manual NVDA: type `hello`, press End to position at the end, press Home — should hear the prompt's first character.
- [ ] Manual NVDA: Shift+Left or Ctrl+Left does NOT announce (existing modifier-gated encode path still runs).
- [ ] Manual NVDA: Up arrow continues to work for cmd history recall (no pre-emptive announce; cmd's rewrite flows through SpeechCursor normally).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_