### PR TITLE
feat(diagnostics): Cycle 47 — CMD interaction test corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,67 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 47 (2026-05-13): CMD interaction test corpus
+
+Adds eight tiny `.cmd` scripts under
+[`scripts/cmd-tests/`](scripts/cmd-tests/README.md) each
+exercising one cmd interaction primitive, plus a
+`Diagnostics → CMD Interaction Tests` submenu that writes the
+quoted script invocation to the PTY input cursor (no Enter)
+so the maintainer can review + press Enter to run. The
+corpus is the foundation for the post-Cycle-46 "evaluate how
+basic interaction works beyond `echo` / `dir`" pass.
+
+- **The eight scripts**:
+  - `test-01-echo.cmd` — multi-line `echo` output (basic
+    output narration + cap behaviour).
+  - `test-02-text-input.cmd` — `set /p name=...` text input
+    (line-edited prompt + echo back).
+  - `test-03-numeric-input.cmd` — `set /p num=...` +
+    `set /a` arithmetic (the maintainer's specific example
+    in the feature ask).
+  - `test-04-yes-no.cmd` — `choice /c YN` single-keystroke
+    prompt.
+  - `test-05-multi-choice.cmd` — `choice /c 1234 /n`
+    multi-option (the closest cmd analogue to Claude's
+    tool-use selection lists).
+  - `test-06-pause.cmd` — `pause` between output sections.
+  - `test-07-progress.cmd` — loop with `timeout` (tests
+    mid-stream narration under `TupleFinalOnly`).
+  - `test-08-stderr.cmd` — `>&2` redirected stderr output.
+
+- **Test-marker discipline**: every script wraps its body
+  in `=== PTYSPEAK-TEST-START: <id> ===` / `=== PTYSPEAK-
+  TEST-END: <id> ===` markers so the boundaries appear in
+  `Ctrl+Shift+D` snapshots. The `Program.fs` handler emits
+  an INFO log line (`CmdTest invoked. TestId=<id>`) on menu
+  click; combined with the in-script markers, timing
+  correlation between the click and the resulting
+  `ContentHistory` entries is one `grep` away.
+
+- **Wiring**: eight `HotkeyRegistry.CmdTest*` AppCommands
+  (menu-only — no keyboard accelerators); one shared
+  `runCmdTest testId` helper in `Program.fs` that resolves
+  `AppContext.BaseDirectory/scripts/cmd-tests/<id>.cmd`,
+  writes the quoted invocation via
+  `TerminalView.WritePtyBytes`, and announces "Test command
+  inserted: `<id>`. Press Enter to run." through
+  `ActivityIds.diagnostic`. Eight thin wrappers bind one
+  AppCommand each. The 8 corresponding `MenuItem_CmdTest*`
+  entries in `MainWindow.xaml` are picked up by the
+  reflective menu-binding loop.
+
+- **`Terminal.App.fsproj`** copies the scripts (and the
+  README) flat into `<install-dir>/scripts/cmd-tests/` via a
+  `<Content Include="..\..\scripts\cmd-tests\*.cmd">` glob
+  with `<Link>scripts\cmd-tests\%(Filename)%(Extension)`.
+
+- **`HotkeyRegistryTests`** documented-commands set extended
+  to pin all eight new AppCommands. The Cycle 26b mirror
+  test (`AppReservedHotkeysMirrorTests`) is unaffected since
+  the new commands are menu-only (no `Key`/`Modifiers` →
+  no `AppReservedHotkeys` row required).
+
 ### Cycle 46 post-audit follow-up (2026-05-13): ready-prompt earcon to a click + Data → Last Output submenu
 
 Two small follow-ups to the audit PR per maintainer feedback:

--- a/scripts/cmd-tests/README.md
+++ b/scripts/cmd-tests/README.md
@@ -1,0 +1,96 @@
+# CMD interaction test corpus
+
+> **Snapshot**: Cycle 47 (2026-05-13).
+> Eight tiny `.cmd` scripts, each exercising one cmd interaction
+> primitive in a maintainer-walkable form.
+
+## Why these exist
+
+Cycle 46 wrapped up the substrate (`ContentHistory`) + channel
+(`Edit` control + caret + capped `Announce`) for basic terminal
+output. Now we need to know how those interact with the *other*
+things cmd can do beyond plain `echo`: prompted input, choice
+prompts, pauses, progress loops, stderr.
+
+Rather than walking the matrix entirely from memory or
+ad-hocing each test inside a debug session, each interaction
+primitive gets its own minimal script. The maintainer
+(KyleKeane) walks them through the `Diagnostics → CMD
+Interaction Tests` menu; the menu inserts the script
+invocation into the PTY input cursor so the script invocation
+can be reviewed (or edited) before pressing Enter.
+
+Each script is wrapped in start / end markers visible in
+`Ctrl+Shift+D` snapshots and the `FileLogger` log:
+
+```
+=== PTYSPEAK-TEST-START: <id> ===
+...
+=== PTYSPEAK-TEST-END: <id> ===
+```
+
+The corresponding F# handler emits an INFO log line
+(`CmdTest invoked. TestId=<id>`) when the menu item is
+clicked, so timing correlation between the menu click and
+the resulting `ContentHistory` entries is straightforward.
+
+## The scripts
+
+| File | What it exercises | What to listen for |
+|---|---|---|
+| `test-01-echo.cmd` | Multi-line `echo` output | All eight numbered lines audible; ready-prompt click at end |
+| `test-02-text-input.cmd` | `set /p name=...` text input | Prompt announces; typed name echoes back in greeting |
+| `test-03-numeric-input.cmd` | `set /p num=...` + `set /a` arithmetic | Number-plus-one calculation narrates after Enter |
+| `test-04-yes-no.cmd` | `choice /c YN` single-keystroke prompt | "Continue? Y, N?" prompt audible; branch result narrates |
+| `test-05-multi-choice.cmd` | `choice /c 1234 /n` multi-option | Four options announced; user picks 1-4; chosen branch narrates |
+| `test-06-pause.cmd` | `pause` between output sections | First section narrates; pause prompt audible; second section narrates after keypress |
+| `test-07-progress.cmd` | Loop with `timeout` between steps | ~5s silent (under `TupleFinalOnly`); all five steps narrate together at tuple finalise |
+| `test-08-stderr.cmd` | `>&2` redirected error / warning lines | All lines audible; no audible distinction between stdout and stderr (pty-speak doesn't separate them today) |
+
+## How the menu wiring works
+
+1. Each `.cmd` file is copied flat into `<install-dir>/scripts/cmd-tests/`
+   at build time via the `<Content Include="..\..\scripts\cmd-tests\*.cmd">`
+   block in
+   [`src/Terminal.App/Terminal.App.fsproj`](../../src/Terminal.App/Terminal.App.fsproj).
+2. `HotkeyRegistry.AppCommand` has one case per test
+   (`CmdTestEcho`, `CmdTestTextInput`, etc., menu-only — no
+   keyboard accelerator). See
+   [`src/Terminal.Core/HotkeyRegistry.fs`](../../src/Terminal.Core/HotkeyRegistry.fs).
+3. `Program.fs runCmdTest <id>` resolves the script path via
+   `AppContext.BaseDirectory + scripts/cmd-tests/<id>.cmd`,
+   writes a quoted invocation to the PTY via
+   `TerminalView.WritePtyBytes`, and announces "Test command
+   inserted: `<id>`. Press Enter to run." through
+   `ActivityIds.diagnostic`.
+4. The corresponding `MainWindow.xaml` `MenuItem` is named
+   `MenuItem_CmdTestEcho` etc.; the reflective binding loop
+   in `compose()` finds it via
+   `window.GetType().GetField(...)` and wires the routed
+   command.
+
+The invocation never includes a trailing `\r` — the user has
+to press Enter explicitly. This avoids accidental execution
+and lets the maintainer add redirects / pipes if useful
+(e.g. tack `> result.txt` onto the inserted command).
+
+## Adding a new test
+
+1. Create `scripts/cmd-tests/test-NN-<slug>.cmd` with the
+   start / end markers + the interaction body.
+2. Add `CmdTest<Slug>` to the `AppCommand` DU,
+   `HotkeyRegistry.nameOf`, `HotkeyRegistry.builtIns`,
+   and `HotkeyRegistry.allCommands` (all four, per the
+   `HotkeyRegistryTests` documented-commands assertion).
+3. Add `runCmdTest<Slug> () = runCmdTest "test-NN-<slug>"`
+   in `Program.fs` near the other test wrappers.
+4. Add `bind HotkeyRegistry.CmdTest<Slug> runCmdTest<Slug>`
+   in the same `bind` block.
+5. Add `MenuItem_CmdTest<Slug>` to the CMD Interaction
+   Tests submenu in `MainWindow.xaml`.
+6. Add `HotkeyRegistry.CmdTest<Slug>` to the
+   `HotkeyRegistryTests` documented-commands set.
+7. Update this README's table.
+
+Each step is small and the discipline forces a reviewer to
+acknowledge each addition.

--- a/scripts/cmd-tests/test-01-echo.cmd
+++ b/scripts/cmd-tests/test-01-echo.cmd
@@ -1,0 +1,23 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 01 — simple echo
+REM
+REM Exercises:
+REM   * Basic multi-line stdout narration through ContentHistory.
+REM   * Output-announce cap (Cycle 46 post-audit). This script
+REM     emits ~10 lines; the body is well under the 800-char cap
+REM     so the auto-narrate should read all of it.
+REM
+REM Pass criterion (NVDA): all numbered lines audible end-to-end;
+REM ready-prompt click fires once at the end.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-01-echo ===
+echo This is a simple echo test.
+echo Line 2 of 8.
+echo Line 3 of 8.
+echo Line 4 of 8.
+echo Line 5 of 8.
+echo Line 6 of 8.
+echo Line 7 of 8.
+echo Last line. If you heard all eight numbered lines, output narration is healthy.
+echo === PTYSPEAK-TEST-END: test-01-echo ===

--- a/scripts/cmd-tests/test-02-text-input.cmd
+++ b/scripts/cmd-tests/test-02-text-input.cmd
@@ -1,0 +1,19 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 02 — text input via `set /p`
+REM
+REM Exercises:
+REM   * cmd's built-in line-edited prompt (`set /p`). User types a
+REM     string + Enter; cmd captures it into a variable.
+REM   * Tests whether pty-speak's input echo behaves usefully
+REM     during a script-driven prompt (vs the shell prompt).
+REM
+REM Pass criterion (NVDA): the prompt "Enter your name:" is
+REM announced; the user can type a name; the echoed greeting
+REM is narrated after Enter.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-02-text-input ===
+echo This test prompts for a text string and echoes it back.
+set /p name=Enter your name:
+echo Hello, %name%! Your name has %name:~0,1% as its first letter.
+echo === PTYSPEAK-TEST-END: test-02-text-input ===

--- a/scripts/cmd-tests/test-03-numeric-input.cmd
+++ b/scripts/cmd-tests/test-03-numeric-input.cmd
@@ -1,0 +1,21 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 03 — numeric input + calculation
+REM
+REM Exercises:
+REM   * `set /p` numeric prompt + `set /a` arithmetic. The
+REM     maintainer's exact requested example: "prompt me for a
+REM     number and then return 1+ that number".
+REM   * If the user types non-numeric text, `set /a` errors —
+REM     useful to hear how stderr / "Invalid number" messages
+REM     surface.
+REM
+REM Pass criterion (NVDA): the prompt is announced; user types a
+REM number + Enter; "<n> + 1 = <n+1>" reads back cleanly.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-03-numeric-input ===
+echo This test prompts for a number and reports its successor.
+set /p num=Enter a number:
+set /a result=%num%+1
+echo %num% + 1 = %result%
+echo === PTYSPEAK-TEST-END: test-03-numeric-input ===

--- a/scripts/cmd-tests/test-04-yes-no.cmd
+++ b/scripts/cmd-tests/test-04-yes-no.cmd
@@ -1,0 +1,23 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 04 — yes / no choice
+REM
+REM Exercises:
+REM   * cmd's `choice /c YN` primitive — single-keystroke prompt
+REM     (no Enter required). Different shape than `set /p`:
+REM     the user presses Y or N and the script branches.
+REM   * Tests whether NVDA hears the "Y, N?" prompt cmd emits
+REM     before the user is expected to press a key.
+REM
+REM Pass criterion (NVDA): "Continue? Y, N?" reads aloud; user
+REM presses Y or N (no Enter); branch result is narrated.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-04-yes-no ===
+echo This test asks a yes/no question. Press Y or N (no Enter needed).
+choice /c YN /m "Continue?"
+if errorlevel 2 (
+    echo You chose No.
+) else (
+    echo You chose Yes.
+)
+echo === PTYSPEAK-TEST-END: test-04-yes-no ===

--- a/scripts/cmd-tests/test-05-multi-choice.cmd
+++ b/scripts/cmd-tests/test-05-multi-choice.cmd
@@ -1,0 +1,27 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 05 — multi-option choice
+REM
+REM Exercises:
+REM   * cmd's `choice /c 1234` primitive with a four-way
+REM     numbered selection. Tests how multi-option prompts
+REM     surface — they're the closest cmd analogue to Claude's
+REM     tool-use selection lists.
+REM   * `/n` suppresses the default "[1,2,3,4]?" trailer so we
+REM     can see whether NVDA picks up the prompt text alone.
+REM
+REM Pass criterion (NVDA): the four options are presented;
+REM user presses 1-4; chosen branch narrates.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-05-multi-choice ===
+echo This test offers four numbered choices.
+echo   1: Coffee
+echo   2: Tea
+echo   3: Water
+echo   4: Cancel
+choice /c 1234 /n /m "Pick 1-4:"
+if errorlevel 4 (echo You picked Cancel.) ^
+else if errorlevel 3 (echo You picked Water.) ^
+else if errorlevel 2 (echo You picked Tea.) ^
+else (echo You picked Coffee.)
+echo === PTYSPEAK-TEST-END: test-05-multi-choice ===

--- a/scripts/cmd-tests/test-06-pause.cmd
+++ b/scripts/cmd-tests/test-06-pause.cmd
@@ -1,0 +1,26 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 06 — pause / continue
+REM
+REM Exercises:
+REM   * cmd's `pause` builtin (prints "Press any key to continue . . ."
+REM     and waits for a keystroke).
+REM   * Tests an intermediate-stop interaction: there's output
+REM     before the pause, the user has to press any key, then
+REM     more output continues. Useful for hearing whether the
+REM     "Press any key..." prompt is announced and whether the
+REM     post-pause content narrates correctly.
+REM
+REM Pass criterion (NVDA): the first three lines narrate; the
+REM pause prompt is announced; any keypress continues; the
+REM final three lines narrate.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-06-pause ===
+echo First section, line 1.
+echo First section, line 2.
+echo First section, line 3.
+pause
+echo Second section, line 1.
+echo Second section, line 2.
+echo Second section, line 3.
+echo === PTYSPEAK-TEST-END: test-06-pause ===

--- a/scripts/cmd-tests/test-07-progress.cmd
+++ b/scripts/cmd-tests/test-07-progress.cmd
@@ -1,0 +1,31 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 07 — progress loop
+REM
+REM Exercises:
+REM   * Long-running script with periodic output. Uses `timeout`
+REM     to spread the steps across a few seconds; each step
+REM     prints "Step N of 5". Tests whether mid-stream narration
+REM     keeps up under the `TupleFinalOnly` ShellPolicy default.
+REM   * Without `LineByLine` set, the output reaches NVDA as one
+REM     800-char-capped Announce at tuple finalise, not per-line
+REM     during the loop. The script intentionally takes >5s so
+REM     the maintainer can hear the difference.
+REM
+REM Pass criterion (NVDA): no audible feedback during the loop
+REM (silent ~5s); on completion, all five "Step N of 5" lines
+REM narrate together at tuple finalise.
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-07-progress ===
+echo Starting a 5-step progress loop with 1s between steps.
+echo Step 1 of 5
+timeout /t 1 /nobreak >nul
+echo Step 2 of 5
+timeout /t 1 /nobreak >nul
+echo Step 3 of 5
+timeout /t 1 /nobreak >nul
+echo Step 4 of 5
+timeout /t 1 /nobreak >nul
+echo Step 5 of 5
+echo Progress loop complete.
+echo === PTYSPEAK-TEST-END: test-07-progress ===

--- a/scripts/cmd-tests/test-08-stderr.cmd
+++ b/scripts/cmd-tests/test-08-stderr.cmd
@@ -1,0 +1,26 @@
+@echo off
+REM ---------------------------------------------------------------
+REM Cycle 47 CMD interaction test 08 — stderr output
+REM
+REM Exercises:
+REM   * stdout vs stderr surfacing. Lines redirected to `>&2`
+REM     go to the process's stderr stream. ConPTY merges
+REM     stderr into the PTY output, so pty-speak's parser sees
+REM     a unified stream — but the user can listen for whether
+REM     errors are perceptually distinct from regular output.
+REM   * Tests whether anything in pty-speak special-cases
+REM     stderr-ish content (it doesn't today; the Cycle 8d.2
+REM     colour-detection plan was reverted).
+REM
+REM Pass criterion (NVDA): all six lines audible; "Warning" and
+REM "Error" lines mixed in with the regular lines (no audible
+REM stream distinction since pty-speak doesn't separate them).
+REM ---------------------------------------------------------------
+echo === PTYSPEAK-TEST-START: test-08-stderr ===
+echo Regular line one.
+echo Warning: this line is on stderr.>&2
+echo Regular line two.
+echo Error: this line is also on stderr.>&2
+echo Regular line three.
+echo Regular line four.
+echo === PTYSPEAK-TEST-END: test-08-stderr ===

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2807,6 +2807,73 @@ module Program =
                     toSay,
                     ActivityIds.output)
 
+        // Cycle 47 — CMD interaction test runner. The user
+        // selects one of eight `Diagnostics → CMD Interaction
+        // Tests → ...` menu items; this writes the script
+        // invocation to the PTY input cursor so the user can
+        // review + press Enter to run. Doesn't auto-Enter so
+        // the maintainer keeps control (avoid surprising the
+        // user with an automatic execution; also lets them
+        // edit the path if they want to redirect output to a
+        // file or pipe to another command first).
+        //
+        // The PTY write goes through `TerminalView.WritePtyBytes`
+        // which is the same path keystrokes use, so cmd sees
+        // it as typed input. cmd's default ECHO behaviour
+        // echoes the path back so it shows up in
+        // ContentHistory; NVDA will read the announce we fire
+        // ("Test command inserted: <id>") rather than the path
+        // bytes themselves.
+        //
+        // Path resolution: scripts live under
+        // `<install-dir>/scripts/cmd-tests/<id>.cmd` per the
+        // `<Content Include>` glob in `Terminal.App.fsproj`.
+        // `AppContext.BaseDirectory` is the install dir at
+        // runtime.
+        let runCmdTest (testId: string) : unit =
+            let log =
+                Logger.get "Terminal.App.Program.runCmdTest"
+            log.LogInformation(
+                "CmdTest invoked. TestId={TestId}", testId)
+            let scriptPath =
+                System.IO.Path.Combine(
+                    AppContext.BaseDirectory,
+                    "scripts",
+                    "cmd-tests",
+                    sprintf "%s.cmd" testId)
+            if not (System.IO.File.Exists scriptPath) then
+                log.LogError(
+                    "CmdTest script missing. TestId={TestId} Path={Path}",
+                    testId, scriptPath)
+                window.TerminalSurface.Announce(
+                    sprintf "Could not find test script %s." testId,
+                    ActivityIds.error)
+            else
+                // Quote the path (handles spaces in install
+                // dir like "Program Files (x86)") and append
+                // a trailing space so the user can type more
+                // arguments / redirects before Enter if they
+                // want.
+                let invocation =
+                    sprintf "\"%s\" " scriptPath
+                let bytes =
+                    System.Text.Encoding.UTF8.GetBytes(invocation)
+                window.TerminalSurface.WritePtyBytes(bytes)
+                window.TerminalSurface.Announce(
+                    sprintf
+                        "Test command inserted: %s. Press Enter to run."
+                        testId,
+                    ActivityIds.diagnostic)
+
+        let runCmdTestEcho () = runCmdTest "test-01-echo"
+        let runCmdTestTextInput () = runCmdTest "test-02-text-input"
+        let runCmdTestNumericInput () = runCmdTest "test-03-numeric-input"
+        let runCmdTestYesNo () = runCmdTest "test-04-yes-no"
+        let runCmdTestMultiChoice () = runCmdTest "test-05-multi-choice"
+        let runCmdTestPause () = runCmdTest "test-06-pause"
+        let runCmdTestProgress () = runCmdTest "test-07-progress"
+        let runCmdTestStderr () = runCmdTest "test-08-stderr"
+
         // session-log file path. Reads `sessionLogWriter` (post
         // -Cycle-24c) + `persistenceConfig.Mode` (post-Cycle-24a)
         // from compose-local state. The closure is defined here
@@ -3155,6 +3222,14 @@ module Program =
         bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
         bind HotkeyRegistry.OpenLastOutput runOpenLastOutput
         bind HotkeyRegistry.AnnounceLastOutput runAnnounceLastOutput
+        bind HotkeyRegistry.CmdTestEcho runCmdTestEcho
+        bind HotkeyRegistry.CmdTestTextInput runCmdTestTextInput
+        bind HotkeyRegistry.CmdTestNumericInput runCmdTestNumericInput
+        bind HotkeyRegistry.CmdTestYesNo runCmdTestYesNo
+        bind HotkeyRegistry.CmdTestMultiChoice runCmdTestMultiChoice
+        bind HotkeyRegistry.CmdTestPause runCmdTestPause
+        bind HotkeyRegistry.CmdTestProgress runCmdTestProgress
+        bind HotkeyRegistry.CmdTestStderr runCmdTestStderr
         // Cycle 43a — diagnostic chunk extractors + grep dialog.
         // All menu-only (no keyboard accelerator); `bindHotkey`
         // skips the KeyBinding installation but still registers

--- a/src/Terminal.App/Terminal.App.fsproj
+++ b/src/Terminal.App/Terminal.App.fsproj
@@ -48,6 +48,28 @@
       <Link>test-process-cleanup.ps1</Link>
     </Content>
     <!--
+      Cycle 47 — CMD interaction test corpus. Each `.cmd` script
+      under `scripts/cmd-tests/` exercises one cmd interaction
+      primitive (echo, `set /p` text/numeric input, `choice`
+      yes-no / multi-option, `pause`, progress loop with
+      `timeout`, stderr). The corresponding
+      `Diagnostics → CMD Interaction Tests → ...` menu items in
+      `MainWindow.xaml` write a quoted invocation of the script
+      to the PTY input cursor so the user can review + press
+      Enter to run.
+      `<Link>` flattens them next to `Terminal.App.exe` under a
+      `scripts\cmd-tests\` subdirectory so the runtime path
+      resolution uses `AppContext.BaseDirectory + scripts\cmd-tests\<name>`.
+    -->
+    <Content Include="..\..\scripts\cmd-tests\*.cmd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>scripts\cmd-tests\%(Filename)%(Extension)</Link>
+    </Content>
+    <Content Include="..\..\scripts\cmd-tests\README.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>scripts\cmd-tests\README.md</Link>
+    </Content>
+    <!--
       Cycle 38a — canonical interaction-pair corpus. The TOML
       file lives in `tests/fixtures/` (alongside other planned
       replay fixtures per `docs/ACCESSIBILITY-TESTING.md:50-69`)

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -113,6 +113,21 @@ module HotkeyRegistry =
         // when the user wants spoken rather than text-editor
         // surface.
         | AnnounceLastOutput
+        // Cycle 47 — CMD interaction tests. Each menu item
+        // writes a quoted invocation of the corresponding
+        // `scripts/cmd-tests/*.cmd` script to the PTY input
+        // cursor (no Enter); the user reviews + presses Enter
+        // to run. No keyboard accelerators (menu-only); too
+        // many to assign reasonable mnemonics. Mirrors the
+        // shape of `RunProcessCleanupScript`.
+        | CmdTestEcho
+        | CmdTestTextInput
+        | CmdTestNumericInput
+        | CmdTestYesNo
+        | CmdTestMultiChoice
+        | CmdTestPause
+        | CmdTestProgress
+        | CmdTestStderr
         // Cycle 26c — first menu-only command. Interactive
         // process-cleanup test (`scripts/test-process-cleanup.ps1`)
         // surfaced via Diagnostics → Test Process Cleanup. No
@@ -191,6 +206,14 @@ module HotkeyRegistry =
         | AnnounceSessionLogPath -> "AnnounceSessionLogPath"
         | OpenLastOutput -> "OpenLastOutput"
         | AnnounceLastOutput -> "AnnounceLastOutput"
+        | CmdTestEcho -> "CmdTestEcho"
+        | CmdTestTextInput -> "CmdTestTextInput"
+        | CmdTestNumericInput -> "CmdTestNumericInput"
+        | CmdTestYesNo -> "CmdTestYesNo"
+        | CmdTestMultiChoice -> "CmdTestMultiChoice"
+        | CmdTestPause -> "CmdTestPause"
+        | CmdTestProgress -> "CmdTestProgress"
+        | CmdTestStderr -> "CmdTestStderr"
         | RunProcessCleanupScript -> "RunProcessCleanupScript"
         | CloseWindow -> "CloseWindow"
         | ExitApp -> "ExitApp"
@@ -302,6 +325,43 @@ module HotkeyRegistry =
             Key = Some (Letter 'A')
             Modifiers = Some ctrlShift
             Description = "Re-narrate last command output (capped at 800 chars; Cycle 46 post-audit)" }
+          // Cycle 47 — CMD interaction test corpus. All menu-
+          // only (no keyboard accelerators). Each item writes
+          // an invocation of the corresponding `.cmd` script
+          // to the PTY input cursor; the user reviews + Enters
+          // to run.
+          { Command = CmdTestEcho
+            Key = None
+            Modifiers = None
+            Description = "CMD test: simple echo (Cycle 47)" }
+          { Command = CmdTestTextInput
+            Key = None
+            Modifiers = None
+            Description = "CMD test: text input via set /p (Cycle 47)" }
+          { Command = CmdTestNumericInput
+            Key = None
+            Modifiers = None
+            Description = "CMD test: numeric input + set /a calculation (Cycle 47)" }
+          { Command = CmdTestYesNo
+            Key = None
+            Modifiers = None
+            Description = "CMD test: yes/no choice via choice /c YN (Cycle 47)" }
+          { Command = CmdTestMultiChoice
+            Key = None
+            Modifiers = None
+            Description = "CMD test: multi-option choice via choice /c 1234 (Cycle 47)" }
+          { Command = CmdTestPause
+            Key = None
+            Modifiers = None
+            Description = "CMD test: pause / continue (Cycle 47)" }
+          { Command = CmdTestProgress
+            Key = None
+            Modifiers = None
+            Description = "CMD test: progress loop with timeout (Cycle 47)" }
+          { Command = CmdTestStderr
+            Key = None
+            Modifiers = None
+            Description = "CMD test: stderr output (Cycle 47)" }
           // Cycle 26c — menu-only; no default keyboard accelerator.
           // Surfaced as Diagnostics → Test Process Cleanup.
           { Command = RunProcessCleanupScript
@@ -467,6 +527,14 @@ module HotkeyRegistry =
           AnnounceSessionLogPath
           OpenLastOutput
           AnnounceLastOutput
+          CmdTestEcho
+          CmdTestTextInput
+          CmdTestNumericInput
+          CmdTestYesNo
+          CmdTestMultiChoice
+          CmdTestPause
+          CmdTestProgress
+          CmdTestStderr
           RunProcessCleanupScript
           CloseWindow
           ExitApp

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -200,6 +200,40 @@
                 <MenuItem x:Name="MenuItem_OpenManualTests"
                           x:FieldModifier="public"
                           Header="Open Manual _Tests" />
+                <!-- Cycle 47 — CMD interaction test corpus.
+                     Each child writes a quoted invocation of
+                     the corresponding scripts/cmd-tests/*.cmd
+                     script to the PTY input cursor (no Enter);
+                     the user reviews + presses Enter to run.
+                     All menu-only (no keyboard accelerators).
+                     Headers prefix with the test number so
+                     they sort + read predictably in the menu. -->
+                <MenuItem Header="CMD Interaction T_ests">
+                    <MenuItem x:Name="MenuItem_CmdTestEcho"
+                              x:FieldModifier="public"
+                              Header="_1: Simple Echo" />
+                    <MenuItem x:Name="MenuItem_CmdTestTextInput"
+                              x:FieldModifier="public"
+                              Header="_2: Text Input" />
+                    <MenuItem x:Name="MenuItem_CmdTestNumericInput"
+                              x:FieldModifier="public"
+                              Header="_3: Numeric Input + Calculation" />
+                    <MenuItem x:Name="MenuItem_CmdTestYesNo"
+                              x:FieldModifier="public"
+                              Header="_4: Yes / No Choice" />
+                    <MenuItem x:Name="MenuItem_CmdTestMultiChoice"
+                              x:FieldModifier="public"
+                              Header="_5: Multi-Option Choice" />
+                    <MenuItem x:Name="MenuItem_CmdTestPause"
+                              x:FieldModifier="public"
+                              Header="_6: Pause / Continue" />
+                    <MenuItem x:Name="MenuItem_CmdTestProgress"
+                              x:FieldModifier="public"
+                              Header="_7: Progress Loop" />
+                    <MenuItem x:Name="MenuItem_CmdTestStderr"
+                              x:FieldModifier="public"
+                              Header="_8: Stderr Output" />
+                </MenuItem>
                 <Separator />
                 <!-- Cycle 43a — diagnostic chunking. Top-level
                      `Copy Latest Bundle` and `Grep Diagnostics`

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -87,6 +87,18 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // Cycle 46 post-audit — re-narrate last command
               // output capped at 800 chars (Ctrl+Shift+A).
               HotkeyRegistry.AnnounceLastOutput
+              // Cycle 47 — CMD interaction test corpus (eight
+              // menu-only items under Diagnostics → CMD
+              // Interaction Tests; each inserts a quoted
+              // script invocation into the PTY input cursor).
+              HotkeyRegistry.CmdTestEcho
+              HotkeyRegistry.CmdTestTextInput
+              HotkeyRegistry.CmdTestNumericInput
+              HotkeyRegistry.CmdTestYesNo
+              HotkeyRegistry.CmdTestMultiChoice
+              HotkeyRegistry.CmdTestPause
+              HotkeyRegistry.CmdTestProgress
+              HotkeyRegistry.CmdTestStderr
               // Cycle 26c — first menu-only command. Surfaced
               // via Diagnostics → Test Process Cleanup; no
               // keyboard accelerator.


### PR DESCRIPTION
## Summary

Eight tiny `.cmd` scripts under [`scripts/cmd-tests/`](scripts/cmd-tests/README.md) each exercising one cmd interaction primitive, plus a `Diagnostics → CMD Interaction Tests` submenu that writes the quoted script invocation to the PTY input cursor (no Enter) so you can review + press Enter to run.

This is the foundation for the "evaluate how basic interaction works beyond `echo` / `dir`" pass you asked for. Each menu item is its own diagnostic walkthrough — click it, hear the announce, press Enter, walk through whatever cmd's primitive does, and report back what was surprising.

## The eight scripts

| File | What it exercises | What to listen for |
|---|---|---|
| `test-01-echo.cmd` | Multi-line `echo` output | All eight numbered lines audible; ready-prompt click at end |
| `test-02-text-input.cmd` | `set /p name=...` text input | Prompt announces; typed name echoes back in greeting |
| `test-03-numeric-input.cmd` | `set /p num=...` + `set /a` arithmetic (your specific example) | Number-plus-one calculation narrates after Enter |
| `test-04-yes-no.cmd` | `choice /c YN` single-keystroke prompt | "Continue? Y, N?" prompt audible; branch result narrates |
| `test-05-multi-choice.cmd` | `choice /c 1234 /n` multi-option | Four options announced; user picks 1-4; chosen branch narrates |
| `test-06-pause.cmd` | `pause` between output sections | First section narrates; pause prompt audible; second section narrates after keypress |
| `test-07-progress.cmd` | Loop with `timeout` between steps | ~5s silent (under `TupleFinalOnly`); all five steps narrate together at tuple finalise |
| `test-08-stderr.cmd` | `>&2` redirected stderr | All lines audible; no audible distinction between stdout and stderr |

Each script is wrapped in markers visible in `Ctrl+Shift+D` snapshots:

```
=== PTYSPEAK-TEST-START: <id> ===
...
=== PTYSPEAK-TEST-END: <id> ===
```

…and the F# handler emits an INFO log line (`CmdTest invoked. TestId=<id>`) when the menu item is clicked. Combined, you can correlate "I clicked the menu" with "this content arrived in `ContentHistory`" via a single `grep`.

## Why menu-inserts-but-doesn't-Enter

Per your instruction: "the menu command would simply insert a command into the current input cursor position". Doesn't auto-run; you review, optionally edit (e.g. tack `> result.txt` on for redirect), then press Enter.

The PTY write goes through `TerminalView.WritePtyBytes` which is the same path keystrokes use, so cmd sees the inserted text as typed input. The accompanying `Announce(activityId=diagnostic)` tells you which test was inserted in case you want a moment to recall before pressing Enter.

## Files

- `scripts/cmd-tests/` (NEW, ~135 lines) — 8 `.cmd` scripts + README.
- `src/Terminal.App/Terminal.App.fsproj` — `<Content Include>` glob copies the scripts flat under `<install-dir>/scripts/cmd-tests/`.
- `src/Terminal.Core/HotkeyRegistry.fs` — 8 new `CmdTest*` AppCommand DU cases + `nameOf` + `builtIns` + `allCommands` entries.
- `src/Terminal.App/Program.fs` — one `runCmdTest testId` helper + 8 thin wrappers + 8 `bind` calls.
- `src/Views/MainWindow.xaml` — `Diagnostics → CMD Interaction Tests` submenu with 8 named MenuItems (picked up by the reflective binding loop).
- `tests/Tests.Unit/HotkeyRegistryTests.fs` — 8 new entries in the documented-commands assertion.
- `CHANGELOG.md` — Cycle 47 entry.

## Test plan

- [ ] Full Windows build green.
- [ ] xUnit suite green (`HotkeyRegistryTests` and `AppReservedHotkeysMirrorTests` both stay happy — the 8 new commands are menu-only so the mirror invariant doesn't require `AppReservedHotkeys` rows).
- [ ] **Manual walk** (the actual point of this PR): after the build lands, open the preview, navigate `Diagnostics → CMD Interaction Tests`, and walk through each test in order. Report back what's surprising. The diagnostic correlation is: each menu click leaves an `INFO CmdTest invoked. TestId=<id>` log line, and each script run leaves the start/end markers in `ContentHistory`. You can grab everything via `Ctrl+Shift+D` after a session.

## What's deliberately not in this PR

- BEL / ANSI-color tests (need binary bytes embedded in `.cmd` files; editor-unfriendly + a separate concern).
- Programmatic marker detection in the parser (the markers are visible in `Ctrl+Shift+D` already; no parser changes needed yet).
- Tests for Claude shell interactions (separate corpus when we tackle Claude streaming).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_