### PR TITLE
feat: post-Enter delta announce for sub-prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 49 PR-B (2026-05-14): post-Enter delta announce for sub-prompts
+
+When the user responds to a sub-prompt (`set /p`, `pause`,
+`choice`, etc.) and presses Enter, the tuple-finalise announce
+now narrates **only the post-Enter content** instead of replaying
+the entire `OutputText` from the top of the command. The
+sub-prompt's prompt text and the user's typed response remain
+reachable via `Ctrl+Shift+Up/Down` SpeechCursor manual review.
+
+Mechanism: at `EnterPressed` after a `SubPromptIdle`, the
+composition root snapshots the screen and renders the active
+tuple's output rows from the prompt row through the cursor row
+into `lastAnnouncedText`. The existing tuple-finalise prefix-trim
+(introduced in the Cycle 48 post-PR-F batch) then slices that
+preamble off `tuple.OutputText` so only the bytes the script
+produced **after** the user submitted their response get
+announced. Test 02 (`02-input.cmd`) used to re-narrate "This is
+the input test." through "Hello, John!" verbatim each time the
+user hit Enter; now it speaks just the post-Enter delta.
+
+Cycle 49 plan: [`docs/CYCLE-49-PLAN.md`](docs/CYCLE-49-PLAN.md).
+
 ### Cycle 49 PR-A (2026-05-14): SpeechCursor manual nav collapses blanks
 
 `Ctrl+Shift+Up/Down/End` now skip entries that produce no audible

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -990,6 +990,34 @@ module Program =
         // ContentHistory seqs. Resets to "" on shell hot-switch.
         let mutable lastAnnouncedText : string = ""
 
+        // Cycle 49 PR-B — sub-prompt response watermark.
+        //
+        // `awaitingSubPromptEnter` flips true when SubPromptIdle
+        // transitions Executing → Composing (a sub-prompt has
+        // surfaced); flips false on EnterPressed (the user
+        // submitted) OR PromptDetected (a new top-level prompt
+        // arrived without the user ever responding to the sub-
+        // prompt — script bailed, shell crashed, etc.).
+        //
+        // `capturePreambleForSubPromptResponse` is installed
+        // further down (after `currentSession` enters scope) and
+        // overwrites `lastAnnouncedText` with the full on-screen
+        // content rendered from the active tuple's prompt row
+        // through the cursor row at EnterPressed time. The
+        // existing tuple-finalise prefix-trim (search for
+        // `lastAnnouncedText.Length > 0` below) then slices that
+        // preamble off `tuple.OutputText` so only the post-Enter
+        // delta gets announced. Test 02 (`set /p name=`) used to
+        // narrate the entire output from "This is the input
+        // test." down because `lastAnnouncedText` only carried
+        // the sub-prompt's own announce text (`"Enter your
+        // name:"`); the screen-rendered preamble captured here
+        // matches `tuple.OutputText`'s prefix and the
+        // existing trim fires.
+        let mutable awaitingSubPromptEnter : bool = false
+        let mutable capturePreambleForSubPromptResponse
+            : (unit -> unit) = (fun () -> ())
+
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
         // so the prompt-boundary handler and the selection-
@@ -1616,6 +1644,25 @@ module Program =
                                 "shell-interaction-sub-prompt"
                                 ""
                         OutputDispatcher.dispatch readyEvent
+                    // Cycle 49 PR-B — sub-prompt response
+                    // watermark bookkeeping. Track whether the
+                    // most recent state change parked us in
+                    // Composing-via-SubPromptIdle so the upcoming
+                    // EnterPressed can overwrite `lastAnnouncedText`
+                    // with the full on-screen preamble and the
+                    // tuple-finalise prefix-trim downstream slices
+                    // the post-Enter delta cleanly. PromptDetected
+                    // resets the flag in case the user never
+                    // responded (script bailed mid sub-prompt).
+                    match outcome.Trigger with
+                    | ShellInteraction.SubPromptIdle _ when isSubPromptTransition ->
+                        awaitingSubPromptEnter <- true
+                    | ShellInteraction.PromptDetected _ ->
+                        awaitingSubPromptEnter <- false
+                    | ShellInteraction.EnterPressed _ when awaitingSubPromptEnter ->
+                        capturePreambleForSubPromptResponse ()
+                        awaitingSubPromptEnter <- false
+                    | _ -> ()
                 | None ->
                     shellInteractionLog.LogDebug(
                         "ShellInteraction trigger no-op for current state: {State} --[{Trigger}]--",
@@ -1669,6 +1716,57 @@ module Program =
         // Cycle 24c — initial sink for the first shell's
         // SessionId. None when persistence is MemoryOnly.
         sessionLogWriter <- sessionLogWriterFactory currentSession.SessionId
+
+        // Cycle 49 PR-B — install the real
+        // `capturePreambleForSubPromptResponse` body now that
+        // `currentSession` is in scope. recordTransitionImpl
+        // (declared earlier) invokes this whenever the user
+        // presses Enter on a sub-prompt response so the
+        // tuple-finalise prefix-trim sees the full on-screen
+        // preamble in `lastAnnouncedText` and only announces the
+        // post-Enter delta.
+        //
+        // Runs on the UI thread (same thread the keyboard write
+        // callback and the dispatcher-timer SubPromptIdle tick
+        // run on). `screen.SnapshotRows` is thread-safe (the
+        // parser dispatches its mutations through the same
+        // dispatcher), and `currentSession` is read only here on
+        // the dispatcher thread, so no extra synchronisation
+        // beyond the existing actor-model contract is needed.
+        capturePreambleForSubPromptResponse <-
+            fun () ->
+                try
+                    let _, (cursorRow, _), snapshot =
+                        screen.SnapshotRows(0, screen.Rows)
+                    let promptRowOpt =
+                        match currentSession.Active with
+                        | Some active -> active.PromptRowIndex
+                        | None -> None
+                    match promptRowOpt with
+                    | Some promptRow when
+                        cursorRow > promptRow
+                        && promptRow >= 0
+                        && cursorRow < snapshot.Length ->
+                        let lines = ResizeArray<string>()
+                        let startRow = promptRow + 1
+                        let endRow = cursorRow
+                        for r in startRow .. endRow do
+                            if r >= 0 && r < snapshot.Length then
+                                let line = CanonicalState.renderRow snapshot r
+                                if not (System.String.IsNullOrEmpty line) then
+                                    lines.Add(line)
+                        let preamble = String.concat "\n" lines
+                        if preamble.Length > 0 then
+                            log.LogInformation(
+                                "PR-B sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} Length={Len}",
+                                promptRow, cursorRow, preamble.Length)
+                            lastAnnouncedText <- preamble
+                    | _ -> ()
+                with ex ->
+                    log.LogWarning(
+                        ex,
+                        "capturePreambleForSubPromptResponse failed: {Message}",
+                        ex.Message)
 
         // SessionModel Tier 1.D — heuristic prompt-boundary
         // detector. Per-shell regex + stability window
@@ -2003,6 +2101,22 @@ module Program =
                 // audible text — keep the cap silent at the
                 // channel layer and trust the hotkey + log to
                 // surface the cap when needed.
+                //
+                // Cycle 49 PR-B (2026-05-14) — post-Enter delta
+                // announce: when the user responds to a sub-prompt
+                // (`set /p`, `pause`, `choice`, etc.) `lastAnnouncedText`
+                // has been overwritten at EnterPressed time by
+                // `capturePreambleForSubPromptResponse` with the
+                // full on-screen content from the active tuple's
+                // prompt row through the cursor row. The prefix-trim
+                // below then slices that preamble off
+                // `tuple.OutputText` so only the post-Enter delta
+                // (the bytes the script produced AFTER the user
+                // submitted their response) gets announced. The
+                // sub-prompt's own prompt text + the user's typed
+                // response are reachable via SpeechCursor manual
+                // navigation; auto-narration covers only what's
+                // new since the user last engaged.
                 // Cycle 47 follow-up (2026-05-13, post-preview.113)
                 // — revert from the watermark-slice approach back
                 // to announcing `tuple.OutputText` directly. The


### PR DESCRIPTION
Cycle 49 PR-B. When the user submits a sub-prompt response (set /p, pause, choice, etc.), the tuple-finalise announce now narrates only the post-Enter content instead of replaying the entire OutputText from the top.

Mechanism: a new EnterPressed handler in recordTransitionImpl captures the on-screen preamble (active tuple's prompt row through the cursor row) at the moment the user presses Enter on a sub-prompt response, writes it to lastAnnouncedText. The existing tuple-finalise prefix-trim then slices that preamble off tuple.OutputText so only the bytes the script produced AFTER the user submitted their response get announced.

The sub-prompt's prompt text + the user's typed response remain reachable via SpeechCursor manual review
(Ctrl+Shift+Up/Down).

Two-flag bookkeeping (`awaitingSubPromptEnter` + lazy install of `capturePreambleForSubPromptResponse`) keeps the change scoped to the sub-prompt path; primary-command EnterPresseds are not affected.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
