### PR TITLE
fix(announce): flush pending speech on every meaningful keystroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,33 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Changed (Cycle 45c follow-up): every keystroke flushes pending NVDA output speech
+
+`MostRecent` (shipped 2026-05-12 in PR #282) clears NVDA's
+pending speech queue, but only when **we** call `Announce`
+again. The pipeline only fires `Announce` on tuple-finalise,
+hotkey announces, diagnostics, and SpeechCursor navigation —
+plain typing into the prompt and Alt-opening a menu don't.
+Result: after `dir` produced a ~3 KB output announce, NVDA
+read it to completion (~2 minutes) even when the user pressed
+Alt or started typing the next command, because nothing else
+displaced it.
+
+`OnPreviewKeyDown` now fires an empty `MostRecent` notification
+on every key that isn't a bare modifier — `Shift` (NVDA pause),
+`Ctrl`, `Win`, `NumLock`, `Scroll`, `Insert` (NVDA modifier),
+`CapsLock`, and the numpad-NoLock cluster are deliberately
+skipped so screen-reader gestures keep working. Alt is **not**
+skipped — pressing Alt to open the menu now interrupts a long
+output read as the user expects. Function keys are not skipped
+either; the empty MostRecent is cheap and consistent with the
+rule "any user-initiated activity resets the speech state".
+
+Currently-synthesised audio still plays to its natural chunk
+boundary (NVDA only clears chunks it hasn't handed to SAPI
+yet), so there can be a brief residual "tail" before silence —
+that's the cost of NVDA's pipeline, not our queue logic.
+
 ### Changed (Cycle 45c follow-up): silence idle FileLogger spam in `HeuristicPromptDetector`
 
 Maintainer dogfood 2026-05-12: every line of a 50-line

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -618,6 +618,28 @@ public class TerminalView : FrameworkElement
 
         var pressedModifiers = Keyboard.Modifiers;
 
+        // Cycle 45c follow-up (2026-05-12) — speech-queue flush
+        // hook. ANY meaningful keystroke fires an empty
+        // `MostRecent` announce to clear NVDA's pending output
+        // queue. This is the architectural answer to the "I
+        // can't interrupt a long `dir` read by typing or
+        // pressing Alt" problem: the prior queue stays alive
+        // until the next `Announce` fires, and typing /
+        // Alt-menu don't naturally fire `Announce` (typing
+        // goes to PTY only; Alt opens a WPF menu through a
+        // separate UIA channel). Calling
+        // `FlushPendingOutputSpeech` here makes every keystroke
+        // a flush event. Filtered to skip bare modifier-only
+        // presses so `Shift` (NVDA pause), `Ctrl`, `Win`,
+        // `CapsLock`, etc. do NOT inadvertently clear speech.
+        // `Insert` and the numpad-NoLock cluster are filtered
+        // by `IsScreenReaderCandidate` further down and via
+        // the same exclusion here.
+        if (!IsBareModifierKey(e.Key) && !IsScreenReaderCandidate(e.Key))
+        {
+            FlushPendingOutputSpeech();
+        }
+
         // For Alt-modified gestures WPF reports e.Key == Key.System
         // and the actual key in e.SystemKey. We deliberately do NOT
         // unwrap that here: every reserved hotkey today is a clean
@@ -1000,6 +1022,61 @@ public class TerminalView : FrameworkElement
     /// and Numpad-as-arrow with NumLock off is suppressed. Both
     /// trade-offs are accepted to preserve screen-reader navigation.
     /// </summary>
+    /// <summary>
+    /// Cycle 45c follow-up — keys that are JUST a modifier press
+    /// (no character produced, no command issued). Pressing one of
+    /// these on its own should NOT flush the NVDA speech queue:
+    /// <c>Shift</c> is NVDA's pause-speech gesture; <c>Ctrl</c> /
+    /// <c>Win</c> / <c>CapsLock</c> on their own are chord
+    /// preludes or system-level toggles, not user-initiated
+    /// activity that wants a fresh start. Alt is deliberately NOT
+    /// in this list — pressing Alt activates a WPF menu and the
+    /// user's expectation is that the previous read interrupts.
+    /// Function keys (F1..F12) are also NOT in this list — they
+    /// may trigger app behaviour (help, fullscreen) whose own
+    /// announces would displace the prior queue anyway, and a
+    /// pre-emptive flush is consistent with the rule "any user
+    /// action that's not a bare modifier resets the speech state".
+    /// </summary>
+    private static bool IsBareModifierKey(Key key)
+    {
+        return key == Key.LeftShift
+            || key == Key.RightShift
+            || key == Key.LeftCtrl
+            || key == Key.RightCtrl
+            || key == Key.LWin
+            || key == Key.RWin
+            || key == Key.NumLock
+            || key == Key.Scroll;
+    }
+
+    /// <summary>
+    /// Cycle 45c follow-up — clear NVDA's pending output speech
+    /// queue. Fires an empty <c>MostRecent</c> notification on
+    /// <c>ActivityIds.output</c>; per the UIA contract this
+    /// removes all previously-queued notifications with the same
+    /// property. Currently-synthesised audio still plays to its
+    /// natural chunk boundary (NVDA only clears chunks it hasn't
+    /// handed to SAPI yet), but the long tail of a 3 KB <c>dir</c>
+    /// read becomes ~one chunk of speech instead of two minutes.
+    ///
+    /// Called from <see cref="OnPreviewKeyDown"/> for every key
+    /// that isn't a bare modifier — see
+    /// <see cref="IsBareModifierKey"/> for the exclusion list.
+    /// Cheap: when the queue is empty the call is a no-op at the
+    /// UIA layer.
+    /// </summary>
+    private void FlushPendingOutputSpeech()
+    {
+        var peer = UIElementAutomationPeer.FromElement(this);
+        if (peer is null) return;
+        peer.RaiseNotificationEvent(
+            AutomationNotificationKind.Other,
+            AutomationNotificationProcessing.MostRecent,
+            string.Empty,
+            ActivityIds.output);
+    }
+
     private static bool IsScreenReaderCandidate(Key key)
     {
         if (key == Key.Insert) return true;


### PR DESCRIPTION
## Summary

Cycle 45c follow-up. Closes the architectural gap PR #282 exposed: `MostRecent` (UIA queue-clear) only takes effect when **we** call `Announce` again. Plain typing and Alt-opening a menu don't fire `Announce` (typing goes straight to the PTY encoder; Alt activates WPF's menu through a different UIA channel), so a long `dir` output read kept running for ~2 minutes regardless of what the user did next.

`OnPreviewKeyDown` now fires an empty `MostRecent` notification on every keystroke that isn't a bare modifier. The exclusion list (`IsBareModifierKey`):
- `Shift` — NVDA pause-speech gesture
- `Ctrl` / `Win` — chord preludes
- `NumLock` / `Scroll` — system toggles
- `Insert` + `CapsLock` + numpad-NoLock cluster (filtered via `IsScreenReaderCandidate`) — screen-reader gestures

**Alt is deliberately NOT excluded** — pressing Alt to open the menu now interrupts a long output read as the maintainer expects. Function keys are not excluded either — the empty `MostRecent` call is cheap, and "any user-initiated activity resets the speech state" is a more consistent rule than carving out F-key exceptions.

## Trade-off

Currently-synthesised audio still plays to its natural chunk boundary (NVDA only clears chunks it hasn't handed to SAPI yet), so there can be a brief residual "tail" before silence. That's intrinsic to NVDA's pipeline; the alternative would be sending shorter chunks (~100-200 chars) to NVDA but `MostRecent` would then clobber each chunk with the next, so we'd only hear the last chunk. Architectural tension; not worth solving until per-shell streaming modes are revisited.

## Test plan

- [ ] CI green (Windows build + xUnit suite + lints).
- [ ] After preview-build install, run `dir` in cmd. While NVDA reads the output, press `Alt`. Expect: read stops (modulo brief chunk-flush tail) and the menu announces.
- [ ] Run `dir`, then start typing `echo` immediately. Expect: read stops on the first letter; the new prompt's tuple-final announces normally when Enter is pressed.
- [ ] Press `Shift` alone during a `dir` read. Expect: NVDA's normal pause-speech behaviour, no flush from our side.
- [ ] Press `Ctrl+Shift+H` during a `dir` read. Expect: read interrupts immediately; the health-check announce plays (this already worked via the hotkey's own `Announce`, but worth confirming the new flush doesn't regress it).
- [ ] Press `Insert` alone during a `dir` read. Expect: read continues; `Insert` reaches NVDA's modifier path uninterrupted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_