### PR TITLE
revert: remove keystroke flush — every keystroke audibly says "blank"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,38 +15,30 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
-### Changed (Cycle 45c follow-up): every keystroke flushes pending NVDA output speech
+### Reverted (Cycle 45c follow-up): keystroke flush of pending NVDA output speech
 
-`MostRecent` (shipped 2026-05-12 in PR #282) clears NVDA's
-pending speech queue, but only when **we** call `Announce`
-again. The pipeline only fires `Announce` on tuple-finalise,
-hotkey announces, diagnostics, and SpeechCursor navigation —
-plain typing into the prompt and Alt-opening a menu don't.
-Result: after `dir` produced a ~3 KB output announce, NVDA
-read it to completion (~2 minutes) even when the user pressed
-Alt or started typing the next command, because nothing else
-displaced it.
+PR #284 added a `MostRecent` notification on every keystroke,
+intended to clear NVDA's pending speech queue when the user
+typed or pressed Alt during a long output read. PR #285 changed
+the payload from `""` to `" "` after NVDA was found to drop
+empty `displayString` events before reaching its
+`cancelSpeech()` path.
 
-`OnPreviewKeyDown` now fires a single-space `MostRecent`
-notification on every key that isn't a bare modifier — `Shift`
-(NVDA pause), `Ctrl`, `Win`, `NumLock`, `Scroll`, `Insert` (NVDA
-modifier), `CapsLock`, and the numpad-NoLock cluster are
-deliberately skipped so screen-reader gestures keep working.
-Alt is **not** skipped — pressing Alt to open the menu now
-interrupts a long output read as the user expects. Function
-keys are not skipped either; the call is cheap and consistent
-with the rule "any user-initiated activity resets the speech
-state".
+Both versions were wrong. Empty-payload version was silently
+filtered by NVDA and did nothing. Single-space version made
+NVDA verbalise every keystroke as **"blank"** without
+interrupting the in-progress long read — the worst of both
+worlds.
 
-The payload is a single space, NOT the empty string. PR #284
-shipped this with `string.Empty` and the maintainer reported
-"this did not fix it" — NVDA's UIA notification handler
-short-circuits on falsy `displayString` (no
-`speech.cancelSpeech()`, no queue clear, no interrupt). A lone
-space character has no phoneme so SAPI renders it as silence,
-but the notification still reaches NVDA's cancel-pending path
-and interrupts the currently-playing audio at the SAPI driver
-level.
+Reverting the keystroke flush entirely. The underlying problem
+— a single ~19 KB output notification on a busy `dir` taking
+~5–10 minutes to read with no interruption path short of
+restart — is **architectural**: the UIA `RaiseNotificationEvent`
+primitive isn't designed for streaming long content, and
+trying to interrupt it post-hoc with another notification fights
+NVDA's design. A real fix lives at the announce-side (cap
+length / summary + review-cursor / replace notification model
+with a UIA TextEdit caret), not in the keyboard handler.
 
 ### Changed (Cycle 45c follow-up): silence idle FileLogger spam in `HeuristicPromptDetector`
 

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -618,28 +618,6 @@ public class TerminalView : FrameworkElement
 
         var pressedModifiers = Keyboard.Modifiers;
 
-        // Cycle 45c follow-up (2026-05-12) — speech-queue flush
-        // hook. ANY meaningful keystroke fires an empty
-        // `MostRecent` announce to clear NVDA's pending output
-        // queue. This is the architectural answer to the "I
-        // can't interrupt a long `dir` read by typing or
-        // pressing Alt" problem: the prior queue stays alive
-        // until the next `Announce` fires, and typing /
-        // Alt-menu don't naturally fire `Announce` (typing
-        // goes to PTY only; Alt opens a WPF menu through a
-        // separate UIA channel). Calling
-        // `FlushPendingOutputSpeech` here makes every keystroke
-        // a flush event. Filtered to skip bare modifier-only
-        // presses so `Shift` (NVDA pause), `Ctrl`, `Win`,
-        // `CapsLock`, etc. do NOT inadvertently clear speech.
-        // `Insert` and the numpad-NoLock cluster are filtered
-        // by `IsScreenReaderCandidate` further down and via
-        // the same exclusion here.
-        if (!IsBareModifierKey(e.Key) && !IsScreenReaderCandidate(e.Key))
-        {
-            FlushPendingOutputSpeech();
-        }
-
         // For Alt-modified gestures WPF reports e.Key == Key.System
         // and the actual key in e.SystemKey. We deliberately do NOT
         // unwrap that here: every reserved hotkey today is a clean
@@ -1022,67 +1000,6 @@ public class TerminalView : FrameworkElement
     /// and Numpad-as-arrow with NumLock off is suppressed. Both
     /// trade-offs are accepted to preserve screen-reader navigation.
     /// </summary>
-    /// <summary>
-    /// Cycle 45c follow-up — keys that are JUST a modifier press
-    /// (no character produced, no command issued). Pressing one of
-    /// these on its own should NOT flush the NVDA speech queue:
-    /// <c>Shift</c> is NVDA's pause-speech gesture; <c>Ctrl</c> /
-    /// <c>Win</c> / <c>CapsLock</c> on their own are chord
-    /// preludes or system-level toggles, not user-initiated
-    /// activity that wants a fresh start. Alt is deliberately NOT
-    /// in this list — pressing Alt activates a WPF menu and the
-    /// user's expectation is that the previous read interrupts.
-    /// Function keys (F1..F12) are also NOT in this list — they
-    /// may trigger app behaviour (help, fullscreen) whose own
-    /// announces would displace the prior queue anyway, and a
-    /// pre-emptive flush is consistent with the rule "any user
-    /// action that's not a bare modifier resets the speech state".
-    /// </summary>
-    private static bool IsBareModifierKey(Key key)
-    {
-        return key == Key.LeftShift
-            || key == Key.RightShift
-            || key == Key.LeftCtrl
-            || key == Key.RightCtrl
-            || key == Key.LWin
-            || key == Key.RWin
-            || key == Key.NumLock
-            || key == Key.Scroll;
-    }
-
-    /// <summary>
-    /// Cycle 45c follow-up — clear NVDA's pending output speech
-    /// queue. Fires a single-space <c>MostRecent</c> notification
-    /// on <c>ActivityIds.output</c>; per the UIA contract this
-    /// removes all previously-queued notifications with the same
-    /// property AND triggers NVDA's <c>speech.cancelSpeech()</c>
-    /// path, which interrupts currently-playing audio at the SAPI
-    /// driver — not just the un-synthesised tail.
-    ///
-    /// The payload is a single space, NOT the empty string,
-    /// because NVDA's UIA notification handler short-circuits on
-    /// empty <c>displayString</c> (no cancel, no queue clear,
-    /// nothing) — first version of this method shipped in
-    /// PR #284 with empty string and the maintainer reported
-    /// "this did not fix it". A lone space character has no
-    /// phoneme so SAPI renders it as silence, but the
-    /// notification still reaches NVDA's cancel-pending path.
-    ///
-    /// Called from <see cref="OnPreviewKeyDown"/> for every key
-    /// that isn't a bare modifier — see
-    /// <see cref="IsBareModifierKey"/> for the exclusion list.
-    /// </summary>
-    private void FlushPendingOutputSpeech()
-    {
-        var peer = UIElementAutomationPeer.FromElement(this);
-        if (peer is null) return;
-        peer.RaiseNotificationEvent(
-            AutomationNotificationKind.Other,
-            AutomationNotificationProcessing.MostRecent,
-            " ",
-            ActivityIds.output);
-    }
-
     private static bool IsScreenReaderCandidate(Key key)
     {
         if (key == Key.Insert) return true;


### PR DESCRIPTION
## Summary

Reverting PR #284 + PR #285. The keystroke flush approach was wrong on both payload variants:

- **PR #284 (empty string)**: NVDA's UIA notification handler short-circuits on falsy `displayString`. Did nothing.
- **PR #285 (single space)**: NVDA verbalises the lone space as the word **"blank"** on every keystroke. Maintainer report: "every character I type is called Blank and it has not solved the long output dilemma."

So we got verbal noise on every keypress AND failed to interrupt the in-progress read. Worst of both worlds.

## Why the approach can't be salvaged with a different payload

The diagnostic log shows the underlying problem:

```
21:06:53.087 Announce ActivityId=pty-speak.output MsgLen=18953 Processing=MostRecent
```

We hand NVDA a single 19 KB notification for the `dir` output. At normal speech rate that's 5–10 minutes of speech in one indivisible blob. UIA `RaiseNotificationEvent` is a status-message channel, not a streaming-content channel. Trying to post-hoc interrupt it with another notification fights NVDA's design — and we have no good payload for the interrupt (`""` is filtered, `" "` says "blank", anything non-trivial generates verbal noise).

The real fix lives at the **announce side** — either cap announce length with a summary + review-cursor handoff, or replace the UIA Notification model entirely with a UIA TextEdit caret. Those are architectural decisions, not keyboard-handler patches.

## What this PR does

- Removes `FlushPendingOutputSpeech` and `IsBareModifierKey` from `src/Views/TerminalView.cs`.
- Removes the `OnPreviewKeyDown` call site.
- Restores the keyboard handler to its pre-PR-284 state.
- CHANGELOG entry documents the revert and points at the architectural follow-up.

## Test plan

- [ ] CI green.
- [ ] After preview-build install: type any character into the prompt. Expect: **no** "blank" verbalisation per keystroke. Normal NVDA character-echo (if enabled in NVDA settings) is fine.
- [ ] Long `dir` output still reads as it does today (this PR doesn't fix that — the architectural follow-up does).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_