### PR TITLE
docs: capture Cycle 45 aural-UX backlog from maintainer dogfood

### DIFF
--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -2121,3 +2121,121 @@ a fixture to `HotkeyRegistryTests.fs` pinning the gesture as
 unbound (mirrors the `Ctrl+Shift+G is unbound` and
 `Ctrl+Shift+M is unbound` fixtures Cycle 27 added).
 
+## Cycle 45 aural-UX backlog (planned settings + features)
+
+Captured 2026-05-12 from maintainer dogfood on the post-Cycle-45
+build. These are user-facing preferences and small features the
+maintainer flagged during validation — none are blocking, but
+each is a concrete improvement worth tracking until a dedicated
+follow-up cycle (likely "Cycle 45f — verbosity modes") picks
+them up.
+
+### Navigation-key announce shape
+
+The Cycle 45 nav-key echo (PR #265 + #266) announces a single
+character when the user presses Backspace / Delete / Left /
+Right / Home. The current behaviour matches NVDA's text-editor
+convention. Maintainer-requested alternative settings:
+
+- **Home key**: announce the entire current line (the typed
+  input AND/OR the prompt path) instead of just the char at
+  column 0. Variant: announce just the typed input portion
+  WITHOUT the prompt path prefix (more useful when the prompt
+  is a long absolute path).
+- Insertion point for the future toggle:
+  `src/Views/TerminalView.cs` `AnnounceNavigationEcho`
+  (the `Key.Home` arm of the switch). Surrounding doc-comment
+  carries a `// Cycle 45 backlog:` marker.
+
+### Prompt-path verbosity
+
+For shells whose prompt is a long absolute path
+(`C:\Users\Kyle\AppData\Local\...\>`), the path content
+dominates the announce. Maintainer-requested settings:
+
+- **Suppress the full path** in announces, leaving just the
+  final directory name (`Local>` rather than `C:\Users\…\Local>`)
+- **Suppress the path entirely** for a minimal prompt cue
+- **Keep the full path** (today's default)
+- Insertion point: SpeechCursor `renderEntry` for the
+  PromptStart marker (currently returns `None`; future logic
+  could read the prompt text from the SessionTuple's
+  ActivePromptText and apply the user-selected verbosity rule)
+
+### Speech-cursor keyboard accelerators
+
+Speech-cursor navigation is currently menu-only (`Display →
+Speech Cursor → ...`). Maintainer-requested accelerator:
+
+- **`Ctrl+Up` / `Ctrl+Down`** for entry-by-entry navigation —
+  `SpeechCursorPrevious` / `SpeechCursorNext`. Direct keyboard
+  access is much faster than menu walks for review-driven use.
+- **`Ctrl+Shift+Up` / `Ctrl+Shift+Down`** for chunk-level
+  navigation (jump to the START of a logical input or output
+  chunk, skipping over multiple TextSpans within one chunk).
+  Requires the semantic-label work below.
+- Implementation: change the `Key = None, Modifiers = None`
+  rows in `HotkeyRegistry.builtIns` for `SpeechCursorPrevious`
+  / `SpeechCursorNext` / `SpeechCursorJumpToLatest` /
+  `SpeechCursorToggleMode` to bind the gesture; mirror in
+  `src/Views/TerminalView.cs` `AppReservedHotkeys` (Cycle 26b
+  mirror invariant). Verify no NVDA collision on Ctrl+Up/Down
+  — NVDA's default review-cursor commands use `NVDA+Up/Down`
+  not `Ctrl+Up/Down`, so the gesture is free in screen-reader
+  mode.
+
+### ContentHistory semantic labels (input vs output)
+
+To support the "inject past input into current input" feature
+the maintainer flagged for the future, every `ContentHistory.Entry`
+needs to carry a label of whether it originated from typed
+input or cmd output. The label powers:
+
+- **"Output chunk 2 of 5"** style navigation announces that
+  collapse multiple consecutive TextSpans within a single
+  output chunk into one navigable unit
+- **`Ctrl+Shift+Up/Down`** chunk-level jump (above)
+- **Future "inject this past input"** action — when the speech
+  cursor is parked on a labelled-as-input entry, the user can
+  trigger an action that pastes that text back into the
+  current input buffer
+
+Implementation sketch: add a `Source: EntrySource` field to
+each Entry record (DU: `TypedInput | CmdOutput | Marker`); set
+it at `appendFromEvent` / `appendMarker` time based on
+SessionModel's current ActiveTupleState. The post-tuple-seal
+labelling pass that counts output chunks ("2 of 5") can run as
+part of the tuple-finalise side effect, mutating the entries'
+labels with index information.
+
+### NVDA "Read Current Line" follows the cmd cursor
+
+NVDA's "Read Current Line" command (default gesture
+`NVDA+Up Arrow`) typically reads the line at the **system
+caret** position. In a normal text edit (Notepad, web form),
+the system caret follows the user's typing. In pty-speak's
+`TerminalAutomationPeer`, the UIA peer exposes a Document
+with a Text pattern but does NOT track a caret position;
+NVDA's read-current-line consequently reads whatever line the
+review cursor was last on, which can drift away from the
+actual cmd input row.
+
+The proper fix is to expose a caret via the Text pattern's
+`ITextRangeProvider.GetCaretRange` (or equivalent) and fire
+`AutomationEvents.TextSelectionChangedEvent` whenever cmd's
+cursor moves (which we already track via Screen state changes).
+That'd make NVDA read the correct line on each read-current-line
+gesture, AND eliminate the need for the manual nav-echo we
+shipped in #265 — NVDA's keyboard echo would Just Work.
+
+Insertion point:
+`src/Terminal.Accessibility/TerminalAutomationPeer.fs` — the
+ITextProvider implementation. Likely needs a substantial
+revisit; not a one-line fix.
+
+This is arguably the highest-leverage UIA improvement in the
+backlog because it fixes nav-echo, read-current-line, AND
+brings pty-speak closer to "indistinguishable from a normal
+text input control" from NVDA's perspective. Worth scoping
+properly before tackling.
+

--- a/src/Terminal.Accessibility/TerminalAutomationPeer.fs
+++ b/src/Terminal.Accessibility/TerminalAutomationPeer.fs
@@ -390,6 +390,30 @@ type internal TerminalAutomationPeer
     override _.GetPattern(patternInterface: PatternInterface) : obj | null =
         match patternInterface with
         | PatternInterface.Text ->
+            // Cycle 45 backlog (docs/USER-SETTINGS.md "NVDA Read
+            // Current Line follows the cmd cursor"): the
+            // ITextProvider currently exposes the screen grid as
+            // a single Document range usable for the review
+            // cursor, but does NOT track a system-caret position.
+            // NVDA's "Read Current Line" (default NVDA+Up Arrow)
+            // and its keyboard-echo path both want a caret —
+            // without one they fall back to "wherever the review
+            // cursor last sat", which drifts away from the cmd
+            // input cursor's actual row.
+            //
+            // Proper fix: implement
+            // `ITextRangeProvider.GetCaretRange` (or equivalent)
+            // backed by `Screen.Cursor.Row` / `Screen.Cursor.Col`,
+            // and fire `AutomationEvents.TextSelectionChangedEvent`
+            // when those values change (Screen already exposes
+            // `SequenceNumber` and `ModeChanged`; a parallel
+            // CursorChanged event would feed this peer). That
+            // unifies multiple Cycle 45-era issues — nav-echo
+            // (#265 / #266 wouldn't be needed; NVDA's native
+            // keyboard echo would Just Work), read-current-line,
+            // and review-cursor-vs-input-cursor coherence. Out of
+            // scope for Cycle 45; scope as its own cycle when
+            // bandwidth allows.
             let result : obj | null = textProvider
             result
         | _ -> base.GetPattern(patternInterface)

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -133,6 +133,20 @@ module ContentHistory =
     /// The complete entry taxonomy. Order of cases doesn't matter
     /// for correctness; this listing matches the canonical
     /// architectural docs.
+    ///
+    /// Cycle 45 backlog (docs/USER-SETTINGS.md "ContentHistory
+    /// semantic labels"): every entry will eventually carry a
+    /// `Source` label distinguishing typed-input from
+    /// cmd-output. The label powers "Output chunk 2 of 5" style
+    /// navigation announces, `Ctrl+Shift+Up/Down` chunk jumps,
+    /// and the maintainer's future "inject this past input into
+    /// current input" action. Cheapest implementation: add a
+    /// `Source: EntrySource` field to each *Data record; set it
+    /// at append-time based on SessionModel's `ActiveTupleState`
+    /// (`AwaitingCommandStart` → TypedInput; `EditingCommand` /
+    /// `OutputStreaming` → CmdOutput). The "chunk index" labels
+    /// can be added as a post-tuple-seal pass that walks the
+    /// entries grouped by Source and writes back the index.
     type Entry =
         | TextSpan of TextSpanData
         | Newline of NewlineData

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -326,6 +326,20 @@ module HotkeyRegistry =
             Modifiers = None
             Description = "Extract the version + environment header (version, OS, .NET, PID) to the clipboard (Cycle 43a; Snapshot)" }
           // Cycle 45 Commit 2 — SpeechCursor navigation. Menu-only.
+          //
+          // Cycle 45 backlog (docs/USER-SETTINGS.md "Speech-cursor
+          // keyboard accelerators"): the maintainer flagged
+          // `Ctrl+Up` / `Ctrl+Down` as natural gestures for
+          // Previous / Next, and `Ctrl+Shift+Up/Down` for
+          // chunk-level jumps (depends on semantic-label work).
+          // Switching from menu-only to gesture-bearing is just
+          // a `Key = None` → `Some (Letter / arrow)` edit + the
+          // matching TerminalView.AppReservedHotkeys mirror row
+          // (the Cycle 26b parity test pins both surfaces).
+          // Verify no NVDA collision before binding —
+          // `Ctrl+Up/Down` should be free in screen-reader mode
+          // (NVDA's default review-cursor commands are
+          // `NVDA+Up/Down`).
           { Command = SpeechCursorNext
             Key = None
             Modifiers = None

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -269,6 +269,16 @@ module SpeechCursor =
                 // Tuple-internal boundary markers don't announce
                 // by themselves. The TextSpans they bracket are
                 // what the user hears.
+                //
+                // Cycle 45 backlog (docs/USER-SETTINGS.md
+                // "Prompt-path verbosity"): future user setting
+                // could announce a shortened form of the prompt
+                // here (final-directory-only, or fully
+                // suppressed) so a sighted-style "I'm in
+                // C:\Users\Kyle\...>" cue is replaced with a
+                // briefer "Kyle>" or with silence. Pull the
+                // prompt text from m.Payload or from
+                // SessionModel.ActivePromptText.
                 None
             | ContentHistory.MarkerKind.Custom _ ->
                 // Future modes will define their own announce

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -766,6 +766,13 @@ public class TerminalView : FrameworkElement
             Key.Delete => col < _screen.Cols - 1 ? col + 1 : (int?)null,
             Key.Left => col > 0 ? col - 1 : (int?)null,
             Key.Right => col < _screen.Cols - 1 ? col + 1 : (int?)null,
+            // Cycle 45 backlog (docs/USER-SETTINGS.md
+            // "Navigation-key announce shape"): future user
+            // setting could announce the entire current line
+            // (or just the typed input portion without the
+            // prompt-path prefix) on Home, instead of the char
+            // at column 0. Hook the configurable behaviour here
+            // by branching on the user-selected mode.
             Key.Home => 0,
             _ => null,
         };


### PR DESCRIPTION
## Summary

Pure documentation + comments. Captures five discrete UX-improvement requests from maintainer dogfood on the post-Cycle-45 build, so future cycles can pick them up without re-discovering the design via another dogfood session.

## What's captured

`docs/USER-SETTINGS.md` gains a new top-level section **"Cycle 45 aural-UX backlog (planned settings + features)"** listing:

1. **Navigation-key announce shape** — Home key alternative to announce the whole line / typed input rather than just the char at col 0.
2. **Prompt-path verbosity** — settings to suppress the full path in announces when the prompt is a long absolute path.
3. **Speech-cursor keyboard accelerators** — Ctrl+Up/Down for Previous/Next; Ctrl+Shift+Up/Down for chunk-level jumps (depends on item 4).
4. **ContentHistory semantic labels (input vs output)** — per-entry `Source` label powering "Output chunk 2 of 5" announces, chunk-jump gestures, and the "inject past input into current input" action.
5. **NVDA Read Current Line follows the cmd cursor** — proper `ITextRangeProvider.GetCaretRange` support in `TerminalAutomationPeer`. Highest-leverage UIA improvement: would eliminate the manual nav-echo from #265/#266 because NVDA's keyboard echo would Just Work natively.

Each entry in the doc carries: current-state description, maintainer-requested behaviour, and the precise insertion point in the code.

## Code-side breadcrumbs

`// Cycle 45 backlog:` markers added at each insertion point so a future contributor (Claude or human) can jump directly to the edit site:

- `src/Views/TerminalView.cs` (`Key.Home` arm of `AnnounceNavigationEcho`)
- `src/Terminal.Core/SpeechCursor.fs` (PromptStart marker rendering in `renderEntry`)
- `src/Terminal.Core/HotkeyRegistry.fs` (SpeechCursor* `builtIns` rows)
- `src/Terminal.Core/ContentHistory.fs` (Entry DU comment)
- `src/Terminal.Accessibility/TerminalAutomationPeer.fs` (`GetPattern` Text arm)

## What this PR is NOT

No behaviour change. No new feature. Pure documentation + inline comments.

## Test plan

- [ ] CI green (link checker validates intra-repo doc references)

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_