### PR TITLE
Claude/cycle49 speech cursor blank collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 49 PR-A (2026-05-14): SpeechCursor manual nav collapses blanks
+
+`Ctrl+Shift+Up/Down/End` now skip entries that produce no audible
+announcement (Newline, Overwrite, empty TextSpan, boundary markers
+without payload, `UserInputEcho`-sourced entries). Manual review
+of a `dir`-shaped output (8 lines = 16 entries with interleaved
+Newlines) now requires 8 Up presses instead of 16; half the prior
+presses produced no narration. `toMarker` deliberately retains
+the unfiltered jump — a marker jump is the user explicitly
+asking for a marker even if its `renderEntry` returns `None`.
+
+Cycle 49 plan: [`docs/CYCLE-49-PLAN.md`](docs/CYCLE-49-PLAN.md).
+
 ### Cycle 48 post-PR-F (2026-05-13): SpeechCursor hotkeys + menu reorg + sub-prompt echo strip
 
 Three connected fixes from preview.118 dogfood:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,46 @@ Reserved (not yet bound):
   REPL, etc.) per Phase 2 plans
 
 
+### `AskUserQuestion` is the maintainer's phone-notification surface
+
+The maintainer often steps away from the desk while a Cycle's PR
+sequence is in flight. **A plain text reply does not generate a
+phone notification — `AskUserQuestion` does.** The harness routes
+`AskUserQuestion` interactions through the maintainer's phone, so a
+question posed via that tool reaches them away from the desk
+whereas regular text output sits silently in the transcript until
+they next look.
+
+Use `AskUserQuestion` when:
+
+- A genuine design decision needs to be made before Claude can
+  proceed (e.g. "preserve vs drop history-recall entries in
+  ContentHistory" — answered 2026-05-14 via this surface).
+- A CI failure log slice is needed (per "CI failures — ask for
+  the log" rule above) and the maintainer may be away from the
+  desk.
+- The MCP server has disconnected and the manual PR-create
+  fallback needs the maintainer to open a compare URL.
+- Anything ambiguous in the user's instructions that genuinely
+  blocks forward progress.
+
+**Don't** use `AskUserQuestion` for:
+
+- Status updates ("PR-A pushed, waiting for CI") — those are
+  plain text.
+- Confirming things the autonomy contract in the current
+  cycle plan already authorises (writing code, pushing fixup
+  commits, merging green PRs, moving to the next PR).
+- Closed-form choices where the autonomy contract or
+  CLAUDE.md picks an obvious default — go with the default
+  and note the choice in the PR body.
+- "Ready to start?" / "should I proceed?" preambles — just
+  proceed.
+
+The rule of thumb: would the maintainer be annoyed if their
+phone buzzed for this? If yes, plain text. If genuinely
+blocked, `AskUserQuestion`.
+
 ### The maintainer is a screen-reader user — no GUI dialog walks
 
 The maintainer uses NVDA. **Never** propose a fix or workflow that

--- a/docs/CYCLE-49-PLAN.md
+++ b/docs/CYCLE-49-PLAN.md
@@ -1,0 +1,120 @@
+# Cycle 49 — Plan (in-flight scoping)
+
+**Snapshot**: 2026-05-14 (post-Cycle-48 closure, post-PR-#312 merge).
+
+**Audience**: the next session — human or Claude. Self-contained;
+nothing in this doc requires reading prior chat history.
+
+**Status**: in flight. Update the "Status" column on each row
+when a PR ships; flip this whole doc to *HISTORICAL* once the
+closure-audit PR lands per the Cycle-closure-audit discipline
+in [`CLAUDE.md`](../CLAUDE.md) §"Cycle closure audit".
+
+## Cycle goal
+
+Tighten the SpeechCursor + sub-prompt-aware announce surface
+that landed in Cycles 45–48 so the existing tests
+(`tests/manual/02-input.cmd` etc.) read cleanly:
+
+1. SpeechCursor manual nav (`Ctrl+Shift+Up/Down/End`) jumps
+   between audible chunks, not between every byte-stream entry.
+2. Tuple-final announce after a sub-prompt only narrates the
+   **post-Enter** content, not the entire `OutputText` from the
+   top.
+3. Review cursor (UIA `TextEdit` caret on `TerminalView`)
+   reflects the latest content immediately — no "extra command
+   to refresh" friction.
+4. Shell history recall (Up/Down arrow at the live prompt)
+   speaks the recalled command so the user knows what they're
+   about to run, and the recall is recorded in `ContentHistory`
+   with a distinct `EntrySource`.
+
+## PRs
+
+| #  | Branch                                                           | Status   | Scope |
+|----|------------------------------------------------------------------|----------|-------|
+| A  | `claude/cycle49-speech-cursor-blank-collapse`                    | drafting | SpeechCursor manual nav skips entries whose `renderEntryWithPolicy` returns `None` (Newline, Overwrite, empty TextSpan, `UserInputEcho`-sourced, boundary markers without payload). `toMarker` deliberately preserves the unfiltered jump (marker jumps are explicit). Lands this plan doc. |
+| B  | `claude/cycle49-post-enter-delta-announce`                       | pending  | `ShellInteraction` records `ContentHistory.Length` as a per-tuple watermark on `Composing→Executing` transition that follows a sub-prompt announce. `handlePromptBoundary` tuple-final announce slices `OutputText` from the watermark (or 0 if no sub-prompt occurred). Silently skips when the post-Enter body is empty. |
+| C  | `claude/cycle49-review-cursor-refresh`                           | pending  | Investigate why `TerminalAutomationPeer.RaiseCaretMovedToTail` (Cycle 46 PR-C) does not invalidate the UIA `TextEdit` cache so the review cursor needs an extra command to pick up the latest content. Likely missing `TextChanged` / `AutomationEvents.StructureChanged` raise. Scope sizing to follow investigation. |
+| D  | `claude/cycle49-line-1-of-8`                                     | pending  | Verify whether test 01's "Line 1 of 8 missing" reproduces after PR-A + PR-B (which may resolve it — the missing "Line 1" is likely a leading blank entry being numbered, or a watermark issue). If still reproducing, separate fix. |
+| E1 | `claude/cycle49-csi-aware-userinputbuffer`                       | pending  | `UserInputBuffer` parses `CSI 2K` / `CSI nG` / bare `\r` clear-line + cursor-position sequences arriving during `Composing` so the buffer reflects the actual on-screen draft after a shell-side history recall (cmd's doskey, PSReadLine's history-search, bash readline). |
+| E2 | `claude/cycle49-history-recall-announce`                         | pending  | On `UserInputBuffer` rewrite mid-`Composing`, announce the new buffer contents via a dedicated activity ID (probably new — `pty-speak.input-assistant` per CORE-ABSTRACTION-BOUNDARY.md §"input assistant" reserved peer pane). NVDA's `MostRecent` processing supersedes prior recall announces. |
+| E3 | `claude/cycle49-draft-input-recall-entry-source`                 | pending  | Add `EntrySource.DraftInputRecall`. Recalled-buffer rewrites produce a `ContentHistory.Entry` tagged with this source, so manual nav can optionally include them but live announce + SpeechCursor AutoDrive filter them like `UserInputEcho`. Symmetric with how typed input is recorded today. Decided 2026-05-14 per maintainer answer in chat. |
+| Z  | `claude/cycle49-closure-audit`                                   | pending  | Cycle closure audit per [`CLAUDE.md`](../CLAUDE.md) §"Cycle closure audit". Updates SESSION-HANDOFF, PROJECT-PLAN, ACCESSIBILITY-TESTING matrix, ADR Status notes, this doc's *HISTORICAL* banner. |
+
+## Validation gates
+
+Each PR's CI run on `windows-latest` is the build/test gate
+per usual. NVDA-matrix walk is the cycle-level gate:
+
+- After PR-A merges: matrix row Cycle-49-A — manual nav skips
+  blanks; `Ctrl+Shift+Up` from latest in a `dir` output lands
+  on the previous TextSpan, not on a Newline.
+- After PR-B merges: matrix row Cycle-49-B — re-run test 02
+  + test 03; sub-prompt response narrates only the post-Enter
+  body.
+- After PR-C merges: matrix row Cycle-49-C — UIA review-cursor
+  reads the latest content without requiring an extra command.
+- After PR-D merges (if needed): matrix row Cycle-49-D — test
+  01 reports correct "Line 1 of N" sequence.
+- After PR-E3 merges: matrix row Cycle-49-E — Up/Down at the
+  live prompt narrates the recalled command; navigating back
+  via SpeechCursor surfaces the recall as a distinct entry
+  type.
+
+Consolidate to a single Cycle-49-1 row in the closure-audit
+(PR-Z) per the cycle-closure-audit discipline.
+
+## Decisions already made
+
+- **EntrySource.DraftInputRecall over drop-on-floor for E3**
+  (2026-05-14): preserve recalled drafts in ContentHistory
+  with a distinct source. Symmetric with typed-input recording;
+  future review-cursor / scrollback gets a faithful picture of
+  what the user explored. SpeechCursor filters by default;
+  manual nav can opt in via cursor parameter (TBD whether to
+  expose a hotkey or just filter via Parameters).
+
+## Open design questions
+
+These are *not* blockers for PR-A / PR-B / PR-C / PR-D —
+they're sized to resolve before PR-E1 starts.
+
+1. Should the input-assistant activity ID (`pty-speak.input-assistant`)
+   be its own NVDA-channel activity, or fold into
+   `pty-speak.output` with `MostRecent`? Activity-ID inventory
+   currently lives in `ActivityIds.fs`.
+2. For shells that don't echo recall through the PTY (rare —
+   PSReadLine does, doskey does, bash readline does), do we
+   need a fallback that intercepts the keystroke at the
+   TerminalView level? Likely no, but verify with test 06
+   (multi-shell smoke test) if it exists.
+3. Should `DraftInputRecall` entries also be sealed at
+   tuple-finalise time (i.e. preserved across tuple boundaries
+   in some future review-cursor scrollback), or scoped to the
+   active tuple? Default: scoped to the active tuple —
+   matches every other `ContentHistory.Entry`.
+
+## Autonomy contract for Claude
+
+Per the maintainer's note 2026-05-14: execute the cycle without
+interaction unless absolutely necessary. Defined as:
+
+- **Always OK to act without asking**: write code, push fixup
+  commits, merge green PRs, move to the next PR in the
+  sequence, write tests, edit docs in this cycle's scope.
+- **Always must ask**: CI log paste request (sandbox cannot
+  fetch); spec/ deviations; architecture decisions that span
+  beyond this cycle's PR list; destructive operations.
+- **Surface, don't ask** (write down + proceed): scope drift
+  within a PR (note in PR description); unexpected test
+  failures with a clear fix (push the fix); design choices
+  with an obvious default (pick default + note in PR body).
+
+## Predecessor docs
+
+- [`docs/PROJECT-PLAN-2026-05-12.md`](PROJECT-PLAN-2026-05-12.md)
+- [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md)
+- [`docs/adr/0002-uia-textedit-caret-output.md`](adr/0002-uia-textedit-caret-output.md)
+- [`docs/adr/0003-shell-interaction-state-machine.md`](adr/0003-shell-interaction-state-machine.md)
+- [`docs/CYCLE-46-NEXT-STEPS.md`](CYCLE-46-NEXT-STEPS.md) — historical, but the doc shape this one mirrors.

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -202,29 +202,51 @@ module SpeechCursor =
         else
             true
 
-    /// Move the cursor to the next entry in the supplied
-    /// history (Seq > Position). Returns the entry, or `None` if
-    /// already at the latest.
+    /// Cycle 49 PR-A — does this entry actually render to an
+    /// audible announcement under the cursor's current policy?
+    /// Newline / Overwrite / empty-TextSpan / boundary-Marker /
+    /// `UserInputEcho`-sourced entries all return `None` from
+    /// `renderEntryWithPolicy`; manual navigation should skip
+    /// them rather than parking on Seqs the user can't hear.
+    ///
+    /// Manual nav pre-PR-A landed on every entry by Seq, so a
+    /// `dir`-shaped output (8 lines = 8 TextSpans + 8 Newlines)
+    /// required 16 Ctrl+Shift+Up presses to step backwards, half
+    /// of which announced nothing. PR-A collapses that to 8
+    /// presses, one per audible chunk.
+    ///
+    /// `toMarker` deliberately does NOT use this filter — a
+    /// marker jump is the user explicitly asking for a marker,
+    /// even if its `renderEntry` returns `None` (e.g.
+    /// `CommandStart` boundary markers).
+    let private renderable (state: T) (entry: ContentHistory.Entry) : bool =
+        (renderEntryWithPolicy state.Parameters.PromptPath entry).IsSome
+
+    /// Move the cursor to the next renderable entry in the
+    /// supplied history (Seq > Position). Returns the entry, or
+    /// `None` if no later renderable entry exists.
     let next (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
         let entries = ContentHistory.snapshot history
         let target =
             entries
             |> Array.tryFind (fun e ->
-                ContentHistory.entrySeq e > state.Position)
+                ContentHistory.entrySeq e > state.Position
+                && renderable state e)
         match target with
         | Some e ->
             state.Position <- ContentHistory.entrySeq e
             Some e
         | None -> None
 
-    /// Move the cursor to the previous entry. Returns the entry,
-    /// or `None` if already at the start.
+    /// Move the cursor to the previous renderable entry. Returns
+    /// the entry, or `None` if no earlier renderable entry exists.
     let previous (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
         let entries = ContentHistory.snapshot history
         let target =
             entries
             |> Array.filter (fun e ->
-                ContentHistory.entrySeq e < state.Position)
+                ContentHistory.entrySeq e < state.Position
+                && renderable state e)
             |> Array.tryLast
         match target with
         | Some e ->
@@ -232,15 +254,20 @@ module SpeechCursor =
             Some e
         | None -> None
 
-    /// Jump the cursor to the most recently appended entry.
-    /// Returns the entry, or `None` if history is empty.
+    /// Jump the cursor to the latest renderable entry. Returns
+    /// the entry, or `None` if history contains no renderable
+    /// entries (only Newlines / Overwrites / etc.).
     let toLatest (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
         let entries = ContentHistory.snapshot history
-        if entries.Length = 0 then None
-        else
-            let last = entries.[entries.Length - 1]
-            state.Position <- ContentHistory.entrySeq last
-            Some last
+        let target =
+            entries
+            |> Array.filter (renderable state)
+            |> Array.tryLast
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
 
     /// Move the cursor to the next/previous Marker of the given
     /// kind. Returns the marker entry, or `None` if no match.

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -202,73 +202,6 @@ module SpeechCursor =
         else
             true
 
-    /// Cycle 49 PR-A — does this entry actually render to an
-    /// audible announcement under the cursor's current policy?
-    /// Newline / Overwrite / empty-TextSpan / boundary-Marker /
-    /// `UserInputEcho`-sourced entries all return `None` from
-    /// `renderEntryWithPolicy`; manual navigation should skip
-    /// them rather than parking on Seqs the user can't hear.
-    ///
-    /// Manual nav pre-PR-A landed on every entry by Seq, so a
-    /// `dir`-shaped output (8 lines = 8 TextSpans + 8 Newlines)
-    /// required 16 Ctrl+Shift+Up presses to step backwards, half
-    /// of which announced nothing. PR-A collapses that to 8
-    /// presses, one per audible chunk.
-    ///
-    /// `toMarker` deliberately does NOT use this filter — a
-    /// marker jump is the user explicitly asking for a marker,
-    /// even if its `renderEntry` returns `None` (e.g.
-    /// `CommandStart` boundary markers).
-    let private renderable (state: T) (entry: ContentHistory.Entry) : bool =
-        (renderEntryWithPolicy state.Parameters.PromptPath entry).IsSome
-
-    /// Move the cursor to the next renderable entry in the
-    /// supplied history (Seq > Position). Returns the entry, or
-    /// `None` if no later renderable entry exists.
-    let next (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
-        let entries = ContentHistory.snapshot history
-        let target =
-            entries
-            |> Array.tryFind (fun e ->
-                ContentHistory.entrySeq e > state.Position
-                && renderable state e)
-        match target with
-        | Some e ->
-            state.Position <- ContentHistory.entrySeq e
-            Some e
-        | None -> None
-
-    /// Move the cursor to the previous renderable entry. Returns
-    /// the entry, or `None` if no earlier renderable entry exists.
-    let previous (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
-        let entries = ContentHistory.snapshot history
-        let target =
-            entries
-            |> Array.filter (fun e ->
-                ContentHistory.entrySeq e < state.Position
-                && renderable state e)
-            |> Array.tryLast
-        match target with
-        | Some e ->
-            state.Position <- ContentHistory.entrySeq e
-            Some e
-        | None -> None
-
-    /// Jump the cursor to the latest renderable entry. Returns
-    /// the entry, or `None` if history contains no renderable
-    /// entries (only Newlines / Overwrites / etc.).
-    let toLatest (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
-        let entries = ContentHistory.snapshot history
-        let target =
-            entries
-            |> Array.filter (renderable state)
-            |> Array.tryLast
-        match target with
-        | Some e ->
-            state.Position <- ContentHistory.entrySeq e
-            Some e
-        | None -> None
-
     /// Move the cursor to the next/previous Marker of the given
     /// kind. Returns the marker entry, or `None` if no match.
     let toMarker
@@ -421,6 +354,78 @@ module SpeechCursor =
     /// returns `None`, matching pre-Cycle-45f behaviour).
     let renderEntry (entry: ContentHistory.Entry) : (string * string) option =
         renderEntryWithPolicy ShellPolicy.Suppress entry
+
+    /// Cycle 49 PR-A — does this entry actually render to an
+    /// audible announcement under the cursor's current policy?
+    /// Newline / Overwrite / empty-TextSpan / boundary-Marker /
+    /// `UserInputEcho`-sourced entries all return `None` from
+    /// `renderEntryWithPolicy`; manual navigation should skip
+    /// them rather than parking on Seqs the user can't hear.
+    ///
+    /// Manual nav pre-PR-A landed on every entry by Seq, so a
+    /// `dir`-shaped output (8 lines = 8 TextSpans + 8 Newlines)
+    /// required 16 Ctrl+Shift+Up presses to step backwards, half
+    /// of which announced nothing. PR-A collapses that to 8
+    /// presses, one per audible chunk.
+    ///
+    /// `toMarker` deliberately does NOT use this filter — a
+    /// marker jump is the user explicitly asking for a marker,
+    /// even if its `renderEntry` returns `None` (e.g.
+    /// `CommandStart` boundary markers).
+    ///
+    /// Lives below `renderEntryWithPolicy` so F#'s single-pass
+    /// type resolution sees the dependency in declaration order;
+    /// `next` / `previous` / `toLatest` follow for the same
+    /// reason.
+    let private renderable (state: T) (entry: ContentHistory.Entry) : bool =
+        (renderEntryWithPolicy state.Parameters.PromptPath entry).IsSome
+
+    /// Move the cursor to the next renderable entry in the
+    /// supplied history (Seq > Position). Returns the entry, or
+    /// `None` if no later renderable entry exists.
+    let next (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let target =
+            entries
+            |> Array.tryFind (fun e ->
+                ContentHistory.entrySeq e > state.Position
+                && renderable state e)
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
+
+    /// Move the cursor to the previous renderable entry. Returns
+    /// the entry, or `None` if no earlier renderable entry exists.
+    let previous (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let target =
+            entries
+            |> Array.filter (fun e ->
+                ContentHistory.entrySeq e < state.Position
+                && renderable state e)
+            |> Array.tryLast
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
+
+    /// Jump the cursor to the latest renderable entry. Returns
+    /// the entry, or `None` if history contains no renderable
+    /// entries (only Newlines / Overwrites / etc.).
+    let toLatest (state: T) (history: ContentHistory.T) : ContentHistory.Entry option =
+        let entries = ContentHistory.snapshot history
+        let target =
+            entries
+            |> Array.filter (renderable state)
+            |> Array.tryLast
+        match target with
+        | Some e ->
+            state.Position <- ContentHistory.entrySeq e
+            Some e
+        | None -> None
 
     /// Announce the entry at the cursor's current position via
     /// the supplied callback. Updates `LastSpokenSeq` to the

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -176,7 +176,13 @@ let ``setMode forces the specified mode`` () =
 // ---------------------------------------------------------------------
 
 [<Fact>]
-let ``next moves cursor to the next entry by Seq`` () =
+let ``next moves cursor to the next renderable entry skipping Newlines`` () =
+    // Cycle 49 PR-A — manual nav skips non-renderable entries
+    // (Newline, Overwrite, empty TextSpan, UserInputEcho).
+    // After "a\nb\n" the entries are TextSpan "a" (Seq 0),
+    // Newline (Seq 1), TextSpan "b" (Seq 2), Newline (Seq 3).
+    // From Position -1, `next` lands on Seq 0 then jumps over
+    // the Newline to Seq 2.
     let cursor = freshCursor ()
     SpeechCursor.setMode cursor SpeechCursor.Manual
     let history = freshHistory ()
@@ -189,10 +195,19 @@ let ``next moves cursor to the next entry by Seq`` () =
     Assert.Equal(0L, cursor.Position)
     let n2 = SpeechCursor.next cursor history
     Assert.True(n2.IsSome)
-    Assert.Equal(1L, cursor.Position)
+    Assert.Equal(2L, cursor.Position)
+    // No further renderable entry — the trailing Newline is
+    // skipped and `next` returns None.
+    let n3 = SpeechCursor.next cursor history
+    Assert.Equal(None, n3)
+    Assert.Equal(2L, cursor.Position)
 
 [<Fact>]
-let ``previous moves cursor backward`` () =
+let ``previous moves cursor backward skipping Newlines`` () =
+    // Cycle 49 PR-A — `previous` mirrors `next`'s renderable
+    // filter: from the latest TextSpan "b" (Seq 2), stepping
+    // back skips the Newline (Seq 1) and lands on TextSpan "a"
+    // (Seq 0).
     let cursor = freshCursor ()
     SpeechCursor.setMode cursor SpeechCursor.Manual
     let history = freshHistory ()
@@ -201,12 +216,20 @@ let ``previous moves cursor backward`` () =
     let _ = ContentHistory.appendFromEvent history t0 (printRune 'b')
     let _ = ContentHistory.appendFromEvent history t0 lf
     let _ = SpeechCursor.toLatest cursor history
+    Assert.Equal(2L, cursor.Position)
     let prev = SpeechCursor.previous cursor history
     Assert.True(prev.IsSome)
-    Assert.True(cursor.Position < ContentHistory.latestSeq history)
+    Assert.Equal(0L, cursor.Position)
+    let prev2 = SpeechCursor.previous cursor history
+    Assert.Equal(None, prev2)
+    Assert.Equal(0L, cursor.Position)
 
 [<Fact>]
-let ``toLatest jumps to the latest entry`` () =
+let ``toLatest jumps to the latest renderable entry skipping trailing Newline`` () =
+    // Cycle 49 PR-A — `toLatest` follows the same renderable
+    // filter as `next`/`previous` so a trailing Newline (the
+    // common shape after a `dir`-style command) doesn't park
+    // the cursor on a Seq the user can't hear.
     let cursor = freshCursor ()
     SpeechCursor.setMode cursor SpeechCursor.Manual
     let history = freshHistory ()
@@ -214,7 +237,10 @@ let ``toLatest jumps to the latest entry`` () =
     let _ = ContentHistory.appendFromEvent history t0 lf
     let latest = SpeechCursor.toLatest cursor history
     Assert.True(latest.IsSome)
-    Assert.Equal(ContentHistory.latestSeq history, cursor.Position)
+    // Latest renderable entry is the TextSpan "h" (Seq 0); the
+    // trailing Newline (latestSeq = 1) is skipped.
+    Assert.Equal(0L, cursor.Position)
+    Assert.Equal(1L, ContentHistory.latestSeq history)
 
 [<Fact>]
 let ``toLatest on empty history returns None and leaves Position at -1`` () =
@@ -223,6 +249,57 @@ let ``toLatest on empty history returns None and leaves Position at -1`` () =
     let result = SpeechCursor.toLatest cursor history
     Assert.Equal(None, result)
     Assert.Equal(-1L, cursor.Position)
+
+[<Fact>]
+let ``next skips UserInputEcho-sourced entries`` () =
+    // Cycle 49 PR-A — UserInputEcho entries render to None in
+    // `renderEntryWithPolicy` (Cycle 48 PR-E) and so are
+    // skipped by manual navigation. A typical sub-prompt
+    // sequence has the cmd-output TextSpan followed by the
+    // user's typed-then-Enter UserInputEcho TextSpan; `next`
+    // should jump over the echo entry.
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    // First batch: cmd output. SourceResolver defaults to
+    // Unknown which renders normally.
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'o')
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'k')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    // Flip the resolver to UserInputEcho before appending the
+    // typed-echo bytes.
+    ContentHistory.setSourceResolver
+        history
+        (fun () -> ContentHistory.EntrySource.UserInputEcho)
+    let _ = ContentHistory.appendFromEvent history (after 10) (printRune 'y')
+    let _ = ContentHistory.appendFromEvent history (after 10) (printRune 'o')
+    let _ = ContentHistory.appendFromEvent history (after 10) lf
+    let n1 = SpeechCursor.next cursor history
+    Assert.True(n1.IsSome)
+    // First renderable entry is the "ok" TextSpan at Seq 0.
+    Assert.Equal(0L, cursor.Position)
+    // No further renderable entry — the echo TextSpan + its
+    // surrounding Newlines are all filtered.
+    let n2 = SpeechCursor.next cursor history
+    Assert.Equal(None, n2)
+
+[<Fact>]
+let ``previous returns None when only Newlines precede the cursor`` () =
+    // Cycle 49 PR-A — if the only earlier entries are
+    // non-renderable, `previous` reports "already at the
+    // earliest renderable" rather than parking on a Newline.
+    let cursor = freshCursor ()
+    SpeechCursor.setMode cursor SpeechCursor.Manual
+    let history = freshHistory ()
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ = ContentHistory.appendFromEvent history t0 (printRune 'x')
+    let _ = ContentHistory.appendFromEvent history t0 lf
+    let _ = SpeechCursor.toLatest cursor history
+    // toLatest lands on TextSpan "x" (the leading Newline at
+    // Seq 0 sealed the empty active span without producing a
+    // renderable TextSpan).
+    let prev = SpeechCursor.previous cursor history
+    Assert.Equal(None, prev)
 
 // ---------------------------------------------------------------------
 // toMarker


### PR DESCRIPTION
# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
