### PR TITLE
feat: SpeechCursor hotkeys + menu reorg + sub-prompt echo strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,49 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 48 post-PR-F (2026-05-13): SpeechCursor hotkeys + menu reorg + sub-prompt echo strip
+
+Three connected fixes from preview.118 dogfood:
+
+1. **`Ctrl+Shift+Up/Down/End` bound to SpeechCursor**
+   Previous / Next / JumpToLatest. Previously menu-only; the
+   HotkeyRegistry has had a comment anticipating this since
+   Cycle 45. The mirror row in `TerminalView.AppReservedHotkeys`
+   ships alongside per the F#/C# parity tests.
+2. **Menu reorg.** Top-level "Display" renamed to
+   "Interface". The old top-level "Data" menu broken up:
+   "Open Data Folder" and "Edit Config" lifted to Interface
+   direct level (they're infrastructure paths, not output
+   review); the remaining items grouped under "Output
+   History" submenu (Last Output → text editor / re-announce,
+   Copy Session History, Announce Session Log Path).
+   Diagnostics's flat ~10-item list grouped into three
+   submenus: **Probe** (Health Check, Incident Marker, Run
+   Diagnostic Battery), **Test Scripts** (Open Manual Tests,
+   Process Cleanup Test, CMD Interaction Tests), **Inspect**
+   (Copy Latest Bundle, Grep Diagnostics, Extract). Logging
+   Level stays at the top of Diagnostics as a frequent
+   toggle. All mnemonics audited for uniqueness within each
+   submenu.
+3. **Sub-prompt announce strips command echo.** Maintainer
+   reported test 02 (`set/p`) producing garbled announce of
+   `"set /p name=Enter your name:Enter your name:"` after
+   pressing Enter — the SubPromptIdle accumulator included
+   cmd's echo of the typed command line. `recordTransition`
+   now drops everything up to and including the first `\n`
+   in the accumulator before announcing, leaving just the
+   sub-prompt text (e.g., `"Enter your name:"`).
+
+Known issues not addressed in this PR (deferred to follow-up):
+- The review-cursor "needs an extra command to update"
+  behaviour after running a single command — UIA polling /
+  caching issue, requires NVDA-side reasoning.
+- Test 01 "Line 1 of 8" missing from announce (matrix-row
+  validation needed first to confirm whether bug or expected).
+- SpeechCursor menu/hotkey may still land on a sequence of
+  Composing-state entries that all return None — needs
+  diagnostic to confirm.
+
 ### Cycle 48 closure (2026-05-13): six PRs (#306–this) shipped
 
 Six-PR sequence implementing ADR 0003's `ShellInteraction`

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -367,6 +367,9 @@ module Program =
         | HotkeyRegistry.Digit 7 -> Key.D7
         | HotkeyRegistry.Digit 8 -> Key.D8
         | HotkeyRegistry.Digit 9 -> Key.D9
+        | HotkeyRegistry.Up -> Key.Up
+        | HotkeyRegistry.Down -> Key.Down
+        | HotkeyRegistry.End -> Key.End
         | HotkeyRegistry.Digit n ->
             failwithf
                 "HotkeyRegistry.Digit %d out of supported range 1-9 \

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1570,8 +1570,28 @@ module Program =
                             | ShellPolicy.LineByLine -> false
                             | ShellPolicy.Off -> false)
                     if shouldAnnounce then
+                        // Cycle 48 post-PR-F (2026-05-13) —
+                        // strip the user's submitted-command
+                        // echo from the accumulator before
+                        // announcing. After EnterPressed, cmd
+                        // echoes the typed line + `\r\n`
+                        // before emitting the sub-prompt text.
+                        // Including that echo in the announce
+                        // produces the "garbled" output the
+                        // maintainer reported on test 02
+                        // (cmd echoes "set /p name=Enter your
+                        // name:\r\nEnter your name:"; we want
+                        // to announce just the second half).
+                        // Drop everything up to and including
+                        // the first `\n` in the accumulator.
                         let raw = outcome.AccumulatedOutput
-                        let sanitised = AnnounceSanitiser.sanitise raw
+                        let firstLf = raw.IndexOf('\n')
+                        let postEchoRaw =
+                            if firstLf >= 0 && firstLf + 1 < raw.Length then
+                                raw.Substring(firstLf + 1)
+                            else
+                                raw
+                        let sanitised = AnnounceSanitiser.sanitise postEchoRaw
                         let trimmed = sanitised.Trim()
                         if not (System.String.IsNullOrWhiteSpace trimmed) then
                             let toSay =

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -60,6 +60,14 @@ module HotkeyRegistry =
         /// `;` / `:` key (`OemSemicolon` in WPF). Used by
         /// `Ctrl+Shift+;` log-copy hotkey.
         | Semicolon
+        /// Arrow / navigation keys. Cycle 48 post-PR-F binds
+        /// `Ctrl+Shift+Up/Down/End` to SpeechCursor Previous /
+        /// Next / JumpToLatest. NVDA collision check: default
+        /// NVDA review-cursor gestures use the Numpad cluster,
+        /// not Ctrl+Shift+arrow.
+        | Up
+        | Down
+        | End
 
     /// Identity of every app-reserved hotkey command. New
     /// hotkeys append a case here and add a corresponding
@@ -496,16 +504,16 @@ module HotkeyRegistry =
           // (NVDA's default review-cursor commands are
           // `NVDA+Up/Down`).
           { Command = SpeechCursorNext
-            Key = Some Key.Down
-            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Key = Some Down
+            Modifiers = Some ctrlShift
             Description = "Speech Cursor: move to the next entry" }
           { Command = SpeechCursorPrevious
-            Key = Some Key.Up
-            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Key = Some Up
+            Modifiers = Some ctrlShift
             Description = "Speech Cursor: move to the previous entry" }
           { Command = SpeechCursorJumpToLatest
-            Key = Some Key.End
-            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Key = Some End
+            Modifiers = Some ctrlShift
             Description = "Speech Cursor: jump to the latest entry" }
           { Command = SpeechCursorToggleMode
             Key = None
@@ -565,6 +573,9 @@ module HotkeyRegistry =
                 | Letter c -> string (System.Char.ToUpperInvariant c)
                 | Digit n -> string n
                 | Semicolon -> ";"
+                | Up -> "Up"
+                | Down -> "Down"
+                | End -> "End"
             Some (System.String.Join("+", modParts @ [ keyText ]))
         | _ -> None
 

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -496,21 +496,21 @@ module HotkeyRegistry =
           // (NVDA's default review-cursor commands are
           // `NVDA+Up/Down`).
           { Command = SpeechCursorNext
-            Key = None
-            Modifiers = None
-            Description = "Speech Cursor: move to the next entry (Cycle 45 Commit 2)" }
+            Key = Some Key.Down
+            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Description = "Speech Cursor: move to the next entry" }
           { Command = SpeechCursorPrevious
-            Key = None
-            Modifiers = None
-            Description = "Speech Cursor: move to the previous entry (Cycle 45 Commit 2)" }
+            Key = Some Key.Up
+            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Description = "Speech Cursor: move to the previous entry" }
           { Command = SpeechCursorJumpToLatest
-            Key = None
-            Modifiers = None
-            Description = "Speech Cursor: jump to the latest entry (Cycle 45 Commit 2)" }
+            Key = Some Key.End
+            Modifiers = Some (ModifierKeys.Control ||| ModifierKeys.Shift)
+            Description = "Speech Cursor: jump to the latest entry" }
           { Command = SpeechCursorToggleMode
             Key = None
             Modifiers = None
-            Description = "Speech Cursor: toggle AutoDrive / Manual mode (Cycle 45 Commit 2)" } ]
+            Description = "Speech Cursor: toggle AutoDrive / Manual mode (menu-only)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -68,7 +68,15 @@
                  (it's a diagnostic-relevant control, not a
                  display setting). Display now hosts only the
                  Earcons multi-state. -->
-            <MenuItem Header="_Display">
+            <!-- Cycle 48 post-PR-F (2026-05-13) — top-level
+                 "Display" renamed to "Interface" + the previous
+                 top-level "Data" menu nested inside it as a
+                 child submenu. Per maintainer dogfood of
+                 preview.118: top-level had too many siblings;
+                 grouping all interface-presentation + data-
+                 storage concerns under one umbrella reduces
+                 menu-bar scanning. -->
+            <MenuItem Header="_Interface">
                 <MenuItem x:Name="MenuItem_EarconsMode"
                           x:FieldModifier="public"
                           Header="_Earcons">
@@ -79,12 +87,6 @@
                               x:FieldModifier="public"
                               Header="_Muted" />
                 </MenuItem>
-                <!-- Cycle 45 Commit 2 — SpeechCursor navigation
-                     (menu-only). The cursor is the announce-and-
-                     navigate primitive over the ContentHistory
-                     substrate; AutoDrive announces new entries as
-                     they arrive; Manual lets the user navigate
-                     the history at their own pace. -->
                 <MenuItem Header="_Speech Cursor">
                     <MenuItem x:Name="MenuItem_SpeechCursorNext"
                               x:FieldModifier="public"
@@ -99,12 +101,6 @@
                               x:FieldModifier="public"
                               Header="Toggle _Mode (AutoDrive / Manual)" />
                 </MenuItem>
-                <!-- Cycle 45f — per-shell verbosity modes. Pick
-                     applies to the currently-active shell's
-                     runtime override (Layer 3 of the three-layer
-                     settings model); persists across hot-switches
-                     until app restart. See docs/USER-SETTINGS.md
-                     "Verbosity" for the resolution model. -->
                 <MenuItem x:Name="MenuItem_OutputVerbosity"
                           x:FieldModifier="public"
                           Header="_Output Verbosity">
@@ -131,41 +127,44 @@
                               x:FieldModifier="public"
                               Header="F_ull" />
                 </MenuItem>
-            </MenuItem>
-            <MenuItem Header="D_ata">
+                <!-- Cycle 48 post-PR-F (2026-05-13) — infrastructure
+                     items (open data folder, edit config) lifted
+                     from the old Data submenu to Interface direct
+                     level per maintainer feedback. They're not
+                     about command output; they're about where
+                     pty-speak's app data lives. The
+                     last-command + session-history items kept
+                     together under "Output History". -->
                 <MenuItem x:Name="MenuItem_OpenDataFolder"
                           x:FieldModifier="public"
-                          Header="_Open Data Folder" />
+                          Header="Open _Data Folder" />
                 <MenuItem x:Name="MenuItem_OpenConfig"
                           x:FieldModifier="public"
-                          Header="_Edit Config" />
-                <!-- Cycle 46 post-audit (2026-05-13) — group the
-                     two "last command output" affordances under a
-                     dedicated submenu so screen-reader navigation
-                     reaches both with one expand. The named
-                     MenuItems are reachable by the reflective
-                     binding loop (Program.fs ~line 3877) regardless
-                     of XAML nesting depth. -->
-                <MenuItem Header="_Last Output">
-                    <MenuItem x:Name="MenuItem_OpenLastOutput"
+                          Header="Edit _Config" />
+                <MenuItem Header="Output _History">
+                    <MenuItem Header="_Last Output">
+                        <MenuItem x:Name="MenuItem_OpenLastOutput"
+                                  x:FieldModifier="public"
+                                  Header="Open in _Text Editor" />
+                        <MenuItem x:Name="MenuItem_AnnounceLastOutput"
+                                  x:FieldModifier="public"
+                                  Header="_Announce Again" />
+                    </MenuItem>
+                    <MenuItem x:Name="MenuItem_CopyHistoryToClipboard"
                               x:FieldModifier="public"
-                              Header="_Open in Text Editor" />
-                    <MenuItem x:Name="MenuItem_AnnounceLastOutput"
+                              Header="_Copy Session History to Clipboard" />
+                    <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
                               x:FieldModifier="public"
-                              Header="_Announce Again" />
+                              Header="Announce _Session Log Path" />
                 </MenuItem>
-                <MenuItem x:Name="MenuItem_CopyHistoryToClipboard"
-                          x:FieldModifier="public"
-                          Header="Copy _History to Clipboard" />
-                <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
-                          x:FieldModifier="public"
-                          Header="Announce _Session Log Path" />
             </MenuItem>
+            <!-- Cycle 48 post-PR-F (2026-05-13) — Diagnostics
+                 reorganised into three submenus (Probe / Tests /
+                 Inspect) per maintainer preview.118 feedback.
+                 Top-level had ~10 items; grouping by "what it
+                 does" reduces scan depth. Logging Level stays
+                 at top because it's a frequent toggle. -->
             <MenuItem Header="Dia_gnostics">
-                <!-- Cycle 38a-followup — Logging Level moved here
-                     from Display (formerly View). It's a diagnostic
-                     verbosity control, not a display setting. First
-                     item so it's reachable without arrow-scrolling. -->
                 <MenuItem x:Name="MenuItem_LoggingLevel"
                           x:FieldModifier="public"
                           Header="Logging _Level">
@@ -176,95 +175,73 @@
                               x:FieldModifier="public"
                               Header="_Debug" />
                 </MenuItem>
-                <MenuItem x:Name="MenuItem_HealthCheck"
-                          x:FieldModifier="public"
-                          Header="_Health Check" />
-                <MenuItem x:Name="MenuItem_IncidentMarker"
-                          x:FieldModifier="public"
-                          Header="_Incident Marker" />
-                <MenuItem x:Name="MenuItem_RunDiagnostic"
-                          x:FieldModifier="public"
-                          Header="Run Diagnostic _Battery" />
-                <!-- Cycle 26c — first menu-only command (no
-                     keyboard accelerator). Launches the
-                     interactive process-cleanup test script in
-                     a separate PowerShell window. -->
-                <MenuItem x:Name="MenuItem_RunProcessCleanupScript"
-                          x:FieldModifier="public"
-                          Header="Test Process _Cleanup" />
-                <!-- Cycle 38a-followup — second menu-only command.
-                     Filters ACCESSIBILITY-TESTING.md to sections
-                     marked with the DOGFOOD HTML comment, renders
-                     Markdig HTML, and opens in the default browser
-                     for NVDA browse-mode H-key heading navigation. -->
-                <MenuItem x:Name="MenuItem_OpenManualTests"
-                          x:FieldModifier="public"
-                          Header="Open Manual _Tests" />
-                <!-- Cycle 47 — CMD interaction test corpus.
-                     Each child writes a quoted invocation of
-                     the corresponding scripts/cmd-tests/*.cmd
-                     script to the PTY input cursor (no Enter);
-                     the user reviews + presses Enter to run.
-                     All menu-only (no keyboard accelerators).
-                     Cycle 47 follow-up (2026-05-13): dropped
-                     the leading digit prefixes from sub-item
-                     headers — they caused NVDA to read
-                     "1, 1 of 8" as "11 of 8" by speech-running
-                     the mnemonic + position together. Letter
-                     mnemonics now (each unique among siblings)
-                     and the parent gets `_M` (i.e. C_MD Interaction
-                     Tests) so the submenu is reachable via
-                     Alt → G → M from the menu bar. Cycle 47
-                     follow-up post-preview.114 moved the parent
-                     mnemonic from `_C` to `_M` because the original
-                     `_C` collided with Diagnostics' "Test Process
-                     _Cleanup" — Alt + C resolved to whichever item
-                     was first in the menu, not the one the user
-                     intended. -->
-                <MenuItem Header="C_MD Interaction Tests">
-                    <MenuItem x:Name="MenuItem_CmdTestEcho"
+                <!-- Probe — quick "fire an action and watch what
+                     happens" probes: health check, incident
+                     marker, the diagnostic battery. The
+                     longer-running Process Cleanup Test moves
+                     to Test Scripts below (per maintainer
+                     preview.118 feedback) so the accelerators
+                     within Probe stay short + unique. -->
+                <MenuItem Header="_Probe">
+                    <MenuItem x:Name="MenuItem_HealthCheck"
                               x:FieldModifier="public"
-                              Header="_Simple Echo" />
-                    <MenuItem x:Name="MenuItem_CmdTestTextInput"
+                              Header="_Health Check" />
+                    <MenuItem x:Name="MenuItem_IncidentMarker"
                               x:FieldModifier="public"
-                              Header="_Text Input" />
-                    <MenuItem x:Name="MenuItem_CmdTestNumericInput"
+                              Header="_Incident Marker" />
+                    <MenuItem x:Name="MenuItem_RunDiagnostic"
                               x:FieldModifier="public"
-                              Header="_Numeric Input + Calculation" />
-                    <MenuItem x:Name="MenuItem_CmdTestYesNo"
-                              x:FieldModifier="public"
-                              Header="_Yes / No Choice" />
-                    <MenuItem x:Name="MenuItem_CmdTestMultiChoice"
-                              x:FieldModifier="public"
-                              Header="_Multi-Option Choice" />
-                    <MenuItem x:Name="MenuItem_CmdTestPause"
-                              x:FieldModifier="public"
-                              Header="_Pause / Continue" />
-                    <MenuItem x:Name="MenuItem_CmdTestProgress"
-                              x:FieldModifier="public"
-                              Header="Pro_gress Loop" />
-                    <MenuItem x:Name="MenuItem_CmdTestStderr"
-                              x:FieldModifier="public"
-                              Header="Stderr _Output" />
+                              Header="Run Diagnostic _Battery" />
                 </MenuItem>
-                <Separator />
-                <!-- Cycle 43a — diagnostic chunking. Top-level
-                     `Copy Latest Bundle` and `Grep Diagnostics`
-                     are the load-bearing triage tools; the
-                     `Extract` submenu tree provides the catalog of
-                     small targeted slices. All six items are
-                     menu-only (no keyboard accelerators) per the
-                     hotkey-count working-memory ceiling — the
-                     existing Ctrl+Shift+D path stays for users
-                     who want the full battery + clipboard copy
-                     in one keystroke. -->
-                <MenuItem x:Name="MenuItem_CopyLatestBundle"
-                          x:FieldModifier="public"
-                          Header="Copy Latest Bun_dle to Clipboard" />
-                <MenuItem x:Name="MenuItem_GrepDiagnostics"
-                          x:FieldModifier="public"
-                          Header="_Grep Diagnostics..." />
-                <MenuItem Header="E_xtract">
+                <!-- Test Scripts — runnable scripts that exercise
+                     specific subsystems. The CMD Interaction
+                     Tests submenu, the manual-test browser,
+                     and the process-cleanup test all live here
+                     per maintainer preview.118 feedback. -->
+                <MenuItem Header="_Test Scripts">
+                    <MenuItem x:Name="MenuItem_OpenManualTests"
+                              x:FieldModifier="public"
+                              Header="Open _Manual Tests" />
+                    <MenuItem x:Name="MenuItem_RunProcessCleanupScript"
+                              x:FieldModifier="public"
+                              Header="_Process Cleanup Test" />
+                    <MenuItem Header="_CMD Interaction Tests">
+                        <MenuItem x:Name="MenuItem_CmdTestEcho"
+                                  x:FieldModifier="public"
+                                  Header="_Simple Echo" />
+                        <MenuItem x:Name="MenuItem_CmdTestTextInput"
+                                  x:FieldModifier="public"
+                                  Header="_Text Input" />
+                        <MenuItem x:Name="MenuItem_CmdTestNumericInput"
+                                  x:FieldModifier="public"
+                                  Header="_Numeric Input + Calculation" />
+                        <MenuItem x:Name="MenuItem_CmdTestYesNo"
+                                  x:FieldModifier="public"
+                                  Header="_Yes / No Choice" />
+                        <MenuItem x:Name="MenuItem_CmdTestMultiChoice"
+                                  x:FieldModifier="public"
+                                  Header="_Multi-Option Choice" />
+                        <MenuItem x:Name="MenuItem_CmdTestPause"
+                                  x:FieldModifier="public"
+                                  Header="_Pause / Continue" />
+                        <MenuItem x:Name="MenuItem_CmdTestProgress"
+                                  x:FieldModifier="public"
+                                  Header="Pro_gress Loop" />
+                        <MenuItem x:Name="MenuItem_CmdTestStderr"
+                                  x:FieldModifier="public"
+                                  Header="Stderr _Output" />
+                    </MenuItem>
+                </MenuItem>
+                <!-- Inspect — "look at what already happened"
+                     tools: bundle copy, grep, extract submenu. -->
+                <MenuItem Header="_Inspect">
+                    <MenuItem x:Name="MenuItem_CopyLatestBundle"
+                              x:FieldModifier="public"
+                              Header="Copy Latest Bun_dle to Clipboard" />
+                    <MenuItem x:Name="MenuItem_GrepDiagnostics"
+                              x:FieldModifier="public"
+                              Header="_Grep Diagnostics..." />
+                    <MenuItem Header="E_xtract">
                     <MenuItem Header="By _Recency">
                         <MenuItem x:Name="MenuItem_ExtractLast50LogLines"
                                   x:FieldModifier="public"
@@ -324,6 +301,7 @@
                                   Header="Test 08 — _Stderr Output" />
                     </MenuItem>
                 </MenuItem>
+                </MenuItem><!-- /Inspect -->
             </MenuItem>
             <!-- Cycle 28 — Window menu. Both items are menu-only
                  commands (no keyboard accelerator registered with

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -689,6 +689,17 @@ public class TerminalView : FrameworkElement
             // binding for Ctrl+Shift+A.
             (Key.A, ModifierKeys.Control | ModifierKeys.Shift, "Re-narrate last command output (capped)"),
 
+            // Cycle 48 post-PR-F (2026-05-13) — SpeechCursor
+            // navigation accelerators. Per maintainer dogfood
+            // of preview.118: menu-only routing felt buried.
+            // Bound to Ctrl+Shift+Up/Down/End. NVDA collision
+            // check: default NVDA review-cursor commands are
+            // NVDA+Numpad-cluster gestures; Ctrl+Shift+arrows
+            // are free.
+            (Key.Up, ModifierKeys.Control | ModifierKeys.Shift, "Speech Cursor: previous entry"),
+            (Key.Down, ModifierKeys.Control | ModifierKeys.Shift, "Speech Cursor: next entry"),
+            (Key.End, ModifierKeys.Control | ModifierKeys.Shift, "Speech Cursor: jump to latest"),
+
             // Future entries (NOT yet bound; commented for
             // forward-planning):
             //   (Key.R, ModifierKeys.Alt | ModifierKeys.Shift,

--- a/tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs
+++ b/tests/Tests.Unit/AppReservedHotkeysMirrorTests.fs
@@ -64,6 +64,9 @@ let private translateKey (k: HotkeyRegistry.HotkeyKey) : Key =
         | 7 -> Key.D7 | 8 -> Key.D8 | 9 -> Key.D9
         | other -> failwithf "translateKey: unmapped digit %d" other
     | HotkeyRegistry.Semicolon -> Key.OemSemicolon
+    | HotkeyRegistry.Up -> Key.Up
+    | HotkeyRegistry.Down -> Key.Down
+    | HotkeyRegistry.End -> Key.End
 
 let private translateMods (mods: Set<HotkeyRegistry.Modifier>) : ModifierKeys =
     let mutable result = ModifierKeys.None


### PR DESCRIPTION
## Summary

Three post-PR-F follow-ups from your preview.118 dogfood:

### 1. `Ctrl+Shift+Up/Down/End` bound to SpeechCursor

Previous / Next / JumpToLatest. Was menu-only; the
HotkeyRegistry had a comment anticipating this since Cycle
45. Mirror rows in `TerminalView.AppReservedHotkeys` ship
alongside per the F#/C# parity tests.

### 2. Menu reorg

- **Top-level**: "Display" → "Interface". "Data" dissolved.
- **Interface** now: Earcons, Speech Cursor, Output
  Verbosity, Prompt Path, **Open Data Folder** (lifted),
  **Edit Config** (lifted), **Output History** (submenu
  containing Last Output → text editor / re-announce, Copy
  Session History, Announce Session Log Path).
- **Diagnostics**: Logging Level (kept at top); **Probe**
  (Health Check, Incident Marker, Run Diagnostic Battery);
  **Test Scripts** (Open Manual Tests, Process Cleanup
  Test, CMD Interaction Tests); **Inspect** (Copy Latest
  Bundle, Grep Diagnostics, Extract).
- "Test Process Cleanup" moved from Probe → Test Scripts
  (your "push that into a sub-menu of some other category").
- All mnemonics audited; no conflicts within each submenu.

### 3. Sub-prompt announce strips command echo

Test 02 (`set/p`) announced
`"set /p name=Enter your name:Enter your name:"` after
pressing Enter — cmd echoes the typed command line to stdout
before emitting the sub-prompt; the SubPromptIdle accumulator
captured both. `recordTransition` now drops everything up to
and including the first `\n` before announcing. Just the
sub-prompt text remains.

Same root cause as the "path or other information" you heard
on test 03's input prompt — the script-invocation line was
in the accumulator. Fix addresses both.

## Test plan

- [ ] CI green
- [ ] `Ctrl+Shift+Up/Down/End` step through SpeechCursor
- [ ] Test 02: pressing Enter on the set/p prompt produces
      just "Enter your name:" announcement, not the
      garbled doubled version
- [ ] Test 03: numeric input prompt clean
- [ ] Menu structure: Interface (Alt+I) opens with
      Earcons/Speech Cursor/etc/Open Data Folder/Edit
      Config/Output History; Diagnostics (Alt+G) opens with
      Logging Level/Probe/Test Scripts/Inspect

## Known not-fixed

- "Need extra command to refresh review cursor" — UIA
  caching, harder, deferred.
- SpeechCursor may step through many filtered-out entries
  before finding audible content; revisit if it stays
  painful after the hotkey binding ships.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_