### PR TITLE
fix(prompt-detector): re-emit PromptStart after dirty intermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 45f follow-up): silence after screen-filling output
+
+Maintainer NVDA dogfood on the Cycle 45f build surfaced a real
+regression: after running any command that scrolls the entire
+screen (`dir`, `tree`, anything large), the NEXT command's
+output goes unannounced. Sequence to reproduce:
+
+1. `echo hello` → narrates "hello" ✓
+2. `dir` → narrates the output (long) ✓
+3. `echo hello` again → input echoes visually, command runs,
+   "hello" prints on screen, but NVDA stays silent ✗
+
+Root cause: `HeuristicPromptDetector`'s `(text, rowIdx)` dedup
+gate. After a screen-filling output, the prompt lands at the
+last row (rowIdx = 29 on a 30-row screen). The detector emits
+`PromptStart(text="C:\>", rowIdx=29)`. When the next command
+runs, cmd outputs the result, scrolls the screen by one row,
+and redraws the prompt on the **same bottom row with the same
+text**. The dedup gate compares `(text, rowIdx)` to the last
+emission, sees equality, and suppresses the emission —
+SessionModel never seals the tuple, the tuple-finalise
+announce never fires.
+
+Fix: add a `RowDirtyAfterEmit: bool` flag to the detector
+state. Track whether the previously-emitted row went
+non-matching between emissions (i.e., the user typed something
+on the prompt row, making it dirty). When the next clean
+prompt match arrives, emit even if `(text, rowIdx)` matches
+the previous emission. The flag clears on each emission so the
+no-spurious-re-emit behaviour for idle cursor-blinks is
+preserved.
+
+Pre-existing detector tests (cursor-blink suppression,
+different-text emit, different-row emit, post-reset re-emit)
+all keep passing. Two new tests pin the regression and the
+companion "no spurious re-emit on stable idle prompt" case.
+
 ### Added (Cycle 45f): per-shell verbosity modes
 
 Two new menu items under `Display`:

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -153,13 +153,33 @@ module HeuristicPromptDetector =
           /// command cycle (output filled rows below the
           /// previous prompt; new prompt rendered below the
           /// output).
-          LastEmittedPromptRowIndex: int option }
+          LastEmittedPromptRowIndex: int option
+          /// Cycle 45f-followup (2026-05-12) — dirty flag
+          /// that closes the `(text, rowIdx)`-equality
+          /// false-negative. Set to `true` on any frame where
+          /// the previously-emitted row no longer matches the
+          /// prompt regex (e.g., the user typed `echo hello`
+          /// on the prompt row — the row text is now
+          /// `"C:\>echo hello"`, not a clean prompt match).
+          /// Cleared on emission. Forces the gate to emit the
+          /// next stable match regardless of `(text, rowIdx)`
+          /// equality with the last emission.
+          ///
+          /// Without this flag, a command run on a full
+          /// screen (e.g., after `dir` filled the 30 rows)
+          /// produces a redrawn prompt at the SAME row with
+          /// the SAME text as the previous emission — the
+          /// dedup gate suppresses it and SessionModel never
+          /// seals the tuple. cmd users observed silence
+          /// after the first screen-filling output.
+          RowDirtyAfterEmit: bool }
 
     /// Empty initial state.
     let create () : T =
         { PerRowMatches = Map.empty
           LastEmittedPromptText = None
-          LastEmittedPromptRowIndex = None }
+          LastEmittedPromptRowIndex = None
+          RowDirtyAfterEmit = false }
 
     /// Clear all per-row state. Called on shell-switch
     /// (fresh detector for new shell) and on alt-screen
@@ -169,7 +189,8 @@ module HeuristicPromptDetector =
     let reset (state: T) : T =
         { PerRowMatches = Map.empty
           LastEmittedPromptText = None
-          LastEmittedPromptRowIndex = None }
+          LastEmittedPromptRowIndex = None
+          RowDirtyAfterEmit = false }
 
     let private logger = Logger.get "Terminal.Core.HeuristicPromptDetector"
 
@@ -255,6 +276,31 @@ module HeuristicPromptDetector =
                     if Map.containsKey rowIdx nextMatches then
                         nextMatches <- Map.remove rowIdx nextMatches
 
+            // Cycle 45f-followup — RowDirtyAfterEmit accumulation.
+            // Look at the row the detector LAST emitted on. If that
+            // row currently does NOT match the prompt regex, the
+            // user has typed something on the prompt row (e.g.
+            // `"C:\>echo hello"` doesn't match `^[A-Z]:\\.*>\s?$`)
+            // or cmd's output has scrolled the prompt off / overwritten
+            // it. Either way, the NEXT clean-prompt-match on the same
+            // (text, rowIdx) pair is a genuinely-new prompt event,
+            // not a no-op refresh. Persist the bit across ticks so
+            // a multi-tick command cycle (typed → Enter → cmd output
+            // → new prompt → stability accumulation) doesn't lose
+            // it.
+            let dirtyThisTick =
+                match state.LastEmittedPromptRowIndex with
+                | None -> false
+                | Some priorRow ->
+                    if priorRow < 0 || priorRow >= snapshot.Length then
+                        false
+                    else
+                        let priorRowText =
+                            CanonicalState.renderRow snapshot priorRow
+                        not (regex.IsMatch(priorRowText))
+            let rowDirtyAccumulated =
+                state.RowDirtyAfterEmit || dirtyThisTick
+
             // PASS 2 — pick highest-rowIdx among stable matches,
             // apply the row-index-aware emission gate.
             let mutable emitted : PromptBoundaryData option = None
@@ -271,7 +317,9 @@ module HeuristicPromptDetector =
                         bestText <- candidateText
                 // Tier 1.E2.A — row-index-aware emission gate.
                 // A NEW PromptStart fires when the (text, rowIdx)
-                // pair differs from the last emitted pair.
+                // pair differs from the last emitted pair OR the
+                // previously-emitted row was dirtied between
+                // emissions (Cycle 45f-followup).
                 // Catches:
                 //   * Different text: `cd` changed the prompt
                 //     path.
@@ -279,16 +327,26 @@ module HeuristicPromptDetector =
                 //     stable-prompt case where output pushed
                 //     the prompt to a new row after a command
                 //     cycle.
+                //   * Same text, same row, dirty intermission:
+                //     screen-filling output scrolled everything,
+                //     the new prompt redrew on the same row as
+                //     the prior emission, the user already
+                //     typed + ran a command in between (the row
+                //     went non-matching). This used to silently
+                //     dedupe and caused cmd to go silent after
+                //     `dir` or any screen-filling output.
                 // Suppresses:
-                //   * Same text, same row: cursor blink /
-                //     refresh / no real activity.
+                //   * Same text, same row, never dirty: cursor
+                //     blink / refresh / no real activity.
                 let isNewPrompt =
                     match
                         state.LastEmittedPromptText,
                         state.LastEmittedPromptRowIndex
                         with
                     | Some priorText, Some priorRow ->
-                        priorText <> bestText || priorRow <> bestRow
+                        priorText <> bestText
+                        || priorRow <> bestRow
+                        || rowDirtyAccumulated
                     | _ -> true   // first emit
                 if isNewPrompt then
                     emitted <-
@@ -328,8 +386,15 @@ module HeuristicPromptDetector =
                     "HeuristicPromptDetector emitted PromptStart for shell {Shell} (stability {Ms}ms; rowIdx={Row}).",
                     shellKey, stabilityMs, emittedRowIndex)
 
+            // Cycle 45f-followup — reset dirty on emit; otherwise
+            // carry the accumulated value forward.
+            let nextRowDirtyAfterEmit =
+                if emitted.IsSome then false
+                else rowDirtyAccumulated
+
             let nextState =
                 { PerRowMatches = nextMatches
                   LastEmittedPromptText = nextLastEmittedText
-                  LastEmittedPromptRowIndex = nextLastEmittedRowIndex }
+                  LastEmittedPromptRowIndex = nextLastEmittedRowIndex
+                  RowDirtyAfterEmit = nextRowDirtyAfterEmit }
             emitted, nextState

--- a/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
+++ b/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
@@ -689,6 +689,90 @@ let ``same prompt text at SAME row suppresses re-emit (regression guard)`` () =
     Assert.True(r.IsNone)
 
 [<Fact>]
+let ``same (text, row) re-emits after the row went dirty in between (Cycle 45f-followup)`` () =
+    // Cycle 45f-followup — the dir-scroll bug.
+    //
+    // Pre-fix repro:
+    //   1. Screen-filling output (e.g. `dir`) pushes the
+    //      prompt to the bottom row N.
+    //   2. PromptStart fires at (rowIdx=N, text="C:\\>").
+    //   3. User types `echo hello` — row N becomes
+    //      "C:\\>echo hello", no longer matching the regex.
+    //   4. Enter → cmd outputs hello, scrolls by one row, the
+    //      new prompt redraws at row N with text "C:\\>" again.
+    //   5. Detector sees (rowIdx=N, text="C:\\>") = identical
+    //      to the last emission → dedup gate fires → no
+    //      PromptStart emitted → SessionModel never seals →
+    //      tuple-finalise announce never fires → silence.
+    //
+    // The dirty-flag fix: track when the previously-emitted
+    // row goes non-matching across ticks. When the next clean
+    // prompt match arrives on the same (text, rowIdx), emit
+    // anyway because we observed the row dirtied in between.
+    let promptOnly = snapshotOf 1 80 [ "C:\\>" ]
+    let dirtied = snapshotOf 1 80 [ "C:\\>echo hello" ]
+    let detector = HeuristicPromptDetector.create ()
+    // T=0: first detection, prompt seen for the first time.
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect
+            promptOnly noCursor "cmd" t0 detector
+    // T=100: stability reached, emit.
+    let r1, s2 =
+        HeuristicPromptDetector.tryDetect
+            promptOnly noCursor "cmd" (after 100) s1
+    Assert.True(r1.IsSome)
+    Assert.Equal(Some 0, r1.Value.MatchedRowIndex)
+    // T=200: user typed; row no longer matches. No emit (no
+    // stable match). But the detector should observe the row
+    // went dirty.
+    let r2, s3 =
+        HeuristicPromptDetector.tryDetect
+            dirtied noCursor "cmd" (after 200) s2
+    Assert.True(r2.IsNone)
+    // T=400: cmd's response settled; new prompt redrew on the
+    // same row with the same text. Stability needs to
+    // accumulate again from this tick.
+    let _, s4 =
+        HeuristicPromptDetector.tryDetect
+            promptOnly noCursor "cmd" (after 400) s3
+    // T=500: stability reached. The dirty bit accumulated
+    // across ticks means the gate emits even though
+    // (text, rowIdx) = (C:\\>, 0) matches the last emission.
+    let r3, _ =
+        HeuristicPromptDetector.tryDetect
+            promptOnly noCursor "cmd" (after 500) s4
+    Assert.True(
+        r3.IsSome,
+        "expected re-emit after the row went dirty between emissions")
+    Assert.Equal(Some 0, r3.Value.MatchedRowIndex)
+
+[<Fact>]
+let ``RowDirtyAfterEmit clears on the second tick when row stays clean (no spurious re-emit)`` () =
+    // Companion to the dir-scroll test above: confirm we
+    // haven't reintroduced the 20Hz-spam scenario. If the
+    // row STAYS at a clean prompt across many ticks (cursor
+    // blink, idle), the dirty flag stays false and the
+    // detector emits exactly once.
+    let snap = snapshotOf 1 80 [ "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r1, s2 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r1.IsSome)
+    // Walk forward 1 second with no row dirtying. No re-emit
+    // expected at any tick.
+    let mutable state = s2
+    for tickMs in 150 .. 50 .. 1000 do
+        let r, next =
+            HeuristicPromptDetector.tryDetect
+                snap noCursor "cmd" (after tickMs) state
+        Assert.True(
+            r.IsNone,
+            sprintf "spurious re-emit at tick %dms" tickMs)
+        state <- next
+
+[<Fact>]
 let ``same prompt text at DIFFERENT row emits new PromptStart (Cycle 20a headline)`` () =
     // Frame 1: prompt at row 0. Detector emits.
     // Frame 2: same prompt text at row 5 (output filled rows


### PR DESCRIPTION
## Summary

Cycle 45f follow-up. Maintainer dogfood surfaced silence after screen-filling output (`dir`, `tree`, etc.). Repro:

1. `echo hello` → narrates "hello" ✓
2. `dir` → narrates the output ✓
3. `echo hello` again → input echoes visually, "hello" prints on screen, **NVDA silent** ✗

## Root cause

`HeuristicPromptDetector`'s `(text, rowIdx)` dedup gate at `HeuristicPromptDetector.fs:306-313`. After `dir` fills the 30-row screen, the prompt lands at row 29. Detector emits `PromptStart(text="C:\>", rowIdx=29)`. When the next command runs and cmd redraws the prompt on the same row with the same text, the gate compares `(text, rowIdx)` to the last emission, sees equality, suppresses. SessionModel never seals the tuple → tuple-finalise announce never fires.

The gate was protecting against cursor-blink / no-op refresh spam (20Hz emission rate without it). It just used a too-weak identity: `(text, rowIdx)` can't distinguish "the screen redrew the same prompt" from "a real new command cycle ended at the same row with the same prompt."

## Fix

Add `RowDirtyAfterEmit: bool` to detector state:
- Set true when the previously-emitted row no longer matches the prompt regex (= the user typed, dirtying the prompt row)
- Cleared on each emission
- OR-ed into the gate so a dirty intermission forces re-emission

Preserves cursor-blink suppression (idle prompts stay quiet); fixes the false-negative for legit command cycles on a full screen.

## Test plan

- [x] Pre-existing tests still pass (cursor-blink suppression, different-text/row emit, post-reset re-emit)
- [x] New `same (text, row) re-emits after the row went dirty` test pins the regression
- [x] New `RowDirtyAfterEmit clears on the second tick when row stays clean` test confirms no 20Hz spam
- [ ] Maintainer NVDA dogfood: cmd → `echo hello` → `dir` → `echo hello` again → narrates "hello"
- [ ] No regression on idle-prompt silence (history doesn't balloon)

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_