### PR TITLE
fix(speech-cursor): announce tuple OutputText on seal, suppress inflated TextSpan auto-announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 45 follow-up): edit-conflated narration on tuple finalise
+
+Maintainer dogfood (2026-05-12): typing `echo hi`, editing the
+command line with arrows / backspace / delete, restoring it to
+`echo hi`, then pressing Enter produced a "very complex and
+strange result" — inflated 23-character and 48-character
+announces that did not match the actual command (`echo hi`,
+7 chars) or output (`hi`, 2 chars).
+
+Root cause: cmd's command-line editing reprints suffix bytes
+each time the cursor moves over them. Every reprint becomes a
+`Print` VtEvent that accumulates into the active `TextSpan` in
+`ContentHistory`. When the span seals (Enter → newline),
+SpeechCursor's AutoDrive auto-announces the inflated span.
+SessionModel's `SessionTuple.CommandText` / `OutputText` were
+already correct — they capture from the screen grid, which is
+the canonical view of "what cmd thinks is on the line" — but
+the SpeechCursor auto-announce path was unaware of them.
+
+Fix:
+
+1. Added `SkipTextSpansInAutoDrive: bool` to
+   `SpeechCursor.Parameters` (defaults `true`). When set,
+   `onAppend` advances the cursor's `Position` and
+   `LastSpokenSeq` for TextSpan entries without firing an
+   announce; Manual navigation can still revisit them.
+2. `Program.fs handlePromptBoundary` announces
+   `SessionTuple.OutputText` on tuple finalise. Authoritative
+   source: screen-grid-derived capture at the
+   PromptStart-after-completion transition.
+
+Trade-off: streaming output no longer auto-announces line-by-
+line until the next tuple seals. That's the right shape for
+cmd / PowerShell short commands (which always seal on Enter)
+but a regression for long-running streaming workloads
+(Claude's thinking text, `ping -t`, etc.). Cycle 45f will
+introduce per-shell verbosity modes that toggle streaming
+auto-announce back on for streaming-heavy shells.
+
 ### Fixed (Cycle 45 follow-up): Right-arrow + Delete nav-echo direction
 
 Maintainer NVDA dogfood on the post-#265 build confirmed that

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1596,6 +1596,27 @@ module Program =
             // through completed commands. Reset on shell-switch
             // (in `switchToShell` below) still fires; that's a
             // legitimate fresh-slate boundary.
+            // Cycle 45 fixup (2026-05-12) — tuple-finalise output
+            // announce. cmd's command-line editing reprints suffix
+            // bytes whose Print events accumulate into the active
+            // TextSpan, so auto-announcing TextSpans on seal produces
+            // inflated narrations that don't match what the user
+            // actually ran. SessionModel's `SessionTuple` captures
+            // CommandText + OutputText from the screen grid at
+            // finalise time (authoritative) — announce OutputText
+            // here on tuple seal as the user-facing "what did the
+            // shell print" cue. SpeechCursor's TextSpan auto-
+            // announce is suppressed by default
+            // (`Parameters.SkipTextSpansInAutoDrive`); Manual
+            // navigation can still revisit individual TextSpans.
+            // Cycle 45f will introduce verbosity modes that govern
+            // streaming-vs-tuple-final policy per shell.
+            let tupleFinaliseAnnounce =
+                match finalisedOpt with
+                | Some tuple
+                    when not (System.String.IsNullOrWhiteSpace tuple.OutputText) ->
+                    Some tuple.OutputText
+                | _ -> None
             let boundaryAction () =
                 match markerKind with
                 | Some k ->
@@ -1606,6 +1627,10 @@ module Program =
                         speechCursor
                         contentHistory
                         speechCursorAnnounce
+                | None -> ()
+                match tupleFinaliseAnnounce with
+                | Some text ->
+                    speechCursorAnnounce (text, ActivityIds.output)
                 | None -> ()
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
             |> ignore

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -62,12 +62,35 @@ module SpeechCursor =
           /// When true, AutoDrive suspends on `SelectionShown`
           /// (and resumes on `SelectionDismissed`). Defaults
           /// true; the standard interaction-mode handoff.
-          SuspendAutoDriveOnSelection: bool }
+          SuspendAutoDriveOnSelection: bool
+          /// When true, AutoDrive does NOT announce `TextSpan`
+          /// entries; the cursor still advances (Position +
+          /// LastSpokenSeq) so Manual navigation can revisit
+          /// them, but no live announce fires.
+          ///
+          /// Cycle 45 fixup (2026-05-12): cmd's command-line
+          /// editing (arrows / backspace / delete reflowing the
+          /// suffix) reprints suffix bytes whose `Print` events
+          /// accumulate into the active TextSpan. Auto-
+          /// announcing that span on seal produces inflated /
+          /// edit-history-conflated narrations that do not
+          /// match the actual `CommandText` / `OutputText`
+          /// SessionModel captures from the screen grid. The
+          /// authoritative source for "what did the user run +
+          /// what did the shell print" is `SessionTuple` (see
+          /// `SessionModel.SessionTuple.{CommandText,OutputText}`);
+          /// `Program.fs handlePromptBoundary` announces that
+          /// on tuple finalise. SpeechCursor's TextSpan-by-
+          /// TextSpan auto-announce stays suppressed by default
+          /// until verbosity-mode work (Cycle 45f) introduces
+          /// per-shell streaming-vs-tuple-final policy.
+          SkipTextSpansInAutoDrive: bool }
 
     let defaultParameters : Parameters =
         { InitialMode = AutoDrive
           SkipSpinnersInAutoDrive = true
-          SuspendAutoDriveOnSelection = true }
+          SuspendAutoDriveOnSelection = true
+          SkipTextSpansInAutoDrive = true }
 
     /// Cursor state. Mutated in-place by the navigation /
     /// announce APIs. Single-threaded by convention (dispatcher
@@ -221,6 +244,12 @@ module SpeechCursor =
     /// bell on `pty-speak.output` (no dedicated id for bell-via-
     /// announce; the earcon channel handles the audible cue
     /// separately).
+    ///
+    /// Note: AutoDrive's TextSpan-skip behaviour
+    /// (`Parameters.SkipTextSpansInAutoDrive`) is enforced in
+    /// `onAppend`, not here. Manual navigation (`speakCurrent`)
+    /// still renders TextSpans so the user can review them
+    /// explicitly.
     let renderEntry (entry: ContentHistory.Entry) : (string * string) option =
         match entry with
         | ContentHistory.TextSpan d ->
@@ -390,14 +419,26 @@ module SpeechCursor =
                 | _ -> ()
 
                 // (2) Announce decision uses the current effective
-                //     drive.
+                //     drive. TextSpan entries advance the cursor
+                //     silently when SkipTextSpansInAutoDrive is on
+                //     (the default, per the Cycle 45 fixup note on
+                //     Parameters): the live announce is suppressed
+                //     but Position + LastSpokenSeq still update so
+                //     Manual navigation finds them and the
+                //     "already spoken?" gate stays monotonic.
                 if autoDriveActive state && autoDriveAdvanceable state entry then
                     if s > state.Position then
                         state.Position <- s
-                    match renderEntry entry with
-                    | Some (text, activityId) ->
-                        announce (text, activityId)
-                    | None -> ()
+                    let suppressTextSpan =
+                        match entry with
+                        | ContentHistory.TextSpan _ ->
+                            state.Parameters.SkipTextSpansInAutoDrive
+                        | _ -> false
+                    if not suppressTextSpan then
+                        match renderEntry entry with
+                        | Some (text, activityId) ->
+                            announce (text, activityId)
+                        | None -> ()
                     state.LastSpokenSeq <- s
 
                 // (3) Post-suspend modulation: SelectionShown sets

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -35,6 +35,18 @@ let private freshHistory () : ContentHistory.T =
 let private freshCursor () : SpeechCursor.T =
     SpeechCursor.create SpeechCursor.defaultParameters
 
+/// Cycle 45 fixup (2026-05-12): the default
+/// `SkipTextSpansInAutoDrive = true` suppresses TextSpan
+/// auto-announce in production (cmd's edit-suffix-reprint
+/// pattern would otherwise produce inflated narrations).
+/// Tests that pin the underlying TextSpan-announce mechanism
+/// (so verbosity-mode work can still toggle it back on per
+/// shell) construct a cursor with the flag flipped off.
+let private cursorWithTextSpanAnnounce () : SpeechCursor.T =
+    SpeechCursor.create
+        { SpeechCursor.defaultParameters with
+            SkipTextSpansInAutoDrive = false }
+
 /// Capture-collector for announce callbacks. Returns the
 /// callback + a getter for the accumulated (text, activityId)
 /// pairs.
@@ -64,7 +76,11 @@ let ``new cursor starts in AutoDrive at Position -1 with nothing spoken`` () =
 
 [<Fact>]
 let ``AutoDrive announces appended TextSpans in seq order`` () =
-    let cursor = freshCursor ()
+    // Uses the TextSpan-announce variant: the production
+    // default suppresses TextSpan auto-announce
+    // (`SkipTextSpansInAutoDrive = true`), so this test
+    // explicitly opts the underlying mechanism back on.
+    let cursor = cursorWithTextSpanAnnounce ()
     let history = freshHistory ()
     let announce, snap = capture ()
     ContentHistory.appendFromEvent history t0 (printRune 'h') |> ignore
@@ -81,8 +97,34 @@ let ``AutoDrive announces appended TextSpans in seq order`` () =
     Assert.True(cursor.LastSpokenSeq >= 0L)
 
 [<Fact>]
-let ``AutoDrive does not re-announce entries it has already spoken`` () =
+let ``AutoDrive default suppresses TextSpan announces but advances cursor`` () =
+    // Cycle 45 fixup (2026-05-12): `SkipTextSpansInAutoDrive`
+    // defaults to true so cmd's edit-suffix-reprint pattern
+    // doesn't produce inflated narrations. The cursor still
+    // advances (Position + LastSpokenSeq) so Manual review
+    // can revisit the entry. Authoritative output-narration
+    // happens at tuple-finalise via `SessionTuple.OutputText`
+    // (see `Program.fs handlePromptBoundary`).
     let cursor = freshCursor ()
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    ContentHistory.appendFromEvent history t0 (printRune 'h') |> ignore
+    ContentHistory.appendFromEvent history t0 (printRune 'i') |> ignore
+    ContentHistory.appendFromEvent history t0 lf |> ignore
+    SpeechCursor.onAppend cursor history announce
+    // No live announce — the TextSpan is silenced under the
+    // new default.
+    Assert.Empty(snap ())
+    // Cursor still advanced and the watermark moved, so the
+    // entry is reachable via Manual navigation and won't be
+    // re-spoken on a duplicate onAppend call.
+    let latest = ContentHistory.latestSeq history
+    Assert.Equal(latest, cursor.Position)
+    Assert.Equal(latest, cursor.LastSpokenSeq)
+
+[<Fact>]
+let ``AutoDrive does not re-announce entries it has already spoken`` () =
+    let cursor = cursorWithTextSpanAnnounce ()
     let history = freshHistory ()
     let announce, snap = capture ()
     ContentHistory.appendFromEvent history t0 (printRune 'a') |> ignore
@@ -245,7 +287,12 @@ let ``toMarker with no matching kind returns None`` () =
 
 [<Fact>]
 let ``SelectionShown marker suspends AutoDrive announces`` () =
-    let cursor = freshCursor ()
+    // Uses the TextSpan-announce variant so the "X" suffix
+    // suppression is checked against an actually-announceable
+    // TextSpan (under the production default, TextSpans are
+    // silenced regardless of suspend state — the suppression
+    // would be untestable without flipping the flag).
+    let cursor = cursorWithTextSpanAnnounce ()
     let history = freshHistory ()
     let announce, snap = capture ()
     ContentHistory.appendFromEvent history t0 (printRune 'h') |> ignore
@@ -276,7 +323,10 @@ let ``SelectionShown marker suspends AutoDrive announces`` () =
 
 [<Fact>]
 let ``SelectionDismissed marker resumes AutoDrive announces`` () =
-    let cursor = freshCursor ()
+    // Uses the TextSpan-announce variant so "Z" is a
+    // detectable resume signal (TextSpans are silenced under
+    // the production default).
+    let cursor = cursorWithTextSpanAnnounce ()
     let history = freshHistory ()
     let announce, snap = capture ()
     ContentHistory.appendMarker


### PR DESCRIPTION
## Summary

Maintainer dogfood (2026-05-12): typing `echo hi`, editing the command line with arrows / backspace / delete, restoring it to `echo hi`, then pressing Enter produced a "very complex and strange result" — inflated 23-character and 48-character announces that did not match the actual command (`echo hi`, 7 chars) or output (`hi`, 2 chars).

### Root cause

cmd reprints suffix bytes each time the cursor moves over them during command-line editing. Every reprint produces a `Print` VtEvent that accumulates into the active `TextSpan` in `ContentHistory`. When the span seals (Enter → newline), SpeechCursor's AutoDrive auto-announces the inflated span. SessionModel's `SessionTuple.CommandText` / `OutputText` were already correct — they capture from the screen grid, which is the canonical view of "what cmd thinks is on the line" — but the SpeechCursor auto-announce path was unaware of them.

### Fix

1. Added `SkipTextSpansInAutoDrive: bool` to `SpeechCursor.Parameters` (defaults `true`). When set, `onAppend` advances the cursor's `Position` and `LastSpokenSeq` for TextSpan entries without firing an announce; Manual navigation can still revisit them.
2. `Program.fs handlePromptBoundary` announces `SessionTuple.OutputText` on tuple finalise. Authoritative source: screen-grid-derived capture at the PromptStart-after-completion transition.

### Trade-off (deferred to Cycle 45f)

Streaming output no longer auto-announces line-by-line until the next tuple seals. That's the right shape for cmd / PowerShell short commands (which always seal on Enter) but a regression for long-running streaming workloads (Claude's thinking text, `ping -t`, etc.). Cycle 45f will introduce per-shell verbosity modes that toggle streaming auto-announce back on for streaming-heavy shells.

## Test plan

- [x] CI green on the modified `SpeechCursorTests.fs` (existing TextSpan-announce assertions migrated to a `cursorWithTextSpanAnnounce` helper; new test pins the default-suppress + cursor-advance behaviour)
- [ ] Maintainer NVDA dogfood: `echo hi` (no editing) → NVDA announces "hi" on Enter
- [ ] Maintainer NVDA dogfood: `echo hi` with arrow / backspace / delete editing, then restore + Enter → NVDA announces "hi" (not the inflated 23 / 48 char garbage)
- [ ] `dir` in cmd → NVDA announces the full output on Enter (single tuple-seal announce; not line-by-line streaming — that's the deferred verbosity-modes work)
- [ ] Speech-cursor Next / Previous still navigates to individual TextSpan entries via Manual mode (Position + LastSpokenSeq still advance under suppression)

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_