### PR TITLE
diag: build provenance in bundle header + detector dirty-flag trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,35 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 45f follow-up): diagnostic build provenance + detector trace
+
+Diagnostic bundles now emit a `Build:` line in the header
+carrying the full `AssemblyInformationalVersion` (including
+the `+sha` suffix the release pipeline stamps). The existing
+`Version:` line keeps the bare semver for human-readable
+contexts; the new `Build:` line gives a paste-back the exact
+commit identity so maintainer + Claude can verify which fixes
+are in the build being dogfooded. Skipped when the SHA suffix
+isn't present (avoids a redundant duplicate line).
+
+`HeuristicPromptDetector` gained two Debug-level trace lines
+to make the dirty-flag fix (PR #272) observable in dogfood
+logs:
+- `dirty-flag set for shell ...` — fires on the
+  `false → true` transition (when the previously-emitted
+  prompt row stops matching, i.e. the user just typed on the
+  prompt). Single log per dirty episode, no 20Hz noise.
+- `SUPPRESSED PromptStart for shell ... rowDirtyAccumulated=...`
+  — fires when the gate sees a stable prompt match but the
+  identity check (`(text, row, dirty)`) decides "not a new
+  prompt." Captures the case where a legitimate new prompt is
+  being incorrectly dedupe-suppressed; the `rowDirtyAccumulated`
+  value reveals whether the dirty bit fired as expected.
+
+Together these tell us, on the next post-screen-fill silence
+regression, exactly whether the detector saw the prompt at
+all and what the gate decided.
+
 ### Fixed (Cycle 45f follow-up): silence after screen-filling output
 
 Maintainer NVDA dogfood on the Cycle 45f build surfaced a real

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -784,6 +784,29 @@ module Diagnostics =
             | _ -> "unknown"
         with _ -> "unknown"
 
+    /// Cycle 45f-followup (2026-05-12) — full informational
+    /// version *including* any `+sha` trailer that the build
+    /// pipeline appends. The stripped variant above is intended
+    /// for human-facing surfaces (startup log, "About" UI);
+    /// the raw variant is for diagnostic-bundle headers so a
+    /// paste-back unambiguously records WHICH commit produced
+    /// the build (handy for verifying "is my fix actually in
+    /// the build I'm dogfooding?"). Returns `"unknown"` only
+    /// if the attribute is missing entirely.
+    let private resolveInformationalVersionWithSha () : string =
+        try
+            let asm = System.Reflection.Assembly.GetExecutingAssembly()
+            let attr =
+                System.Attribute.GetCustomAttribute(
+                    asm,
+                    typeof<System.Reflection.AssemblyInformationalVersionAttribute>)
+            match attr with
+            | :? System.Reflection.AssemblyInformationalVersionAttribute as a
+                when not (System.String.IsNullOrWhiteSpace a.InformationalVersion) ->
+                a.InformationalVersion
+            | _ -> "unknown"
+        with _ -> "unknown"
+
     let private resolveDiagnosticLogPath (now: DateTime) : string =
         let root =
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
@@ -928,7 +951,16 @@ module Diagnostics =
         appendLine "pty-speak diagnostic snapshot (Cycle 25b)"
         appendLine (sprintf "Captured: %s UTC" (now.ToString("yyyy-MM-dd HH:mm:ss")))
         let version = resolveInformationalVersion ()
+        let versionFull = resolveInformationalVersionWithSha ()
         appendLine (sprintf "Version: %s" version)
+        // Cycle 45f-followup — emit the full +sha-suffixed
+        // version (when the build pipeline stamped it) on a
+        // separate line so a paste-back unambiguously identifies
+        // which commit produced this build. Skip the line if
+        // there's no SHA to differentiate.
+        if versionFull <> version
+           && versionFull <> "unknown" then
+            appendLine (sprintf "Build: %s" versionFull)
         appendLine (sprintf "OS: %s" (Environment.OSVersion.VersionString))
         appendLine (sprintf ".NET: %s" (Environment.Version.ToString()))
         appendLine (sprintf "Process ID: %d" (System.Diagnostics.Process.GetCurrentProcess().Id))
@@ -1019,7 +1051,14 @@ module Diagnostics =
         appendLine "pty-speak diagnostic snapshot (Cycle 43a lightweight)"
         appendLine (sprintf "Captured: %s UTC" (now.ToString("yyyy-MM-dd HH:mm:ss")))
         let version = resolveInformationalVersion ()
+        let versionFull = resolveInformationalVersionWithSha ()
         appendLine (sprintf "Version: %s" version)
+        // Cycle 45f-followup — `Build:` line carries the full
+        // SHA-suffixed informational version when the build
+        // pipeline stamped one (mirrors the full-bundle header).
+        if versionFull <> version
+           && versionFull <> "unknown" then
+            appendLine (sprintf "Build: %s" versionFull)
         appendLine (sprintf "OS: %s" (Environment.OSVersion.VersionString))
         appendLine (sprintf ".NET: %s" (Environment.Version.ToString()))
         appendLine (sprintf "Process ID: %d" (System.Diagnostics.Process.GetCurrentProcess().Id))

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -300,6 +300,25 @@ module HeuristicPromptDetector =
                         not (regex.IsMatch(priorRowText))
             let rowDirtyAccumulated =
                 state.RowDirtyAfterEmit || dirtyThisTick
+            // Cycle 45f-followup — trace the dirty-bit
+            // transitions so a screen-filling-output dogfood
+            // can show whether the gate is seeing the
+            // intermission. Only logs on the transition
+            // (false → true) to avoid 20Hz noise during
+            // sustained dirty state.
+            if dirtyThisTick && not state.RowDirtyAfterEmit then
+                let priorRowText =
+                    match state.LastEmittedPromptRowIndex with
+                    | Some priorRow
+                        when priorRow >= 0
+                        && priorRow < snapshot.Length ->
+                        CanonicalState.renderRow snapshot priorRow
+                    | _ -> "<n/a>"
+                logger.LogDebug(
+                    "HeuristicPromptDetector dirty-flag set for shell {Shell}: priorRow={PriorRow} priorRowText='{PriorRowText}' (previously-emitted prompt row no longer matches the regex).",
+                    shellKey,
+                    state.LastEmittedPromptRowIndex,
+                    priorRowText)
 
             // PASS 2 — pick highest-rowIdx among stable matches,
             // apply the row-index-aware emission gate.
@@ -383,8 +402,28 @@ module HeuristicPromptDetector =
 
             if emitted.IsSome then
                 logger.LogDebug(
-                    "HeuristicPromptDetector emitted PromptStart for shell {Shell} (stability {Ms}ms; rowIdx={Row}).",
-                    shellKey, stabilityMs, emittedRowIndex)
+                    "HeuristicPromptDetector emitted PromptStart for shell {Shell} (stability {Ms}ms; rowIdx={Row}; rowDirtyAccumulated={Dirty}).",
+                    shellKey, stabilityMs, emittedRowIndex, rowDirtyAccumulated)
+            // Cycle 45f-followup — also trace the gate-suppression
+            // case. If we found a stable match but the gate said
+            // "not new" (text + row matched the last emission AND
+            // we never observed a dirty intermission), log the
+            // suppression with enough context to diagnose. This
+            // is the case that produces the post-screen-fill
+            // silence regression; the trace tells us whether the
+            // dirty flag was correctly true or wrongly false at
+            // the suppression moment.
+            elif stableMatches.Count > 0 then
+                let bestRow, bestText =
+                    stableMatches.[stableMatches.Count - 1]
+                logger.LogDebug(
+                    "HeuristicPromptDetector SUPPRESSED PromptStart for shell {Shell} at rowIdx={Row} text='{Text}': priorRow={PriorRow} priorText='{PriorText}' rowDirtyAccumulated={Dirty}.",
+                    shellKey,
+                    bestRow,
+                    bestText,
+                    state.LastEmittedPromptRowIndex,
+                    state.LastEmittedPromptText,
+                    rowDirtyAccumulated)
 
             // Cycle 45f-followup — reset dirty on emit; otherwise
             // carry the accumulated value forward.


### PR DESCRIPTION
## Summary

Two observability improvements to make the post-screen-fill silence regression diagnosable. PR #272's dirty-flag fix is in the build the maintainer is testing (preview.99 confirmed) but is still failing — without per-tick trace, we're guessing about why.

### 1. Build provenance in bundle headers

Diagnostic bundles (both full + lightweight) now emit a `Build:` line carrying the full `AssemblyInformationalVersion` including the `+sha` suffix the release pipeline stamps. The `Version:` line keeps the bare semver. A paste-back now records the exact commit identity so we can verify which fixes are actually in the build being dogfooded without guessing from release dates.

### 2. Detector dirty-flag trace

`HeuristicPromptDetector` adds two Debug-level log lines:

- **`dirty-flag set for shell ...`** — fires once on the `false → true` transition when the previously-emitted prompt row stops matching (single log per dirty episode; no 20Hz noise).
- **`SUPPRESSED PromptStart for shell ... rowDirtyAccumulated=...`** — fires when the gate sees a stable match but `(text, row, dirty)` says "not new." Captures the exact case where a legitimate new prompt is incorrectly dedupe-suppressed; `rowDirtyAccumulated` value tells us whether the dirty bit set as expected.

Next dogfood of the post-screen-fill sequence will produce either:
- A `SUPPRESSED` line → the gate is firing wrong; the trace shows why
- No `SUPPRESSED` line → the detector never saw the prompt at all (different bug class)

Either way the silent regression becomes a single-grep diagnostic.

## Test plan

- [x] Existing tests pass (logging is additive; no behaviour change)
- [ ] Maintainer dogfood preview.100 (this PR + #272): run `echo hi` → `dir` → `echo hi` again, capture diagnostic, share the lines containing `PromptStart` or `dirty-flag`
- [ ] Verify the `Build:` line appears in the new bundle header with the `+sha` suffix

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_