### PR TITLE
feat(uia): typing-window suppression + announce content logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 47 follow-up (2026-05-13, post-preview.114): typing-window UIA suppression + Announce content logging
+
+**Symptom**: maintainer reported NVDA reading aloud each accreting
+prefix as letters are typed at the cmd prompt
+(`"e"`, `"ec"`, `"ech"`, `"echo"`, ...), distinct from NVDA's
+keyboard-hook `Speak typed characters` behaviour and therefore not
+silenceable via the user's NVDA settings.
+
+**Root cause**: NVDA's `ITextProvider` polling re-reads
+`DocumentRange` periodically on a focused UIA Edit. As cmd echoes
+each typed character back into ContentHistory, the active
+(unsealed) TextSpan grows char-by-char; the materialised tail
+changes between polls; NVDA detects the diff and announces it as
+inserted text.
+
+**Fix**: `ContentHistoryMaterialiser.materialise` takes a
+`lastKeystrokeAtUtc` argument. While a keystroke is within the
+350 ms typing window, the materialiser calls a new
+`ContentHistory.tailTextWithMarkersSealedOnly` variant that
+excludes the active span — NVDA polling sees a stable tail across
+successive captures. After the window elapses, the active span
+re-enters the view so the review cursor can navigate to it.
+
+`TerminalView.OnPreviewKeyDown` stamps `_lastKeystrokeAtUtc` on
+every non-modifier key. `ContentHistoryTextProvider` exposes the
+stamp via a `Func<DateTime>` delegate so the materialiser reads
+it lazily on each UIA call.
+
+**Observability**: `TerminalView.Announce`'s existing INFO log
+entry (`RaiseNotificationEvent firing. ActivityId=... MsgLen=...`)
+now has a paired Debug entry carrying the first 60 chars of the
+announce text (`MsgHead="hi"`). Grep the diagnostic-bundle's
+FileLogger section for `MsgHead=` to audit "what did NVDA hear?"
+without live audio capture.
+
+**NVDA settings recommendation** added to
+`docs/ACCESSIBILITY-TESTING.md` § Test environment:
+`Speak typed characters` is user preference;
+`Speak typed words` should be `Off`;
+`Speech interruption for typed character` should be `On`.
+
+Matrix rows Cycle 47-21 (typing-window suppression) + 47-22
+(announce-trail audit) added.
+
 ### Cycle 47 follow-up (2026-05-13, post-preview.114): preserve newlines in diagnostic bundle + relabel markers + synthesise end-output
 
 Three connected fixes from the maintainer's preview.114 review walk

--- a/docs/ACCESSIBILITY-TESTING.md
+++ b/docs/ACCESSIBILITY-TESTING.md
@@ -67,6 +67,34 @@ run on every release.
 - A second audio output device available (USB headset is fine) so that
   earcons and TTS can be routed separately.
 
+### NVDA settings recommendation
+
+NVDA's keyboard hook controls char- and word-level typing speech
+independently of pty-speak. The recommended settings for
+`pty-speak` use under NVDA Settings → Keyboard:
+
+- **Speak typed characters**: user preference. If `Off` is desired
+  for pty-speak but `On` (e.g. "Edit controls") in other apps, the
+  setting is global; there's no per-app override without a custom
+  NVDA add-on.
+- **Speak typed words**: `Off`. Words assemble from typed chars
+  via NVDA's keyboard hook, independent of any UIA event pty-speak
+  raises. Leaving it `On` produces a word announce on each space /
+  punctuation as the user types — typically undesirable inside a
+  shell where command tokens vary line-by-line.
+- **Speech interruption for typed character**: `On`. Pairs with
+  the ControlType=Edit + UIA caret-event surface (Cycle 46 PR-C)
+  so typing always interrupts in-flight speech, even with the two
+  settings above turned off.
+
+Cycle 47 follow-up post-preview.114 also added an app-side
+typing-window gate on the UIA Text-pattern materialiser
+(`ContentHistoryMaterialiser.materialise` → `tailTextWithMarkersSealedOnly`
+when keystrokes are fresh) so NVDA's `ITextProvider` polling
+doesn't surface mid-keystroke active-span deltas as inserted text.
+The gate runs independent of the user's NVDA settings — see
+matrix row Cycle 47-21.
+
 ## Test data
 
 > **Status (Stage 3b on `main`):** the `tests/fixtures/` directory and
@@ -1328,6 +1356,8 @@ you mid-keystroke).
 | **47-18** | **Diagnostic bundle preserves newlines**: run `echo hi` once. Press `Ctrl+Shift+D`. Paste the bundle into any monospace text view. Locate the `--- CONTENT HISTORY (last 64KB) ---` section. | The content shows the cmd banner on multiple lines, `echo hi` on its own line, `hi` on its own line, and the next prompt's path on its own line — not the pre-fix squashed `"echo hihiC:\\Users\\..."` single-line blob. The newlines ContentHistory's CRLF events recorded are preserved by `sanitiseForBundle`. |
 | **47-19** | **Marker labels in begin/end form**: run two commands (e.g. `echo first` then `echo second`). Press `NVDA + Numpad7` to move the review cursor to the top of the document; press Down-Arrow line-by-line through the buffer. | Marker lines read as `"--- begin prompt ---"`, `"--- end prompt ---"`, `"--- begin output ---"`, `"--- end output ---"` (the four-marker model) rather than the previous singleton `"--- prompt ---"` / `"--- input begins ---"` etc. Cmd only emits `PromptStart` directly — see 47-20 for `--- end output ---` synthesis between cmd commands. |
 | **47-20** | **Synthesised `--- end output ---` between cmd commands**: run two commands (e.g. `echo first` then `echo second`). Press `NVDA + Numpad7`, then Down-Arrow through the buffer between `first`'s output and `second`'s prompt. | The review cursor surfaces `--- end output ---` between `first`'s output bytes and `second`'s prompt (specifically: it appears AFTER `second`'s prompt-path TextSpan in the rendered tail because the active span seals at marker-insertion time and the new prompt's path arrived just before — heuristic placement). Without the synthesis, the cmd shell would only show `--- begin prompt ---` markers and no "end" boundary. Shells with OSC 133 (claude) get all four markers naturally. |
+| **47-21** | **Typing-window suppression silences mid-keystroke word announces**: with NVDA's `Speak typed characters` set per preference but `Speak typed words` `Off`, type `echo hi` at the cmd prompt slowly enough to hear NVDA's per-keystroke read. | NVDA announces each typed character (from its keyboard hook) but does NOT additionally announce the accreting prefix as if it were inserted text (`"e"`, `"ec"`, `"ech"`, `"echo"`, ...). The UIA Text-pattern view stays stable across NVDA's `ITextProvider` polls while a keystroke is within the 350 ms typing window. After ~½ second of no typing, press `NVDA + Numpad7` and Down-Arrow: the review cursor navigates the just-typed text (it re-enters the materialised view once the window elapses). |
+| **47-22** | **Announce-trail audit via Debug log**: enable Debug logging (`View → Logging Level → Debug`), then run `echo hi`. Press `Ctrl+Shift+D` and paste the bundle. Grep the `--- FILELOGGER ACTIVE LOG ---` section for `MsgHead=`. | Each `RaiseNotificationEvent firing` line at INFO now has a paired Debug entry containing the first 60 chars of the announce text (`MsgHead="hi"` for the tuple-final auto-narrate, marker labels for menu announces, etc.). Gives forensics access to "what did NVDA hear?" without needing live audio capture. |
 
 **Diagnostic decoder.** If a test's prompt isn't audible
 before user input (47-3 / 47-4 / 47-5 / 47-6 / 47-7 fail):

--- a/src/Terminal.Accessibility/ContentHistoryTextRange.fs
+++ b/src/Terminal.Accessibility/ContentHistoryTextRange.fs
@@ -30,6 +30,24 @@ module internal ContentHistoryMaterialiser =
     [<Literal>]
     let TailCapBytes = 262144
 
+    /// Cycle 47 follow-up (2026-05-13) post-preview.114 —
+    /// typing-window duration. If the maintainer has typed a
+    /// key within this window before NVDA polls
+    /// `ITextProvider.DocumentRange`, the materialiser
+    /// excludes the active (unsealed) TextSpan from the
+    /// returned tail. After the window elapses with no
+    /// keystrokes, the next poll includes the active span
+    /// again. 350 ms is comfortably above WPF's typical
+    /// dispatcher latency for a single keypress + cmd echo
+    /// round-trip (observed ~30–80 ms on the maintainer's
+    /// machine) and below human-perceptible "I stopped
+    /// typing" pause (~500 ms). Tunable if dogfood surfaces
+    /// either under-suppression (NVDA still reads mid-word) or
+    /// over-suppression (review cursor lags noticeably behind
+    /// the keystroke).
+    [<Literal>]
+    let TypingWindowMs = 350.0
+
     /// Materialise the current `ContentHistory` tail to a
     /// single string. Returns the empty string if `history`
     /// is null (the early-startup case before
@@ -45,13 +63,36 @@ module internal ContentHistoryMaterialiser =
     /// can walk between commands via prompt-to-prompt
     /// navigation rather than scanning prose for boundaries.
     ///
+    /// Cycle 47 follow-up (2026-05-13) post-preview.114 —
+    /// `lastKeystrokeAtUtc` gates active-span inclusion.
+    /// `DateTime.MinValue` means "no typing-window suppression"
+    /// (caller doesn't care or hasn't wired the keystroke
+    /// source yet). Any value within the last `TypingWindowMs`
+    /// flips the tail to the sealed-only variant so NVDA's
+    /// `ITextProvider` polling sees a stable view across
+    /// successive captures.
+    ///
     /// The diagnostic-bundle path still uses `tailText`
     /// (markers-stripped) so paste-back triage stays
     /// readable — the marker lines would be noise there.
-    let materialise (history: ContentHistory.T | null) : string =
+    let materialise
+            (history: ContentHistory.T | null)
+            (lastKeystrokeAtUtc: DateTime)
+            : string =
         match history with
         | null -> ""
-        | h -> ContentHistory.tailTextWithMarkers h TailCapBytes
+        | h ->
+            let now = DateTime.UtcNow
+            let elapsed = (now - lastKeystrokeAtUtc).TotalMilliseconds
+            let typingActive =
+                lastKeystrokeAtUtc <> DateTime.MinValue
+                && elapsed >= 0.0
+                && elapsed < TypingWindowMs
+            if typingActive then
+                ContentHistory.tailTextWithMarkersSealedOnly
+                    h TailCapBytes
+            else
+                ContentHistory.tailTextWithMarkers h TailCapBytes
 
 /// UIA `ITextRangeProvider` over a materialised
 /// `ContentHistory` tail. Endpoints are character offsets
@@ -490,7 +531,18 @@ type internal ContentHistoryTextRange
 /// `SetContentHistory`, mirroring the existing `SetScreen` /
 /// `SetDisplayBuffer` injection pattern.
 type internal ContentHistoryTextProvider
-    (historySource: Func<ContentHistory.T | null>) =
+    (historySource: Func<ContentHistory.T | null>,
+     lastKeystrokeAtUtcSource: Func<DateTime>) =
+
+    /// Convenience constructor for callers that don't wire a
+    /// keystroke source (tests, future renderers). Falls back
+    /// to `DateTime.MinValue`, which disables typing-window
+    /// suppression — every `DocumentRange` call materialises
+    /// the full tail including the active span.
+    new (historySource: Func<ContentHistory.T | null>) =
+        ContentHistoryTextProvider(
+            historySource,
+            Func<DateTime>(fun () -> DateTime.MinValue))
 
     /// Build a range covering the entire current materialised
     /// tail. Returns an empty range when `historySource`
@@ -498,7 +550,9 @@ type internal ContentHistoryTextProvider
     /// `TerminalView.SetContentHistory` has been called).
     member private _.CaptureFullRange() : ITextRangeProvider =
         let history = historySource.Invoke()
-        let text = ContentHistoryMaterialiser.materialise history
+        let lastKeystroke = lastKeystrokeAtUtcSource.Invoke()
+        let text =
+            ContentHistoryMaterialiser.materialise history lastKeystroke
         ContentHistoryTextRange(text, 0, text.Length)
         :> ITextRangeProvider
 

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -319,12 +319,28 @@ module ContentHistory =
     /// marker rendering without diverging on the byte-cap +
     /// tail-walk machinery.
     let private tailTextInternal
-            (state: T) (maxBytes: int) (includeMarkers: bool) : string =
+            (state: T)
+            (maxBytes: int)
+            (includeMarkers: bool)
+            (includeActiveSpan: bool)
+            : string =
         lock state.Gate (fun () ->
             let frames = ResizeArray<string>()
             let mutable bytes = 0
             // Active span first (it's the most recent content).
-            if state.ActiveSpanText.Length > 0 then
+            // Cycle 47 follow-up (2026-05-13) post-preview.114 —
+            // `includeActiveSpan` gates whether the unsealed
+            // active TextSpan participates in the rendered tail.
+            // The UIA Text-pattern materialiser sets this to
+            // `false` during the user's typing window so NVDA's
+            // periodic `ITextProvider` polling doesn't see the
+            // mid-keystroke deltas + announce them as inserted
+            // text (the preview.114 "words being read aloud while
+            // I type" failure mode). Substrate consumers
+            // (diagnostic bundle, SpeechCursor manual nav) keep
+            // `true` so paste-back triage + review-cursor
+            // navigation still surface the in-progress span.
+            if includeActiveSpan && state.ActiveSpanText.Length > 0 then
                 let text = state.ActiveSpanText.ToString()
                 frames.Add(text)
                 bytes <- bytes + System.Text.Encoding.UTF8.GetByteCount(text)
@@ -367,8 +383,11 @@ module ContentHistory =
     /// N KB) ---` section without forcing the caller to allocate
     /// the full reconstruction first. Markers are stripped; for
     /// the markers-rendered variant see `tailTextWithMarkers`.
+    /// Includes the active (unsealed) span — paste-back triage
+    /// expects to see whatever the user just typed / cmd just
+    /// printed mid-stream.
     let tailText (state: T) (maxBytes: int) : string =
-        tailTextInternal state maxBytes false
+        tailTextInternal state maxBytes false true
 
     /// Cycle 47 follow-up (2026-05-13) — variant of `tailText`
     /// that renders `Marker` entries as labelled boundary lines
@@ -379,7 +398,24 @@ module ContentHistory =
     /// keeps using `tailText` (no marker noise) so paste-back
     /// triage stays readable.
     let tailTextWithMarkers (state: T) (maxBytes: int) : string =
-        tailTextInternal state maxBytes true
+        tailTextInternal state maxBytes true true
+
+    /// Cycle 47 follow-up (2026-05-13) post-preview.114 —
+    /// markers-rendered tail variant that EXCLUDES the active
+    /// (unsealed) TextSpan. Used by the UIA Text-pattern
+    /// materialiser during the user's typing window so NVDA's
+    /// `ITextProvider` polling sees stable content across
+    /// successive captures even as cmd echoes each typed
+    /// character back into the active span. Without this gate,
+    /// the maintainer's preview.114 dogfood surfaced NVDA
+    /// reading aloud each accreting prefix
+    /// (`"e"`, `"ec"`, `"ech"`, `"echo"`, ...) as if it were
+    /// inserted text — distinct from NVDA's keyboard-hook
+    /// `Speak typed characters` behaviour and therefore not
+    /// silenceable via the user's NVDA settings.
+    let tailTextWithMarkersSealedOnly
+            (state: T) (maxBytes: int) : string =
+        tailTextInternal state maxBytes true false
 
     /// Cycle 45c — reconstruct the user-visible text payload for
     /// entries whose Seq is strictly between `fromSeqExclusive`

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -75,6 +75,22 @@ public class TerminalView : FrameworkElement
     private ContentHistory.T? _contentHistory;
 
     /// <summary>
+    /// Cycle 47 follow-up (2026-05-13) post-preview.114 — UTC
+    /// timestamp of the most recent <see cref="OnPreviewKeyDown"/>
+    /// firing. Read by <see cref="ContentHistoryTextProvider"/>'s
+    /// keystroke-source delegate so the UIA Text-pattern view can
+    /// suppress the active (unsealed) TextSpan while the user is
+    /// typing — NVDA's <c>ITextProvider</c> polling otherwise
+    /// announces the accreting mid-keystroke text deltas
+    /// ("e", "ec", "ech", ...) as inserted text, independent of
+    /// the user's "Speak typed characters" NVDA setting. Written
+    /// on the WPF UI thread (where key events fire); read on the
+    /// UIA RPC thread (where NVDA queries DocumentRange). Atomic
+    /// 64-bit reads / writes on x64 + ARM64 — no lock needed.
+    /// </summary>
+    private DateTime _lastKeystrokeAtUtc = DateTime.MinValue;
+
+    /// <summary>
     /// Stage 6 PR-B — sink for keyboard / paste / focus bytes. Set
     /// by <see cref="SetPtyHost"/> from <c>Program.fs compose ()</c>
     /// after the ConPtyHost is up. Until set (and during teardown),
@@ -173,7 +189,9 @@ public class TerminalView : FrameworkElement
         // an empty range. PR-D deleted the legacy screen-grid
         // `TerminalTextProvider`. See
         // `docs/adr/0002-uia-textedit-caret-output.md`.
-        TextProvider = new ContentHistoryTextProvider(() => _contentHistory);
+        TextProvider = new ContentHistoryTextProvider(
+            () => _contentHistory,
+            () => _lastKeystrokeAtUtc);
 
         // Stage 6 PR-B — paste hook. ApplicationCommands.Paste fires
         // for right-click → Paste, Edit menu → Paste, and any future
@@ -391,6 +409,24 @@ public class TerminalView : FrameworkElement
                 log,
                 "RaiseNotificationEvent firing. ActivityId={ActivityId} MsgLen={MsgLen} Processing={Processing}",
                 activityId, message.Length, processing);
+            // Cycle 47 follow-up (2026-05-13) post-preview.114 —
+            // first 60 chars of the announce text at Debug so a
+            // diagnostic-bundle paste-back can grep `MsgHead=` and
+            // see exactly what NVDA was asked to read at each
+            // notification raise. Already an audible signal so
+            // the privacy posture is unchanged; INFO stays as the
+            // metadata-only baseline (length + activityId).
+            if (log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+            {
+                var head = message.Length <= 60
+                    ? message
+                    : message.Substring(0, 60) + "...";
+                head = Terminal.Core.AnnounceSanitiser.sanitise(head);
+                Microsoft.Extensions.Logging.LoggerExtensions.LogDebug(
+                    log,
+                    "RaiseNotificationEvent firing. ActivityId={ActivityId} MsgHead={MsgHead}",
+                    activityId, head);
+            }
             peer.RaiseNotificationEvent(
                 AutomationNotificationKind.Other,
                 processing,
@@ -695,6 +731,24 @@ public class TerminalView : FrameworkElement
     protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
         base.OnPreviewKeyDown(e);
+
+        // Cycle 47 follow-up (2026-05-13) post-preview.114 — record
+        // the keystroke time before the gesture-dispatch logic
+        // below runs, so the UIA materialiser sees the typing
+        // window open on the very first key in a burst. Modifier-
+        // only keypresses (Ctrl, Alt, Shift) are excluded because
+        // they don't generate cmd-side echo and stamping them
+        // would extend the suppression window through chord
+        // shortcuts (Ctrl+Shift+D etc.) where the active span
+        // genuinely isn't changing.
+        if (e.Key != Key.LeftCtrl && e.Key != Key.RightCtrl
+            && e.Key != Key.LeftAlt && e.Key != Key.RightAlt
+            && e.Key != Key.LeftShift && e.Key != Key.RightShift
+            && e.Key != Key.LWin && e.Key != Key.RWin
+            && e.Key != Key.System)
+        {
+            _lastKeystrokeAtUtc = DateTime.UtcNow;
+        }
 
         var pressedModifiers = Keyboard.Modifiers;
 

--- a/tests/Tests.Unit/ContentHistoryTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTests.fs
@@ -655,6 +655,19 @@ let ``tailTextWithMarkers preserves text content alongside marker lines`` () =
             dirIdx markerIdx abIdx result)
 
 [<Fact>]
+let ``tailTextWithMarkersSealedOnly excludes the active span`` () =
+    // Cycle 47 follow-up (2026-05-13) post-preview.114 — the
+    // typing-window gate in the UIA materialiser routes through
+    // this variant. The unsealed tail (here: "in_progress")
+    // must NOT contribute.
+    let state = freshHistory ()
+    feed state t0 [ printRune 's'; printRune 'e'; printRune 'a'; printRune 'l'; printRune 'e'; printRune 'd'; lf ] |> ignore
+    feed state t0 [ printRune 'i'; printRune 'n'; printRune '_'; printRune 'p'; printRune 'r'; printRune 'o'; printRune 'g'; printRune 'r'; printRune 'e'; printRune 's'; printRune 's' ] |> ignore
+    let result = ContentHistory.tailTextWithMarkersSealedOnly state 4096
+    Assert.Contains("sealed", result)
+    Assert.DoesNotContain("in_progress", result)
+
+[<Fact>]
 let ``tailText and tailTextWithMarkers agree when no markers exist`` () =
     let state = freshHistory ()
     feed state t0 [ printRune 'a'; printRune 'b'; lf; printRune 'c'; lf ] |> ignore

--- a/tests/Tests.Unit/ContentHistoryTextRangeTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTextRangeTests.fs
@@ -72,27 +72,27 @@ let private innerRange (r: ITextRangeProvider) : ContentHistoryTextRange =
 
 [<Fact>]
 let ``materialise returns empty string when history is null`` () =
-    let result = ContentHistoryMaterialiser.materialise null
+    let result = ContentHistoryMaterialiser.materialise null DateTime.MinValue
     Assert.Equal("", result)
 
 [<Fact>]
 let ``materialise returns empty string for fresh history`` () =
     let state = freshHistory ()
-    let result = ContentHistoryMaterialiser.materialise state
+    let result = ContentHistoryMaterialiser.materialise state DateTime.MinValue
     Assert.Equal("", result)
 
 [<Fact>]
 let ``materialise returns active span text after Print events`` () =
     let state = freshHistory ()
     feedText state "abc"
-    let result = ContentHistoryMaterialiser.materialise state
+    let result = ContentHistoryMaterialiser.materialise state DateTime.MinValue
     Assert.Equal("abc", result)
 
 [<Fact>]
 let ``materialise reconstructs across newlines`` () =
     let state = freshHistory ()
     feedText state "line1\nline2\nline3"
-    let result = ContentHistoryMaterialiser.materialise state
+    let result = ContentHistoryMaterialiser.materialise state DateTime.MinValue
     Assert.Equal("line1\nline2\nline3", result)
 
 [<Fact>]
@@ -114,11 +114,54 @@ let ``materialise renders Marker entries as navigable boundary lines`` () =
     ContentHistory.appendMarker
         state ContentHistory.MarkerKind.CommandFinished t0 None
     |> ignore
-    let result = ContentHistoryMaterialiser.materialise state
+    let result = ContentHistoryMaterialiser.materialise state DateTime.MinValue
     Assert.Contains("--- begin output ---", result)
     Assert.Contains("--- end output ---", result)
     Assert.Contains("echo hi", result)
     Assert.Contains("hi", result)
+
+// ---------------------------------------------------------------------
+// Typing-window suppression (Cycle 47 follow-up post-preview.114)
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``materialise excludes active span when keystroke is fresh`` () =
+    // Maintainer is mid-typing. The unsealed `abc` should NOT
+    // appear in the materialised view so NVDA's polling sees a
+    // stable tail across successive captures.
+    let state = freshHistory ()
+    feedText state "settled\n"
+    feedText state "abc"
+    // Wallclock NOW is "still typing".
+    let lastKey = DateTime.UtcNow
+    let result = ContentHistoryMaterialiser.materialise state lastKey
+    Assert.Contains("settled", result)
+    Assert.DoesNotContain("abc", result)
+
+[<Fact>]
+let ``materialise includes active span when keystroke is stale`` () =
+    // Last keystroke was longer ago than the typing window.
+    // The active span re-enters the view so the review cursor
+    // can navigate to it.
+    let state = freshHistory ()
+    feedText state "settled\n"
+    feedText state "abc"
+    let lastKey = DateTime.UtcNow.AddSeconds(-5.0)
+    let result = ContentHistoryMaterialiser.materialise state lastKey
+    Assert.Contains("settled", result)
+    Assert.Contains("abc", result)
+
+[<Fact>]
+let ``materialise includes active span when keystroke is MinValue`` () =
+    // Default / unset / opt-out path: caller passes
+    // DateTime.MinValue to signal "no typing-window
+    // suppression". The active span is always included.
+    let state = freshHistory ()
+    feedText state "settled\n"
+    feedText state "abc"
+    let result = ContentHistoryMaterialiser.materialise state DateTime.MinValue
+    Assert.Contains("settled", result)
+    Assert.Contains("abc", result)
 
 // ---------------------------------------------------------------------
 // Clone / Compare / CompareEndpoints


### PR DESCRIPTION
## Summary

Maintainer reported NVDA reading each accreting prefix as letters
are typed at the cmd prompt (`"e"`, `"ec"`, `"ech"`, `"echo"`,
...), distinct from NVDA's keyboard-hook `Speak typed characters`
behaviour and **not silenceable via NVDA settings**.

**Root cause**: NVDA's `ITextProvider` polling re-reads
`DocumentRange` periodically on a focused UIA Edit. As cmd echoes
each typed character into the ContentHistory active span, the
materialised tail changes between polls; NVDA detects the diff
and announces it as inserted text.

**Fix**: app-side typing-window gate on the UIA Text-pattern
view.
- `ContentHistoryMaterialiser.materialise` takes a
  `lastKeystrokeAtUtc` argument.
- While a keystroke is within a 350 ms window, the materialiser
  calls a new `ContentHistory.tailTextWithMarkersSealedOnly`
  variant that excludes the active span.
- NVDA polling sees a stable tail; no diff to announce.
- Active span re-enters the view after the window elapses so the
  review cursor can still navigate to it.
- `TerminalView.OnPreviewKeyDown` stamps `_lastKeystrokeAtUtc` on
  every non-modifier key.
- `ContentHistoryTextProvider` exposes the stamp via a
  `Func<DateTime>` delegate.

**Observability**: `TerminalView.Announce` now logs the first 60
chars of the announce text at Debug (`MsgHead="..."`). Grep the
bundle's FileLogger for `MsgHead=` to audit "what did NVDA hear?"
without live audio capture.

**NVDA settings recommendation** added to test environment doc:
- `Speak typed characters` — user preference (global setting)
- `Speak typed words` — `Off` (else words get spoken on each
  space/punctuation independent of pty-speak)
- `Speech interruption for typed character` — `On` (pairs with
  the ControlType=Edit surface so typing always interrupts
  speech)

## Test plan

- [ ] CI green
- [ ] **Cycle 47-21** Typing-window silences mid-keystroke word
      announces (type `echo hi` slowly; NVDA reads chars per
      keyboard hook but does NOT announce accreting prefixes as
      inserted text)
- [ ] **Cycle 47-22** Diagnostic bundle's FileLogger section
      contains `MsgHead=` lines paired with each `RaiseNotificationEvent firing` INFO line

If the typing-window over-suppresses (review cursor lags
noticeably) or under-suppresses (NVDA still reads mid-word), the
350 ms constant in `ContentHistoryMaterialiser.TypingWindowMs` is
the knob to tune.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_