### PR TITLE
fix(session-model): announce tuple output for heuristic-only shells after scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Fixed (Cycle 45c fixup): NVDA silent after second command following scrolled output
+
+Maintainer reproducer 2026-05-12: run `echo hi` → `dir` → `echo hi`.
+NVDA announces the first two but goes silent on the third. The
+diagnostic snapshot showed the just-finalised `SessionTuple` had
+empty `CommandText` AND empty `OutputText`, so the
+tuple-finalise-announce path (gated on non-whitespace `OutputText`)
+produced nothing for NVDA to read.
+
+**Root cause** (pre-existing, not introduced by Cycle 45c): cmd
+doesn't emit OSC 133 markers, so
+`extractContentFromContentHistory` returned `None` (it required
+both `PromptStart` AND `OutputStart` markers). SessionModel then
+fell back to `extractContent`'s screen-row walk against the
+snapshot — which fails when the output has scrolled enough that
+the prior prompt and the new prompt share a `rowIdx` (both at
+the bottom of the screen at row 29). The row-walk can't
+distinguish "same row" from "no content between prompts" and
+returns empty.
+
+ContentHistory had the data (sequenced typed-entry log, no
+same-row ambiguity) — we just weren't slicing it for the
+heuristic-only path.
+
+**Fix**: extend `extractContentFromContentHistory` with a
+PromptStart-only fallback. When the OSC 133 `OutputStart` marker
+is absent but a prior `PromptStart` marker is present, slice
+the blob from that marker to MaxValue — that's the just-
+finalising tuple's combined typed-input + output text. The
+trailing portion (the new prompt's rendered text, which landed
+in ContentHistory before the boundary fired) is trimmed via
+the boundary's `MatchedRowText`. The remainder is split on the
+first newline (cmd's wire format is "echo hi\nhi\n…") into
+`(CommandText, OutputText)`.
+
+OSC 133-emitting shells (Claude, future ones) keep the clean
+two-marker split. Shells without any markers (initial-startup
+case) keep falling back to `extractContent`.
+
+Tests: `tests/Tests.Unit/SessionModelTests.fs` gains 3 new cases
+pinning the PromptStart-only path (with + without
+`newPromptText` trim) and the OSC 133 regression pin (both
+markers → OSC 133 split wins).
+
 ### Changed (Cycle 45c follow-up): post-cleanup docs + onboarding refresh
 
 Post-Cycle-45c audit + documentation sweep ensuring the repo's

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -772,6 +772,7 @@ module SessionModel =
     /// degenerate case of a shell that emits A but not C / D.
     let private extractContentFromContentHistory
             (history: ContentHistory.T)
+            (newPromptText: string option)
             : (string * string) option
             =
         match
@@ -781,6 +782,9 @@ module SessionModel =
                 history ContentHistory.MarkerKind.OutputStart
         with
         | Some promptStart, Some outputStart ->
+            // OSC 133 path — shell emitted both PromptStart and
+            // OutputStart, so we have a clean (command, output)
+            // split.
             let commandText =
                 ContentHistory.sliceText
                     history promptStart.Seq outputStart.Seq
@@ -788,6 +792,66 @@ module SessionModel =
                 ContentHistory.sliceText
                     history outputStart.Seq System.Int64.MaxValue
             Some (commandText, outputText)
+        | Some promptStart, None ->
+            // Cycle 45c fixup (2026-05-12) — heuristic-only path
+            // (cmd / vanilla PowerShell). No OSC 133 markers, so
+            // we slice the entire blob between the prior
+            // PromptStart marker (the only one in ContentHistory
+            // at extraction time — the new boundary's marker is
+            // appended *after* this function returns, by the
+            // dispatcher-scheduled boundaryAction in Program.fs)
+            // and the tail. That blob is the just-finalising
+            // tuple's combined (command + output) text.
+            //
+            // Why this exists: the prior `extractContent` row-walk
+            // against the screen snapshot fails when the output
+            // scrolls enough that the prior prompt and the new
+            // prompt land on the same `rowIdx`. The maintainer's
+            // 2026-05-12 dogfood after `dir` + second `echo hi`
+            // reproduced this: tuple finalised with empty
+            // CmdText/OutText, NVDA went silent. ContentHistory's
+            // sequenced typed-entry log doesn't have the
+            // same-rowIdx ambiguity.
+            //
+            // The trailing portion of the blob carries the *new*
+            // prompt's rendered text (it arrived in
+            // ContentHistory before the heuristic detector
+            // declared "stable PromptStart"). Trim it via
+            // `newPromptText` if present.
+            //
+            // Split on first newline: cmd's wire format is
+            // "echo hi\r\nhi\r\n<new-prompt>". First line is the
+            // typed command (cmd echoes the keystrokes back);
+            // the rest is shell output.
+            let raw =
+                ContentHistory.sliceText
+                    history promptStart.Seq System.Int64.MaxValue
+            let withoutNewPrompt =
+                match newPromptText with
+                | Some p when not (System.String.IsNullOrEmpty p)
+                              && raw.EndsWith(p) ->
+                    raw.Substring(0, raw.Length - p.Length)
+                | _ -> raw
+            let trimmed =
+                (withoutNewPrompt.TrimStart('\r', '\n')).TrimEnd('\r', '\n')
+            if System.String.IsNullOrWhiteSpace trimmed then None
+            else
+                let nlIdx = trimmed.IndexOf('\n')
+                if nlIdx < 0 then
+                    // No newline in the blob — the user typed
+                    // something that the shell didn't echo a
+                    // separate output line for (rare in cmd; can
+                    // happen for `cd` etc. that print nothing).
+                    // Attribute it to CommandText so OutputText
+                    // stays empty (avoids announcing the typed
+                    // command at NVDA when there was no output).
+                    Some (trimmed, "")
+                else
+                    let cmd =
+                        trimmed.Substring(0, nlIdx).TrimEnd('\r')
+                    let out =
+                        trimmed.Substring(nlIdx + 1)
+                    Some (cmd, out)
         | _ -> None
 
     /// Cycle 45c — ContentHistory-driven substrate finalize.
@@ -815,7 +879,12 @@ module SessionModel =
         // boundary). Other boundary kinds skip the thunk.
         let contentOverride : (unit -> (string * string) option) option =
             if useContentHistory then
-                Some (fun () -> extractContentFromContentHistory history)
+                // Pass the new boundary's MatchedRowText so the
+                // heuristic-only path can trim it off the blob's
+                // tail (see comment in extractContentFromContentHistory).
+                let newPromptText = boundary.MatchedRowText
+                Some (fun () ->
+                    extractContentFromContentHistory history newPromptText)
             else
                 None
         applyAndCaptureCore state boundary snapshot contentOverride

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -1669,3 +1669,103 @@ let ``Cycle 45c — applyAndCaptureWithContentHistory preserves Active state thr
                 history true
     Assert.True(s3.Active.IsSome)
     Assert.Equal(SessionModel.ActiveTupleState.OutputStreaming, s3.Active.Value.State)
+
+// =====================================================================
+// Cycle 45c fixup (2026-05-12) — heuristic-only path: when only
+// PromptStart markers are present (no OSC 133 OutputStart), slice
+// the blob between the prior PromptStart and the tail. Reproduces
+// the maintainer's "second echo hi after dir is silent" report:
+// the prior `extractContent` row-walk fails when output scrolls
+// enough that consecutive prompts share a row index, but the
+// ContentHistory has the typed-input + output bytes accurately.
+// =====================================================================
+
+[<Fact>]
+let ``Cycle 45c fixup — PromptStart-only path slices blob between consecutive prompts`` () =
+    // Simulate cmd: prior PromptStart marker in history; then typed
+    // input "echo hi", newline, output "hi", newline, new prompt text.
+    // The boundary fires with MatchedRowText = the new prompt text.
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    // Prior prompt's PromptStart marker
+    let history = appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    // User-typed input + shell echo + output + new prompt text
+    let history = feedHistoryBytes history (after 5) (System.Text.Encoding.ASCII.GetBytes "echo hi\nhi\nC:\\>")
+    // Drive the SessionModel cycle. handlePromptBoundary calls
+    // applyAndCaptureWithContentHistory with the new boundary; the
+    // thunk runs extractContentFromContentHistory which should
+    // detect "PromptStart present, OutputStart absent" and slice.
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "$ ") [||]
+                history true
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundaryWithText (BoundaryKind.CommandFinished (Some 0)) (after 200) "C:\\>")
+            [||]
+            history true
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    // The blob "echo hi\nhi\nC:\\>" with new-prompt trim → "echo hi\nhi"
+    // → split on first newline → ("echo hi", "hi").
+    Assert.Equal("echo hi", tuple.CommandText)
+    Assert.Equal("hi", tuple.OutputText)
+
+[<Fact>]
+let ``Cycle 45c fixup — PromptStart-only path with empty newPromptText doesn't crash`` () =
+    // When the boundary has no MatchedRowText (e.g. OSC 133 source),
+    // the trim path is skipped. The blob then includes any trailing
+    // text that may have been added; it's still split on newline.
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    let history = appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    let history = feedHistoryBytes history (after 5) (System.Text.Encoding.ASCII.GetBytes "ls\nfile1\nfile2\n")
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "$ ") [||]
+                history true
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    // CommandFinished boundary with no MatchedRowText (MatchedRowText=None).
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
+            history true
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    Assert.Equal("ls", tuple.CommandText)
+    Assert.Contains("file1", tuple.OutputText)
+    Assert.Contains("file2", tuple.OutputText)
+
+[<Fact>]
+let ``Cycle 45c fixup — OSC 133 path still wins when both markers present`` () =
+    // Regression pin: if both PromptStart AND OutputStart are
+    // present, the OSC 133 split must win — not the heuristic
+    // blob path.
+    let initial = SessionModel.create "claude" 100
+    let history = freshHistory ()
+    let history = appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    let history = feedHistoryBytes history (after 5) (System.Text.Encoding.ASCII.GetBytes "explain this\n")
+    let history = appendHistoryMarker history (after 10) ContentHistory.MarkerKind.OutputStart
+    let history = feedHistoryBytes history (after 15) (System.Text.Encoding.ASCII.GetBytes "Here is the explanation.\n")
+    let s1 = SessionModel.applyWithContentHistory
+                initial (boundaryWithText BoundaryKind.PromptStart t0 "$ ") [||]
+                history true
+    let s2 = SessionModel.applyWithContentHistory
+                s1 (boundary BoundaryKind.CommandStart (after 100)) [||]
+                history true
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2 (boundary (BoundaryKind.CommandFinished (Some 0)) (after 200)) [||]
+            history true
+    Assert.True(finalisedOpt.IsSome)
+    let tuple = finalisedOpt.Value
+    // OSC 133 split: command between PromptStart and OutputStart,
+    // output between OutputStart and tail.
+    Assert.Contains("explain this", tuple.CommandText)
+    Assert.Contains("Here is the explanation", tuple.OutputText)
+    // The command must NOT appear in the output (OSC 133 split is
+    // clean).
+    Assert.DoesNotContain("explain this", tuple.OutputText)


### PR DESCRIPTION
## Summary

Maintainer dogfood 2026-05-12 (post-Cycle-45c release build) reproduced a regression: running `echo hi` → `dir` → `echo hi` announces the first two commands' output via NVDA but goes **silent on the third**. The bug is **pre-existing, not introduced by Cycle 45c** — it exists in `extractContent`'s screen-row walk and surfaces when output scrolling makes consecutive prompts land on the same `rowIdx`.

## What the logs showed

Diagnostic snapshot at `17:17:48` after the dogfood sequence:

```
RecentTuple[0]: CmdText=""  OutText=""              ← second echo hi → silent
RecentTuple[1]: CmdText=""  OutText="05/12/2026..."  ← dir → spoken
RecentTuple[2]: CmdText="echo hi"  OutText="hi"       ← first echo hi → spoken
```

`tupleFinaliseAnnounce` is gated on `tuple.OutputText` being non-whitespace. Tuple[0] has empty `OutputText` → no announce fires → silence.

## Root cause

Cmd doesn't emit OSC 133 markers, so `extractContentFromContentHistory` returned `None` (it required **both** `PromptStart` AND `OutputStart`). SessionModel then fell back to `extractContent`'s screen-row walk against the snapshot — which fails when the output has scrolled enough that the prior prompt and the new prompt share a `rowIdx` (both at the bottom of the screen at row 29). The row-walk can't distinguish "same row" from "no content between prompts" and returns empty strings.

ContentHistory had the data the whole time — its sequenced typed-entry log has no same-row ambiguity. We just weren't slicing it for the heuristic-only path.

## Fix

Extend `extractContentFromContentHistory` with a **PromptStart-only fallback**:

- **OSC 133 path** (both `PromptStart` + `OutputStart`): clean two-marker split (unchanged)
- **PromptStart-only path** (new): slice the blob from the prior `PromptStart` marker's `Seq` to `MaxValue`. That's the just-finalising tuple's combined typed-input + output text. Trim the trailing new prompt text via `boundary.MatchedRowText`. Split on the first newline — cmd's wire format is `"echo hi\nhi\n<new-prompt>"`, so first-newline split gives `(CommandText="echo hi", OutputText="hi")`
- **No markers at all**: still falls back to `extractContent`'s row-walk (unchanged)

The new `PromptStart-only` branch needs the boundary's `MatchedRowText` to trim, so `applyAndCaptureWithContentHistory` now passes it into the thunk closure.

## Test coverage

3 new tests in `tests/Tests.Unit/SessionModelTests.fs`:
- **PromptStart-only path with `newPromptText` trim** → clean `(CommandText="echo hi", OutputText="hi")` split
- **PromptStart-only path with no `MatchedRowText`** → still works, blob split on first newline
- **OSC 133 regression pin**: both markers present → OSC 133 split wins, not the heuristic blob path

## Diff

| File | + | - |
|---|---:|---:|
| `CHANGELOG.md` | 44 | 0 |
| `src/Terminal.Core/SessionModel.fs` | 71 | 1 |
| `tests/Tests.Unit/SessionModelTests.fs` | 100 | 0 |
| **Total** | **+215** | **−1** |

## User-visible behaviour

**Before (this reproducer)**: third command silent.
**After**: third command announces `"hi"` (or whatever the shell output was).

OSC 133-emitting shells (Claude, future shells) are unchanged — the two-marker path still wins when both markers are present (covered by the regression-pin test).

For cmd / vanilla PowerShell, the `SessionTuple.CommandText` / `OutputText` fields now reflect a heuristic first-newline split rather than the row-walk's smart trimming. The user's `Ctrl+Shift+Y` history dump will look slightly different post-fix — the announce-side experience is the priority.

## Test plan

- [ ] Windows build + test passes (the 3 new SessionModelTests cases must compile + pass)
- [ ] Maintainer pulls fresh build, re-runs `echo hi` → `dir` → `echo hi` and confirms all three are announced
- [ ] Spot-check Claude shell (OSC 133 path) still works as before — no regression in the OSC 133 split

## Out of scope (not in this PR)

- The diagnostic battery's `Plain echo emits StreamChunk only` test fails post-Cycle-45c (expects `StreamChunk` events from the deleted `StreamPathway`). Diagnostic-only; doesn't affect user experience. Separate fix.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_