### PR TITLE
chore(detector): gate idle SUPPRESSED PromptStart trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 45c follow-up): silence idle FileLogger spam in `HeuristicPromptDetector`
+
+Maintainer dogfood 2026-05-12: every line of a 50-line
+`Diagnostics → Extract → Last 50 Log Lines` extract was
+`HeuristicPromptDetector SUPPRESSED PromptStart … rowDirtyAccumulated=False`.
+At idle the detector ticks every 50 ms and the steady-state
+prompt always passes the "stable match" gate but fails the
+"row went dirty since last emit" gate, so the suppression
+trace fired ~20 times per second — ~5 KB/sec of pure-noise log
+output and ~18 MB/hour of FileLogger writes.
+
+Gated the trace on `rowDirtyAccumulated=true`. The diagnostic
+value (the post-screen-fill silence regression hunt this line
+was originally added for) lives entirely in the `true` branch
+— that's the "row went dirty then came back to the same
+prompt" case. The `false` branch is steady-state suppression
+with nothing to learn from.
+
 ### Changed (Cycle 45c follow-up): announce queueing now uses `MostRecent` for every activity-id
 
 Maintainer dogfood 2026-05-12 named the symptom: after running

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -413,7 +413,22 @@ module HeuristicPromptDetector =
             // silence regression; the trace tells us whether the
             // dirty flag was correctly true or wrongly false at
             // the suppression moment.
-            elif stableMatches.Count > 0 then
+            //
+            // Cycle 45c follow-up (2026-05-12) — gate this trace
+            // on `rowDirtyAccumulated=True`. Without the gate the
+            // line fires every 50 ms tick at idle (the stable
+            // match is always the same prompt the detector just
+            // emitted), producing ~5 KB/sec of pure-noise log
+            // output and ~18 MB/hour of FileLogger writes at
+            // idle. Maintainer dogfood 2026-05-12: every line of
+            // a 50-line `--- LAST 50 LOG LINES ---` extract was
+            // this message. The diagnostic value (the regression
+            // hunt) lives entirely in the `True` branch — that's
+            // the "row went dirty then came back to the same
+            // prompt" case. The `False` branch is just the
+            // expected steady-state suppression and has nothing
+            // to learn from.
+            elif stableMatches.Count > 0 && rowDirtyAccumulated then
                 let bestRow, bestText =
                     stableMatches.[stableMatches.Count - 1]
                 logger.LogDebug(


### PR DESCRIPTION
## Summary

Cycle 45c follow-up. Maintainer dogfood 2026-05-12: every line of a 50-line `Diagnostics → Extract → Last 50 Log Lines` extract was `HeuristicPromptDetector SUPPRESSED PromptStart … rowDirtyAccumulated=False`. At idle the detector ticks every 50 ms; the steady-state prompt always passes the "stable match" gate but fails the "row went dirty since last emit" gate, so the suppression trace fired ~20 times per second — **~5 KB/sec of pure-noise log output, ~18 MB/hour of FileLogger writes at idle.**

The trace was added in the Cycle 45f-followup regression hunt (`commit ac08bf7`) to surface "row went dirty then came back to the same prompt" cases. Its diagnostic value lives entirely in the `rowDirtyAccumulated=true` branch — the `false` branch is just steady-state suppression with nothing to learn from. Added the `&& rowDirtyAccumulated` clause to the existing `elif stableMatches.Count > 0` guard so the trace only fires when the diagnostic is actually informative.

## Test plan

- [ ] CI green (Windows build + xUnit suite + lints).
- [ ] After preview-build install, sit idle for a few seconds at a fresh cmd prompt, then press `Diagnostics → Extract → Last 50 Log Lines`. Expect: the extract is **not** dominated by `SUPPRESSED PromptStart` lines — `Heartbeat` and other genuine events become visible.
- [ ] Run a command that triggers the original regression scenario (mid-output edit, screen fill); the `SUPPRESSED PromptStart … rowDirtyAccumulated=True` line still fires when the dirty flag is true, preserving the diagnostic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_