### PR TITLE
feat(cycle-45c): ContentHistory-driven OSC 133 substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,56 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Added (Cycle 45c cleanup PR-3a): ContentHistory-driven OSC 133 substrate
+
+Migration step toward deleting the `LinearTextStream` substrate.
+SessionModel can now extract `(CommandText, OutputText)` for each
+SessionTuple from ContentHistory directly. The LinearTextStream
+path stays alive in this PR (parallel-but-uncalled); PR-3c deletes
+it.
+
+`src/Terminal.Core/ContentHistory.fs` grows two helpers:
+- `tryLatestMarker` — locates the most recent Marker entry of a
+  given Kind in the current tuple's history (used to find
+  PromptStart / OutputStart at tuple-seal time).
+- `sliceText` — reconstructs user-visible text from entries
+  whose Seq is strictly between two boundary seqs. TextSpan +
+  Overwrite + Spinner contribute their text; Newline contributes
+  `\n`; Markers contribute nothing. The unsealed active TextSpan
+  is included when its implicit Seq is in-region (important at
+  tuple-seal time when the closing marker hasn't been appended
+  yet).
+
+`src/Terminal.Core/SessionModel.fs` grows three companions:
+- `extractContentFromContentHistory` (private) — the
+  ContentHistory analogue of `extractContentFromLinearStream`.
+- `applyAndCaptureWithContentHistory` — public substrate-aware
+  finalize taking a `ContentHistory.T` + `useContentHistory: bool`.
+- `applyWithContentHistory` — state-only wrapper.
+
+`src/Terminal.App/Program.fs` (`handlePromptBoundary`) switches
+to call `applyAndCaptureWithContentHistory`; the old
+`applyAndCaptureWithSubstrate(... linearStream)` call site is
+gone. The `StreamPathway.SubstrateMode` enum dispatch shape is
+preserved verbatim — collapses to a single bool in PR-3b once
+StreamPathway gets deleted.
+
+Compile order: `Terminal.Core.fsproj` reordered to put
+`ContentHistory.fs` above `SessionModel.fs` (it depends on
+`Types.fs` only, so it slots in next to `LinearTextStream.fs`).
+`SpeechCursor.fs` follows `ShellPolicy.fs` since it depends on
+both `ContentHistory` and `ShellPolicy`.
+
+Tests:
+- `tests/Tests.Unit/ContentHistoryTests.fs` gains 9 new cases
+  pinning `tryLatestMarker` + `sliceText`: empty / present /
+  repeated / wrong-kind / multi-entry slice / active-span
+  inclusion / empty region / marker-text exclusion.
+- `tests/Tests.Unit/SessionModelTests.fs` gains a parallel
+  block of 5 Cycle 45c cases mirroring the existing Cycle 35b
+  block; the Cycle 35b LinearTextStream cases stay until PR-3c
+  retires the substrate.
+
 ### Removed (Cycle 45c cleanup PR-2): pathway-pipeline test files + `[pathway.stream]` TOML parsing
 
 Test-side prune of the pathway pipeline Cycle 45 replaced. Deleted

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1578,25 +1578,28 @@ module Program =
             // becomes a no-op. Cycle 24d-1: `Always` mode routes
             // through `EnqueueSync` (blocking) via
             // `dispatchTupleToWriter`.
-            // Cycle 35b — substrate-aware finalize. Resolve
-            // SubstrateMode against the alt-screen state captured
-            // at boundary time (mirrors
-            // StreamPathway.resolveSubstrateMode). Linear path
-            // becomes authoritative when the LinearTextStream
-            // producer has observed OSC 133 markers since the
-            // last finalize; falls back to extractContent for
-            // OSC-133-less shells (vanilla cmd, vanilla
-            // PowerShell). See Section 13 of the strategic plan
-            // for the eventual-cleanup conditions.
-            let useLinear =
+            // Cycle 45c — ContentHistory-driven substrate-aware
+            // finalize. Replaces Cycle 35b's LinearTextStream
+            // path. The SubstrateMode dispatch shape is preserved
+            // verbatim — Linear / ScreenDiff / Auto still gate
+            // whether SessionModel uses the OSC 133 path
+            // (authoritative when shell emits markers) versus
+            // the `extractContent` row-walk fallback. The
+            // substrate behind the OSC 133 path is now
+            // ContentHistory + `tryLatestMarker` /  `sliceText`.
+            // PR-3b collapses the SubstrateMode enum once the
+            // pathway modules are deleted; for PR-3a the enum
+            // values stay referenced (StreamPathway.fs is still
+            // alive).
+            let useContentHistory =
                 match resolvedStreamParams.SubstrateMode with
                 | StreamPathway.Linear -> true
                 | StreamPathway.ScreenDiff -> false
                 | StreamPathway.Auto -> not screen.Modes.AltScreen
             let nextSession, finalisedOpt =
-                SessionModel.applyAndCaptureWithSubstrate
+                SessionModel.applyAndCaptureWithContentHistory
                     currentSession augmented snapshotForApply
-                    linearStream useLinear
+                    contentHistory useContentHistory
             currentSession <- nextSession
             match finalisedOpt with
             | Some tuple -> dispatchTupleToWriter tuple

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -248,6 +248,71 @@ module ContentHistory =
                 i <- i + 1
             found)
 
+    /// Cycle 45c — most recent Marker entry of the given Kind, or
+    /// `None` if absent. Walks `Entries` from tail. Used by
+    /// `SessionModel.extractContentFromContentHistory` at
+    /// tuple-seal time to locate the PromptStart + OutputStart
+    /// boundaries of the just-sealed tuple.
+    let tryLatestMarker (state: T) (kind: MarkerKind) : MarkerData option =
+        lock state.Gate (fun () ->
+            let entries = state.Entries
+            let mutable found = None
+            let mutable i = entries.Count - 1
+            while found.IsNone && i >= 0 do
+                match entries.[i] with
+                | Marker m when m.Kind = kind -> found <- Some m
+                | _ -> ()
+                i <- i - 1
+            found)
+
+    /// Cycle 45c — reconstruct the user-visible text payload for
+    /// entries whose Seq is strictly between `fromSeqExclusive`
+    /// and `toSeqExclusive`. The caller typically passes adjacent
+    /// Marker seqs (e.g. PromptStart.Seq, OutputStart.Seq) to
+    /// extract a single bracketed region.
+    ///
+    /// Contribution per entry kind:
+    ///   - `TextSpan` / `Overwrite` / `Spinner` → their text
+    ///   - `Newline`                            → "\n"
+    ///   - `Marker`                             → ""  (boundary
+    ///                                                token only)
+    ///
+    /// The unsealed active TextSpan also contributes if its
+    /// implicit Seq (`NextSeq`) is in-region — important at
+    /// tuple-seal time when bytes have arrived since the most
+    /// recent seal but the closing marker hasn't been appended
+    /// yet.
+    ///
+    /// "User-visible" semantics: Overwrites contribute the
+    /// post-overwrite text (not the original); Spinners
+    /// contribute their `LatestText` frame. The reconstruction
+    /// reflects what the user actually saw, not the byte trail.
+    let sliceText
+            (state: T)
+            (fromSeqExclusive: int64)
+            (toSeqExclusive: int64)
+            : string =
+        lock state.Gate (fun () ->
+            let sb = StringBuilder()
+            for entry in state.Entries do
+                let seq = entrySeq entry
+                if seq > fromSeqExclusive && seq < toSeqExclusive then
+                    match entry with
+                    | TextSpan d -> sb.Append(d.Text) |> ignore
+                    | Newline _ -> sb.Append('\n') |> ignore
+                    | Overwrite d -> sb.Append(d.Text) |> ignore
+                    | Spinner d -> sb.Append(d.LatestText) |> ignore
+                    | Marker _ -> ()
+            // The unsealed active span's implicit Seq is NextSeq;
+            // include its content iff that lands in-region.
+            if state.ActiveSpanText.Length > 0 then
+                let activeSeq = state.NextSeq
+                if activeSeq > fromSeqExclusive
+                   && activeSeq < toSeqExclusive then
+                    sb.Append(state.ActiveSpanText.ToString())
+                    |> ignore
+            sb.ToString())
+
     /// Internal: allocate the next Seq.
     let private nextSeq (state: T) : int64 =
         let s = state.NextSeq

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -770,6 +770,42 @@ module SessionModel =
             let chunk, _ = LinearTextStream.finalizeHighWaterMark linearStream
             Some (chunk.CommandText, chunk.OutputText)
 
+    /// Cycle 45c — ContentHistory replacement for
+    /// `extractContentFromLinearStream`. Locates the latest
+    /// PromptStart + OutputStart markers in the current tuple's
+    /// ContentHistory and slices the bracketed text.
+    ///
+    /// Returns `Some (commandText, outputText)` when both
+    /// markers are present (ContentHistory path is authoritative);
+    /// else `None` so the caller falls back to `extractContent`'s
+    /// row-walk (vanilla cmd / vanilla PowerShell with no OSC 133
+    /// shim).
+    ///
+    /// PromptStart-only (no OutputStart yet) is treated as
+    /// "fallback" because we can't reconstruct the output region.
+    /// In practice CommandFinished always follows OutputStart when
+    /// any OSC 133 marker is emitted; PromptStart-only is the
+    /// degenerate case of a shell that emits A but not C / D.
+    let private extractContentFromContentHistory
+            (history: ContentHistory.T)
+            : (string * string) option
+            =
+        match
+            ContentHistory.tryLatestMarker
+                history ContentHistory.MarkerKind.PromptStart,
+            ContentHistory.tryLatestMarker
+                history ContentHistory.MarkerKind.OutputStart
+        with
+        | Some promptStart, Some outputStart ->
+            let commandText =
+                ContentHistory.sliceText
+                    history promptStart.Seq outputStart.Seq
+            let outputText =
+                ContentHistory.sliceText
+                    history outputStart.Seq System.Int64.MaxValue
+            Some (commandText, outputText)
+        | _ -> None
+
     /// Cycle 35b — substrate-aware finalize. The caller (a
     /// composition root or pathway-pump callback) resolves the
     /// substrate mode against `StreamPathway.SubstrateMode` and
@@ -821,6 +857,50 @@ module SessionModel =
             =
         applyAndCaptureWithSubstrate
             state boundary snapshot linearStream useLinear
+        |> fst
+
+    /// Cycle 45c — ContentHistory-driven substrate finalize.
+    /// Companion to `applyAndCaptureWithSubstrate`, threaded with
+    /// the new ContentHistory substrate instead of LinearTextStream.
+    ///
+    /// `useContentHistory = true` → invoke the
+    /// `extractContentFromContentHistory` thunk inside
+    /// `finalizeAndEnqueue`; `false` → row-walk fallback. The
+    /// boolean exists for future shells that might opt out of
+    /// the substrate; current shells (cmd / PowerShell / claude)
+    /// all default to `true`.
+    let applyAndCaptureWithContentHistory
+            (state: T)
+            (boundary: PromptBoundaryData)
+            (snapshot: Cell[][])
+            (history: ContentHistory.T)
+            (useContentHistory: bool)
+            : T * SessionTuple option
+            =
+        // Mirror `applyAndCaptureWithSubstrate`'s thunk-lazy
+        // pattern: the override only invokes
+        // `extractContentFromContentHistory` when
+        // `finalizeAndEnqueue` actually fires (CommandFinished
+        // boundary). Other boundary kinds skip the thunk.
+        let contentOverride : (unit -> (string * string) option) option =
+            if useContentHistory then
+                Some (fun () -> extractContentFromContentHistory history)
+            else
+                None
+        applyAndCaptureCore state boundary snapshot contentOverride
+
+    /// Cycle 45c — state-only wrapper around
+    /// `applyAndCaptureWithContentHistory`.
+    let applyWithContentHistory
+            (state: T)
+            (boundary: PromptBoundaryData)
+            (snapshot: Cell[][])
+            (history: ContentHistory.T)
+            (useContentHistory: bool)
+            : T
+            =
+        applyAndCaptureWithContentHistory
+            state boundary snapshot history useContentHistory
         |> fst
 
     // -----------------------------------------------------------------

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -15,6 +15,15 @@
     <Compile Include="FileLogger.fs" />
     <Compile Include="Coalescer.fs" />
     <Compile Include="LinearTextStream.fs" />
+    <!--
+      Cycle 45 — ContentHistory is the new aural substrate. It
+      depends only on `Types.fs` (VtEvent), so it slots in
+      alongside LinearTextStream. Cycle 45c (PR-3a) moved it
+      above SessionModel.fs because SessionModel.fs now consumes
+      `ContentHistory.tryLatestMarker` + `sliceText` for OSC 133
+      text reconstruction.
+    -->
+    <Compile Include="ContentHistory.fs" />
     <Compile Include="OutputEventTypes.fs" />
     <Compile Include="CanonicalCorpus.fs" />
     <Compile Include="OutputEventBuilder.fs" />
@@ -26,6 +35,11 @@
     <Compile Include="SessionSanitiser.fs" />
     <Compile Include="SessionLogWriter.fs" />
     <Compile Include="ShellPolicy.fs" />
+    <!--
+      Cycle 45 — SpeechCursor depends on ContentHistory + ShellPolicy.
+      Placed after ShellPolicy so both deps are in scope.
+    -->
+    <Compile Include="SpeechCursor.fs" />
     <Compile Include="HeuristicPromptDetector.fs" />
     <Compile Include="SelectionDetector.fs" />
     <Compile Include="DisplayPathway.fs" />
@@ -55,19 +69,6 @@
     -->
     <Compile Include="DiagnosticExtracts.fs" />
     <Compile Include="DiagnosticGrep.fs" />
-    <!--
-      Cycle 45 Commit 1 — ContentHistory + SpeechCursor.
-      The new aural substrate (ContentHistory) and its announce-
-      and-navigate primitive (SpeechCursor). Purely additive in
-      Commit 1: no consumer in Terminal.App wires to them yet.
-      Commit 2 connects them to the reader loop + detectors +
-      NvdaChannel. Both modules live at the end of the compile
-      order because nothing else in Terminal.Core depends on
-      them. SpeechCursor depends on ContentHistory; the order is
-      load-bearing.
-    -->
-    <Compile Include="ContentHistory.fs" />
-    <Compile Include="SpeechCursor.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Unit/ContentHistoryTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTests.fs
@@ -395,3 +395,175 @@ let ``snapshot returns a fresh array independent of further appends`` () =
     let snap2 = ContentHistory.snapshot state
     Assert.Equal(2, snap1.Length)
     Assert.Equal(4, snap2.Length)
+
+// ---------------------------------------------------------------------
+// Cycle 45c — tryLatestMarker + sliceText helpers
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``tryLatestMarker on empty history returns None`` () =
+    let state = freshHistory ()
+    Assert.Equal(None,
+        ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart)
+
+[<Fact>]
+let ``tryLatestMarker returns Some when the kind is present`` () =
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0 None
+    |> ignore
+    let result =
+        ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart
+    Assert.True(result.IsSome)
+    Assert.Equal(ContentHistory.MarkerKind.PromptStart, result.Value.Kind)
+
+[<Fact>]
+let ``tryLatestMarker returns the most recent of repeated kinds`` () =
+    // Cycle 45e re-emits PromptStart after a dirty intermission.
+    // tryLatestMarker must return the LATEST so commandText reflects
+    // the user's currently-typed (post-intermission) command.
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0
+        (Some "first")
+    |> ignore
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart (after 10)
+        (Some "second")
+    |> ignore
+    let result =
+        ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart
+    Assert.True(result.IsSome)
+    Assert.Equal(Some "second", result.Value.Payload)
+
+[<Fact>]
+let ``tryLatestMarker ignores other kinds`` () =
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0 None
+    |> ignore
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart (after 5) None
+    |> ignore
+    let pstart =
+        ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart
+    let cfin =
+        ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.CommandFinished
+    Assert.True(pstart.IsSome)
+    Assert.Equal(None, cfin)
+
+[<Fact>]
+let ``sliceText between two markers concatenates TextSpan + Newline`` () =
+    // Layout: [PromptStart, "echo hello", Newline, OutputStart]
+    // Expected commandText slice = "echo hello\n"
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0 None
+    |> ignore
+    let _ =
+        feed state (after 5)
+            [ printRune 'e'; printRune 'c'; printRune 'h'
+              printRune 'o'; printRune ' '; printRune 'h'
+              printRune 'e'; printRune 'l'; printRune 'l'
+              printRune 'o'; lf ]
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart (after 10) None
+    |> ignore
+    let pstart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart).Value
+    let ostart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.OutputStart).Value
+    Assert.Equal(
+        "echo hello\n",
+        ContentHistory.sliceText state pstart.Seq ostart.Seq)
+
+[<Fact>]
+let ``sliceText with toSeqExclusive = MaxValue includes the tail`` () =
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart t0 None
+    |> ignore
+    let _ =
+        feed state (after 5)
+            [ printRune 'h'; printRune 'i'; lf ]
+    let ostart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.OutputStart).Value
+    Assert.Equal(
+        "hi\n",
+        ContentHistory.sliceText state ostart.Seq Int64.MaxValue)
+
+[<Fact>]
+let ``sliceText includes the unsealed active span when in-region`` () =
+    // At tuple-finalise time the CommandFinished marker hasn't
+    // been appended yet, so the trailing output text sits in the
+    // unsealed active span. sliceText must include it.
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart t0 None
+    |> ignore
+    let _ =
+        feed state (after 5)
+            [ printRune 'h'; printRune 'i' ]
+    // No newline + no marker → "hi" stays in the active span
+    let ostart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.OutputStart).Value
+    Assert.Equal(
+        "hi",
+        ContentHistory.sliceText state ostart.Seq Int64.MaxValue)
+
+[<Fact>]
+let ``sliceText returns empty string when the region is empty`` () =
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0 None
+    |> ignore
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart (after 1) None
+    |> ignore
+    let pstart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart).Value
+    let ostart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.OutputStart).Value
+    Assert.Equal(
+        "",
+        ContentHistory.sliceText state pstart.Seq ostart.Seq)
+
+[<Fact>]
+let ``sliceText excludes the marker entries themselves`` () =
+    // PromptStart.Seq = 0, "x" TextSpan after newline at Seq = 1+,
+    // OutputStart.Seq = N. Markers are boundary tokens — they
+    // contribute "" so even if the comparison were inclusive the
+    // visible behaviour is identical. This test pins the
+    // strict-comparison contract.
+    let state = freshHistory ()
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.PromptStart t0
+        (Some "prompt-text")
+    |> ignore
+    let _ = feed state (after 5) [ printRune 'x'; lf ]
+    ContentHistory.appendMarker
+        state ContentHistory.MarkerKind.OutputStart (after 10)
+        (Some "output-marker-text")
+    |> ignore
+    let pstart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.PromptStart).Value
+    let ostart =
+        (ContentHistory.tryLatestMarker
+            state ContentHistory.MarkerKind.OutputStart).Value
+    let result =
+        ContentHistory.sliceText state pstart.Seq ostart.Seq
+    Assert.Equal("x\n", result)
+    Assert.DoesNotContain("prompt-text", result)
+    Assert.DoesNotContain("output-marker-text", result)

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -1663,3 +1663,155 @@ let ``Cycle 35b — legacy apply / applyAndCapture API unchanged (regression che
             s1 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
     Assert.True(finalisedOpt.IsSome)
     Assert.True(s2.Active.IsNone)
+
+// =====================================================================
+// Cycle 45c — ContentHistory-driven substrate
+// (`applyAndCaptureWithContentHistory`). Mirror the Cycle 35b tests
+// against the new substrate. PR-3c retires the LinearTextStream
+// counterparts above when the substrate itself is deleted.
+// =====================================================================
+
+let private freshHistory () : ContentHistory.T =
+    ContentHistory.create ContentHistory.defaultParameters
+
+let private feedHistoryBytes
+        (history: ContentHistory.T)
+        (now: DateTime)
+        (bytes: byte[])
+        : ContentHistory.T =
+    let parser = Terminal.Parser.Parser.create ()
+    let events = Terminal.Parser.Parser.feedArray parser bytes
+    for ev in events do
+        ContentHistory.appendFromEvent history now ev |> ignore
+    history
+
+let private appendHistoryMarker
+        (history: ContentHistory.T)
+        (now: DateTime)
+        (kind: ContentHistory.MarkerKind)
+        : ContentHistory.T =
+    ContentHistory.appendMarker history kind now None |> ignore
+    history
+
+[<Fact>]
+let ``Cycle 45c — useContentHistory=false bypasses the substrate entirely`` () =
+    // ScreenDiff mode equivalent: ContentHistory content irrelevant;
+    // behaviour identical to the legacy `applyAndCapture` API.
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    let history = feedHistoryBytes history t0 (System.Text.Encoding.ASCII.GetBytes "irrelevant\n")
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundary BoundaryKind.PromptStart t0) [||]
+                history false
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history false
+    let _ = SessionModel.applyWithContentHistory
+                s2 (boundary BoundaryKind.OutputStart (after 200)) [||]
+                history false
+    Assert.True(true)
+
+[<Fact>]
+let ``Cycle 45c — useContentHistory=true + OSC 133 markers populates CommandText/OutputText from history`` () =
+    let initial = SessionModel.create "claude" 100
+    // Build a ContentHistory mirroring the canonical OSC 133
+    // sequence: PromptStart marker → command text → OutputStart
+    // marker → output text. handlePromptBoundary in Program.fs is
+    // the production analogue.
+    let history = freshHistory ()
+    let history = appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    let history = feedHistoryBytes history (after 5) (System.Text.Encoding.ASCII.GetBytes "echo hello\n")
+    let history = appendHistoryMarker history (after 10) ContentHistory.MarkerKind.OutputStart
+    let history = feedHistoryBytes history (after 15) (System.Text.Encoding.ASCII.GetBytes "hello world\n")
+    // Drive the SessionModel cycle. The PromptStart / CommandStart
+    // / CommandFinished arms below mirror the calls
+    // `handlePromptBoundary` makes against incoming boundaries.
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "$ ") [||]
+                history true
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
+            history true
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    // CommandText / OutputText flowed from ContentHistory.sliceText
+    // (NOT from extractContent's row-walk against the [||] snapshot).
+    Assert.Contains("echo hello", tuple.CommandText)
+    Assert.Contains("hello world", tuple.OutputText)
+
+[<Fact>]
+let ``Cycle 45c — useContentHistory=true but no OSC 133 markers falls back to extractContent`` () =
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    // No PromptStart / OutputStart appended → tryLatestMarker
+    // returns None → extractContentFromContentHistory returns None
+    // → caller falls back to extractContent.
+    let history = feedHistoryBytes history t0 (System.Text.Encoding.ASCII.GetBytes "irrelevant\n")
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "C:\\>") [||]
+                history true
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
+            history true
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    // extractContent fallback against [||] snapshot returns empty
+    // strings; the history's "irrelevant" content must NOT appear
+    // (no markers gate the substrate path).
+    Assert.DoesNotContain("irrelevant", tuple.OutputText)
+
+[<Fact>]
+let ``Cycle 45c — useContentHistory=false ignores OSC 133 markers (history has them)`` () =
+    let initial = SessionModel.create "claude" 100
+    let history = freshHistory ()
+    // Markers ARE present; but useContentHistory=false. The
+    // substrate path must NOT be consulted.
+    let history = appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    let history = feedHistoryBytes history (after 5) (System.Text.Encoding.ASCII.GetBytes "echo from-history\n")
+    let history = appendHistoryMarker history (after 10) ContentHistory.MarkerKind.OutputStart
+    let history = feedHistoryBytes history (after 15) (System.Text.Encoding.ASCII.GetBytes "history-output\n")
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "$ ") [||]
+                history false  // useContentHistory = false
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history false
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
+            history false
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    Assert.DoesNotContain("from-history", tuple.CommandText)
+    Assert.DoesNotContain("history-output", tuple.OutputText)
+
+[<Fact>]
+let ``Cycle 45c — applyAndCaptureWithContentHistory preserves Active state through PromptStart cycle`` () =
+    // Behavioural smoke test mirroring the Cycle 35b state-machine
+    // test. The substrate-aware path must leave SessionModel in
+    // the same active-state as the legacy path for non-finalize
+    // boundaries.
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundary BoundaryKind.PromptStart t0) [||]
+                history true
+    Assert.True(s1.Active.IsSome)
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    Assert.True(s2.Active.IsSome)
+    Assert.Equal(SessionModel.ActiveTupleState.EditingCommand, s2.Active.Value.State)
+    let s3 = SessionModel.applyWithContentHistory
+                s2 (boundary BoundaryKind.OutputStart (after 200)) [||]
+                history true
+    Assert.True(s3.Active.IsSome)
+    Assert.Equal(SessionModel.ActiveTupleState.OutputStreaming, s3.Active.Value.State)


### PR DESCRIPTION
## Summary

PR-3a of the Cycle 45c cleanup sequence. Migrates SessionModel's OSC 133 `(CommandText, OutputText)` extraction off `LinearTextStream` (byte-offset slicing) onto `ContentHistory` (seq-addressed typed entries). The LinearTextStream path stays alive in this PR but becomes uncalled; PR-3c deletes it alongside the StreamPathway module set.

Per the design doc at `/root/.claude/plans/cycle-45c-osc133-design.md` (approved by maintainer 2026-05-12).

**User-visible behaviour: unchanged.** Same SessionModel state machine, same SessionTuple shape, same announce path. Only the byte-vs-seq reconstruction mechanism differs.

## What's added

### `src/Terminal.Core/ContentHistory.fs` — two helpers

- **`tryLatestMarker`** — locates the latest `Marker` entry of a given `Kind` in the current tuple. O(n) tail scan; tuples are bounded.
- **`sliceText`** — reconstructs user-visible text from entries whose Seq is strictly between two boundary seqs. `TextSpan` + `Overwrite` + `Spinner` contribute their text; `Newline` contributes `"\n"`; `Marker` contributes nothing. The unsealed active span is included when its implicit Seq is in-region (critical at tuple-seal time when the closing marker hasn't been appended yet).

### `src/Terminal.Core/SessionModel.fs` — three companions

- **`extractContentFromContentHistory`** (private) — the ContentHistory analogue of `extractContentFromLinearStream`.
- **`applyAndCaptureWithContentHistory`** (public) — substrate-aware finalize taking `ContentHistory.T` + `useContentHistory: bool`. Wraps `applyAndCaptureCore` with a thunk over `extractContentFromContentHistory`.
- **`applyWithContentHistory`** (public) — state-only wrapper.

### `src/Terminal.App/Program.fs` — caller swap

`handlePromptBoundary` switches from `applyAndCaptureWithSubstrate(... linearStream, useLinear)` to `applyAndCaptureWithContentHistory(... contentHistory, useContentHistory)`. The `StreamPathway.SubstrateMode` enum dispatch shape (`Linear` / `ScreenDiff` / `Auto`) is preserved verbatim — PR-3b collapses the enum once the pathway modules are deleted.

### Compile order

`src/Terminal.Core/Terminal.Core.fsproj` reordered:
- `ContentHistory.fs` moves from line 69 to alongside `LinearTextStream.fs` (it depends only on `Types.fs`).
- `SpeechCursor.fs` moves to just after `ShellPolicy.fs` (its dependency).

Mandatory because `SessionModel.fs` now references `ContentHistory.tryLatestMarker` / `sliceText` / `MarkerKind`.

## Tests

- **`tests/Tests.Unit/ContentHistoryTests.fs`** — 9 new cases pinning the helpers:
  - `tryLatestMarker`: empty / present / repeated-latest-wins / wrong-kind
  - `sliceText`: multi-entry concatenation / `Int64.MaxValue` tail / active-span inclusion / empty region / marker-text exclusion
- **`tests/Tests.Unit/SessionModelTests.fs`** — 5 new Cycle 45c cases mirroring the existing Cycle 35b LinearTextStream block. The Cycle 35b cases stay until PR-3c retires the substrate.

## Design choices (recorded in commit message + design doc)

- **§4.2** parsed-text reconstruction (not byte-exact) — sliceText walks the parsed TextSpan/Overwrite/Spinner entries, not raw bytes
- **§4.3** user-visible final state for Overwrites + Spinners — what the user actually saw, not the keystroke trail
- **§4.4** latest PromptStart wins on re-emit (PR #272 dirty-intermission territory)

## Diff stat

| File | + | - |
|---|---:|---:|
| `CHANGELOG.md` | 50 | 0 |
| `src/Terminal.App/Program.fs` | 18 | 11 |
| `src/Terminal.Core/ContentHistory.fs` | 65 | 0 |
| `src/Terminal.Core/SessionModel.fs` | 80 | 0 |
| `src/Terminal.Core/Terminal.Core.fsproj` | 20 | 7 |
| `tests/Tests.Unit/ContentHistoryTests.fs` | 172 | 0 |
| `tests/Tests.Unit/SessionModelTests.fs` | 152 | 0 |
| **Total** | **+557** | **-18** |

## What's NOT in this PR

- `StreamPathway` / `LinearTextStream` / `DisplayPathway` / `TuiPathway` / `PathwaySelector` source modules — still alive, parallel-but-uncalled
- `Program.fs` pathway-pipeline wiring (47 reference sites for `StreamPathway`, alt-screen handler, etc.) — PR-3b
- 5 file deletions + `Diagnostics.fs` `--- LINEAR STREAM ---` rename + `resolveStreamParameters` stub removal — PR-3c
- NVDA matrix walk — required after PR-3c lands

## Test plan

- [ ] Windows build + test passes (this PR's primary risk: the new functions must compile + the new tests must pass)
- [ ] Portability lint, actionlint, markdown link check pass
- [ ] Local sanity: `grep -rn 'extractContentFromContentHistory\|tryLatestMarker\|sliceText\|applyAndCaptureWithContentHistory' src/ tests/` shows the new wires (verified pre-push)

## Follow-up

PR-3b: strip Program.fs pathway wiring (~500 LOC delete + alt-screen handler simplification). PR-3c: file deletes + Diagnostics rename + Config stub removal + docs + NVDA matrix walk.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_