### PR TITLE
fix(announce): flush with single-space, not empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,20 +27,26 @@ read it to completion (~2 minutes) even when the user pressed
 Alt or started typing the next command, because nothing else
 displaced it.
 
-`OnPreviewKeyDown` now fires an empty `MostRecent` notification
-on every key that isn't a bare modifier — `Shift` (NVDA pause),
-`Ctrl`, `Win`, `NumLock`, `Scroll`, `Insert` (NVDA modifier),
-`CapsLock`, and the numpad-NoLock cluster are deliberately
-skipped so screen-reader gestures keep working. Alt is **not**
-skipped — pressing Alt to open the menu now interrupts a long
-output read as the user expects. Function keys are not skipped
-either; the empty MostRecent is cheap and consistent with the
-rule "any user-initiated activity resets the speech state".
+`OnPreviewKeyDown` now fires a single-space `MostRecent`
+notification on every key that isn't a bare modifier — `Shift`
+(NVDA pause), `Ctrl`, `Win`, `NumLock`, `Scroll`, `Insert` (NVDA
+modifier), `CapsLock`, and the numpad-NoLock cluster are
+deliberately skipped so screen-reader gestures keep working.
+Alt is **not** skipped — pressing Alt to open the menu now
+interrupts a long output read as the user expects. Function
+keys are not skipped either; the call is cheap and consistent
+with the rule "any user-initiated activity resets the speech
+state".
 
-Currently-synthesised audio still plays to its natural chunk
-boundary (NVDA only clears chunks it hasn't handed to SAPI
-yet), so there can be a brief residual "tail" before silence —
-that's the cost of NVDA's pipeline, not our queue logic.
+The payload is a single space, NOT the empty string. PR #284
+shipped this with `string.Empty` and the maintainer reported
+"this did not fix it" — NVDA's UIA notification handler
+short-circuits on falsy `displayString` (no
+`speech.cancelSpeech()`, no queue clear, no interrupt). A lone
+space character has no phoneme so SAPI renders it as silence,
+but the notification still reaches NVDA's cancel-pending path
+and interrupts the currently-playing audio at the SAPI driver
+level.
 
 ### Changed (Cycle 45c follow-up): silence idle FileLogger spam in `HeuristicPromptDetector`
 

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -1052,19 +1052,25 @@ public class TerminalView : FrameworkElement
 
     /// <summary>
     /// Cycle 45c follow-up — clear NVDA's pending output speech
-    /// queue. Fires an empty <c>MostRecent</c> notification on
-    /// <c>ActivityIds.output</c>; per the UIA contract this
+    /// queue. Fires a single-space <c>MostRecent</c> notification
+    /// on <c>ActivityIds.output</c>; per the UIA contract this
     /// removes all previously-queued notifications with the same
-    /// property. Currently-synthesised audio still plays to its
-    /// natural chunk boundary (NVDA only clears chunks it hasn't
-    /// handed to SAPI yet), but the long tail of a 3 KB <c>dir</c>
-    /// read becomes ~one chunk of speech instead of two minutes.
+    /// property AND triggers NVDA's <c>speech.cancelSpeech()</c>
+    /// path, which interrupts currently-playing audio at the SAPI
+    /// driver — not just the un-synthesised tail.
+    ///
+    /// The payload is a single space, NOT the empty string,
+    /// because NVDA's UIA notification handler short-circuits on
+    /// empty <c>displayString</c> (no cancel, no queue clear,
+    /// nothing) — first version of this method shipped in
+    /// PR #284 with empty string and the maintainer reported
+    /// "this did not fix it". A lone space character has no
+    /// phoneme so SAPI renders it as silence, but the
+    /// notification still reaches NVDA's cancel-pending path.
     ///
     /// Called from <see cref="OnPreviewKeyDown"/> for every key
     /// that isn't a bare modifier — see
     /// <see cref="IsBareModifierKey"/> for the exclusion list.
-    /// Cheap: when the queue is empty the call is a no-op at the
-    /// UIA layer.
     /// </summary>
     private void FlushPendingOutputSpeech()
     {
@@ -1073,7 +1079,7 @@ public class TerminalView : FrameworkElement
         peer.RaiseNotificationEvent(
             AutomationNotificationKind.Other,
             AutomationNotificationProcessing.MostRecent,
-            string.Empty,
+            " ",
             ActivityIds.output);
     }
 


### PR DESCRIPTION
## Summary

PR #284 wired `OnPreviewKeyDown` → `FlushPendingOutputSpeech` with an **empty-string** `MostRecent` notification. Maintainer reported "this did not fix it" — typing into the prompt and pressing Alt still didn't interrupt the long `dir` output read.

**Root cause**: NVDA's UIA notification handler short-circuits on falsy `displayString` — empty string returns early, before `speech.cancelSpeech()` is even called. So our flush was silently no-oping at NVDA's input layer. (WPF's `RaiseNotificationEvent` may also filter empty payloads at the `AutomationPeer` layer — uncertain, but a contributing possibility.)

**Fix**: send a single space (`" "`) instead. The space is truthy at NVDA's notification-handler filter, so `cancelSpeech()` runs and interrupts the currently-playing SAPI audio chunk. SAPI renders a lone space as silence (no phoneme), so the user hears nothing per keystroke — same UX as the empty-string version was intended to deliver, but actually working.

## Why this isn't a config thing

If we'd had access to a `Diagnostics → Grep diagnostics` log slice covering `RaiseNotificationEvent firing. ActivityId=pty-speak.output MsgLen=0` we could've confirmed the flush call was reaching `Announce` but being dropped further down. Without that log we shipped on the empty-string hypothesis, which turned out to be wrong. The lesson: don't pass empty strings to `RaiseNotificationEvent` even when the queue-clear semantic is documented as "just clear, don't speak" — the listening screen reader can filter the event entirely.

## Test plan

- [ ] CI green (Windows build + xUnit + lints + link check).
- [ ] After preview-build install: run `dir`. While NVDA reads, press `Alt`. Expect: read **interrupts** (not just "tail flush"), menu announces.
- [ ] Run `dir`, then start typing `echo`. Expect: read interrupts on the first letter.
- [ ] Press `Shift` alone during a `dir` read. Expect: NVDA's normal pause-speech behaviour, no interrupt from our side.
- [ ] Press `Insert` alone during a `dir` read. Expect: read continues; NVDA's modifier path reaches the user uninterrupted.
- [ ] Listen carefully on each keystroke during normal typing. Expect: no audible "space" / "click" / artifact from the flush call.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_