### PR TITLE
fix(nav-echo): Right arrow direction + add Delete key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 45 follow-up): Right-arrow + Delete nav-echo direction
+
+Maintainer NVDA dogfood on the post-#265 build confirmed that
+Backspace announces the deleted character correctly (matches
+NVDA's text-editor behaviour), but called out two refinements:
+
+1. **Right arrow** previously announced the cell being moved
+   PAST (`Col`). NVDA's text-editor convention is to announce
+   the cell now to the right of the cursor after the move
+   (`Col + 1`). Fixed.
+
+2. **Delete key** was deliberately skipped in #265 pending
+   semantic clarity. The maintainer confirmed the desired
+   behaviour matches NVDA's text-editor convention: announce
+   the char that will shift left into the cursor's position
+   after the delete (`Col + 1`, read BEFORE forwarding to PTY).
+   Added.
+
+Backspace, Left, and Home are unchanged; their existing
+behaviour already matches NVDA's text-editor convention.
+
+### Deferred — Up / Down arrow recall announce + verbosity defaults
+
+Both concerns share a design space: when does typed-echo
+announce, when does cmd-driven content announce, and how does
+that interact with shells (cmd's typed echo + history recall,
+PowerShell's PSReadLine, Claude's streaming output)?
+
+The Up arrow case is concrete: cmd's response writes the
+recalled command line without a trailing newline, so
+ContentHistory's active TextSpan never seals and SpeechCursor
+never announces. The fix is wiring `ContentHistory.tick`
+(idle-seal) into the pump's `handleTick`, but the threshold
+choice is a trade-off — aggressive (200ms) double-announces
+typed text with NVDA's keyboard echo; slow (1000ms+) delays
+the Up arrow announce.
+
+Scoped as a follow-up cycle (likely "Cycle 45f — verbosity
+modes") that also addresses the maintainer's
+"echo hi → hi → C:\\Users" verbosity concern (suppress
+typed-command-echo and next-prompt-line by default with
+per-shell config knobs).
+
 ### Added (Cycle 45 follow-up): Navigation-key echo for backspace + arrows
 
 Maintainer NVDA dogfood surfaced that Backspace / Left arrow /

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -705,35 +705,51 @@ public class TerminalView : FrameworkElement
     /// Cycle 45 follow-up — read-only helper that announces the
     /// screen-cell character at the navigation key's destination
     /// position. Called from <see cref="OnPreviewKeyDown"/> for
-    /// Backspace / Left / Right / Home before the keystroke is
-    /// encoded and forwarded to the PTY. The PTY-side processing
-    /// continues unaffected; this is purely an additional NVDA
-    /// signal to fill the gap left by our UIA peer not firing
-    /// caret-change events.
+    /// Backspace / Delete / Left / Right / Home before the
+    /// keystroke is encoded and forwarded to the PTY. The
+    /// PTY-side processing continues unaffected; this is purely
+    /// an additional NVDA signal to fill the gap left by our UIA
+    /// peer not firing caret-change events.
     /// </summary>
     /// <remarks>
-    /// Per-key mapping:
+    /// Per-key mapping (mirrors NVDA's text-editor conventions:
+    /// Backspace announces the char that just got deleted;
+    /// arrows / Delete announce the char that ends up to the
+    /// right of the cursor's new position):
     /// <list type="bullet">
-    ///   <item><description><see cref="Key.Back"/> — char that will be
-    ///   deleted (cell at <c>(Cursor.Row, Cursor.Col - 1)</c>). Skipped
-    ///   when cursor is already at column 0.</description></item>
-    ///   <item><description><see cref="Key.Left"/> — char the cursor
-    ///   will move onto (cell at <c>(Cursor.Row, Cursor.Col - 1)</c>).
-    ///   Skipped at column 0.</description></item>
-    ///   <item><description><see cref="Key.Right"/> — char the cursor
-    ///   will move PAST (current cell, <c>(Cursor.Row, Cursor.Col)</c>).
-    ///   Skipped at the last column.</description></item>
+    ///   <item><description><see cref="Key.Back"/> (Backspace) —
+    ///   char that will be deleted (cell at
+    ///   <c>(Cursor.Row, Cursor.Col - 1)</c>). Skipped when cursor
+    ///   is already at column 0.</description></item>
+    ///   <item><description><see cref="Key.Delete"/> — char that
+    ///   will shift left into the cursor position (cell at
+    ///   <c>(Cursor.Row, Cursor.Col + 1)</c>; read BEFORE the
+    ///   delete so we capture the char that's about to become the
+    ///   new "char-to-right-of-cursor"). Skipped when cursor is
+    ///   at the last column.</description></item>
+    ///   <item><description><see cref="Key.Left"/> — char now to
+    ///   the right of the cursor after the move (cell at
+    ///   <c>(Cursor.Row, Cursor.Col - 1)</c>). Skipped at column 0.</description></item>
+    ///   <item><description><see cref="Key.Right"/> — char now to
+    ///   the right of the cursor after the move (cell at
+    ///   <c>(Cursor.Row, Cursor.Col + 1)</c>). Skipped at the last
+    ///   column. (Earlier revision incorrectly read the cell
+    ///   being moved PAST; corrected to match NVDA's
+    ///   text-editor convention.)</description></item>
     ///   <item><description><see cref="Key.Home"/> — char at
     ///   <c>(Cursor.Row, 0)</c>.</description></item>
     /// </list>
-    /// Up / Down / End / PgUp / PgDn / Delete are intentionally NOT
-    /// handled here. Up/Down in cmd recall history (the screen
-    /// rewrites after cmd responds; SpeechCursor picks that up
-    /// via the normal append path). End requires scanning for the
-    /// last non-blank cell which has unclear semantics for cmd's
-    /// prompt-line edit buffer. Delete's behaviour varies by shell.
-    /// All five can be added in a follow-up once their specific
-    /// announcement semantics are nailed down.
+    /// Up / Down / End / PgUp / PgDn are intentionally NOT handled
+    /// here. Up/Down in cmd recall history — the screen rewrites
+    /// after cmd responds (without a trailing newline), so the
+    /// announce needs to fire after cmd's output settles. That
+    /// requires wiring `ContentHistory.tick` into the pump's
+    /// `handleTick`, which interacts with the verbosity-mode
+    /// design (when does typed-echo announce, when does
+    /// cmd-driven content announce). Deferred to a separate cycle
+    /// that addresses both concerns together. End requires
+    /// scanning for the last non-blank cell which has unclear
+    /// semantics for cmd's prompt-line edit buffer.
     /// </remarks>
     private void AnnounceNavigationEcho(Key key)
     {
@@ -747,8 +763,9 @@ public class TerminalView : FrameworkElement
         int? targetCol = key switch
         {
             Key.Back => col > 0 ? col - 1 : (int?)null,
+            Key.Delete => col < _screen.Cols - 1 ? col + 1 : (int?)null,
             Key.Left => col > 0 ? col - 1 : (int?)null,
-            Key.Right => col < _screen.Cols - 1 ? col : (int?)null,
+            Key.Right => col < _screen.Cols - 1 ? col + 1 : (int?)null,
             Key.Home => 0,
             _ => null,
         };


### PR DESCRIPTION
## Summary

Two small refinements to the navigation-key echo (#265) from maintainer NVDA dogfood feedback:

1. **Right arrow direction.** Previously announced the cell being moved PAST (`Col`). NVDA's text-editor convention is the cell **now to the right of the cursor** after the move (`Col + 1`). Corrected.

2. **Delete key.** Skipped in #265 pending semantic clarity. The maintainer confirmed NVDA's text-editor convention: announce the char that will shift left into the cursor's position after the delete (`Col + 1`, read BEFORE forwarding to PTY so we capture the value before cmd processes the deletion).

Backspace, Left, and Home are unchanged — they already match NVDA's convention.

## What's deferred (not in this PR)

**Up / Down arrow recall announce.** Real bug, but design-heavier. cmd's response to Up writes the recalled command line without a trailing newline (just `\r` + erase + new text), so ContentHistory's active `TextSpan` never seals and SpeechCursor never announces. The fix needs `ContentHistory.tick` wired into the pump's `handleTick`, but the idle-seal threshold is a trade-off: aggressive (200ms) double-announces typed text with NVDA's keyboard echo (regressing the "once-not-twice" win); slow (1000ms+) delays the Up arrow announce. Scoped as part of "Cycle 45f — verbosity modes" together with the maintainer's "echo hi → hi → C:\\Users" verbosity concern (suppress typed-command-echo + next-prompt-line by default with per-shell config knobs).

**Speech-cursor input/output semantic labels** — for the maintainer's future "inject past input into current input" navigation feature. Noted; needs the verbosity-mode design to land first since it's the same data shape.

## Test plan

- [ ] CI green
- [ ] Manual NVDA: type `abcde`, press Left twice → hear "d", "c" (chars now to right of cursor).
- [ ] Manual NVDA: from previous state, press Right twice → hear "d", "e" (chars now to right of cursor after move).
- [ ] Manual NVDA: from previous state, press Delete → hear the char that shifts left into the cursor position (whatever was at `Col + 1`).
- [ ] Backspace continues to announce the deleted char (unchanged from #265).
- [ ] Home continues to announce char at column 0 (unchanged from #265).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_