### PR TITLE
fix(accessibility): cap tuple-final output Announce + Ctrl+Shift+O open-last-output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,25 @@ runs to completion) can cancel mid-utterance.
   item `MenuItem_OpenLastOutput` under "Data" in
   `MainWindow.xaml`. The reflective menu-binding loop
   (`Program.fs` ~line 3877) picks it up automatically.
+- **`Ctrl+Shift+A` — re-narrate last command output**
+  (mnemonic: *A*nnounce). Spoken counterpart to
+  `Ctrl+Shift+O` for the user who missed the auto-narrate
+  (was speaking, typing, switched window). Re-speaks the
+  most recent tuple's `OutputText` via the same
+  `TerminalView.Announce` channel + `ActivityIds.output`
+  activity ID, capped at the same `OutputAnnounceCapChars`
+  (800) the auto-narrate uses. NVDA's `MostRecent`
+  processing means re-pressing supersedes the prior
+  in-flight `pty-speak.output` notification, so the user can
+  use it as a "say it again" / "say it louder" lever.
+  Announces "No prior output." when `History` is empty;
+  "Last command produced no output." when the latest
+  tuple's `OutputText` is whitespace-only.
+- **Hotkey wiring (`Ctrl+Shift+A`)**: new
+  `HotkeyRegistry.AnnounceLastOutput` AppCommand
+  (Letter 'A' + ctrlShift); registered in
+  `AppReservedHotkeys`; menu item
+  `MenuItem_AnnounceLastOutput` under "Data".
 - **CLAUDE.md** §"Currently shipped" hotkey list gains a
   `Ctrl+Shift+O` entry alongside the existing `Ctrl+Shift+S` /
   `Ctrl+Shift+Y` companions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,70 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 46 post-audit (2026-05-13): cap tuple-final output Announce + `Ctrl+Shift+O` open-last-output
+
+Resolves the "DIR freezes all speech for ~5 minutes" symptom
+the maintainer reported on the post-audit preview build
+(version 0.0.1-preview.109, commit `bb0b239`).
+
+**Root cause (confirmed via `Ctrl+Shift+D` log slice 2026-05-13
+06:30:58 UTC)**: `SessionModel finalize extraction CmdLen=5
+OutLen=18953` → `RaiseNotificationEvent firing.
+ActivityId=pty-speak.output MsgLen=18953 Processing=MostRecent`.
+A single 19 KB notification hits NVDA's queue; NVDA hands to
+SAPI as one ~5–10 minute utterance which neither
+`MostRecent` (different `activityId` → no supersede) nor the
+Edit-control typed-character interrupt (NVDA's interrupt
+runs at the keyboard layer; once SAPI has begun a render it
+runs to completion) can cancel mid-utterance.
+
+**Fix**:
+
+- **`Program.fs` `OutputAnnounceCapChars = 800`**. The
+  boundary handler caps `tupleFinaliseAnnounce` to the last
+  800 characters of the tuple's `OutputText` before passing
+  to `TerminalView.Announce`. Worst-case SAPI utterance is
+  now ~30–60 seconds rather than 5–10 minutes; user can
+  interrupt by typing (Edit-control flow), pressing Alt, or
+  running another command that triggers its own announce.
+  No prefix or suffix is added to the audible text — the
+  truncation is silent at the channel; a
+  `Tuple-final announce truncated.` log line at INFO
+  records `OriginalLen` / `CappedLen` for diagnosis.
+- **`Ctrl+Shift+O` — open last output in default text
+  editor** (mnemonic: O for *O*pen Output). Writes the most
+  recent tuple's full `OutputText` to a fresh timestamped
+  file under `%LOCALAPPDATA%\PtySpeak\extracts\last-output-<ts>.txt`
+  and launches it via `Process.Start` with
+  `UseShellExecute=true` (registered `.txt` handler — Notepad
+  by default, or whatever the user configured). The
+  announce-then-700ms-delay pattern matches `Ctrl+Shift+E`
+  (Edit config). Announces "Opening last output." on
+  success, "No prior output." when `SessionModel.History`
+  is empty.
+- **Hotkey wiring**: new `HotkeyRegistry.OpenLastOutput`
+  AppCommand (Letter 'O' + ctrlShift); registered in
+  `AppReservedHotkeys` (`src/Views/TerminalView.cs`); menu
+  item `MenuItem_OpenLastOutput` under "Data" in
+  `MainWindow.xaml`. The reflective menu-binding loop
+  (`Program.fs` ~line 3877) picks it up automatically.
+- **CLAUDE.md** §"Currently shipped" hotkey list gains a
+  `Ctrl+Shift+O` entry alongside the existing `Ctrl+Shift+S` /
+  `Ctrl+Shift+Y` companions.
+- **`docs/ACCESSIBILITY-TESTING.md`** Cycle 46 matrix gains
+  rows 46-11 (cap behaviour on `dir`), 46-12 (`Ctrl+Shift+O`
+  happy path), and 46-13 (`Ctrl+Shift+O` empty-history
+  guard) + a diagnostic-decoder paragraph for cap / hotkey
+  failure modes.
+
+**Claude shell unaffected**. `Claude`'s
+`ShellPolicy.Streaming` is `LineByLine` (not `TupleFinalOnly`),
+so the boundary handler's `tupleFinaliseAnnounce` is `None`
+on every prompt and the cap path is never entered. Each
+streaming chunk arrives via `SpeechCursor.onAppend` →
+`Announce` independently and `MostRecent` does the right
+thing per-chunk.
+
 ### Cycle 46 closure audit + Option ★★ pivot (no-spoken-output fix)
 
 Post-PR-D audit PR sweeping for drift between the now-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,17 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   whatever the user has configured). Announces "Opening last
   output." on success; "No prior output." when
   `SessionModel.History` is empty.
+- `Ctrl+Shift+A` — re-narrate the last command's `OutputText`
+  via NVDA, capped at the same `OutputAnnounceCapChars` (800)
+  the auto-narrate uses (Cycle 46 post-audit, 2026-05-13). For
+  the user who missed the auto-Announce (was speaking, typing,
+  switched window). Spoken counterpart to `Ctrl+Shift+O`'s
+  text-editor surface. Uses the same `ActivityIds.output`
+  activity ID, so NVDA's `MostRecent` processing supersedes
+  any other in-flight `pty-speak.output` notification.
+  Announces "No prior output." when `SessionModel.History`
+  is empty; "Last command produced no output." when the
+  latest tuple's `OutputText` is whitespace-only.
 
 Multi-state menu items (Cycle 27 paradigm; menu-only, no
 keyboard accelerator):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,19 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   and `Ctrl+Shift+D` (which folds the same summary into the
   bundle's `--- SESSION LOG ---` section so a paste-back
   carries it without a separate keystroke).
+- `Ctrl+Shift+O` — open the last command's full `OutputText`
+  in the default text editor (Cycle 46 post-audit, 2026-05-13).
+  Companion to the 800-char tuple-final `Announce` cap in
+  `Program.fs` (`OutputAnnounceCapChars`): the cap keeps the
+  audible read interruptible for a `dir`-shaped output; this
+  hotkey is the escape hatch for hearing / reading the full
+  body. Writes a fresh timestamped file under
+  `%LOCALAPPDATA%\PtySpeak\extracts\last-output-<ts>.txt` and
+  launches it via `Process.Start` with `UseShellExecute=true`
+  (the registered `.txt` handler — Notepad by default, or
+  whatever the user has configured). Announces "Opening last
+  output." on success; "No prior output." when
+  `SessionModel.History` is empty.
 
 Multi-state menu items (Cycle 27 paradigm; menu-only, no
 keyboard accelerator):

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1249,6 +1249,9 @@ to a post-Cycle-46 fixup PR rather than tagging a release.
 | **46-8** | Claude REPL + a streaming response. | Mid-stream chunks flow through `ContentHistory.appendFromEvent`; the caret-move event fires per tuple finalisation. Streaming should feel like NVDA is reading along with the model, not a delayed block-read at the end. |
 | **46-9** | Non-output notifications: press `Ctrl+Shift+H` (health check), `Ctrl+Shift+S` (session-log path), `Ctrl+Shift+D` (diagnostic snapshot). | Each still produces a notification-style announce. ADR §"Decision" clause 5 keeps notifications for non-terminal-content events; the caret-only path is for terminal command I/O. |
 | **46-10** | Trigger an error (e.g. a malformed escape sequence; `printf '\033[?garbage'` in cmd). | `ActivityIds.error` notification fires as today. Error path was not touched by Cycle 46. |
+| **46-11** | cmd + `dir` of a moderately-large directory (the install dir works; produces ~19 KB of output). Listen for the audible read after the command completes. | NVDA reads the last ~800 chars of output and stops cleanly. Pre-cap behaviour was a single 5–10 minute SAPI utterance that NVDA could not interrupt; post-cap the utterance is bounded to ~30–60 seconds. Subsequent commands' announces are no longer queued behind the giant read. |
+| **46-12** | After 46-11, press `Ctrl+Shift+O`. | A new text editor window opens (whichever app handles `.txt` files) with the full `OutputText` of the most recent tuple. NVDA announces "Opening last output." then transitions focus to the editor. The file lives under `%LOCALAPPDATA%\PtySpeak\extracts\last-output-<timestamp>.txt`. |
+| **46-13** | Restart pty-speak (so `History` is empty), focus the terminal, press `Ctrl+Shift+O` before running any command. | NVDA announces "No prior output." No editor opens. No file is written. |
 
 **Diagnostic decoder.** If 46-1 fails (focus still announces
 "document"): `TerminalAutomationPeer.GetAutomationControlTypeCore`
@@ -1271,7 +1274,16 @@ site). If 46-6 fails: the
 `runSpeechCursorNext/Previous/JumpToLatest` handlers in
 `Program.fs` may have accidentally been routed through the
 caret helper — those should stay on `window.TerminalSurface.Announce`
-per the PR-D scope refinement.
+per the PR-D scope refinement. If 46-11 NVDA still hangs on
+the `dir` read for minutes: the `OutputAnnounceCapChars` cap
+in `Program.fs` either isn't being applied (check for
+`Tuple-final announce truncated.` log line at
+INFO level in the FileLogger active log) or the cap value is
+too large for SAPI's chunking — drop from 800 to 400 and
+retest. If 46-12 the editor opens but is empty: the tuple
+finalised with an empty `OutputText` (cmd / PowerShell can
+do this for commands that don't emit visible output — try a
+clearly-visible command like `dir` instead).
 
 ## Recording results
 

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1252,6 +1252,9 @@ to a post-Cycle-46 fixup PR rather than tagging a release.
 | **46-11** | cmd + `dir` of a moderately-large directory (the install dir works; produces ~19 KB of output). Listen for the audible read after the command completes. | NVDA reads the last ~800 chars of output and stops cleanly. Pre-cap behaviour was a single 5–10 minute SAPI utterance that NVDA could not interrupt; post-cap the utterance is bounded to ~30–60 seconds. Subsequent commands' announces are no longer queued behind the giant read. |
 | **46-12** | After 46-11, press `Ctrl+Shift+O`. | A new text editor window opens (whichever app handles `.txt` files) with the full `OutputText` of the most recent tuple. NVDA announces "Opening last output." then transitions focus to the editor. The file lives under `%LOCALAPPDATA%\PtySpeak\extracts\last-output-<timestamp>.txt`. |
 | **46-13** | Restart pty-speak (so `History` is empty), focus the terminal, press `Ctrl+Shift+O` before running any command. | NVDA announces "No prior output." No editor opens. No file is written. |
+| **46-14** | After 46-11, press `Ctrl+Shift+A`. | NVDA re-narrates the last ~800 chars of the most recent output via `ActivityIds.output`. Useful when the auto-narrate was missed (user was speaking, typing, switched window). Same cap as the auto-narrate. |
+| **46-15** | Fresh app (no commands run), press `Ctrl+Shift+A`. | NVDA announces "No prior output." No re-narration. |
+| **46-16** | Run `echo` with no argument (cmd shell will print a single empty-line response), then press `Ctrl+Shift+A`. | NVDA announces "Last command produced no output." (the latest tuple's `OutputText` is whitespace-only; covered by the `IsNullOrWhiteSpace` guard). |
 
 **Diagnostic decoder.** If 46-1 fails (focus still announces
 "document"): `TerminalAutomationPeer.GetAutomationControlTypeCore`

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2700,8 +2700,7 @@ module Program =
                 let extractsDir =
                     System.IO.Path.Combine(
                         Environment.GetFolderPath(
-                            Environment.SpecialFolder.LocalApplicationData)
-                        |> nonNull,
+                            Environment.SpecialFolder.LocalApplicationData),
                         "PtySpeak",
                         "extracts")
                 let filePath =

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2758,6 +2758,56 @@ module Program =
                         sprintf "Could not save output: %s" safe,
                         ActivityIds.error)
 
+        // Cycle 46 post-audit (2026-05-13) — re-narrate the
+        // latest finalised tuple's `OutputText`, capped at the
+        // same `OutputAnnounceCapChars` the auto-narrate uses.
+        // For the user who missed the auto-Announce (was
+        // speaking, typing, switched window, etc.). Goes
+        // through the same `TerminalView.Announce` channel +
+        // `ActivityIds.output` activity ID, so it supersedes
+        // any other in-flight `pty-speak.output` notification
+        // via NVDA's `MostRecent` processing — the cap keeps
+        // the utterance bounded to ~30–60s either way.
+        //
+        // `Ctrl+Shift+O` is the companion when the user wants
+        // the FULL output (writes to a file + opens the default
+        // text editor); this hotkey is the spoken counterpart.
+        let runAnnounceLastOutput () : unit =
+            let log =
+                Logger.get "Terminal.App.Program.runAnnounceLastOutput"
+            log.LogInformation(
+                "Ctrl+Shift+A pressed — re-narrating last output.")
+            let snapshot = currentSession
+            match snapshot.History |> Seq.tryLast with
+            | None ->
+                log.LogInformation(
+                    "No prior output to re-narrate (History is empty).")
+                window.TerminalSurface.Announce(
+                    "No prior output.",
+                    ActivityIds.diagnostic)
+            | Some tuple when System.String.IsNullOrWhiteSpace tuple.OutputText ->
+                log.LogInformation(
+                    "Latest tuple has empty OutputText.")
+                window.TerminalSurface.Announce(
+                    "Last command produced no output.",
+                    ActivityIds.diagnostic)
+            | Some tuple ->
+                let toSay =
+                    if tuple.OutputText.Length <= OutputAnnounceCapChars then
+                        tuple.OutputText
+                    else
+                        tuple.OutputText.Substring(
+                            tuple.OutputText.Length - OutputAnnounceCapChars)
+                if toSay.Length < tuple.OutputText.Length then
+                    log.LogInformation(
+                        "Re-narrate truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
+                        tuple.OutputText.Length,
+                        toSay.Length,
+                        OutputAnnounceCapChars)
+                window.TerminalSurface.Announce(
+                    toSay,
+                    ActivityIds.output)
+
         // session-log file path. Reads `sessionLogWriter` (post
         // -Cycle-24c) + `persistenceConfig.Mode` (post-Cycle-24a)
         // from compose-local state. The closure is defined here
@@ -3105,6 +3155,7 @@ module Program =
         bind HotkeyRegistry.CopyHistoryToClipboard runCopyHistoryToClipboard
         bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
         bind HotkeyRegistry.OpenLastOutput runOpenLastOutput
+        bind HotkeyRegistry.AnnounceLastOutput runAnnounceLastOutput
         // Cycle 43a — diagnostic chunk extractors + grep dialog.
         // All menu-only (no keyboard accelerator); `bindHotkey`
         // skips the KeyBinding installation but still registers

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -24,6 +24,26 @@ module Program =
     let private ScreenRows = 30
     let private ScreenCols = 120
 
+    /// Cycle 46 post-audit (2026-05-13) — cap for the tuple-
+    /// final `Announce(text, ActivityIds.output)` call's payload
+    /// length. The pre-cap behaviour shipped a single 19 KB
+    /// notification for a default-shell `dir`, which NVDA hands
+    /// to SAPI as one ~5–10 minute utterance that cannot be
+    /// interrupted by another notification or by the
+    /// Edit-control typed-character setting (NVDA's interrupt
+    /// path doesn't displace an in-flight SAPI render).
+    /// 800 characters caps the worst-case utterance to roughly
+    /// 30–60 seconds at normal SAPI rate; the user hears the
+    /// tail of the output, which usually carries the
+    /// most-relevant bytes (final summary / next prompt / exit
+    /// status). Full output remains in `ContentHistory` and is
+    /// reachable via the `Ctrl+Shift+O` open-last-output hotkey
+    /// (writes the tuple's full `OutputText` to a temp file
+    /// under `%LOCALAPPDATA%\PtySpeak\extracts\` and opens it
+    /// in the default text editor) or via `Ctrl+Shift+Y`
+    /// (copies the SessionModel history to the clipboard).
+    let private OutputAnnounceCapChars = 800
+
     /// GitHub Releases endpoint Velopack pulls update metadata
     /// from. `prerelease=true` because Stage 11 ships on the
     /// `0.0.x-preview.N` channel; once the line graduates to
@@ -1720,9 +1740,41 @@ module Program =
                 // NVDA's typed-character interrupt. See the
                 // matching comment on `speechCursorAnnounce`
                 // above for the full rationale.
+                //
+                // Cycle 46 post-audit (2026-05-13) — cap the
+                // tuple-final announce at the last
+                // OutputAnnounceCapChars characters. The
+                // pre-cap behaviour shipped one giant Announce
+                // (observed: MsgLen=18953 for a default-shell
+                // `dir`) which becomes a 5–10 minute single
+                // SAPI utterance NVDA cannot interrupt — neither
+                // `MostRecent` on a different `activityId` nor
+                // the Edit-control typed-character setting
+                // displaces an in-flight SAPI render. Capping at
+                // ~800 chars keeps the worst-case utterance to
+                // ~30–60 seconds; the user hears the tail of the
+                // command's output (typically the most relevant
+                // bytes — final summary line / next prompt /
+                // exit status). Full output is preserved in
+                // ContentHistory and reachable via
+                // `Ctrl+Shift+O` (open last output in the default
+                // text editor) or `Ctrl+Shift+Y` (copy session
+                // history to clipboard).
+                //
+                // No prefix or NVDA instruction is added to the
+                // audible text — keep the cap silent at the
+                // channel layer and trust the hotkey + log to
+                // surface the cap when needed.
                 match tupleFinaliseAnnounce with
                 | Some text ->
-                    window.TerminalSurface.Announce(text, ActivityIds.output)
+                    let toSay =
+                        if text.Length <= OutputAnnounceCapChars then text
+                        else text.Substring(text.Length - OutputAnnounceCapChars)
+                    if toSay.Length < text.Length then
+                        log.LogInformation(
+                            "Tuple-final announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
+                            text.Length, toSay.Length, OutputAnnounceCapChars)
+                    window.TerminalSurface.Announce(toSay, ActivityIds.output)
                     raiseCaretMovedToTail ()
                 | None -> ()
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
@@ -2605,6 +2657,107 @@ module Program =
             ()
 
         // Cycle 24e — `Ctrl+Shift+S`: announce the active
+        // Cycle 46 post-audit (2026-05-13) — open the latest
+        // tuple's full `OutputText` in the default text editor.
+        // Companion to the 800-char tuple-final Announce cap:
+        // the cap keeps the audible read interruptible; this
+        // hotkey is the escape hatch for hearing / reading the
+        // full output when the cap matters.
+        //
+        // File path:
+        //   %LOCALAPPDATA%\PtySpeak\extracts\last-output-<ts>.txt
+        // A fresh timestamped file per invocation (matches the
+        // Diagnostics → Grep diagnostics extract pattern). The
+        // accumulation in `extracts\` is bounded by the user's
+        // explicit invocation count; no auto-pruning.
+        //
+        // Defaults to the most recently-finalised tuple
+        // (`History |> Seq.tryLast`). Mid-command Active tuples
+        // aren't surfaced — the user can wait for the prompt to
+        // return. If the history is empty, the hotkey announces
+        // "No prior output" rather than opening an empty file.
+        //
+        // The 700ms announce-then-launch delay mirrors
+        // `runOpenConfig`'s pattern: NVDA finishes speaking the
+        // confirmation before the editor takes focus and starts
+        // its own UIA traffic.
+        let runOpenLastOutput () : unit =
+            let log =
+                Logger.get "Terminal.App.Program.runOpenLastOutput"
+            log.LogInformation(
+                "Ctrl+Shift+O pressed — opening last output in default editor.")
+            let snapshot = currentSession
+            match snapshot.History |> Seq.tryLast with
+            | None ->
+                log.LogInformation(
+                    "No prior output to open (History is empty).")
+                window.TerminalSurface.Announce(
+                    "No prior output.",
+                    ActivityIds.diagnostic)
+            | Some tuple ->
+                let timestamp =
+                    DateTime.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss-fff")
+                let extractsDir =
+                    System.IO.Path.Combine(
+                        Environment.GetFolderPath(
+                            Environment.SpecialFolder.LocalApplicationData)
+                        |> nonNull,
+                        "PtySpeak",
+                        "extracts")
+                let filePath =
+                    System.IO.Path.Combine(
+                        extractsDir,
+                        sprintf "last-output-%s.txt" timestamp)
+                try
+                    System.IO.Directory.CreateDirectory(extractsDir)
+                    |> ignore
+                    System.IO.File.WriteAllText(
+                        filePath,
+                        tuple.OutputText,
+                        System.Text.Encoding.UTF8)
+                    log.LogInformation(
+                        "Wrote last output to file. Path={Path} OutputLen={Len}",
+                        filePath, tuple.OutputText.Length)
+                    window.TerminalSurface.Announce(
+                        "Opening last output.",
+                        ActivityIds.diagnostic)
+                    let _ =
+                        task {
+                            do! Task.Delay(700)
+                            let action () =
+                                try
+                                    let psi =
+                                        System.Diagnostics.ProcessStartInfo()
+                                    psi.FileName <- filePath
+                                    psi.UseShellExecute <- true
+                                    System.Diagnostics.Process.Start(psi)
+                                    |> ignore
+                                with ex ->
+                                    let safe =
+                                        AnnounceSanitiser.sanitise ex.Message
+                                    log.LogError(
+                                        ex,
+                                        "Could not launch text editor: {Path}",
+                                        filePath)
+                                    window.TerminalSurface.Announce(
+                                        sprintf
+                                            "Could not open output file: %s"
+                                            safe,
+                                        ActivityIds.error)
+                            do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                            ()
+                        }
+                    ()
+                with ex ->
+                    let safe = AnnounceSanitiser.sanitise ex.Message
+                    log.LogError(
+                        ex,
+                        "Could not write last-output file at {Path}.",
+                        filePath)
+                    window.TerminalSurface.Announce(
+                        sprintf "Could not save output: %s" safe,
+                        ActivityIds.error)
+
         // session-log file path. Reads `sessionLogWriter` (post
         // -Cycle-24c) + `persistenceConfig.Mode` (post-Cycle-24a)
         // from compose-local state. The closure is defined here
@@ -2951,6 +3104,7 @@ module Program =
         bind HotkeyRegistry.RunDiagnostic runDiagnostic
         bind HotkeyRegistry.CopyHistoryToClipboard runCopyHistoryToClipboard
         bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
+        bind HotkeyRegistry.OpenLastOutput runOpenLastOutput
         // Cycle 43a — diagnostic chunk extractors + grep dialog.
         // All menu-only (no keyboard accelerator); `bindHotkey`
         // skips the KeyBinding installation but still registers

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -96,6 +96,15 @@ module HotkeyRegistry =
         | CopyHistoryToClipboard
         // Cycle 24e — announce active session-log file path.
         | AnnounceSessionLogPath
+        // Cycle 46 post-audit (2026-05-13) — open the latest
+        // tuple's full OutputText in the default text editor.
+        // Companion to the 800-char tuple-final Announce cap;
+        // when the cap truncates a long output, this hotkey
+        // surfaces the full text on demand. Writes a fresh
+        // timestamped file under
+        // %LOCALAPPDATA%\PtySpeak\extracts\ and shell-executes
+        // it (registered .txt handler).
+        | OpenLastOutput
         // Cycle 26c — first menu-only command. Interactive
         // process-cleanup test (`scripts/test-process-cleanup.ps1`)
         // surfaced via Diagnostics → Test Process Cleanup. No
@@ -172,6 +181,7 @@ module HotkeyRegistry =
         | SwitchToClaude -> "SwitchToClaude"
         | CopyHistoryToClipboard -> "CopyHistoryToClipboard"
         | AnnounceSessionLogPath -> "AnnounceSessionLogPath"
+        | OpenLastOutput -> "OpenLastOutput"
         | RunProcessCleanupScript -> "RunProcessCleanupScript"
         | CloseWindow -> "CloseWindow"
         | ExitApp -> "ExitApp"
@@ -269,6 +279,13 @@ module HotkeyRegistry =
             Key = Some (Letter 'S')
             Modifiers = Some ctrlShift
             Description = "Announce the active session-log file path (Cycle 24e)" }
+          // Cycle 46 post-audit (2026-05-13) — open last
+          // command output in the default text editor.
+          // Companion to the tuple-final Announce cap.
+          { Command = OpenLastOutput
+            Key = Some (Letter 'O')
+            Modifiers = Some ctrlShift
+            Description = "Open last command output in default text editor (Cycle 46 post-audit)" }
           // Cycle 26c — menu-only; no default keyboard accelerator.
           // Surfaced as Diagnostics → Test Process Cleanup.
           { Command = RunProcessCleanupScript
@@ -432,6 +449,7 @@ module HotkeyRegistry =
           SwitchToClaude
           CopyHistoryToClipboard
           AnnounceSessionLogPath
+          OpenLastOutput
           RunProcessCleanupScript
           CloseWindow
           ExitApp

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -105,6 +105,14 @@ module HotkeyRegistry =
         // %LOCALAPPDATA%\PtySpeak\extracts\ and shell-executes
         // it (registered .txt handler).
         | OpenLastOutput
+        // Cycle 46 post-audit (2026-05-13) — re-narrate the
+        // latest tuple's OutputText (capped at the same 800
+        // chars the boundary handler's auto-narrate uses). For
+        // the user who missed the auto-Announce (was speaking,
+        // typing, switched window). Companion to OpenLastOutput
+        // when the user wants spoken rather than text-editor
+        // surface.
+        | AnnounceLastOutput
         // Cycle 26c — first menu-only command. Interactive
         // process-cleanup test (`scripts/test-process-cleanup.ps1`)
         // surfaced via Diagnostics → Test Process Cleanup. No
@@ -182,6 +190,7 @@ module HotkeyRegistry =
         | CopyHistoryToClipboard -> "CopyHistoryToClipboard"
         | AnnounceSessionLogPath -> "AnnounceSessionLogPath"
         | OpenLastOutput -> "OpenLastOutput"
+        | AnnounceLastOutput -> "AnnounceLastOutput"
         | RunProcessCleanupScript -> "RunProcessCleanupScript"
         | CloseWindow -> "CloseWindow"
         | ExitApp -> "ExitApp"
@@ -286,6 +295,13 @@ module HotkeyRegistry =
             Key = Some (Letter 'O')
             Modifiers = Some ctrlShift
             Description = "Open last command output in default text editor (Cycle 46 post-audit)" }
+          // Cycle 46 post-audit (2026-05-13) — re-narrate the
+          // latest tuple's OutputText (capped at the same
+          // 800 chars as the auto-narrate).
+          { Command = AnnounceLastOutput
+            Key = Some (Letter 'A')
+            Modifiers = Some ctrlShift
+            Description = "Re-narrate last command output (capped at 800 chars; Cycle 46 post-audit)" }
           // Cycle 26c — menu-only; no default keyboard accelerator.
           // Surfaced as Diagnostics → Test Process Cleanup.
           { Command = RunProcessCleanupScript
@@ -450,6 +466,7 @@ module HotkeyRegistry =
           CopyHistoryToClipboard
           AnnounceSessionLogPath
           OpenLastOutput
+          AnnounceLastOutput
           RunProcessCleanupScript
           CloseWindow
           ExitApp

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -145,6 +145,9 @@
                 <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
                           x:FieldModifier="public"
                           Header="Announce _Session Log Path" />
+                <MenuItem x:Name="MenuItem_OpenLastOutput"
+                          x:FieldModifier="public"
+                          Header="Open _Last Output" />
             </MenuItem>
             <MenuItem Header="Dia_gnostics">
                 <!-- Cycle 38a-followup — Logging Level moved here

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -148,6 +148,9 @@
                 <MenuItem x:Name="MenuItem_OpenLastOutput"
                           x:FieldModifier="public"
                           Header="Open _Last Output" />
+                <MenuItem x:Name="MenuItem_AnnounceLastOutput"
+                          x:FieldModifier="public"
+                          Header="_Announce Last Output" />
             </MenuItem>
             <MenuItem Header="Dia_gnostics">
                 <!-- Cycle 38a-followup — Logging Level moved here

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -635,6 +635,16 @@ public class TerminalView : FrameworkElement
             // check: no default NVDA binding for Ctrl+Shift+O.
             (Key.O, ModifierKeys.Control | ModifierKeys.Shift, "Open last command output in default editor"),
 
+            // Cycle 46 post-audit (2026-05-13) — re-narrate the
+            // last command output (capped at the same 800 chars
+            // the auto-narrate uses). Mnemonic: A for
+            // *A*nnounce. Companion to Ctrl+Shift+O — Ctrl+Shift+O
+            // opens the full output in a text editor;
+            // Ctrl+Shift+A re-speaks the bounded chunk through
+            // NVDA. NVDA collision check: no default NVDA
+            // binding for Ctrl+Shift+A.
+            (Key.A, ModifierKeys.Control | ModifierKeys.Shift, "Re-narrate last command output (capped)"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -621,6 +621,20 @@ public class TerminalView : FrameworkElement
             // OS level.
             (Key.S, ModifierKeys.Control | ModifierKeys.Shift, "Announce session-log file path"),
 
+            // Cycle 46 post-audit (2026-05-13) — open the last
+            // command output in the default text editor.
+            // Mnemonic: O for *O*pen Output. Companion to the
+            // 800-char tuple-final Announce cap (Program.fs
+            // `OutputAnnounceCapChars`): when a long command
+            // (e.g. `dir`, `git log`) produces output that
+            // exceeds the cap, the user hears the trailing
+            // ~800 chars; Ctrl+Shift+O writes the full
+            // OutputText to a fresh timestamped file under
+            // %LOCALAPPDATA%\PtySpeak\extracts\ and opens it
+            // via the registered .txt handler. NVDA collision
+            // check: no default NVDA binding for Ctrl+Shift+O.
+            (Key.O, ModifierKeys.Control | ModifierKeys.Shift, "Open last command output in default editor"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -81,6 +81,9 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               HotkeyRegistry.CopyHistoryToClipboard
               // Cycle 24e — announce session-log file path.
               HotkeyRegistry.AnnounceSessionLogPath
+              // Cycle 46 post-audit — open last command output
+              // in default text editor (Ctrl+Shift+O).
+              HotkeyRegistry.OpenLastOutput
               // Cycle 26c — first menu-only command. Surfaced
               // via Diagnostics → Test Process Cleanup; no
               // keyboard accelerator.

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -84,6 +84,9 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // Cycle 46 post-audit — open last command output
               // in default text editor (Ctrl+Shift+O).
               HotkeyRegistry.OpenLastOutput
+              // Cycle 46 post-audit — re-narrate last command
+              // output capped at 800 chars (Ctrl+Shift+A).
+              HotkeyRegistry.AnnounceLastOutput
               // Cycle 26c — first menu-only command. Surfaced
               // via Diagnostics → Test Process Cleanup; no
               // keyboard accelerator.


### PR DESCRIPTION
## Summary

Resolves the "DIR freezes all speech for ~5 minutes" symptom you reported on the post-audit preview build (version `0.0.1-preview.109`, commit `bb0b239`).

**Root cause** (from your `Ctrl+Shift+D` snapshot, 2026-05-13 06:30:58 UTC):

```
SessionModel finalize extraction CmdLen=5 OutLen=18953
RaiseNotificationEvent firing. ActivityId=pty-speak.output MsgLen=18953 Processing=MostRecent
```

A single 19 KB notification → NVDA → SAPI as one ~5–10 minute utterance. Neither `MostRecent` (different `activityId` doesn't supersede) nor the Edit-control typed-character interrupt (runs at the keyboard layer, can't cancel an in-flight SAPI render) can stop it mid-utterance.

## What this PR does

### 1. Cap the tuple-final `Announce` at 800 chars

New constant `Program.OutputAnnounceCapChars = 800`. The boundary handler caps `tupleFinaliseAnnounce` to the last 800 characters of `tuple.OutputText` before passing to `TerminalView.Announce`. Worst-case SAPI utterance is now ~30–60 seconds rather than 5–10 minutes; user can interrupt naturally.

No prefix or suffix in the audible text per your direction. An INFO log line records the truncation (`OriginalLen` / `CappedLen`) for diagnosis.

### 2. New `Ctrl+Shift+O` — open last output in default text editor

Companion to the cap. Writes the most recent finalised tuple's full `OutputText` to a fresh timestamped file under `%LOCALAPPDATA%\PtySpeak\extracts\last-output-<ts>.txt` and launches it via `Process.Start` with `UseShellExecute=true` (the registered `.txt` handler — Notepad by default, or whatever you've configured).

- Announces `"Opening last output."` on success.
- Announces `"No prior output."` when `SessionModel.History` is empty.
- The announce-then-700ms-delay-then-launch pattern mirrors `Ctrl+Shift+E` (Edit Config).

### 3. Claude shell unaffected

Claude's `ShellPolicy.Streaming` is `LineByLine` (not `TupleFinalOnly`), so `tupleFinaliseAnnounce` is `None` on every Claude prompt and the cap path is never entered. Each streaming chunk arrives via `SpeechCursor.onAppend` → `Announce` with the chunk text (tens to hundreds of chars), and `MostRecent` does the right thing per-chunk. The cap is specifically for the cmd / PowerShell `TupleFinalOnly` shape that produces single giant blobs at the prompt return.

## Wiring (all data-driven)

- `HotkeyRegistry.OpenLastOutput` AppCommand DU case + `nameOf` row + `builtIns` row + `allCommands` entry.
- `TerminalView.AppReservedHotkeys` entry for `Key.O + Ctrl+Shift`.
- `MainWindow.xaml` MenuItem `MenuItem_OpenLastOutput` under the Data menu — picked up automatically by the reflective menu-binding loop at `Program.fs:3877`.
- `HotkeyRegistryTests.fs` documented-commands set updated.

## Why this is what we can do today

Per the conversation, the architectural fix (proper `ITextProvider.GetSelection()` semantics so NVDA reads via the text-pattern speech machinery, which IS chunkable and interruptible) is real, but a multi-cycle investment that needs NVDA-side experimentation and the right invariants between `GetSelection` returns / `TextChanged` events / `TextSelectionChanged` events. The cap + escape-hatch hotkey is the responsible move with the API surface that exists today. The Cycle 46 substrate is what unlocks doing better later; the `RaiseCaretMovedToTail` helper introduced in PR-C is the natural place to wire any future improvements behind one call site.

This is also universal across screen readers running ahead of SAPI / equivalent synthesisers — NVDA, JAWS, Narrator, VoiceOver all delegate to a renderer that needs N seconds to render N seconds of speech, and none of them mid-utterance-cancel for arbitrary notifications. Not fishy on our side; it's the floor of the API.

## Test plan

- [ ] Full Windows build green.
- [ ] xUnit suite green (`HotkeyRegistryTests` and `AppReservedHotkeysMirrorTests` both pin the new `OpenLastOutput` entry).
- [ ] **NVDA matrix gate Cycle 46-11 / 46-12 / 46-13** ([`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md)) before tagging the next release:
  - **46-11**: cmd + `dir`. NVDA reads the last ~800 chars and stops cleanly; subsequent commands' announces aren't queued behind the giant read.
  - **46-12**: `Ctrl+Shift+O` after `dir`. Text editor opens with the full output; NVDA announces "Opening last output."
  - **46-13**: Fresh app, no prior command, press `Ctrl+Shift+O`. NVDA announces "No prior output." No editor opens.

## What's deliberately not in this PR

- The proper `ITextProvider.GetSelection()` / `TextChanged` route (Cycle 46+1 candidate).
- Capping mid-stream `SpeechCursor.onAppend` announces — those are already chunk-sized.
- Changing the default `OutputAnnounceCapChars` value — 800 is the initial guess; tunable later.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_