### PR TITLE
feat(audit): idle-flush + CMD-tests menu fixes + Esc-clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,86 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 47 follow-up (2026-05-13): idle-flush + menu fixes + Esc-clear
+
+Three connected fixes the maintainer surfaced after walking the
+Cycle 47 corpus on the post-Cycle-46-audit preview build:
+
+#### 1. Idle-flush for intra-script prompts
+
+**Symptom**: `test-02-text-input.cmd` (and any `set /p` /
+`pause` / `choice` script) didn't speak the prompt until
+after the user had typed input and pressed Enter. The user
+had to guess what cmd was asking for.
+
+**Root cause**: under `TupleFinalOnly` streaming, the
+boundary-handler `Announce` fires only at `PromptStart`
+(shell-prompt boundary). An intra-script `set /p` prompt
+doesn't emit `PromptStart` — cmd just stops writing bytes
+and waits for keystroke input. The auto-narrate had no
+trigger; the prompt sat silently in `ContentHistory` until
+the script completed and a fresh shell prompt appeared.
+
+**Fix**: new `ShellPolicy.IdleFlushMs : int option` field +
+WPF `DispatcherTimer` ticking every 100 ms. When the parser
+has been idle for ≥ N ms AND `ContentHistory.latestSeq` is
+past the new `lastAnnouncedSeq` watermark, slice the gap,
+cap at `OutputAnnounceCapChars` (800), fire
+`Announce(text, ActivityIds.output)`, advance the watermark.
+
+The tuple-finalise path now also slices from the watermark
+rather than announcing `tuple.OutputText` whole, so
+idle-flush + tuple-finalise share one source of truth and
+don't double-narrate. If idle-flushes covered the whole
+script, tuple-finalise's slice is empty and is silent — the
+ready-prompt earcon click is the only "command complete"
+cue (intentional; user already heard the content).
+
+`ShellPolicy.IdleFlushMs` defaults:
+- `cmd`, `powershell`: `Some 350` (responsive during a
+  `set /p` pause; tolerant of `dir`-style line emission
+  rates).
+- `claude`: `None` (Claude's per-token streaming hits the
+  threshold too rarely AND would overlap a future
+  `LineByLine` policy; idle-flush stays opt-in for Claude
+  pending the streaming-experience cycle).
+
+Watermark resets to `-1L` on `ContentHistory.reset` (shell
+hot-switch) so post-switch narration starts from a clean
+state.
+
+#### 2. CMD Interaction Tests menu: `C` accelerator + numbering fix
+
+- Parent menu header `"CMD Interaction T_ests"` →
+  `"_CMD Interaction Tests"`. Reachable via `Alt → G → C`
+  from the menu bar.
+- Sub-item headers dropped the leading `_N:` digit prefix
+  that caused NVDA to read "1, item 1 of 8" as "11 of 8"
+  (the mnemonic-digit + position-N collision). Each sub-
+  item now has a unique letter mnemonic:
+  `_Simple Echo` / `_Text Input` / `_Numeric Input + Calculation`
+  / `_Yes / No Choice` / `_Multi-Option Choice` /
+  `_Pause / Continue` / `Pro_gress Loop` / `Stderr _Output`.
+
+#### 3. `runCmdTest` Esc-prefix to clear the input buffer
+
+`runCmdTest` now prepends `0x1B` (Esc) to the script
+invocation bytes. cmd.exe's cooked-mode line editor treats
+Esc as "clear the current input buffer", so anything the
+user had partially typed before clicking the menu item
+gets wiped before our quoted script invocation lands.
+Avoids the "we appended to whatever was already there and
+broke the parse" failure mode.
+
+Files: `src/Terminal.Core/ShellPolicy.fs` (new field +
+defaults), `src/Terminal.App/Program.fs` (compose-level
+`lastAnnouncedSeq` + `DispatcherTimer` + boundary-handler
+rewrite + shell-switch reset + `runCmdTest` Esc prefix),
+`src/Views/MainWindow.xaml` (menu headers),
+`tests/Tests.Unit/ShellPolicyTests.fs` (idle-flush
+defaults assertion), `CHANGELOG.md`,
+`docs/ACCESSIBILITY-TESTING.md` (Cycle 47 matrix rows).
+
 ### Cycle 47 (2026-05-13): CMD interaction test corpus
 
 Adds eight tiny `.cmd` scripts under

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -1288,6 +1288,59 @@ finalised with an empty `OutputText` (cmd / PowerShell can
 do this for commands that don't emit visible output — try a
 clearly-visible command like `dir` instead).
 
+### Cycle 47 — CMD interaction test corpus + idle-flush
+
+Cycle 47 shipped a `Diagnostics → CMD Interaction Tests`
+submenu corpus exercising each cmd interaction primitive
+(echo / `set /p` text + numeric / `choice` yes-no + multi
+/ `pause` / progress loop / stderr) and an idle-flush
+mechanism that fires `Announce` after a configurable parser-
+idle period so intra-script prompts (`set /p`, `pause`,
+`choice`) speak before the user has to guess what's being
+asked. Each matrix row walks one script through the submenu
++ verifies the new behaviour.
+
+Pre-walk setup: bind a fresh preview build with the post-
+Cycle-47-follow-up `main` and a default config. Default
+shell = `cmd`. NVDA running. No active typing in the
+prompt before each test (so the Esc-clear can't surprise
+you mid-keystroke).
+
+| Row | Test | Pass criterion |
+|---|---|---|
+| **47-1** | Open Alt menu → arrow to `Diagnostics` → arrow to `CMD Interaction Tests` (`C`) → submenu opens. | NVDA announces "CMD Interaction Tests, submenu". Each sub-item reads as e.g. "Simple Echo, item 1 of 8" — no `"11 of 8"` garbling from the old digit-prefixed mnemonics. |
+| **47-2** | Click `Simple Echo` (test 01). | NVDA announces "Test command inserted: test-01-echo. Press Enter to run." The script path is now in the cmd input buffer. Press Enter; all eight numbered lines audible; ready-prompt click at the end. |
+| **47-3** | Click `Text Input` (test 02). Listen **before** typing anything. | NVDA announces "Test command inserted: test-02-text-input. Press Enter to run." Press Enter. Wait ~½ second. Idle-flush fires: NVDA narrates "This test prompts for a text string and echoes it back. Enter your name:" **before** you've typed anything. Type a name + Enter; NVDA narrates the greeting line. |
+| **47-4** | Click `Numeric Input + Calculation` (test 03). | Same pattern as 47-3 but for `set /p num=` + `set /a`. Prompt audible before typing; result audible after Enter. |
+| **47-5** | Click `Yes / No Choice` (test 04). | Idle-flush narrates the test description + `"Continue? [Y, N]?"` prompt **before** the user presses Y or N. Single-key press; branch result narrates. |
+| **47-6** | Click `Multi-Option Choice` (test 05). | Idle-flush narrates the four options + the `"Pick 1-4:"` prompt before the user picks. |
+| **47-7** | Click `Pause / Continue` (test 06). | First section audible; idle-flush narrates the cmd `"Press any key to continue . . ."` prompt; press any key; second section audible. |
+| **47-8** | Click `Progress Loop` (test 07). | The five `"Step N of 5"` lines arrive across ~5 seconds. Idle-flush fires every ~350 ms during the gaps between steps, so each `"Step N of 5"` is narrated separately, not all batched at tuple finalise as it would have been pre-Cycle-47. |
+| **47-9** | Click `Stderr Output` (test 08). | All six lines audible (no audible distinction between stdout and stderr; pty-speak unified streams). |
+| **47-10** | **Esc-clear behaviour**: type `garbage` into the cmd prompt without Enter. Open the submenu, click any test (e.g. `Simple Echo`). | The `garbage` text is wiped; the inserted invocation is `"...test-01-echo.cmd"` alone, ready for Enter. Without the Esc prefix, the typed `garbage` would prepend to the invocation and break the parse. |
+| **47-11** | **`Ctrl+Shift+A` after a test ran**: walk test 01, then press `Ctrl+Shift+A`. | NVDA re-narrates the last 800 chars of the test's output — the same content the auto-narrate produced when the test finalised. |
+| **47-12** | **`Ctrl+Shift+O` after a test ran**: walk test 07 (progress loop), then press `Ctrl+Shift+O`. | The default text editor opens with the full `OutputText` of the just-finished progress-loop tuple. All five `"Step N of 5"` lines visible alongside the start / end markers. |
+
+**Diagnostic decoder.** If a test's prompt isn't audible
+before user input (47-3 / 47-4 / 47-5 / 47-6 / 47-7 fail):
+the idle-flush isn't firing. Check the FileLogger log for
+`Idle-flush announce.` lines at INFO; if absent, the
+`ShellPolicy.IdleFlushMs` value is `None` for the active
+shell (check `currentShellPolicy` via a fresh
+`Ctrl+Shift+D` snapshot — the diagnostic battery doesn't
+include it today; could be added later) or the
+`DispatcherTimer` failed to start. If 47-2 fails with
+"NVDA announces nothing on menu click": the
+`MenuItem_CmdTest*` reflective wiring (`Program.fs` line
+~3877) didn't find a matching named MenuItem — check
+`MainWindow.xaml`'s `x:Name` matches the AppCommand
+`nameOf` result. If 47-8 batches all five steps instead of
+narrating each: the idle-flush threshold is too high
+(should be ≤ the inter-step gap; tune `IdleFlushMs` down
+from 350 if needed). If 47-10 the `garbage` text still
+prepends the invocation: the Esc byte didn't reach cmd —
+verify `runCmdTest` is prepending `0x1Buy` to the bytes.
+
 ## Recording results
 
 For each release tag:

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1765,17 +1765,43 @@ module Program =
                 // audible text — keep the cap silent at the
                 // channel layer and trust the hotkey + log to
                 // surface the cap when needed.
+                // Cycle 47 follow-up (2026-05-13) — slice from
+                // the idle-flush watermark to the current
+                // ContentHistory tail rather than announcing
+                // `tuple.OutputText` whole. The watermark
+                // captures whatever idle-flush has already
+                // narrated during the script; tuple-finalise
+                // here just announces the residual gap (zero,
+                // typically, if idle-flushes kept up). Avoids
+                // double-narration when idle-flush has covered
+                // the tuple. `tupleFinaliseAnnounce` is still
+                // checked because it carries the streaming-
+                // policy gate and the non-blank-output filter
+                // — the slice path inherits both implicitly
+                // (None payload → skip; blank slice → skip).
                 match tupleFinaliseAnnounce with
-                | Some text ->
-                    let toSay =
-                        if text.Length <= OutputAnnounceCapChars then text
-                        else text.Substring(text.Length - OutputAnnounceCapChars)
-                    if toSay.Length < text.Length then
-                        log.LogInformation(
-                            "Tuple-final announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
-                            text.Length, toSay.Length, OutputAnnounceCapChars)
-                    window.TerminalSurface.Announce(toSay, ActivityIds.output)
-                    raiseCaretMovedToTail ()
+                | Some _ ->
+                    let latest = ContentHistory.latestSeq contentHistory
+                    if latest > lastAnnouncedSeq then
+                        let text =
+                            ContentHistory.sliceText
+                                contentHistory
+                                lastAnnouncedSeq
+                                (latest + 1L)
+                        if not (System.String.IsNullOrWhiteSpace text) then
+                            let toSay =
+                                if text.Length <= OutputAnnounceCapChars then text
+                                else text.Substring(text.Length - OutputAnnounceCapChars)
+                            if toSay.Length < text.Length then
+                                log.LogInformation(
+                                    "Tuple-final announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
+                                    text.Length, toSay.Length, OutputAnnounceCapChars)
+                            log.LogInformation(
+                                "Tuple-final announce. SliceFrom={From} SliceTo={To} Length={Len}",
+                                lastAnnouncedSeq, latest, toSay.Length)
+                            window.TerminalSurface.Announce(toSay, ActivityIds.output)
+                            raiseCaretMovedToTail ()
+                        lastAnnouncedSeq <- latest
                 | None -> ()
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
             |> ignore
@@ -2353,6 +2379,27 @@ module Program =
         // weird-looking entry occasionally is acceptable.
         let mutable lastReadUtc = DateTimeOffset.UtcNow
 
+        // Cycle 47 follow-up (2026-05-13) — idle-flush watermark.
+        // Tracks the highest ContentHistory `seq` whose content
+        // has already been narrated via Announce. The boundary
+        // handler (tuple finalise) and the idle-flush
+        // `DispatcherTimer` both:
+        //   1. Slice from `lastAnnouncedSeq` to current
+        //      `latestSeq` (via `ContentHistory.sliceText`),
+        //   2. Cap at `OutputAnnounceCapChars` (800),
+        //   3. Fire `Announce(text, ActivityIds.output)`,
+        //   4. Advance `lastAnnouncedSeq` to the new latest.
+        //
+        // The unified watermark means tuple-finalise doesn't
+        // re-announce content that idle-flush already covered;
+        // idle-flush fills the intra-script gaps (`set /p`
+        // pauses, `pause` builtin, slow output between
+        // sections) that PromptStart-driven tuple-finalise
+        // would otherwise leave silent. Initial value -1L
+        // matches `ContentHistory.latestSeq` on a fresh empty
+        // history.
+        let mutable lastAnnouncedSeq : int64 = -1L
+
         // Stage 7-followup PR-F — incident-marker handler. Single
         // press writes a clear "=== INCIDENT MARKER {timestamp} ==="
         // boundary line to the active log via the standard
@@ -2854,10 +2901,22 @@ module Program =
                 // a trailing space so the user can type more
                 // arguments / redirects before Enter if they
                 // want.
+                //
+                // Cycle 47 follow-up (2026-05-13) — prepend an
+                // `Esc` (0x1B) byte before the invocation.
+                // cmd.exe's cooked-mode line editor treats Esc
+                // as "clear the current input buffer", so any
+                // text the user had partially typed before
+                // clicking the menu item is wiped before our
+                // script invocation lands. Without this, the
+                // invocation appends to whatever was already
+                // pending and breaks parsing.
                 let invocation =
                     sprintf "\"%s\" " scriptPath
-                let bytes =
+                let cmdBytes =
                     System.Text.Encoding.UTF8.GetBytes(invocation)
+                let bytes =
+                    Array.append [| 0x1Buy |] cmdBytes
                 window.TerminalSurface.WritePtyBytes(bytes)
                 window.TerminalSurface.Announce(
                     sprintf
@@ -3371,6 +3430,87 @@ module Program =
                 dueTime = TimeSpan.FromSeconds(5.0),
                 period = TimeSpan.FromSeconds(5.0))
 
+        // Cycle 47 follow-up (2026-05-13) — idle-flush
+        // dispatcher. Ticks every 100 ms on the WPF dispatcher;
+        // if `currentShellPolicy.IdleFlushMs` is `Some N` AND
+        // the parser has been idle for ≥ N ms (i.e.
+        // `lastReadUtc` is at least N ms in the past) AND
+        // `ContentHistory.latestSeq` is past
+        // `lastAnnouncedSeq`, slice the gap, cap at
+        // `OutputAnnounceCapChars`, fire
+        // `Announce(text, ActivityIds.output)`, advance the
+        // watermark.
+        //
+        // Solves the intra-script `set /p` / `pause` /
+        // `choice` problem: cmd just stops emitting bytes
+        // when it's waiting for keystroke input; no
+        // `PromptStart` fires; the tuple-finalise auto-narrate
+        // is silent until the script completes. With idle-flush,
+        // the parser-quiet period IS the trigger — after 350 ms
+        // of stillness, pty-speak announces whatever has
+        // accumulated since the last announce.
+        //
+        // 350 ms threshold (configurable per-shell via
+        // `ShellPolicy.IdleFlushMs`) is short enough to feel
+        // responsive during a `set /p` pause, long enough to
+        // avoid firing between rapid output chunks of a normal
+        // streaming command (`dir`'s line-emission rate is well
+        // under 350 ms per line, but each chunk produces
+        // multiple lines so 350 ms idle = the whole batch is
+        // done streaming).
+        //
+        // Uses `DispatcherTimer` (WPF UI thread) rather than
+        // `System.Threading.Timer` because `Announce` calls
+        // through `peer.RaiseNotificationEvent` which must run
+        // on the WPF dispatcher per the UIA peer contract. The
+        // tuple-finalise path achieves this via
+        // `window.Dispatcher.InvokeAsync`; here we just run
+        // natively on the dispatcher thread to begin with.
+        let idleFlushTimer = DispatcherTimer()
+        idleFlushTimer.Interval <- TimeSpan.FromMilliseconds(100.0)
+        idleFlushTimer.Tick.Add(fun _ ->
+            try
+                match currentShellPolicy.IdleFlushMs with
+                | Some thresholdMs ->
+                    let idleMs =
+                        (DateTimeOffset.UtcNow - lastReadUtc).TotalMilliseconds
+                    if idleMs >= float thresholdMs then
+                        let latest = ContentHistory.latestSeq contentHistory
+                        if latest > lastAnnouncedSeq then
+                            let text =
+                                ContentHistory.sliceText
+                                    contentHistory
+                                    lastAnnouncedSeq
+                                    (latest + 1L)
+                            if not (System.String.IsNullOrWhiteSpace text) then
+                                let toSay =
+                                    if text.Length <= OutputAnnounceCapChars then text
+                                    else
+                                        text.Substring(
+                                            text.Length - OutputAnnounceCapChars)
+                                log.LogInformation(
+                                    "Idle-flush announce. SliceFrom={From} SliceTo={To} IdleMs={Idle:F0} Threshold={Threshold} Length={Len}",
+                                    lastAnnouncedSeq,
+                                    latest,
+                                    idleMs,
+                                    thresholdMs,
+                                    toSay.Length)
+                                window.TerminalSurface.Announce(
+                                    toSay, ActivityIds.output)
+                                raiseCaretMovedToTail ()
+                            lastAnnouncedSeq <- latest
+                | None -> ()
+            with ex ->
+                // Idle-flush exceptions must not wedge the
+                // timer. Log + continue; the next tick fires
+                // the same path and would surface a persistent
+                // bug rather than silently nothing.
+                log.LogWarning(
+                    ex,
+                    "Idle-flush tick raised exception: {Message}",
+                    ex.Message))
+        idleFlushTimer.Start()
+
         // Stage 7 PR-C — extracted from the initial-spawn branch
         // so the shell-switch coordinator below can reuse the
         // exact same wiring without duplication. Wires the
@@ -3726,6 +3866,23 @@ module Program =
                                         // dispatcher thread.
                                         ContentHistory.reset contentHistory
                                         SpeechCursor.reset speechCursor
+                                        // Cycle 47 follow-up —
+                                        // reset the idle-flush
+                                        // watermark when
+                                        // ContentHistory's
+                                        // sequence numbering
+                                        // restarts. Without
+                                        // this, the comparison
+                                        // `latest > watermark`
+                                        // would stay false
+                                        // until the new shell
+                                        // accumulated more
+                                        // seqs than the old
+                                        // one had — meaning
+                                        // initial new-shell
+                                        // output would silently
+                                        // skip narration.
+                                        lastAnnouncedSeq <- -1L
                                         // Cycle 45f — apply the
                                         // new shell's verbosity
                                         // policy through the

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -897,6 +897,25 @@ module Program =
         let mutable speechCursor =
             SpeechCursor.create SpeechCursor.defaultParameters
 
+        // Cycle 47 follow-up (2026-05-13) — idle-flush watermark.
+        // Declared at compose-top alongside `contentHistory` so
+        // both the boundary handler (further down in compose) and
+        // the idle-flush `DispatcherTimer` (further down still)
+        // can close over it. Tracks the highest ContentHistory
+        // `seq` whose content has already been narrated via
+        // Announce; both paths slice from this watermark, cap at
+        // `OutputAnnounceCapChars`, fire Announce, advance the
+        // watermark. The unified watermark means tuple-finalise
+        // doesn't re-announce content idle-flush already covered,
+        // and idle-flush fills the intra-script gaps
+        // (`set /p` pauses, `pause` builtin, slow output between
+        // sections) that PromptStart-driven tuple-finalise would
+        // otherwise leave silent. Initial value -1L matches
+        // `ContentHistory.latestSeq` on a fresh empty history;
+        // resets to -1L on shell hot-switch (see
+        // `ContentHistory.reset` call site in `switchToShell`).
+        let mutable lastAnnouncedSeq : int64 = -1L
+
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
         // so the prompt-boundary handler and the selection-
@@ -2378,27 +2397,6 @@ module Program =
         // possible) but the heartbeat is a diagnostic; one
         // weird-looking entry occasionally is acceptable.
         let mutable lastReadUtc = DateTimeOffset.UtcNow
-
-        // Cycle 47 follow-up (2026-05-13) — idle-flush watermark.
-        // Tracks the highest ContentHistory `seq` whose content
-        // has already been narrated via Announce. The boundary
-        // handler (tuple finalise) and the idle-flush
-        // `DispatcherTimer` both:
-        //   1. Slice from `lastAnnouncedSeq` to current
-        //      `latestSeq` (via `ContentHistory.sliceText`),
-        //   2. Cap at `OutputAnnounceCapChars` (800),
-        //   3. Fire `Announce(text, ActivityIds.output)`,
-        //   4. Advance `lastAnnouncedSeq` to the new latest.
-        //
-        // The unified watermark means tuple-finalise doesn't
-        // re-announce content that idle-flush already covered;
-        // idle-flush fills the intra-script gaps (`set /p`
-        // pauses, `pause` builtin, slow output between
-        // sections) that PromptStart-driven tuple-finalise
-        // would otherwise leave silent. Initial value -1L
-        // matches `ContentHistory.latestSeq` on a fresh empty
-        // history.
-        let mutable lastAnnouncedSeq : int64 = -1L
 
         // Stage 7-followup PR-F — incident-marker handler. Single
         // press writes a clear "=== INCIDENT MARKER {timestamp} ==="

--- a/src/Terminal.Core/ShellPolicy.fs
+++ b/src/Terminal.Core/ShellPolicy.fs
@@ -83,6 +83,31 @@ module ShellPolicy =
         { ShellKey: string
           Streaming: StreamingMode
           PromptPath: PromptPathMode
+          /// Cycle 47 follow-up (2026-05-13) — idle-flush
+          /// threshold. When `Some N`, an idle-flush timer
+          /// fires `Announce(text, ActivityIds.output)` if the
+          /// parser has been idle for at least N ms AND
+          /// `ContentHistory` has unannounced content past the
+          /// last-announced watermark. Solves the
+          /// "intra-script `set /p` prompt doesn't speak until
+          /// after the user has typed" problem: the boundary
+          /// handler only fires `Announce` at `PromptStart`
+          /// (shell-prompt boundary), but a `set /p` prompt
+          /// inside a script doesn't emit `PromptStart` — cmd
+          /// just stops writing and waits. The idle-flush fills
+          /// that gap.
+          ///
+          /// `None` disables idle-flush — useful for shells like
+          /// Claude that already stream per-token frequently
+          /// enough that the threshold rarely triggers AND any
+          /// flush would partially overlap a per-token
+          /// `LineByLine` announce. 350 ms is the default for
+          /// cmd / PowerShell — short enough to feel responsive
+          /// during a `set /p` pause, long enough to avoid
+          /// firing between rapid output chunks of a normal
+          /// command (`dir`'s line emission rate is well under
+          /// 350 ms per line).
+          IdleFlushMs: int option
           // -- Cycle 45g consolidation seats; unread in 45f --
           /// Regex string for `HeuristicPromptDetector` to match
           /// against the cursor row when detecting prompt
@@ -109,6 +134,7 @@ module ShellPolicy =
               { ShellKey = "cmd"
                 Streaming = TupleFinalOnly
                 PromptPath = Suppress
+                IdleFlushMs = Some 350
                 PromptRegex = Some @"^[A-Za-z]:\\.*>\s?$"
                 PromptStabilityMs = Some 150
                 SelectionEnabled = false }
@@ -116,6 +142,7 @@ module ShellPolicy =
               { ShellKey = "powershell"
                 Streaming = TupleFinalOnly
                 PromptPath = Suppress
+                IdleFlushMs = Some 350
                 PromptRegex = Some @"^PS [A-Za-z]:\\.*>\s?$"
                 PromptStabilityMs = Some 200
                 SelectionEnabled = false }
@@ -123,6 +150,7 @@ module ShellPolicy =
               { ShellKey = "claude"
                 Streaming = TupleFinalOnly
                 PromptPath = Suppress
+                IdleFlushMs = None
                 PromptRegex = None
                 PromptStabilityMs = None
                 SelectionEnabled = true } ]

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -206,33 +206,40 @@
                      script to the PTY input cursor (no Enter);
                      the user reviews + presses Enter to run.
                      All menu-only (no keyboard accelerators).
-                     Headers prefix with the test number so
-                     they sort + read predictably in the menu. -->
-                <MenuItem Header="CMD Interaction T_ests">
+                     Cycle 47 follow-up (2026-05-13): dropped
+                     the leading digit prefixes from sub-item
+                     headers — they caused NVDA to read
+                     "1, 1 of 8" as "11 of 8" by speech-running
+                     the mnemonic + position together. Letter
+                     mnemonics now (each unique among siblings)
+                     and the parent gets `_C` so the submenu is
+                     reachable via Alt → G → C from the menu
+                     bar. -->
+                <MenuItem Header="_CMD Interaction Tests">
                     <MenuItem x:Name="MenuItem_CmdTestEcho"
                               x:FieldModifier="public"
-                              Header="_1: Simple Echo" />
+                              Header="_Simple Echo" />
                     <MenuItem x:Name="MenuItem_CmdTestTextInput"
                               x:FieldModifier="public"
-                              Header="_2: Text Input" />
+                              Header="_Text Input" />
                     <MenuItem x:Name="MenuItem_CmdTestNumericInput"
                               x:FieldModifier="public"
-                              Header="_3: Numeric Input + Calculation" />
+                              Header="_Numeric Input + Calculation" />
                     <MenuItem x:Name="MenuItem_CmdTestYesNo"
                               x:FieldModifier="public"
-                              Header="_4: Yes / No Choice" />
+                              Header="_Yes / No Choice" />
                     <MenuItem x:Name="MenuItem_CmdTestMultiChoice"
                               x:FieldModifier="public"
-                              Header="_5: Multi-Option Choice" />
+                              Header="_Multi-Option Choice" />
                     <MenuItem x:Name="MenuItem_CmdTestPause"
                               x:FieldModifier="public"
-                              Header="_6: Pause / Continue" />
+                              Header="_Pause / Continue" />
                     <MenuItem x:Name="MenuItem_CmdTestProgress"
                               x:FieldModifier="public"
-                              Header="_7: Progress Loop" />
+                              Header="Pro_gress Loop" />
                     <MenuItem x:Name="MenuItem_CmdTestStderr"
                               x:FieldModifier="public"
-                              Header="_8: Stderr Output" />
+                              Header="Stderr _Output" />
                 </MenuItem>
                 <Separator />
                 <!-- Cycle 43a — diagnostic chunking. Top-level

--- a/tests/Tests.Unit/ShellPolicyTests.fs
+++ b/tests/Tests.Unit/ShellPolicyTests.fs
@@ -46,6 +46,23 @@ let ``claude default enables selection detector`` () =
     let claude = ShellPolicy.defaults.["claude"]
     Assert.True(claude.SelectionEnabled)
 
+[<Fact>]
+let ``cmd + powershell default IdleFlushMs is Some 350`` () =
+    // Cycle 47 follow-up — idle-flush is enabled by default
+    // for cmd / PowerShell at a 350 ms threshold so intra-
+    // script `set /p` prompts speak before the user has to
+    // guess what's being asked.
+    Assert.Equal(Some 350, ShellPolicy.defaults.["cmd"].IdleFlushMs)
+    Assert.Equal(Some 350, ShellPolicy.defaults.["powershell"].IdleFlushMs)
+
+[<Fact>]
+let ``claude default IdleFlushMs is None`` () =
+    // Claude streams per-token frequently enough that the
+    // idle-flush threshold rarely triggers, and any flush
+    // would partially overlap a per-token `LineByLine`
+    // announce. Disabled by default.
+    Assert.Equal(None, ShellPolicy.defaults.["claude"].IdleFlushMs)
+
 // ---- forShell -------------------------------------------------------
 
 [<Fact>]


### PR DESCRIPTION
## Summary

Three connected fixes for the issues you surfaced walking the Cycle 47 corpus.

### 1. Idle-flush for intra-script prompts (the architectural one)

**Symptom**: `test-02-text-input.cmd` didn't speak its prompt until after you'd typed input and pressed Enter. Same problem affects every script that has an internal `set /p` / `choice` / `pause` — they all stop emitting bytes and wait for keystroke input, but cmd doesn't emit `PromptStart` for an intra-script pause, so the boundary-handler `Announce` has no trigger.

**Fix**: new `ShellPolicy.IdleFlushMs : int option` field + WPF `DispatcherTimer` ticking every 100 ms. After ≥ N ms of parser idle AND `ContentHistory.latestSeq` is past `lastAnnouncedSeq`, slice the gap → cap at 800 → fire `Announce(text, ActivityIds.output)` → advance the watermark.

The tuple-finalise path now also slices from the same watermark (was: announced `tuple.OutputText` whole), so the two paths share one source of truth. If idle-flushes covered the whole script, tuple-finalise's slice is empty and silent — the ready-prompt earcon click is the only "command complete" cue, intentional because you already heard the content.

Defaults:
- `cmd` / `powershell`: `Some 350` (responsive during `set /p`; tolerant of normal command line-emission rates).
- `claude`: `None` (Claude's per-token streaming rarely hits the threshold, and any flush would overlap a future `LineByLine` policy — opt-in pending the streaming-experience cycle).

Watermark resets to `-1L` on `ContentHistory.reset` (shell hot-switch) so post-switch narration starts clean.

### 2. CMD Interaction Tests menu: `C` accelerator + numbering fix

- Parent: `"CMD Interaction T_ests"` → `"_CMD Interaction Tests"`. Now `Alt → G → C` from the menu bar.
- Sub-items: dropped the `_N:` digit prefix that caused NVDA to speech-run "1, item 1 of 8" into "11 of 8". Each sub-item now has a unique letter mnemonic: `_Simple Echo` / `_Text Input` / `_Numeric Input + Calculation` / `_Yes / No Choice` / `_Multi-Option Choice` / `_Pause / Continue` / `Pro_gress Loop` / `Stderr _Output`.

### 3. `runCmdTest` Esc-clear

`runCmdTest` now prepends `0x1B` (Esc) to the bytes written to the PTY. cmd.exe's cooked-mode line editor treats Esc as "clear current input buffer", so any text you'd partially typed before clicking the menu item gets wiped before our quoted invocation lands. Avoids the append-and-break-parse failure mode.

## Test plan

- [ ] Full Windows build green.
- [ ] xUnit suite green (`ShellPolicyTests` extended with `IdleFlushMs` defaults assertions for cmd / powershell / claude).
- [ ] **NVDA matrix gate Cycle 47** ([`docs/ACCESSIBILITY-TESTING.md`](docs/ACCESSIBILITY-TESTING.md) "Cycle 47" section, rows 47-1 → 47-12). The headline checks:
  - **47-1**: menu reads "Simple Echo, item 1 of 8" (no "11 of 8" garble).
  - **47-3 / 47-4 / 47-5 / 47-6 / 47-7**: prompt audible BEFORE the user has to guess what's being asked.
  - **47-8**: progress-loop steps narrated separately as they arrive, not batched.
  - **47-10**: pre-typed `garbage` gets cleared by the Esc prefix.

## Deferred to a follow-up PR (Issue 4 from your feedback)

The "review cursor jumps from one output to the other, doesn't include input lines, no line segmentation" issue points at `ContentHistory.tailText`'s materialised output. I want to **investigate the materialiser carefully** before claiming a fix — the diagnostic snapshot from earlier showed sections concatenated without newlines between them, which suggests either the `Newline` entry's `'\n'` emission isn't reaching the output OR the active-span boundary isn't getting a separator. That investigation belongs in its own focused PR after this one merges. You said it was "perhaps not very important" so I'm punting the focus rather than bundling blind.

## Known small concern (worth knowing before walking)

The very first `PromptStart` after spawn fires before any tuple has finalised, so `tupleFinaliseAnnounce` is `None` and no announce path fires. But the idle-flush will fire after the cmd banner emits and ~350 ms of idle pass — meaning you'll hear "Microsoft Windows [Version 10.0.x.y]..." at startup. That's a behavior change from pre-Cycle-47 silence at spawn. Mostly fine (it's a "shell is ready" cue) but flag in case it's distracting. If so, tune `IdleFlushMs` up or add a "skip if no PromptStart has been seen yet" gate.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_