### PR TITLE
feat(earcon+menu): ready-prompt click sound + Data → Last Output submenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 46 post-audit follow-up (2026-05-13): ready-prompt earcon to a click + Data → Last Output submenu
+
+Two small follow-ups to the audit PR per maintainer feedback:
+
+- **`ready-prompt` earcon re-tuned from a tone to a click.**
+  Was 1200Hz × 60ms (with 5ms attack); now 3000Hz × 15ms
+  (no attack envelope). The 60ms tone overlapped the auto-
+  narrate of the just-finished command in a way the
+  maintainer described as disruptive. The shorter, higher,
+  attack-free form perceptually separates from spoken
+  output and reads as a brief tick rather than a tone.
+  Implementation: parameter-only change in
+  [`src/Terminal.Audio/EarconPalette.fs`](src/Terminal.Audio/EarconPalette.fs);
+  the synthesis path
+  (`EarconWaveform.synthSineEnvelope`) is unchanged. The
+  existing Display → Earcons → Muted toggle silences this
+  + every other earcon globally if the click is still
+  unwanted; per-earcon mute is a follow-up (the maintainer
+  explicitly asked not to over-invest in per-sound config
+  yet).
+- **Menu reorganization: Data → Last Output submenu.**
+  The two `Ctrl+Shift+O` / `Ctrl+Shift+A` affordances added
+  in the audit PR landed loose under the Data menu. They're
+  now grouped under a `Last Output` submenu with two
+  children: `Open in Text Editor`
+  (`MenuItem_OpenLastOutput`) and `Announce Again`
+  (`MenuItem_AnnounceLastOutput`). The reflective
+  menu-binding loop (`Program.fs` ~line 3877) finds the
+  named MenuItems via `window.GetType().GetField(...)`
+  regardless of XAML nesting, so no Program.fs wiring
+  changes are required.
+
+No code paths changed beyond the palette numbers and the
+XAML hierarchy. Hotkeys (Ctrl+Shift+O, Ctrl+Shift+A) are
+unchanged. ACCESSIBILITY-TESTING matrix rows 46-11 → 46-16
+continue to apply.
+
 ### Cycle 46 post-audit (2026-05-13): cap tuple-final output Announce + `Ctrl+Shift+O` open-last-output
 
 Resolves the "DIR freezes all speech for ~5 minutes" symptom

--- a/src/Terminal.Audio/EarconPalette.fs
+++ b/src/Terminal.Audio/EarconPalette.fs
@@ -44,15 +44,19 @@ module EarconPalette =
     ///   colour-detection (yellow rows). Same status as
     ///   error-tone — present in the palette for diagnostic
     ///   coverage, no producer wired yet.
-    /// - `ready-prompt` (1200Hz × 60ms): Cycle 45 — a brief
-    ///   high-pitched chime fired when a command finishes and
-    ///   the shell is ready for the next input. Higher-pitched
-    ///   + shorter than `bell-ping` so it's audibly distinct
-    ///   from the BEL ping; brief enough that consecutive
-    ///   commands don't overlap. Routes through the same
-    ///   non-blocking WASAPI stream as every other earcon, so
-    ///   it plays alongside NVDA's read-back of the OutputText
-    ///   without interrupting speech.
+    /// - `ready-prompt` (3000Hz × 15ms): Cycle 46 post-audit
+    ///   (2026-05-13). Originally shipped at 1200Hz × 60ms but
+    ///   the maintainer reported the 60ms tone was disruptive
+    ///   when it overlapped the auto-narrate of the just-
+    ///   finished command. Re-tuned to a sharp click: shorter
+    ///   (15ms total) + higher pitch (3000Hz; near the upper
+    ///   edge of the speech band so it perceptually separates
+    ///   from spoken output) + no attack envelope (0ms — the
+    ///   transient onset IS the click character). Routes
+    ///   through the same non-blocking WASAPI stream as every
+    ///   other earcon. If the click is still disruptive, the
+    ///   existing Display → Earcons → Muted toggle silences
+    ///   all earcons globally; per-earcon mute is a follow-up.
     /// All earcons stay shorter than the StreamProfile's 200ms
     /// debounce window so consecutive earcons don't overlap.
     /// Tunable in Phase 2 via TOML.
@@ -71,6 +75,6 @@ module EarconPalette =
                 DurationMs = 120
                 AttackMs = 10 }
               "ready-prompt",
-              { FrequencyHz = 1200.0
-                DurationMs = 60
-                AttackMs = 5 } ]
+              { FrequencyHz = 3000.0
+                DurationMs = 15
+                AttackMs = 0 } ]

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -139,18 +139,27 @@
                 <MenuItem x:Name="MenuItem_OpenConfig"
                           x:FieldModifier="public"
                           Header="_Edit Config" />
+                <!-- Cycle 46 post-audit (2026-05-13) — group the
+                     two "last command output" affordances under a
+                     dedicated submenu so screen-reader navigation
+                     reaches both with one expand. The named
+                     MenuItems are reachable by the reflective
+                     binding loop (Program.fs ~line 3877) regardless
+                     of XAML nesting depth. -->
+                <MenuItem Header="_Last Output">
+                    <MenuItem x:Name="MenuItem_OpenLastOutput"
+                              x:FieldModifier="public"
+                              Header="_Open in Text Editor" />
+                    <MenuItem x:Name="MenuItem_AnnounceLastOutput"
+                              x:FieldModifier="public"
+                              Header="_Announce Again" />
+                </MenuItem>
                 <MenuItem x:Name="MenuItem_CopyHistoryToClipboard"
                           x:FieldModifier="public"
                           Header="Copy _History to Clipboard" />
                 <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
                           x:FieldModifier="public"
                           Header="Announce _Session Log Path" />
-                <MenuItem x:Name="MenuItem_OpenLastOutput"
-                          x:FieldModifier="public"
-                          Header="Open _Last Output" />
-                <MenuItem x:Name="MenuItem_AnnounceLastOutput"
-                          x:FieldModifier="public"
-                          Header="_Announce Last Output" />
             </MenuItem>
             <MenuItem Header="Dia_gnostics">
                 <!-- Cycle 38a-followup — Logging Level moved here

--- a/tests/Tests.Unit/EarconProfileTests.fs
+++ b/tests/Tests.Unit/EarconProfileTests.fs
@@ -133,8 +133,10 @@ let ``WarningLine Apply emits one pair with warning-tone ChannelDecision`` () =
 [<Fact>]
 let ``ReadyForInput Apply emits one pair with ready-prompt ChannelDecision`` () =
     // Cycle 45 — fired by `Program.fs handlePromptBoundary`
-    // on tuple finalise. Maps to the 1200Hz × 60ms chime
-    // defined in `EarconPalette.defaultPalette`.
+    // on tuple finalise. Maps to the `ready-prompt` entry in
+    // `EarconPalette.defaultPalette` (Cycle 46 post-audit
+    // re-tuned to 3000Hz × 15ms click; this test pins the
+    // semantic-to-id mapping, not the waveform parameters).
     let profile = EarconProfile.create ()
     let event = buildEvent SemanticCategory.ReadyForInput
     let pairs = profile.Apply event


### PR DESCRIPTION
## Summary

Two small follow-ups to the audit PR per your feedback:

### 1. `ready-prompt` earcon: tone → click

Was **1200Hz × 60ms** with a 5ms attack envelope. Now **3000Hz × 15ms** with no attack — a sharp tick rather than a sustained tone.

Why: you reported the 60ms ready-prompt tone overlapped NVDA's auto-narrate of the just-finished command in a way that was disruptive. Shorter (15ms) + higher (3000Hz; near the upper edge of the speech band, perceptually separate from voice) + no attack (the transient onset IS the click character) reads as a brief tick.

Parameter-only change in `EarconPalette.fs`; the synthesis path (`EarconWaveform.synthSineEnvelope`) is unchanged. If the click itself is still unwanted, the existing Display → Earcons → Muted toggle silences all earcons globally. Per-earcon mute is a future cycle; you explicitly asked not to over-invest in per-sound config yet.

### 2. Data menu: group `Open Last Output` + `Announce Last Output` under a `Last Output` submenu

The two affordances I added in the audit PR landed loose under the `Data` menu. They're now grouped under:

```
Data
├── Open Data Folder
├── Edit Config
├── Last Output                 ← NEW submenu
│   ├── Open in Text Editor     ← MenuItem_OpenLastOutput
│   └── Announce Again          ← MenuItem_AnnounceLastOutput
├── Copy History to Clipboard
└── Announce Session Log Path
```

The reflective menu-binding loop (`Program.fs` ~line 3877) finds the named MenuItems via `window.GetType().GetField(fieldName)` regardless of XAML nesting depth, so no `Program.fs` wiring changes are required. Hotkeys (`Ctrl+Shift+O`, `Ctrl+Shift+A`) are unchanged.

## Files

- `src/Terminal.Audio/EarconPalette.fs` — `ready-prompt` parameters + doc-comment.
- `src/Views/MainWindow.xaml` — `Last Output` submenu.
- `tests/Tests.Unit/EarconProfileTests.fs` — comment touch-up (no assertion change; the test pins the semantic-to-id mapping, not the waveform params).
- `CHANGELOG.md` — entry above the audit PR's section.

## Test plan

- [ ] Full Windows build green.
- [ ] xUnit suite green (`EarconProfileTests` still passes — assertion is on `"ready-prompt"` id, not on `FrequencyHz` / `DurationMs`).
- [ ] **Listen for the click**: after a command finishes, NVDA auto-narrates the (capped 800-char) output. The ready-prompt earcon should now be a near-imperceptible tick rather than the prior 60ms tone, and shouldn't overlap with speech intelligibility.
- [ ] **Menu walk**: Alt → arrow to `Data` → arrow to `Last Output` → expand → both `Open in Text Editor` and `Announce Again` items present and trigger the same handlers as `Ctrl+Shift+O` / `Ctrl+Shift+A`.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_