### PR TITLE
feat(earcon): ready-for-input chime + semantic-output-rendering backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 45 follow-up): ready-for-input earcon
+
+A brief 1200Hz × 60ms chime now plays when the shell finishes a
+command and is ready for the next input. The chime routes
+through the existing `EarconChannel` (WASAPI on a separate
+audio stream from NVDA's TTS), so it plays **concurrently with**
+— and does **not interrupt** — NVDA's read-back of the command
+output. Honours the existing `View → Earcons → Enabled / Muted`
+toggle.
+
+Trigger: `Program.fs handlePromptBoundary` emits a new
+`SemanticCategory.ReadyForInput` OutputEvent when
+`SessionModel.applyAndCapture` returns `finalisedOpt = Some
+tuple` (i.e. a real command-finished boundary, not just a
+prompt redraw). `EarconProfile` maps the new semantic to a new
+`"ready-prompt"` palette entry. Empty payload means
+`NvdaChannel` skips its decision, so the chime never produces
+double speech.
+
+The earcon is audibly distinct from the existing `"bell-ping"`
+(800Hz × 100ms) so users hearing both within a session can
+distinguish "shell BEL'd at me" from "shell finished a command."
+
 ### Fixed (Cycle 45 follow-up): edit-conflated narration on tuple finalise
 
 Maintainer dogfood (2026-05-12): typing `echo hi`, editing the

--- a/docs/USER-SETTINGS.md
+++ b/docs/USER-SETTINGS.md
@@ -2404,3 +2404,68 @@ Insertion points:
 - `src/Terminal.Core/Config.fs` — `ShellOverrides` becomes
   user-supplied overrides ON TOP of the default policy table
 
+### Semantic output rendering — navigable units instead of stream chunks
+
+Captured 2026-05-12 from maintainer dogfood on the
+PR #268 build. Validated outcomes:
+
+- `echo hi` with arrow / backspace / delete editing now
+  narrates cleanly as "hi" (the screen-grid-derived
+  `SessionTuple.OutputText`) instead of the inflated edit-
+  conflated TextSpan from before #268.
+- Long `dir` output reads all the way to the end without
+  truncation; NVDA chunks the payload internally with small
+  pauses between chunks.
+
+Maintainer observation from this dogfood: the inter-chunk
+pauses on long outputs are NVDA's natural read cadence over a
+single `ImportantAll` payload — we don't control the pause
+from the producer side. The next-level shape, which the
+maintainer explicitly raised, is to **render output in a
+semantically navigable format** so the user navigates units
+(rows of `dir`, individual error lines, individual `git log`
+entries, individual `ping` echoes, etc.) rather than waiting
+for NVDA's read-back to traverse a single multi-kilobyte
+payload.
+
+This is not a single feature — it's the natural endpoint of
+work already flagged in the strategic plan. Explicit linkage:
+
+- **Cycle 45e** (ContentHistory-driven visual surface for
+  sighted-pair collaboration, per `PROJECT-PLAN-2026-05-09.md`
+  and `CORE-ABSTRACTION-BOUNDARY.md`) introduces the
+  ContentHistory → primary visual rendering and routes the
+  UIA Document at the same data. Once that lands, NVDA's
+  review cursor speaks the same per-entry units the visual
+  surface highlights — semantic navigation Just Works for
+  any output ContentHistory has typed entries for.
+- **Cycle 45f** (verbosity modes) introduces per-shell
+  streaming-vs-tuple-final policy AND the
+  `ContentHistory.Entry.Source` semantic label work (see
+  "ContentHistory semantic labels (input vs output)" above)
+  — those labels are the input-vs-output dimension of the
+  unit taxonomy. Per-line / per-section / per-chunk units
+  are the orthogonal dimension and would come from per-
+  shell or per-output-type detectors.
+- **Per-shell policy table** (above) — the unit-detector for
+  cmd's `dir` (one row per file), Claude Code's streaming
+  response (one chunk per dialogue turn), `git log` (one
+  entry per commit), etc. each becomes a row in the policy
+  table rather than scattered inline logic. New shells / new
+  output types plug in as additional rows.
+
+The headline payoff for the screen-reader UX: SpeechCursor
+Next / Previous (and the Ctrl+Up/Down accelerators above)
+moves the user through SEMANTIC units regardless of how the
+underlying shell happened to draw them. `dir` becomes 50
+navigable rows; `git log` becomes one navigable commit at a
+time; Claude's streaming response becomes one navigable
+paragraph; the inter-chunk NVDA pause is replaced by the
+user's own pace.
+
+Scope: substantial — depends on Cycle 45e's visual surface
+landing first AND Cycle 45f's semantic-label work. Worth
+naming explicitly here so the connection between the three
+cycles is documented; the actual implementation slots after
+they settle.
+

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1635,6 +1635,27 @@ module Program =
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
             |> ignore
 
+            // Cycle 45 (2026-05-12) — ready-for-input earcon. When a
+            // tuple just sealed (a command actually completed, not
+            // just a prompt redraw), fire a `ReadyForInput`
+            // OutputEvent. The EarconProfile maps this to
+            // `ready-prompt` (1200Hz × 60ms chime); EarconChannel
+            // plays on a separate WASAPI stream, non-blocking, so
+            // NVDA's read-back of the OutputText (queued above via
+            // window.Dispatcher) is NOT interrupted — the chime and
+            // the speech play concurrently. Empty payload means
+            // NvdaChannel skips its decision (no double-up).
+            // Honours the existing View → Earcons → Enabled / Muted
+            // toggle (the channel itself short-circuits when muted).
+            if finalisedOpt.IsSome then
+                let readyEvent =
+                    OutputEvent.create
+                        SemanticCategory.ReadyForInput
+                        Priority.Background
+                        "session-model"
+                        ""
+                OutputDispatcher.dispatch readyEvent
+
             let emitted = activePathway.OnPromptBoundary augmented
             pumpLog.LogDebug(
                 "PathwayPump PromptBoundary {Kind} → {Pathway}.OnPromptBoundary → {Count} events.",

--- a/src/Terminal.Audio/EarconPalette.fs
+++ b/src/Terminal.Audio/EarconPalette.fs
@@ -30,8 +30,8 @@ module EarconPalette =
     /// compatibility (Phase 2).
     type EarconId = string
 
-    /// Default palette. Three entries — the audio side of the
-    /// 8d sub-stages.
+    /// Default palette. Four entries — the audio side of the
+    /// 8d sub-stages plus the Cycle 45 ready-for-input cue.
     /// - `bell-ping` (800Hz × 100ms): triggered by BEL (0x07).
     /// - `error-tone` (400Hz × 150ms): triggered by future
     ///   colour-detection (red rows). Currently unused by any
@@ -44,6 +44,15 @@ module EarconPalette =
     ///   colour-detection (yellow rows). Same status as
     ///   error-tone — present in the palette for diagnostic
     ///   coverage, no producer wired yet.
+    /// - `ready-prompt` (1200Hz × 60ms): Cycle 45 — a brief
+    ///   high-pitched chime fired when a command finishes and
+    ///   the shell is ready for the next input. Higher-pitched
+    ///   + shorter than `bell-ping` so it's audibly distinct
+    ///   from the BEL ping; brief enough that consecutive
+    ///   commands don't overlap. Routes through the same
+    ///   non-blocking WASAPI stream as every other earcon, so
+    ///   it plays alongside NVDA's read-back of the OutputText
+    ///   without interrupting speech.
     /// All earcons stay shorter than the StreamProfile's 200ms
     /// debounce window so consecutive earcons don't overlap.
     /// Tunable in Phase 2 via TOML.
@@ -60,4 +69,8 @@ module EarconPalette =
               "warning-tone",
               { FrequencyHz = 600.0
                 DurationMs = 120
-                AttackMs = 10 } ]
+                AttackMs = 10 }
+              "ready-prompt",
+              { FrequencyHz = 1200.0
+                DurationMs = 60
+                AttackMs = 5 } ]

--- a/src/Terminal.Core/CanonicalCorpus.fs
+++ b/src/Terminal.Core/CanonicalCorpus.fs
@@ -150,6 +150,7 @@ module CanonicalCorpus =
         | "AltScreenEntered" -> Some SemanticCategory.AltScreenEntered
         | "ModeBarrier" -> Some SemanticCategory.ModeBarrier
         | "ParserError" -> Some SemanticCategory.ParserError
+        | "ReadyForInput" -> Some SemanticCategory.ReadyForInput
         | _ -> None
 
     let private parsePaneRouting (s: string) : PaneRouting option =

--- a/src/Terminal.Core/EarconProfile.fs
+++ b/src/Terminal.Core/EarconProfile.fs
@@ -91,6 +91,17 @@ module EarconProfile =
                         event,
                         [| earconDecision "warning-tone" |]
                     |]
+                | SemanticCategory.ReadyForInput ->
+                    // Cycle 45 — shell-ready cue. 1200Hz × 60ms
+                    // chime; non-interrupting (separate WASAPI
+                    // stream from NVDA's TTS). Empty Payload on
+                    // the producer side so NvdaChannel skips —
+                    // earcon plays alongside the OutputText
+                    // read-back without doubling.
+                    [|
+                        event,
+                        [| earconDecision "ready-prompt" |]
+                    |]
                 | _ ->
                     // No earcon for other Semantic categories.
                     [||]

--- a/src/Terminal.Core/NvdaChannel.fs
+++ b/src/Terminal.Core/NvdaChannel.fs
@@ -83,7 +83,8 @@ module NvdaChannel =
         | SemanticCategory.BellRang
         | SemanticCategory.HyperlinkOpened
         | SemanticCategory.PromptDetected
-        | SemanticCategory.CommandSubmitted -> ActivityIds.output
+        | SemanticCategory.CommandSubmitted
+        | SemanticCategory.ReadyForInput -> ActivityIds.output
         | SemanticCategory.Custom _ -> ActivityIds.output
 
     /// Construct a Channel that announces via the supplied

--- a/src/Terminal.Core/OutputEventTypes.fs
+++ b/src/Terminal.Core/OutputEventTypes.fs
@@ -103,6 +103,18 @@ type SemanticCategory =
     /// activates in 8b/8c when profiles + channels start
     /// reading `Priority`.
     | ParserError
+    /// Cycle 45 — fired when a tuple finalises (a command
+    /// completed AND the shell has redrawn the next prompt).
+    /// Carries an empty payload; the EarconProfile maps this
+    /// to `ready-prompt` so the user hears a brief audible
+    /// "shell is ready for the next input" cue alongside NVDA's
+    /// read-back of the OutputText. NvdaChannel skips empty
+    /// payloads so this never produces speech — earcon-only.
+    /// Producer: `Program.fs handlePromptBoundary` on the
+    /// PromptStart-after-completion transition (i.e. only when
+    /// `SessionModel.applyAndCapture` returns `finalisedOpt =
+    /// Some tuple`, not on the very first prompt of a session).
+    | ReadyForInput
     /// User-defined event category. The string is the stable
     /// identifier the producer chooses (e.g. a third-party
     /// Phase 2 extension's "git-prompt-segment"). The `Custom`

--- a/tests/Tests.Unit/EarconProfileTests.fs
+++ b/tests/Tests.Unit/EarconProfileTests.fs
@@ -130,6 +130,23 @@ let ``WarningLine Apply emits one pair with warning-tone ChannelDecision`` () =
     | other -> Assert.Fail(sprintf "Expected RenderEarcon; got %A" other)
 
 [<Fact>]
+let ``ReadyForInput Apply emits one pair with ready-prompt ChannelDecision`` () =
+    // Cycle 45 — fired by `Program.fs handlePromptBoundary`
+    // on tuple finalise. Maps to the 1200Hz × 60ms chime
+    // defined in `EarconPalette.defaultPalette`.
+    let profile = EarconProfile.create ()
+    let event = buildEvent SemanticCategory.ReadyForInput
+    let pairs = profile.Apply event
+    Assert.Equal(1, pairs.Length)
+    let _, decisions = pairs.[0]
+    Assert.Equal(1, decisions.Length)
+    Assert.Equal(EarconChannel.id, decisions.[0].Channel)
+    match decisions.[0].Render with
+    | RenderEarcon earconId ->
+        Assert.Equal("ready-prompt", earconId)
+    | other -> Assert.Fail(sprintf "Expected RenderEarcon; got %A" other)
+
+[<Fact>]
 let ``Custom Semantic Apply returns empty pair array`` () =
     let profile = EarconProfile.create ()
     let event = buildEvent (SemanticCategory.Custom "user-event")


### PR DESCRIPTION
## Summary

Bundles two Cycle 45 follow-ups:

### Feature: ready-for-input earcon (commit 2)

A brief 1200Hz × 60ms chime now plays when the shell finishes a command and is ready for the next input. Routed through the existing `EarconChannel` (WASAPI on a separate audio stream from NVDA's TTS), so it plays **concurrently with** — and does **not interrupt** — NVDA's read-back of the OutputText. Honours the existing `View → Earcons → Enabled / Muted` toggle.

- New `SemanticCategory.ReadyForInput` arm
- New `"ready-prompt"` palette entry (1200Hz × 60ms × 5ms attack — audibly distinct from `bell-ping` at 800Hz)
- `EarconProfile` maps the semantic to the palette entry
- `Program.fs handlePromptBoundary` emits the event when `finalisedOpt = Some tuple` (real command-finished boundary, not every prompt redraw)
- `NvdaChannel.semanticToActivityId` extended for exhaustiveness; empty payload means no double speech
- `EarconProfileTests` pins the new mapping

### Docs: link semantic output rendering to Cycle 45e + 45f + per-shell policy (commit 1)

Maintainer dogfood on PR #268 validated tuple-finalise announce. Flagged the natural next step: render output as semantically navigable units. Documents the three-way linkage between Cycle 45e (visual surface), Cycle 45f (verbosity + semantic labels), and the per-shell policy table.

## Test plan

- [x] CI green (link check + Windows build + lints)
- [ ] Maintainer NVDA dogfood: run a cmd command; hear the OutputText narration AND a brief high-pitched chime layered over it (not blocking speech)
- [ ] Earcons → Muted: chime falls silent; OutputText narration unchanged
- [ ] Bell character (`echo \a` or similar): bell-ping plays (still 800Hz, distinct from ready-prompt's 1200Hz)
- [ ] Long-running command + Ctrl+C: ready-prompt chime still fires on the resulting tuple seal

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5