### PR TITLE
fix(announce): use MostRecent for every activity-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 45c follow-up): announce queueing now uses `MostRecent` for every activity-id
+
+Maintainer dogfood 2026-05-12 named the symptom: after running
+`dir` in cmd the NVDA queue could spend ~2 minutes reading the
+~3 KB tuple-final output. During that read, **nothing else**
+got airtime — the next command's tuple-final, `Alt`-opened
+menus, hotkey announces all sat behind it. The "silent third
+echo" wasn't silence; it was speech queued behind a wall.
+
+`TerminalView.Announce(msg, activityId)` previously routed
+`ActivityIds.output` to `AutomationNotificationProcessing.ImportantAll`
+("queue every announce, read them all"). The 2-arg overload
+now uses `MostRecent` uniformly — a later announce displaces
+the still-queued prior one, so NVDA always reads the most
+recent thing the user did rather than completing a back-log.
+The 3-arg overload remains available for callers that need
+explicit control.
+
+Trade-off: long output reads can be interrupted by a
+subsequent command's announce. Users who want every byte read
+to completion can pivot to manual speech-cursor navigation
+(`Ctrl+Shift+Up` / `Down` / `End`).
+
 ### Changed (Cycle 45c follow-up): diagnostic battery + ContentHistory observability
 
 The `Ctrl+Shift+D` self-test battery's per-shell tests still

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -284,10 +284,24 @@ public class TerminalView : FrameworkElement
     /// </remarks>
     public void Announce(string message, string activityId)
     {
-        var processing = activityId == ActivityIds.output
-            ? AutomationNotificationProcessing.ImportantAll
-            : AutomationNotificationProcessing.MostRecent;
-        Announce(message, activityId, processing);
+        // Cycle 45c follow-up (2026-05-12) — every announce uses
+        // `MostRecent`. Prior behaviour kept `ActivityIds.output`
+        // on `ImportantAll`, which queues every announce and asks
+        // NVDA to read them all to completion. Combined with
+        // Cycle 45f's `TupleFinalOnly` streaming default the
+        // result was: one `dir` produced a single ~3 KB output
+        // announce; NVDA would chew through it for ~2 minutes
+        // before any subsequent announce (the next command's
+        // tuple-final, `Alt` to open a menu, hotkey announces)
+        // could be heard. Maintainer dogfood 2026-05-12 named
+        // the symptom: "I can't use the menus until that large
+        // cue is cleared". `MostRecent` lets a later announce
+        // displace the queued long-output read; UX prioritises
+        // responsiveness over completeness for streaming output.
+        // Users who want every byte read to completion can pivot
+        // to manual speech-cursor navigation
+        // (Ctrl+Shift+Up/Down/End — see SpeechCursor.fs).
+        Announce(message, activityId, AutomationNotificationProcessing.MostRecent);
     }
 
     /// <summary>

--- a/tests/Tests.Unit/NvdaChannelTests.fs
+++ b/tests/Tests.Unit/NvdaChannelTests.fs
@@ -17,11 +17,12 @@ open Terminal.Core
 /// **8a does NOT consult `Priority`.** The behaviour-identical
 /// contract preserves Stage 7's
 /// `TerminalView.Announce(msg, activityId)` 2-arg overload
-/// (`src/Views/TerminalView.cs:292-298`), which picks
-/// `ImportantAll` for `pty-speak.output` and `MostRecent` for
-/// everything else. Tests that pin Priority → Processing
-/// arrive when a future stage migrates the channel to the
-/// 3-arg overload + reads Priority from the event.
+/// (`src/Views/TerminalView.cs`). Post-Cycle-45c-followup every
+/// activity-id resolves to `MostRecent` processing so a newer
+/// announce displaces the queued read of a long tuple-final
+/// output. Tests that pin Priority → Processing arrive when a
+/// future stage migrates the channel to the 3-arg overload +
+/// reads Priority from the event.
 ///
 /// The channel implementation lives at
 /// `src/Terminal.Core/NvdaChannel.fs`. The marshal callback


### PR DESCRIPTION
## Summary

Cycle 45c follow-up. Fixes the symptom the maintainer named on 2026-05-12: after running `dir` in cmd, NVDA could spend ~2 minutes reading the ~3 KB tuple-final output. During that read, **nothing else** got airtime — the next command's tuple-final, `Alt`-opened menus, hotkey announces all sat behind it. The "silent third echo" from PR #280 wasn't silence; it was speech queued behind a wall.

`TerminalView.Announce(msg, activityId)` previously routed `ActivityIds.output` to `AutomationNotificationProcessing.ImportantAll` ("queue every announce, read them all"). The 2-arg overload now uses `AutomationNotificationProcessing.MostRecent` uniformly — a later announce displaces the still-queued prior one, so NVDA always reads the most recent thing the user did rather than completing a backlog.

The 3-arg overload (explicit `processing` parameter) remains available for callers that genuinely need queue-everything semantics.

## Trade-off

Long output reads can be interrupted by subsequent commands. Users who want every byte read to completion can pivot to manual speech-cursor navigation (`Ctrl+Shift+Up` / `Down` / `End` — see `SpeechCursor.fs`).

## Test plan

- [ ] CI green (Windows build + xUnit suite + lints).
- [ ] After preview-build install, run `dir` in cmd, then immediately run `echo hi`. Expect: the `dir` output starts reading; the moment the echo's tuple-final fires, NVDA stops on the long read and announces "hi" instead.
- [ ] Run `dir`, then press `Alt` to open the menu. Expect: NVDA reads the menu item immediately (or after the current word/phrase finishes — the speech engine doesn't always cut mid-utterance), not after a 7-second backlog drain.
- [ ] Manual speech-cursor navigation (`Ctrl+Shift+Up` to step backward through the prior `dir` lines) still works for users who want completeness on demand.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_