### PR TITLE
feat(verbosity): Cycle 45f — per-shell verbosity modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,56 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 45f): per-shell verbosity modes
+
+Two new menu items under `Display`:
+
+- **`Output Verbosity`** (Tuple Final / Line By Line / Off):
+  governs how streaming output narrates per shell. `Tuple
+  Final` (cmd / PowerShell default) keeps PR #268's behaviour
+  — `SessionTuple.OutputText` announces on each tuple seal,
+  individual TextSpans stay quiet during the streaming
+  window. `Line By Line` announces each `TextSpan` as it seals
+  — intended for Claude / `ping -t` / other streaming-heavy
+  shells where the user wants mid-stream cues. `Off` suppresses
+  every streaming AND tuple-finalise announce; SpeechCursor's
+  manual navigation (Next / Previous / Jump To Latest) is the
+  only way to hear output.
+- **`Prompt Path`** (Suppress / Final Directory Only / Full):
+  governs how `PromptStart` markers narrate their payload.
+  `Suppress` (default for every shell) returns nothing.
+  `Final Directory Only` trims path-like prompts to the last
+  directory segment + delimiter (e.g. `"Local>"` from
+  `"C:\Users\Kyle\AppData\Local\>"`). `Full` narrates verbatim.
+
+### Three-layer settings model (Cycle 45f)
+
+A new `src/Terminal.Core/ShellPolicy.fs` module carries the
+per-shell policy record. The effective policy at any moment
+is resolved through three overlay layers:
+
+1. **Compiled defaults** — `ShellPolicy.defaults`; hardcoded
+   baseline per shell.
+2. **TOML user config** — `[shell.<id>] verbosity = "…"` and
+   `prompt_path = "…"` in `config.toml`. Persists across
+   restarts. Loaded once at startup; overlayed on Layer 1 via
+   `Config.resolveShellPolicy`.
+3. **Runtime overrides** — menu picks. Per-shell, ephemeral
+   (lost on app restart). Hot-switching cmd → Claude → cmd
+   preserves the cmd override; switching to Claude reads
+   Claude's own (separate) override / TOML / default.
+
+Defaults match today's behaviour exactly — cmd / PowerShell /
+Claude all start at `Tuple Final` + `Suppress`. No regression
+on the post-#270 baseline.
+
+The `ShellPolicy` record also reserves seats for the Cycle
+45g consolidation refactor (PromptRegex, PromptStabilityMs,
+SelectionEnabled mirroring `HeuristicPromptDetector.fs:184`
+and `SelectionDetector.fs` shell gate). 45g migrates those
+inline match arms to read from the table; 45f keeps them
+inert so this PR stays small.
+
 ### Added (Cycle 45 follow-up): ready-for-input earcon
 
 A brief 1200Hz × 60ms chime now plays when the shell finishes a

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1429,8 +1429,9 @@ module Program =
                 | ShellPolicy.TupleFinalOnly -> true
                 | ShellPolicy.LineByLine -> false
                 | ShellPolicy.Off -> true
+            let current = SpeechCursor.getParameters speechCursor
             let parameters =
-                { speechCursor.Parameters with
+                { current with
                     SkipTextSpansInAutoDrive = skipText
                     PromptPath = resolved.PromptPath }
             SpeechCursor.setParameters speechCursor parameters

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1388,6 +1388,53 @@ module Program =
         let mutable currentShellId : ShellRegistry.ShellId =
             ShellRegistry.Cmd
 
+        // Cycle 45f — per-shell verbosity policy. Resolved at
+        // shell-switch time through a three-layer model:
+        //   1. ShellPolicy.defaults (compiled baseline)
+        //   2. Config.resolveShellPolicy (TOML overlay)
+        //   3. runtimeShellPolicy (menu-driven runtime override;
+        //      lost on app restart)
+        //
+        // `currentShellPolicy` always carries the effective
+        // policy for the active shell — handlePromptBoundary
+        // reads its `Streaming` to gate the tuple-finalise
+        // announce; switchToShell + the View → Output Verbosity
+        // menu mutate it via `applyShellPolicy`.
+        let mutable currentShellPolicy : ShellPolicy.T =
+            ShellPolicy.forShell (shellIdToConfigKey ShellRegistry.Cmd)
+        let mutable runtimeShellPolicy : Map<string, ShellPolicy.T> =
+            Map.empty
+
+        // Resolve and apply the effective policy for `shellKey`
+        // through the three-layer overlay (runtime → TOML →
+        // compiled defaults). Updates `currentShellPolicy` AND
+        // pushes the verbosity dials into
+        // `speechCursor.Parameters` so subsequent `onAppend`
+        // invocations observe the new policy.
+        //
+        // Call sites:
+        //   - Startup-shell alignment (after `chosenShell` resolves)
+        //   - `switchToShell`'s `Ok newHost` branch
+        //   - `View → Output Verbosity` / `Prompt Path` menu picks
+        //     (which write to `runtimeShellPolicy` first, then
+        //     call this to push the change into SpeechCursor)
+        let applyShellPolicy (shellKey: string) : unit =
+            let resolved =
+                match Map.tryFind shellKey runtimeShellPolicy with
+                | Some p -> p
+                | None -> Config.resolveShellPolicy config shellKey
+            currentShellPolicy <- resolved
+            let skipText =
+                match resolved.Streaming with
+                | ShellPolicy.TupleFinalOnly -> true
+                | ShellPolicy.LineByLine -> false
+                | ShellPolicy.Off -> true
+            let parameters =
+                { speechCursor.Parameters with
+                    SkipTextSpansInAutoDrive = skipText
+                    PromptPath = resolved.PromptPath }
+            SpeechCursor.setParameters speechCursor parameters
+
         // SessionModel Tier 1.C — structured-history substrate.
         // One instance per shell session; replaced on
         // Ctrl+Shift+1/2/3 hot-switch (per Q5 resolution
@@ -1605,23 +1652,38 @@ module Program =
             // CommandText + OutputText from the screen grid at
             // finalise time (authoritative) — announce OutputText
             // here on tuple seal as the user-facing "what did the
-            // shell print" cue. SpeechCursor's TextSpan auto-
-            // announce is suppressed by default
-            // (`Parameters.SkipTextSpansInAutoDrive`); Manual
-            // navigation can still revisit individual TextSpans.
-            // Cycle 45f will introduce verbosity modes that govern
-            // streaming-vs-tuple-final policy per shell.
+            // shell print" cue.
+            //
+            // Cycle 45f (2026-05-12) — gate the tuple-finalise
+            // announce on `currentShellPolicy.Streaming`. Under
+            // `TupleFinalOnly` (cmd / PowerShell default) the
+            // announce fires as before. Under `LineByLine` the
+            // per-TextSpan announces already covered the output;
+            // suppressing here avoids double-narration. Under `Off`
+            // both streaming AND tuple-finalise are silent —
+            // SpeechCursor manual navigation is the only way to
+            // hear output.
             let tupleFinaliseAnnounce =
-                match finalisedOpt with
-                | Some tuple
+                match finalisedOpt, currentShellPolicy.Streaming with
+                | Some tuple, ShellPolicy.TupleFinalOnly
                     when not (System.String.IsNullOrWhiteSpace tuple.OutputText) ->
                     Some tuple.OutputText
+                | _ -> None
+            // Cycle 45f — pass `MatchedRowText` as the PromptStart
+            // marker's payload so SpeechCursor.renderEntryWithPolicy
+            // can apply the per-shell `PromptPathMode` (Suppress /
+            // FinalDirOnly / Full). Other marker kinds carry no
+            // payload (renderEntry returns None for them anyway).
+            let markerPayload =
+                match markerKind with
+                | Some ContentHistory.MarkerKind.PromptStart ->
+                    augmented.MatchedRowText
                 | _ -> None
             let boundaryAction () =
                 match markerKind with
                 | Some k ->
                     ContentHistory.appendMarker
-                        contentHistory k DateTime.UtcNow None
+                        contentHistory k DateTime.UtcNow markerPayload
                     |> ignore
                     SpeechCursor.onAppend
                         speechCursor
@@ -2184,6 +2246,14 @@ module Program =
         // resolves to the correct pathway for the running
         // shell.
         currentShellId <- chosenShell.Id
+
+        // Cycle 45f — apply the startup shell's verbosity policy
+        // before any reader output flows. Layer 1 + Layer 2
+        // (compiled defaults + TOML overlay; Layer 3 is empty at
+        // startup). This pushes `Streaming` / `PromptPath` into
+        // `speechCursor.Parameters` so the first PromptStart
+        // marker + first tuple seal respect the policy.
+        applyShellPolicy (shellIdToConfigKey chosenShell.Id)
 
         // Cycle 38b — resolve the active profile set for the
         // chosen shell. Defined here (after `chosenShell` is
@@ -3396,6 +3466,24 @@ module Program =
                                         // dispatcher thread.
                                         ContentHistory.reset contentHistory
                                         SpeechCursor.reset speechCursor
+                                        // Cycle 45f — apply the
+                                        // new shell's verbosity
+                                        // policy through the
+                                        // three-layer overlay
+                                        // (runtime → TOML →
+                                        // compiled defaults).
+                                        // Runs AFTER
+                                        // SpeechCursor.reset (so
+                                        // Position / LastSpokenSeq
+                                        // are clean for the new
+                                        // shell's history) and
+                                        // BEFORE wirePostSpawn
+                                        // below, so the first
+                                        // paint of the new shell
+                                        // narrates under the
+                                        // right policy.
+                                        applyShellPolicy
+                                            (shellIdToConfigKey shell.Id)
                                         // Cycle 38b — re-resolve
                                         // the active profile set
                                         // for the new shell so its
@@ -3572,6 +3660,112 @@ module Program =
                                 | _ -> "Debug logging off."
                             window.TerminalSurface.Announce(cue, ActivityIds.logToggle))
         multiStateBindings.[HotkeyRegistry.LoggingLevel] <- loggingBinding
+
+        // Cycle 45f — Output Verbosity menu binding. Menu pick
+        // writes to `runtimeShellPolicy.[currentShellKey]`
+        // (Layer 3 of the three-layer settings model) then
+        // `applyShellPolicy` pushes the new policy into
+        // `speechCursor.Parameters`. Subsequent
+        // `SpeechCursor.onAppend` invocations observe the new
+        // mode; entries already announced under the previous
+        // policy stay announced (no rewind).
+        let outputVerbosityLog =
+            Logger.get "Terminal.App.Program.bindMultiState.OutputVerbosity"
+        let outputVerbosityDef =
+            HotkeyRegistry.multiStateOf HotkeyRegistry.OutputVerbosity
+        let outputVerbosityBinding =
+            bindMultiState
+                window
+                outputVerbosityDef
+                (fun () ->
+                    match currentShellPolicy.Streaming with
+                    | ShellPolicy.TupleFinalOnly -> "tuple_final"
+                    | ShellPolicy.LineByLine -> "line_by_line"
+                    | ShellPolicy.Off -> "off")
+                (fun target ->
+                    let next =
+                        match target with
+                        | "line_by_line" -> Some ShellPolicy.LineByLine
+                        | "off" -> Some ShellPolicy.Off
+                        | "tuple_final" -> Some ShellPolicy.TupleFinalOnly
+                        | _ -> None
+                    match next with
+                    | None ->
+                        outputVerbosityLog.LogWarning(
+                            "OutputVerbosity set unknown target '{Target}'; ignored.",
+                            target)
+                    | Some streaming ->
+                        let shellKey = shellIdToConfigKey currentShellId
+                        let updated =
+                            { currentShellPolicy with
+                                Streaming = streaming }
+                        runtimeShellPolicy <-
+                            Map.add shellKey updated runtimeShellPolicy
+                        applyShellPolicy shellKey
+                        outputVerbosityLog.LogInformation(
+                            "OutputVerbosity set to {Target} for shell {Shell}.",
+                            target, shellKey)
+                        let cue =
+                            match streaming with
+                            | ShellPolicy.TupleFinalOnly ->
+                                "Output verbosity tuple final."
+                            | ShellPolicy.LineByLine ->
+                                "Output verbosity line by line."
+                            | ShellPolicy.Off ->
+                                "Output verbosity off."
+                        window.TerminalSurface.Announce(
+                            cue, ActivityIds.logToggle))
+        multiStateBindings.[HotkeyRegistry.OutputVerbosity] <-
+            outputVerbosityBinding
+
+        // Cycle 45f — Prompt Path menu binding. Same shape +
+        // scoping as OutputVerbosity.
+        let promptPathLog =
+            Logger.get "Terminal.App.Program.bindMultiState.PromptPathVerbosity"
+        let promptPathDef =
+            HotkeyRegistry.multiStateOf HotkeyRegistry.PromptPathVerbosity
+        let promptPathBinding =
+            bindMultiState
+                window
+                promptPathDef
+                (fun () ->
+                    match currentShellPolicy.PromptPath with
+                    | ShellPolicy.Suppress -> "suppress"
+                    | ShellPolicy.FinalDirOnly -> "final_dir_only"
+                    | ShellPolicy.Full -> "full")
+                (fun target ->
+                    let next =
+                        match target with
+                        | "final_dir_only" -> Some ShellPolicy.FinalDirOnly
+                        | "full" -> Some ShellPolicy.Full
+                        | "suppress" -> Some ShellPolicy.Suppress
+                        | _ -> None
+                    match next with
+                    | None ->
+                        promptPathLog.LogWarning(
+                            "PromptPathVerbosity set unknown target '{Target}'; ignored.",
+                            target)
+                    | Some promptPath ->
+                        let shellKey = shellIdToConfigKey currentShellId
+                        let updated =
+                            { currentShellPolicy with
+                                PromptPath = promptPath }
+                        runtimeShellPolicy <-
+                            Map.add shellKey updated runtimeShellPolicy
+                        applyShellPolicy shellKey
+                        promptPathLog.LogInformation(
+                            "PromptPathVerbosity set to {Target} for shell {Shell}.",
+                            target, shellKey)
+                        let cue =
+                            match promptPath with
+                            | ShellPolicy.Suppress -> "Prompt path suppressed."
+                            | ShellPolicy.FinalDirOnly ->
+                                "Prompt path final directory only."
+                            | ShellPolicy.Full -> "Prompt path full."
+                        window.TerminalSurface.Announce(
+                            cue, ActivityIds.logToggle))
+        multiStateBindings.[HotkeyRegistry.PromptPathVerbosity] <-
+            promptPathBinding
 
         // Cycle 26b — wire the menu items. Walk the
         // `menuCommands` dictionary populated by the `bind`

--- a/src/Terminal.Core/Config.fs
+++ b/src/Terminal.Core/Config.fs
@@ -84,7 +84,19 @@ module Config =
           /// overrides with the listed profile IDs (validated
           /// against the registered `ProfileId`s at composition
           /// time; unknown IDs are logged + dropped).
-          Profiles: string[] option }
+          Profiles: string[] option
+          /// Cycle 45f — per-shell streaming announce mode.
+          /// `None` falls back to `ShellPolicy.forShell` defaults.
+          /// TOML values: `"tuple_final"`, `"line_by_line"`,
+          /// `"off"`. Unknown / non-string values log a Warning
+          /// and fall back.
+          Verbosity: ShellPolicy.StreamingMode option
+          /// Cycle 45f — per-shell prompt-path verbosity. `None`
+          /// falls back to `ShellPolicy.forShell` defaults. TOML
+          /// values: `"suppress"`, `"final_dir_only"`, `"full"`.
+          /// Unknown / non-string values log a Warning and fall
+          /// back.
+          PromptPath: ShellPolicy.PromptPathMode option }
 
     /// Optional overrides for `StreamPathway.Parameters`. Each
     /// field is `int option` so the resolver can merge with
@@ -313,6 +325,46 @@ module Config =
             "# Uncomment + edit to override."
             "# [shell.cmd]"
             "# profiles = [\"passthrough\", \"earcon\", \"selection\"]"
+            ""
+            "# Cycle 45f — per-shell verbosity modes."
+            "# Each [shell.<key>] table may specify `verbosity` and"
+            "# `prompt_path` to govern how NVDA narrates that shell's"
+            "# output. Both keys are independent and optional; omitted"
+            "# keys fall back to the compiled defaults (cmd / PowerShell"
+            "# = \"tuple_final\" + \"suppress\"; claude = same)."
+            "#"
+            "# verbosity values:"
+            "#   \"tuple_final\"  — narrate SessionTuple.OutputText on"
+            "#                     each tuple seal (cmd / PowerShell"
+            "#                     default; matches Cycle 45 behaviour)."
+            "#   \"line_by_line\" — narrate each TextSpan as it seals."
+            "#                     Intended for streaming-heavy shells"
+            "#                     (Claude / `ping -t`). Opting cmd in"
+            "#                     to this re-introduces cmd's"
+            "#                     edit-conflation regression (PR #268)."
+            "#   \"off\"          — suppress every streaming + tuple"
+            "#                     announce. Manual SpeechCursor"
+            "#                     navigation is the only way to hear"
+            "#                     output."
+            "#"
+            "# prompt_path values:"
+            "#   \"suppress\"        — narrate nothing on PromptStart"
+            "#                        (default; the user knows where"
+            "#                        they are)."
+            "#   \"final_dir_only\"  — trim path-like prompts to the"
+            "#                        last directory + delimiter"
+            "#                        (e.g. \"Local>\" from"
+            "#                        \"C:\\Users\\Kyle\\Local>\")."
+            "#   \"full\"            — narrate the prompt verbatim."
+            "#"
+            "# Menu changes via `View → Output Verbosity` /"
+            "# `View → Prompt Path` are runtime overrides (Layer 3);"
+            "# this TOML file is Layer 2 and persists across restarts."
+            "# See docs/USER-SETTINGS.md \"Verbosity\" for the full"
+            "# three-layer resolution model."
+            "# [shell.claude]"
+            "# verbosity = \"line_by_line\""
+            "# prompt_path = \"suppress\""
             ""
         ]
 
@@ -716,6 +768,9 @@ module Config =
                         // default `"stream"` (matching the prior
                         // behaviour for a shell that omitted
                         // `pathway`).
+                        // Cycle 45f — also accepts `verbosity` and
+                        // `prompt_path` enum-string keys; same
+                        // option-typed semantics.
                         let pathwayId =
                             tryGetString shellTable "pathway"
                             |> Option.defaultValue "stream"
@@ -733,16 +788,60 @@ module Config =
                                         key)
                                     None
                                 | _ -> None
+                        // Cycle 45f enum-string parsers — same
+                        // shape as the [pathway.stream]
+                        // backspace_policy / mode_barrier_flush
+                        // parsers. Unknown / non-string values
+                        // log a Warning and return None (falls
+                        // back to ShellPolicy.forShell default).
+                        let readVerbosity () : ShellPolicy.StreamingMode option =
+                            match tryGetString shellTable "verbosity" with
+                            | None ->
+                                if shellTable.ContainsKey("verbosity") then
+                                    logger.LogWarning(
+                                        "Config: [shell.{Key}] verbosity is non-string; ignored.",
+                                        key)
+                                None
+                            | Some "tuple_final" -> Some ShellPolicy.TupleFinalOnly
+                            | Some "line_by_line" -> Some ShellPolicy.LineByLine
+                            | Some "off" -> Some ShellPolicy.Off
+                            | Some other ->
+                                logger.LogWarning(
+                                    "Config: [shell.{Key}] verbosity = '{Value}' is not one of 'tuple_final' / 'line_by_line' / 'off'; ignored.",
+                                    key, other)
+                                None
+                        let readPromptPath () : ShellPolicy.PromptPathMode option =
+                            match tryGetString shellTable "prompt_path" with
+                            | None ->
+                                if shellTable.ContainsKey("prompt_path") then
+                                    logger.LogWarning(
+                                        "Config: [shell.{Key}] prompt_path is non-string; ignored.",
+                                        key)
+                                None
+                            | Some "suppress" -> Some ShellPolicy.Suppress
+                            | Some "final_dir_only" -> Some ShellPolicy.FinalDirOnly
+                            | Some "full" -> Some ShellPolicy.Full
+                            | Some other ->
+                                logger.LogWarning(
+                                    "Config: [shell.{Key}] prompt_path = '{Value}' is not one of 'suppress' / 'final_dir_only' / 'full'; ignored.",
+                                    key, other)
+                                None
+                        let verbosity = readVerbosity ()
+                        let promptPath = readPromptPath ()
                         let hasOverride =
                             tryGetString shellTable "pathway" |> Option.isSome
                             || profiles |> Option.isSome
+                            || verbosity |> Option.isSome
+                            || promptPath |> Option.isSome
                         if hasOverride then
                             result <-
                                 result
                                 |> Map.add
                                     key
                                     { PathwayId = pathwayId
-                                      Profiles = profiles }
+                                      Profiles = profiles
+                                      Verbosity = verbosity
+                                      PromptPath = promptPath }
             result
 
     /// Cycle 19 — parse `[startup]` table. Recognises only
@@ -1083,6 +1182,27 @@ module Config =
         match Map.tryFind shellKey config.ShellOverrides with
         | Some entry -> entry.Profiles
         | None -> None
+
+    /// Cycle 45f — resolve the per-shell policy (Layer 1 +
+    /// Layer 2 of the three-layer settings model). Starts from
+    /// `ShellPolicy.forShell shellKey` (Layer 1 — compiled
+    /// defaults) and overlays any TOML-supplied `verbosity` /
+    /// `prompt_path` keys (Layer 2). Layer 3 (runtime overrides
+    /// from the menu) lives in `Terminal.App.Program.fs` and is
+    /// applied on top of this result at shell-switch time.
+    let resolveShellPolicy
+            (config: Config)
+            (shellKey: string)
+            : ShellPolicy.T =
+        let baseline = ShellPolicy.forShell shellKey
+        match Map.tryFind shellKey config.ShellOverrides with
+        | None -> baseline
+        | Some entry ->
+            { baseline with
+                Streaming =
+                    Option.defaultValue baseline.Streaming entry.Verbosity
+                PromptPath =
+                    Option.defaultValue baseline.PromptPath entry.PromptPath }
 
     /// Resolve the StreamPathway parameters from a Config.
     /// Each field that's `None` in `StreamOverrides` falls

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -491,6 +491,16 @@ module HotkeyRegistry =
         // Cycle 27 — Migrated from the Ctrl+Shift+G toggle.
         // Options: information / debug.
         | LoggingLevel
+        // Cycle 45f — per-shell streaming announce mode. Pick
+        // applies to the currently-active shell's runtime
+        // override (Layer 3 of the three-layer settings model);
+        // hot-switching reverts to that shell's TOML / compiled
+        // default. Options: tuple_final / line_by_line / off.
+        | OutputVerbosity
+        // Cycle 45f — per-shell prompt-path verbosity. Same
+        // scoping as OutputVerbosity. Options: suppress /
+        // final_dir_only / full.
+        | PromptPathVerbosity
 
     /// Stable string name for a multi-state command. Used as
     /// the XAML field-name prefix (`MenuItem_<name>`) for the
@@ -500,6 +510,8 @@ module HotkeyRegistry =
         match cmd with
         | EarconsMode -> "EarconsMode"
         | LoggingLevel -> "LoggingLevel"
+        | OutputVerbosity -> "OutputVerbosity"
+        | PromptPathVerbosity -> "PromptPathVerbosity"
 
     /// One option within a multi-state command. `OptionId` is
     /// the stable snake_case identifier used in XAML field
@@ -542,7 +554,21 @@ module HotkeyRegistry =
             Options =
               [ { OptionId = "information"; DisplayName = "Information" }
                 { OptionId = "debug"; DisplayName = "Debug" } ]
-            Description = "FileLogger min-level Information / Debug (migrated from Ctrl+Shift+G; menu-only since Cycle 27)" } ]
+            Description = "FileLogger min-level Information / Debug (migrated from Ctrl+Shift+G; menu-only since Cycle 27)" }
+          { Command = OutputVerbosity
+            DisplayName = "Output Verbosity"
+            Options =
+              [ { OptionId = "tuple_final"; DisplayName = "Tuple Final" }
+                { OptionId = "line_by_line"; DisplayName = "Line By Line" }
+                { OptionId = "off"; DisplayName = "Off" } ]
+            Description = "Per-shell streaming announce mode (Cycle 45f). Runtime override on the active shell; persists across hot-switches until app restart. See docs/USER-SETTINGS.md \"Verbosity\"." }
+          { Command = PromptPathVerbosity
+            DisplayName = "Prompt Path"
+            Options =
+              [ { OptionId = "suppress"; DisplayName = "Suppress" }
+                { OptionId = "final_dir_only"; DisplayName = "Final Directory Only" }
+                { OptionId = "full"; DisplayName = "Full" } ]
+            Description = "Per-shell prompt-path verbosity on PromptStart marker (Cycle 45f). Same scoping as Output Verbosity." } ]
 
     /// Look up the `MultiStateDef` for a `MultiStateCommand`.
     /// Throws `KeyNotFoundException` if missing — pinned by
@@ -562,4 +588,6 @@ module HotkeyRegistry =
     /// maintained; pinned by `MultiStateRegistryTests`.
     let multiStateAllCommands : MultiStateCommand list =
         [ EarconsMode
-          LoggingLevel ]
+          LoggingLevel
+          OutputVerbosity
+          PromptPathVerbosity ]

--- a/src/Terminal.Core/ShellPolicy.fs
+++ b/src/Terminal.Core/ShellPolicy.fs
@@ -1,0 +1,214 @@
+namespace Terminal.Core
+
+/// Cycle 45f — per-shell policy table.
+///
+/// Single typed record per shell carrying the knobs that govern
+/// how pty-speak narrates output, prompts, and (in future cycles)
+/// detection thresholds for that shell. Three Cycle 45f knobs are
+/// active today (`Streaming`, `PromptPath`), plus three seats
+/// reserved for the Cycle 45g consolidation refactor (PromptRegex,
+/// PromptStabilityMs, SelectionEnabled — these mirror
+/// `HeuristicPromptDetector.fs:184` and `SelectionDetector.fs`
+/// inline match arms that Cycle 45g will collapse into a single
+/// table lookup).
+///
+/// The policy is resolved at shell-switch time in
+/// `Terminal.App.Program.switchToShell` through a three-layer
+/// model:
+///
+///   1. Compiled defaults (this module's `defaults` map)
+///   2. TOML user config (`Config.toml [shell.<id>]` keys)
+///   3. Runtime overrides (a `mutable Map<string, T>` populated
+///      by the `View → Output Verbosity` / `Prompt Path` menus)
+///
+/// Later layers overlay earlier ones. Restarting the app drops
+/// Layer 3 and re-reads Layer 2 → effective per-shell defaults.
+///
+/// See `docs/USER-SETTINGS.md` "Verbosity" section + the Cycle
+/// 45f plan in `/root/.claude/plans/the-repo-linked-to-ticklish-whisper.md`
+/// for the full architectural framing.
+module ShellPolicy =
+
+    /// How streaming output reaches NVDA. Per-shell.
+    ///
+    /// `TupleFinalOnly` (default for cmd / PowerShell) suppresses
+    /// per-`TextSpan` auto-announce during streaming and emits a
+    /// single `SessionTuple.OutputText` announce when the tuple
+    /// seals. Matches the Cycle 45 fixup (PR #268) behaviour that
+    /// solved cmd's edit-conflation regression — the screen-grid-
+    /// derived OutputText is authoritative.
+    ///
+    /// `LineByLine` (intended for streaming-heavy shells like
+    /// Claude or `ping -t`) announces each `TextSpan` as it seals.
+    /// Best paired with shells whose output is naturally newline-
+    /// delimited and whose command line doesn't reflow on edit.
+    /// Opting cmd in to `LineByLine` re-introduces the
+    /// edit-conflation regression — the value is exposed but
+    /// docstring + TOML comments carry the warning.
+    ///
+    /// `Off` suppresses every TextSpan auto-announce AND the
+    /// tuple-finalise announce. SpeechCursor's manual navigation
+    /// (Next / Previous / JumpToLatest) is the only way to hear
+    /// output. Useful for users who want maximum quiet + full
+    /// control over what's spoken.
+    type StreamingMode =
+        | TupleFinalOnly
+        | LineByLine
+        | Off
+
+    /// How the shell's prompt text is narrated when a PromptStart
+    /// marker fires. Per-shell.
+    ///
+    /// `Suppress` (default for every shell) returns `None` from
+    /// `SpeechCursor.renderEntry` on PromptStart — silence on
+    /// every prompt boundary. The user knows where they are.
+    ///
+    /// `FinalDirOnly` trims a path-like prompt to the last
+    /// directory segment + trailing delimiter (e.g.
+    /// `"C:\Users\Kyle\AppData\Local\>"` becomes `"Local>"`).
+    /// Cuts the verbose path noise without losing context.
+    ///
+    /// `Full` narrates the prompt verbatim. For shells with short
+    /// prompts (`claude>`, `>>>`) or users who genuinely want the
+    /// full path.
+    type PromptPathMode =
+        | Suppress
+        | FinalDirOnly
+        | Full
+
+    /// Per-shell policy record. Future-extension seats included
+    /// from day one so Cycle 45g's consolidation refactor doesn't
+    /// need to extend the type.
+    type T =
+        { ShellKey: string
+          Streaming: StreamingMode
+          PromptPath: PromptPathMode
+          // -- Cycle 45g consolidation seats; unread in 45f --
+          /// Regex string for `HeuristicPromptDetector` to match
+          /// against the cursor row when detecting prompt
+          /// boundaries. `None` = use the detector's hardcoded
+          /// default.
+          PromptRegex: string option
+          /// Milliseconds of unchanged cursor-row content before
+          /// the detector considers a prompt "stable" and fires
+          /// PromptStart. `None` = use the detector's hardcoded
+          /// default.
+          PromptStabilityMs: int option
+          /// When true, `SelectionDetector` runs against this
+          /// shell's output (currently only `claude`). When false,
+          /// the detector short-circuits.
+          SelectionEnabled: bool }
+
+    /// Compiled default policy table. Each row matches today's
+    /// hardcoded behaviour exactly — no regression on `cmd` /
+    /// `powershell` / `claude` when the table replaces the
+    /// inline shell matches in Cycle 45g.
+    let defaults : Map<string, T> =
+        Map.ofList
+            [ "cmd",
+              { ShellKey = "cmd"
+                Streaming = TupleFinalOnly
+                PromptPath = Suppress
+                PromptRegex = Some @"^[A-Za-z]:\\.*>\s?$"
+                PromptStabilityMs = Some 150
+                SelectionEnabled = false }
+              "powershell",
+              { ShellKey = "powershell"
+                Streaming = TupleFinalOnly
+                PromptPath = Suppress
+                PromptRegex = Some @"^PS [A-Za-z]:\\.*>\s?$"
+                PromptStabilityMs = Some 200
+                SelectionEnabled = false }
+              "claude",
+              { ShellKey = "claude"
+                Streaming = TupleFinalOnly
+                PromptPath = Suppress
+                PromptRegex = None
+                PromptStabilityMs = None
+                SelectionEnabled = true } ]
+
+    /// Look up the policy for a shell key. Unknown shells fall
+    /// back to `cmd` so a typo or future-shell-not-yet-tabled
+    /// never returns a degenerate record.
+    let forShell (shellKey: string) : T =
+        match Map.tryFind shellKey defaults with
+        | Some policy -> policy
+        | None ->
+            // Synthesise a policy keyed to the requested shell
+            // so consumers see the actual `ShellKey` even though
+            // every field defaults to the cmd profile.
+            { defaults.["cmd"] with ShellKey = shellKey }
+
+    /// Trim a prompt-text payload to the format dictated by the
+    /// `PromptPathMode`. Returns `None` to suppress the announce
+    /// entirely; returns `Some text` to announce that text.
+    ///
+    /// Empty / whitespace input always returns `None` regardless
+    /// of mode (the heuristic detector occasionally captures a
+    /// blank cursor row).
+    ///
+    /// `FinalDirOnly` walks the input right-to-left:
+    ///   1. Strip a trailing whitespace
+    ///   2. Identify the trailing delimiter (`>`, `$`, `#`, `:`)
+    ///      if any — preserved on the output
+    ///   3. Strip trailing path separators (`\`, `/`) before the
+    ///      directory name
+    ///   4. Walk back to the previous path separator
+    ///   5. Return the substring after that separator + the
+    ///      delimiter
+    ///
+    /// If no path separator is found, returns the input verbatim
+    /// (already short).
+    let trimPromptPath
+            (mode: PromptPathMode)
+            (text: string)
+            : string option
+            =
+        if System.String.IsNullOrWhiteSpace text then None
+        else
+            match mode with
+            | Suppress -> None
+            | Full -> Some text
+            | FinalDirOnly ->
+                let trimmed = text.TrimEnd()
+                // Identify trailing delimiter character (if any).
+                let delim =
+                    let last = trimmed.[trimmed.Length - 1]
+                    if last = '>' || last = '$' || last = '#' || last = ':' then
+                        Some last
+                    else
+                        None
+                // Strip the delimiter (if matched) from the path
+                // body so the path-walk operates on directory text.
+                let body =
+                    match delim with
+                    | Some _ -> trimmed.Substring(0, trimmed.Length - 1)
+                    | None -> trimmed
+                // Strip trailing path separators so we don't land
+                // on an empty final segment.
+                let bodyTrimmed = body.TrimEnd([| '\\'; '/' |])
+                if bodyTrimmed.Length = 0 then
+                    // Pure-root prompt (`C:\>` → body was `C:\` →
+                    // bodyTrimmed empty). Just return the input
+                    // verbatim; nothing to trim.
+                    Some text
+                else
+                    // Find the last path separator. Either `\`
+                    // (Windows) or `/` (POSIX) — whichever sits
+                    // later in the string wins.
+                    let lastBackslash = bodyTrimmed.LastIndexOf '\\'
+                    let lastSlash = bodyTrimmed.LastIndexOf '/'
+                    let sepIdx = max lastBackslash lastSlash
+                    if sepIdx < 0 then
+                        // No separator found — body is itself the
+                        // final segment (e.g. `claude>` → body
+                        // `claude`, no `\` or `/`). Return verbatim.
+                        Some text
+                    else
+                        let lastSegment =
+                            bodyTrimmed.Substring(sepIdx + 1)
+                        let withDelim =
+                            match delim with
+                            | Some c -> sprintf "%s%c" lastSegment c
+                            | None -> lastSegment
+                        Some withDelim

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -80,23 +80,45 @@ module SpeechCursor =
           /// what did the shell print" is `SessionTuple` (see
           /// `SessionModel.SessionTuple.{CommandText,OutputText}`);
           /// `Program.fs handlePromptBoundary` announces that
-          /// on tuple finalise. SpeechCursor's TextSpan-by-
-          /// TextSpan auto-announce stays suppressed by default
-          /// until verbosity-mode work (Cycle 45f) introduces
-          /// per-shell streaming-vs-tuple-final policy.
-          SkipTextSpansInAutoDrive: bool }
+          /// on tuple finalise.
+          ///
+          /// Cycle 45f (2026-05-12): this flag now carries the
+          /// `ShellPolicy.StreamingMode = TupleFinalOnly`
+          /// semantics. The per-shell policy resolved at shell-
+          /// switch time flips it on/off — `TupleFinalOnly` /
+          /// `Off` map to `true` (suppress TextSpan announce);
+          /// `LineByLine` maps to `false` (announce on each
+          /// TextSpan seal). The `PromptPath` field below
+          /// carries the orthogonal prompt-verbosity dimension.
+          SkipTextSpansInAutoDrive: bool
+          /// Cycle 45f — how `PromptStart` markers narrate
+          /// their `Payload` text. Default `Suppress` matches
+          /// today's behaviour (no prompt announce at all).
+          /// `FinalDirOnly` trims path-like prompts to the last
+          /// directory segment; `Full` narrates verbatim. See
+          /// `ShellPolicy.PromptPathMode` for full semantics.
+          PromptPath: ShellPolicy.PromptPathMode }
 
     let defaultParameters : Parameters =
         { InitialMode = AutoDrive
           SkipSpinnersInAutoDrive = true
           SuspendAutoDriveOnSelection = true
-          SkipTextSpansInAutoDrive = true }
+          SkipTextSpansInAutoDrive = true
+          PromptPath = ShellPolicy.Suppress }
 
     /// Cursor state. Mutated in-place by the navigation /
     /// announce APIs. Single-threaded by convention (dispatcher
     /// thread); no internal gate needed.
+    ///
+    /// `Parameters` is mutable on the instance (Cycle 45f) so
+    /// shell-switch + the `View → Output Verbosity` menu can
+    /// flip per-shell verbosity without reconstructing the
+    /// cursor (which would lose `Position` + `LastSpokenSeq`).
+    /// Use `setParameters` to update — replays / rewinds are
+    /// not in scope; the new policy applies to subsequent
+    /// appends only.
     type T internal (parameters: Parameters) =
-        member val internal Parameters: Parameters = parameters with get
+        member val internal Parameters: Parameters = parameters with get, set
         /// The Seq of the entry the cursor is currently parked
         /// on. -1 means "before the first entry" (initial state
         /// or after `reset`).
@@ -116,6 +138,15 @@ module SpeechCursor =
     /// Construct a fresh cursor.
     let create (parameters: Parameters) : T =
         T(parameters)
+
+    /// Replace the cursor's `Parameters` (Cycle 45f). Subsequent
+    /// `onAppend` invocations observe the new values; entries
+    /// already announced under the previous policy stay
+    /// announced — `setParameters` does NOT replay or rewind.
+    /// `Position`, `LastSpokenSeq`, `Mode`, and `SelectionSuspend`
+    /// are preserved across the update.
+    let setParameters (state: T) (parameters: Parameters) : unit =
+        state.Parameters <- parameters
 
     /// Current cursor mode (Manual / AutoDrive). The
     /// SelectionSuspend bit doesn't change the reported mode —
@@ -234,23 +265,27 @@ module SpeechCursor =
             Some e
         | None -> None
 
-    /// Render an entry to the (text, activityId) pair the
-    /// announce callback will receive. Pure; tests use this
-    /// directly to assert format.
+    /// Cycle 45f — render an entry under a specific
+    /// `PromptPathMode`. PromptStart markers consult the policy
+    /// to decide whether (and how) to narrate their payload.
+    /// Every other entry kind is unaffected.
     ///
     /// Activity-id choices mirror `NvdaChannel.semanticToActivityId`:
     /// streaming text + selection / prompt boundaries route on
-    /// `pty-speak.output`; alt-screen toggles on `pty-speak.mode`;
-    /// bell on `pty-speak.output` (no dedicated id for bell-via-
-    /// announce; the earcon channel handles the audible cue
-    /// separately).
+    /// `pty-speak.output`; alt-screen toggles on
+    /// `pty-speak.mode`; bell on `pty-speak.output` (no
+    /// dedicated id for bell-via-announce; the earcon channel
+    /// handles the audible cue separately).
     ///
     /// Note: AutoDrive's TextSpan-skip behaviour
     /// (`Parameters.SkipTextSpansInAutoDrive`) is enforced in
     /// `onAppend`, not here. Manual navigation (`speakCurrent`)
     /// still renders TextSpans so the user can review them
     /// explicitly.
-    let renderEntry (entry: ContentHistory.Entry) : (string * string) option =
+    let renderEntryWithPolicy
+            (promptPath: ShellPolicy.PromptPathMode)
+            (entry: ContentHistory.Entry)
+            : (string * string) option =
         match entry with
         | ContentHistory.TextSpan d ->
             if String.IsNullOrEmpty d.Text then None
@@ -291,23 +326,34 @@ module SpeechCursor =
                 // flip this to announce "Bell." for users who
                 // have earcons muted.
                 None
-            | ContentHistory.MarkerKind.PromptStart
+            | ContentHistory.MarkerKind.PromptStart ->
+                // Cycle 45f — narrate the prompt under the
+                // active shell's PromptPathMode.
+                //
+                // - `Suppress` (default for every shell):
+                //   `trimPromptPath` returns `None`; we emit
+                //   nothing.
+                // - `FinalDirOnly`: trims path-like prompts to
+                //   the last directory + delimiter (e.g.
+                //   `"Local>"` from
+                //   `"C:\Users\Kyle\AppData\Local\>"`).
+                // - `Full`: narrates the payload verbatim.
+                //
+                // Empty / missing payload returns `None` under
+                // every mode (the heuristic detector
+                // occasionally captures a blank cursor row).
+                match m.Payload with
+                | None -> None
+                | Some text ->
+                    ShellPolicy.trimPromptPath promptPath text
+                    |> Option.map (fun rendered ->
+                        (rendered, ActivityIds.output))
             | ContentHistory.MarkerKind.CommandStart
             | ContentHistory.MarkerKind.OutputStart
             | ContentHistory.MarkerKind.CommandFinished ->
                 // Tuple-internal boundary markers don't announce
                 // by themselves. The TextSpans they bracket are
                 // what the user hears.
-                //
-                // Cycle 45 backlog (docs/USER-SETTINGS.md
-                // "Prompt-path verbosity"): future user setting
-                // could announce a shortened form of the prompt
-                // here (final-directory-only, or fully
-                // suppressed) so a sighted-style "I'm in
-                // C:\Users\Kyle\...>" cue is replaced with a
-                // briefer "Kyle>" or with silence. Pull the
-                // prompt text from m.Payload or from
-                // SessionModel.ActivePromptText.
                 None
             | ContentHistory.MarkerKind.Custom _ ->
                 // Future modes will define their own announce
@@ -319,6 +365,14 @@ module SpeechCursor =
             // user can navigate to them manually for inspection
             // but they're not narrated by default.
             None
+
+    /// Backwards-compatible wrapper — render an entry under the
+    /// default `PromptPathMode.Suppress`. Existing tests that
+    /// don't care about prompt-path verbosity use this form;
+    /// PromptStart-marker rendering is unaffected (Suppress
+    /// returns `None`, matching pre-Cycle-45f behaviour).
+    let renderEntry (entry: ContentHistory.Entry) : (string * string) option =
+        renderEntryWithPolicy ShellPolicy.Suppress entry
 
     /// Announce the entry at the cursor's current position via
     /// the supplied callback. Updates `LastSpokenSeq` to the
@@ -332,7 +386,7 @@ module SpeechCursor =
         match current state history with
         | None -> false
         | Some entry ->
-            match renderEntry entry with
+            match renderEntryWithPolicy state.Parameters.PromptPath entry with
             | None ->
                 // The entry exists but has no audible
                 // announcement (e.g. Newline, Overwrite). Still
@@ -363,7 +417,7 @@ module SpeechCursor =
         for e in entries do
             let s = ContentHistory.entrySeq e
             if s > lower && s <= throughSeq then
-                match renderEntry e with
+                match renderEntryWithPolicy state.Parameters.PromptPath e with
                 | Some (text, activityId) ->
                     announce (text, activityId)
                     spokenCount <- spokenCount + 1
@@ -435,7 +489,11 @@ module SpeechCursor =
                             state.Parameters.SkipTextSpansInAutoDrive
                         | _ -> false
                     if not suppressTextSpan then
-                        match renderEntry entry with
+                        match
+                            renderEntryWithPolicy
+                                state.Parameters.PromptPath
+                                entry
+                        with
                         | Some (text, activityId) ->
                             announce (text, activityId)
                         | None -> ()

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -139,6 +139,16 @@ module SpeechCursor =
     let create (parameters: Parameters) : T =
         T(parameters)
 
+    /// Read the cursor's current `Parameters`. Cycle 45f —
+    /// public accessor so cross-assembly callers (Program.fs,
+    /// hosted in Terminal.App) can construct a `{ existing with
+    /// ... }` update before handing it back to `setParameters`.
+    /// The underlying `member val Parameters` is `internal` so
+    /// direct field access from Terminal.App fails;
+    /// `getParameters` is the module-level lens.
+    let getParameters (state: T) : Parameters =
+        state.Parameters
+
     /// Replace the cursor's `Parameters` (Cycle 45f). Subsequent
     /// `onAppend` invocations observe the new values; entries
     /// already announced under the previous policy stay

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="SessionPersistence.fs" />
     <Compile Include="SessionSanitiser.fs" />
     <Compile Include="SessionLogWriter.fs" />
+    <Compile Include="ShellPolicy.fs" />
     <Compile Include="HeuristicPromptDetector.fs" />
     <Compile Include="SelectionDetector.fs" />
     <Compile Include="DisplayPathway.fs" />

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -99,6 +99,38 @@
                               x:FieldModifier="public"
                               Header="Toggle _Mode (AutoDrive / Manual)" />
                 </MenuItem>
+                <!-- Cycle 45f — per-shell verbosity modes. Pick
+                     applies to the currently-active shell's
+                     runtime override (Layer 3 of the three-layer
+                     settings model); persists across hot-switches
+                     until app restart. See docs/USER-SETTINGS.md
+                     "Verbosity" for the resolution model. -->
+                <MenuItem x:Name="MenuItem_OutputVerbosity"
+                          x:FieldModifier="public"
+                          Header="_Output Verbosity">
+                    <MenuItem x:Name="MenuItem_OutputVerbosity_tuple_final"
+                              x:FieldModifier="public"
+                              Header="_Tuple Final" />
+                    <MenuItem x:Name="MenuItem_OutputVerbosity_line_by_line"
+                              x:FieldModifier="public"
+                              Header="_Line By Line" />
+                    <MenuItem x:Name="MenuItem_OutputVerbosity_off"
+                              x:FieldModifier="public"
+                              Header="O_ff" />
+                </MenuItem>
+                <MenuItem x:Name="MenuItem_PromptPathVerbosity"
+                          x:FieldModifier="public"
+                          Header="_Prompt Path">
+                    <MenuItem x:Name="MenuItem_PromptPathVerbosity_suppress"
+                              x:FieldModifier="public"
+                              Header="_Suppress" />
+                    <MenuItem x:Name="MenuItem_PromptPathVerbosity_final_dir_only"
+                              x:FieldModifier="public"
+                              Header="_Final Directory Only" />
+                    <MenuItem x:Name="MenuItem_PromptPathVerbosity_full"
+                              x:FieldModifier="public"
+                              Header="F_ull" />
+                </MenuItem>
             </MenuItem>
             <MenuItem Header="_Data">
                 <MenuItem x:Name="MenuItem_OpenDataFolder"

--- a/tests/Tests.Unit/ConfigTests.fs
+++ b/tests/Tests.Unit/ConfigTests.fs
@@ -175,6 +175,72 @@ let ``resolveShellProfiles returns None for a shell with no override section`` (
     let config, _ = loadFromText toml
     Assert.Equal(None, Config.resolveShellProfiles config "cmd")
 
+// ---- Cycle 45f — per-shell verbosity / prompt_path ----------------
+
+[<Fact>]
+let ``[shell.claude] verbosity = "line_by_line" resolves through resolveShellPolicy`` () =
+    let toml =
+        "schema_version = 1\n[shell.claude]\nverbosity = \"line_by_line\"\n"
+    let config, _ = loadFromText toml
+    let policy = Config.resolveShellPolicy config "claude"
+    Assert.Equal(ShellPolicy.LineByLine, policy.Streaming)
+    // PromptPath not overridden — falls back to the compiled default.
+    Assert.Equal(ShellPolicy.Suppress, policy.PromptPath)
+
+[<Fact>]
+let ``[shell.cmd] prompt_path = "final_dir_only" resolves through resolveShellPolicy`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nprompt_path = \"final_dir_only\"\n"
+    let config, _ = loadFromText toml
+    let policy = Config.resolveShellPolicy config "cmd"
+    Assert.Equal(ShellPolicy.FinalDirOnly, policy.PromptPath)
+    // Streaming not overridden — compiled default (TupleFinalOnly).
+    Assert.Equal(ShellPolicy.TupleFinalOnly, policy.Streaming)
+
+[<Fact>]
+let ``[shell.cmd] both verbosity and prompt_path resolve together`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nverbosity = \"off\"\nprompt_path = \"full\"\n"
+    let config, _ = loadFromText toml
+    let policy = Config.resolveShellPolicy config "cmd"
+    Assert.Equal(ShellPolicy.Off, policy.Streaming)
+    Assert.Equal(ShellPolicy.Full, policy.PromptPath)
+
+[<Fact>]
+let ``unknown verbosity value logs Warning and falls back`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nverbosity = \"banana\"\n"
+    let config, logger = loadFromText toml
+    let policy = Config.resolveShellPolicy config "cmd"
+    Assert.Equal(ShellPolicy.TupleFinalOnly, policy.Streaming)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+    let warnings =
+        logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList
+    Assert.Contains(warnings, fun m -> m.Contains("verbosity"))
+
+[<Fact>]
+let ``unknown prompt_path value logs Warning and falls back`` () =
+    let toml =
+        "schema_version = 1\n[shell.cmd]\nprompt_path = \"banana\"\n"
+    let config, logger = loadFromText toml
+    let policy = Config.resolveShellPolicy config "cmd"
+    Assert.Equal(ShellPolicy.Suppress, policy.PromptPath)
+    Assert.True(logger.HasLevel(LogLevel.Warning))
+    let warnings =
+        logger.MessagesAtLevel(LogLevel.Warning) |> Seq.toList
+    Assert.Contains(warnings, fun m -> m.Contains("prompt_path"))
+
+[<Fact>]
+let ``resolveShellPolicy with no TOML override returns compiled defaults`` () =
+    let toml = "schema_version = 1\n"
+    let config, _ = loadFromText toml
+    let cmdPolicy = Config.resolveShellPolicy config "cmd"
+    let claudePolicy = Config.resolveShellPolicy config "claude"
+    Assert.Equal(ShellPolicy.TupleFinalOnly, cmdPolicy.Streaming)
+    Assert.Equal(ShellPolicy.Suppress, cmdPolicy.PromptPath)
+    Assert.Equal(ShellPolicy.TupleFinalOnly, claudePolicy.Streaming)
+    Assert.True(claudePolicy.SelectionEnabled)
+
 // ---- Per-pathway parameter override --------------------------------
 
 [<Fact>]

--- a/tests/Tests.Unit/MultiStateRegistryTests.fs
+++ b/tests/Tests.Unit/MultiStateRegistryTests.fs
@@ -57,7 +57,10 @@ let ``multiStateAllCommands contains exactly the documented commands (Cycle 27)`
             [ // Cycle 27 — migrated from MuteEarcons toggle.
               HotkeyRegistry.EarconsMode
               // Cycle 27 — migrated from ToggleDebugLog toggle.
-              HotkeyRegistry.LoggingLevel ]
+              HotkeyRegistry.LoggingLevel
+              // Cycle 45f — per-shell verbosity modes.
+              HotkeyRegistry.OutputVerbosity
+              HotkeyRegistry.PromptPathVerbosity ]
     let actual = Set.ofList HotkeyRegistry.multiStateAllCommands
     Assert.Equal<Set<HotkeyRegistry.MultiStateCommand>>(expected, actual)
 

--- a/tests/Tests.Unit/ShellPolicyTests.fs
+++ b/tests/Tests.Unit/ShellPolicyTests.fs
@@ -1,0 +1,142 @@
+module PtySpeak.Tests.Unit.ShellPolicyTests
+
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 45f Commit 1 — ShellPolicy pure-function tests.
+// ---------------------------------------------------------------------
+//
+// Pin the policy table's contract:
+//
+//   * defaults exists for cmd / powershell / claude
+//   * each default row matches today's hardcoded behaviour
+//     (TupleFinalOnly + Suppress) so Commit 2's wiring is a
+//     no-regression change
+//   * forShell maps known keys to their defaults
+//   * forShell on unknown shell synthesises a cmd-shaped record
+//     with the requested ShellKey preserved
+//   * trimPromptPath handles each PromptPathMode, edge cases
+//     (empty / whitespace / root-only / no-separator), and the
+//     common shell prompt shapes (cmd, PowerShell, bash)
+
+// ---- defaults table -------------------------------------------------
+
+[<Fact>]
+let ``defaults contains cmd / powershell / claude entries`` () =
+    Assert.True(ShellPolicy.defaults.ContainsKey "cmd")
+    Assert.True(ShellPolicy.defaults.ContainsKey "powershell")
+    Assert.True(ShellPolicy.defaults.ContainsKey "claude")
+
+[<Fact>]
+let ``every default row uses TupleFinalOnly + Suppress`` () =
+    for kv in ShellPolicy.defaults do
+        Assert.Equal(ShellPolicy.TupleFinalOnly, kv.Value.Streaming)
+        Assert.Equal(ShellPolicy.Suppress, kv.Value.PromptPath)
+
+[<Fact>]
+let ``cmd default has prompt regex + stability`` () =
+    let cmd = ShellPolicy.defaults.["cmd"]
+    Assert.True(cmd.PromptRegex.IsSome)
+    Assert.True(cmd.PromptStabilityMs.IsSome)
+    Assert.False(cmd.SelectionEnabled)
+
+[<Fact>]
+let ``claude default enables selection detector`` () =
+    let claude = ShellPolicy.defaults.["claude"]
+    Assert.True(claude.SelectionEnabled)
+
+// ---- forShell -------------------------------------------------------
+
+[<Fact>]
+let ``forShell on a known key returns the default row`` () =
+    let cmd = ShellPolicy.forShell "cmd"
+    Assert.Equal("cmd", cmd.ShellKey)
+    Assert.Equal(ShellPolicy.TupleFinalOnly, cmd.Streaming)
+
+[<Fact>]
+let ``forShell on an unknown key returns cmd shape with the requested key`` () =
+    let bash = ShellPolicy.forShell "bash"
+    Assert.Equal("bash", bash.ShellKey)
+    // Fields mirror the cmd defaults.
+    let cmd = ShellPolicy.defaults.["cmd"]
+    Assert.Equal(cmd.Streaming, bash.Streaming)
+    Assert.Equal(cmd.PromptPath, bash.PromptPath)
+    Assert.Equal(cmd.SelectionEnabled, bash.SelectionEnabled)
+
+// ---- trimPromptPath: Suppress / Full --------------------------------
+
+[<Fact>]
+let ``Suppress returns None for any non-empty text`` () =
+    Assert.Equal(None, ShellPolicy.trimPromptPath ShellPolicy.Suppress "C:\\>")
+    Assert.Equal(None, ShellPolicy.trimPromptPath ShellPolicy.Suppress "claude>")
+
+[<Fact>]
+let ``Full returns Some text verbatim for non-empty input`` () =
+    Assert.Equal(
+        Some "C:\\Users\\Kyle>",
+        ShellPolicy.trimPromptPath ShellPolicy.Full "C:\\Users\\Kyle>")
+
+[<Fact>]
+let ``Empty or whitespace input returns None under every mode`` () =
+    for mode in [ ShellPolicy.Suppress; ShellPolicy.FinalDirOnly; ShellPolicy.Full ] do
+        Assert.Equal(None, ShellPolicy.trimPromptPath mode "")
+        Assert.Equal(None, ShellPolicy.trimPromptPath mode "   ")
+
+// ---- trimPromptPath: FinalDirOnly ----------------------------------
+
+[<Fact>]
+let ``FinalDirOnly trims cmd Windows path to last directory plus delim`` () =
+    Assert.Equal(
+        Some "Local>",
+        ShellPolicy.trimPromptPath
+            ShellPolicy.FinalDirOnly
+            "C:\\Users\\Kyle\\AppData\\Local\\>")
+
+[<Fact>]
+let ``FinalDirOnly trims cmd path without trailing backslash`` () =
+    Assert.Equal(
+        Some "Documents>",
+        ShellPolicy.trimPromptPath
+            ShellPolicy.FinalDirOnly
+            "C:\\Users\\Kyle\\Documents>")
+
+[<Fact>]
+let ``FinalDirOnly trims PowerShell PS-prefixed path`` () =
+    Assert.Equal(
+        Some "Kyle>",
+        ShellPolicy.trimPromptPath
+            ShellPolicy.FinalDirOnly
+            "PS C:\\Users\\Kyle>")
+
+[<Fact>]
+let ``FinalDirOnly trims bash-style path with dollar sign`` () =
+    Assert.Equal(
+        Some "repo$",
+        ShellPolicy.trimPromptPath
+            ShellPolicy.FinalDirOnly
+            "~/repo$")
+
+[<Fact>]
+let ``FinalDirOnly preserves root-only prompts verbatim`` () =
+    // `C:\>` has no inner directory to extract — return as-is.
+    Assert.Equal(
+        Some "C:\\>",
+        ShellPolicy.trimPromptPath ShellPolicy.FinalDirOnly "C:\\>")
+
+[<Fact>]
+let ``FinalDirOnly preserves short prompts without path separators`` () =
+    Assert.Equal(
+        Some "claude>",
+        ShellPolicy.trimPromptPath ShellPolicy.FinalDirOnly "claude>")
+    Assert.Equal(
+        Some ">>>",
+        ShellPolicy.trimPromptPath ShellPolicy.FinalDirOnly ">>>")
+
+[<Fact>]
+let ``FinalDirOnly handles trailing whitespace`` () =
+    Assert.Equal(
+        Some "Local>",
+        ShellPolicy.trimPromptPath
+            ShellPolicy.FinalDirOnly
+            "C:\\Users\\Kyle\\Local>   ")

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -410,6 +410,126 @@ let ``renderEntry returns selection announce for SelectionShown with payload`` (
     | None -> Assert.Fail("expected announce for SelectionShown")
 
 // ---------------------------------------------------------------------
+// Cycle 45f — renderEntryWithPolicy / PromptPathMode
+// ---------------------------------------------------------------------
+
+let private promptMarker (payload: string option) : ContentHistory.Entry =
+    ContentHistory.Marker
+        { Seq = 0L
+          Kind = ContentHistory.MarkerKind.PromptStart
+          At = t0
+          Payload = payload }
+
+[<Fact>]
+let ``PromptStart under Suppress returns None`` () =
+    let entry = promptMarker (Some "C:\\Users\\Kyle\\Local>")
+    Assert.Equal(
+        None,
+        SpeechCursor.renderEntryWithPolicy ShellPolicy.Suppress entry)
+
+[<Fact>]
+let ``PromptStart under FinalDirOnly trims to last directory`` () =
+    let entry = promptMarker (Some "C:\\Users\\Kyle\\Local>")
+    match
+        SpeechCursor.renderEntryWithPolicy ShellPolicy.FinalDirOnly entry
+    with
+    | Some (text, activityId) ->
+        Assert.Equal("Local>", text)
+        Assert.Equal(ActivityIds.output, activityId)
+    | None -> Assert.Fail("expected announce under FinalDirOnly")
+
+[<Fact>]
+let ``PromptStart under Full returns the payload verbatim`` () =
+    let entry = promptMarker (Some "C:\\Users\\Kyle\\Local>")
+    match
+        SpeechCursor.renderEntryWithPolicy ShellPolicy.Full entry
+    with
+    | Some (text, _) ->
+        Assert.Equal("C:\\Users\\Kyle\\Local>", text)
+    | None -> Assert.Fail("expected announce under Full")
+
+[<Fact>]
+let ``PromptStart with empty payload returns None under every mode`` () =
+    let entry = promptMarker (Some "")
+    for mode in [ ShellPolicy.Suppress; ShellPolicy.FinalDirOnly; ShellPolicy.Full ] do
+        Assert.Equal(None, SpeechCursor.renderEntryWithPolicy mode entry)
+
+[<Fact>]
+let ``PromptStart with no payload returns None under every mode`` () =
+    let entry = promptMarker None
+    for mode in [ ShellPolicy.Suppress; ShellPolicy.FinalDirOnly; ShellPolicy.Full ] do
+        Assert.Equal(None, SpeechCursor.renderEntryWithPolicy mode entry)
+
+[<Fact>]
+let ``backwards-compat renderEntry suppresses PromptStart`` () =
+    // The no-policy overload uses Suppress for backwards-compat;
+    // Cycle 45f pinned this so existing tests + callers don't
+    // spontaneously start announcing prompts.
+    let entry = promptMarker (Some "C:\\Users\\Kyle>")
+    Assert.Equal(None, SpeechCursor.renderEntry entry)
+
+// ---------------------------------------------------------------------
+// Cycle 45f — setParameters + LineByLine streaming + Off mode
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``setParameters flips SkipTextSpansInAutoDrive at runtime`` () =
+    let cursor = freshCursor ()
+    Assert.True(cursor.Parameters.SkipTextSpansInAutoDrive)
+    let updated =
+        { cursor.Parameters with SkipTextSpansInAutoDrive = false }
+    SpeechCursor.setParameters cursor updated
+    Assert.False(cursor.Parameters.SkipTextSpansInAutoDrive)
+    // Position + LastSpokenSeq + Mode preserved.
+    Assert.Equal(-1L, cursor.Position)
+    Assert.Equal(-1L, cursor.LastSpokenSeq)
+
+[<Fact>]
+let ``onAppend with SkipTextSpansInAutoDrive=false announces every TextSpan`` () =
+    // Equivalent to flipping the policy to LineByLine — every
+    // sealed TextSpan narrates as it arrives.
+    let cursor = freshCursor ()
+    let lineByLineParams =
+        { cursor.Parameters with SkipTextSpansInAutoDrive = false }
+    SpeechCursor.setParameters cursor lineByLineParams
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    ContentHistory.appendFromEvent history t0 (printRune 'a') |> ignore
+    ContentHistory.appendFromEvent history t0 lf |> ignore
+    ContentHistory.appendFromEvent history (after 10) (printRune 'b') |> ignore
+    ContentHistory.appendFromEvent history (after 10) lf |> ignore
+    SpeechCursor.onAppend cursor history announce
+    let said = snap () |> List.map fst
+    Assert.Equal<string list>([ "a"; "b" ], said)
+
+[<Fact>]
+let ``setParameters mid-stream only affects subsequent appends`` () =
+    // Cycle 45f edge case: flipping the policy does NOT replay
+    // or rewind. Entries already announced under the prior
+    // policy stay announced; subsequent appends obey the new
+    // mode.
+    let cursor = freshCursor ()
+    // Start in LineByLine — first batch will announce.
+    SpeechCursor.setParameters
+        cursor
+        { cursor.Parameters with SkipTextSpansInAutoDrive = false }
+    let history = freshHistory ()
+    let announce, snap = capture ()
+    ContentHistory.appendFromEvent history t0 (printRune 'a') |> ignore
+    ContentHistory.appendFromEvent history t0 lf |> ignore
+    SpeechCursor.onAppend cursor history announce
+    Assert.Equal<string list>([ "a" ], snap () |> List.map fst)
+    // Flip to TupleFinalOnly mid-stream.
+    SpeechCursor.setParameters
+        cursor
+        { cursor.Parameters with SkipTextSpansInAutoDrive = true }
+    ContentHistory.appendFromEvent history (after 10) (printRune 'b') |> ignore
+    ContentHistory.appendFromEvent history (after 10) lf |> ignore
+    SpeechCursor.onAppend cursor history announce
+    // No new announce — "b" was suppressed under the new policy.
+    Assert.Equal<string list>([ "a" ], snap () |> List.map fst)
+
+// ---------------------------------------------------------------------
 // speakSince
 // ---------------------------------------------------------------------
 

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -76,6 +76,7 @@
     -->
     <Compile Include="ContentHistoryTests.fs" />
     <Compile Include="SpeechCursorTests.fs" />
+    <Compile Include="ShellPolicyTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Two user-facing dials, both per-shell, plus a substrate that future cycles consume.

### Streaming announce mode (`Display → Output Verbosity`)

- **Tuple Final** (cmd / PowerShell default) — keeps PR #268's behaviour. `SessionTuple.OutputText` narrates on each tuple seal; mid-stream TextSpans stay quiet so cmd's edit-conflation regression doesn't return.
- **Line By Line** — every sealed TextSpan announces as it arrives. Intended for streaming-heavy shells (Claude, `ping -t`). Closes the regression flagged in PR #268's CHANGELOG: "streaming output no longer auto-announces line-by-line until the next tuple seals... a regression for long-running streaming workloads."
- **Off** — all streaming + tuple-finalise announces silent. SpeechCursor manual nav is the only way to hear output.

### Prompt-path verbosity (`Display → Prompt Path`)

- **Suppress** (default) — no prompt narration on `PromptStart`. Today's behaviour.
- **Final Directory Only** — trims path-like prompts to the last segment (`"Local>"` from `"C:\Users\Kyle\AppData\Local\>"`).
- **Full** — narrates the prompt verbatim.

### Three-layer settings model (maintainer-confirmed in plan mode)

The effective per-shell policy resolves through three overlay layers:

1. **Compiled defaults** — `ShellPolicy.defaults`
2. **TOML user config** — `[shell.<id>] verbosity = "…"` / `prompt_path = "…"`. Loaded once at app startup.
3. **Runtime overrides** — menu picks. Per-shell, ephemeral (lost on restart). Hot-switching cmd → Claude → cmd preserves the cmd override.

Documented in `defaultsTemplate` comments + the CHANGELOG.

### Commit-level breakdown

- **Commit 1** — `feat(shell-policy): Cycle 45f Commit 1 — add ShellPolicy substrate` (additive, no behaviour change; ~150 LOC + tests)
- **Commit 2** — `feat(verbosity): Cycle 45f Commit 2 — wire per-shell verbosity through SpeechCursor + menu` (~300 LOC + tests)

### What's out of scope (deferred)

- HeuristicPromptDetector + SelectionDetector migration to read from the ShellPolicy table — Cycle 45g (pure refactor; the table already carries the seats but no consumer reads them in 45f)
- EditEcho mode (a third axis: "narrate every keystroke")
- Save Current as Default action (Layer 3 → Layer 2 promotion)

## Test plan

- [x] Unit tests for `ShellPolicy` resolution + `trimPromptPath` matrix + `Config.resolveShellPolicy` round-trip + `SpeechCursor.renderEntryWithPolicy` per mode + `setParameters` runtime flip + mid-stream-flip regression pin + MultiStateRegistry exhaustive-set pin
- [ ] Maintainer NVDA dogfood: cmd default → `dir` narrates tuple-final (regression pin)
- [ ] cmd + Output Verbosity → Line By Line + `dir` → per-line narration during scroll
- [ ] claude + Output Verbosity → Line By Line + long response → mid-stream narration before tuple seal
- [ ] cmd + Prompt Path → Final Directory Only + `cd Local && cd ..` → `"Local>"` then `"…>"` (no full path)
- [ ] Hot-switch cmd→claude with Line By Line set on cmd → claude reverts to its own policy; switching back to cmd preserves Line By Line
- [ ] TOML `[shell.claude] verbosity = "line_by_line"` + restart → claude uses LineByLine from boot

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_