### PR TITLE
feat: sub-prompt last-line announce + line-count post-Enter delta (Cycle 49 PR-F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 49 PR-F (2026-05-14): sub-prompt last-line announce + line-count post-Enter slicing
+
+Two connected refinements from preview.121 dogfood:
+
+1. **Sub-prompt announce: just the last line.** Pre-PR-F, the
+   sub-prompt accumulator was narrated wholesale after a
+   leading-echo strip. For `test-02-text-input.cmd` the
+   accumulator carried three lines —
+   `=== PTYSPEAK-TEST-START: test-02-text-input ===`,
+   `This test prompts for a text string and echoes it back.`,
+   and `Enter your name:` — and NVDA's word-by-word read of the
+   embedded `02` ("test-**zero two**-text-input") confused the
+   listener. PR-F narrows the announce to the LAST non-empty
+   line, where the cursor is parked waiting for input. The
+   preceding preamble lines remain reachable via SpeechCursor
+   manual review.
+2. **Post-Enter delta via line-count slicing.** PR-B's text
+   prefix-trim approach (overwrite `lastAnnouncedText` with the
+   screen-rendered preamble; `tuple.OutputText.StartsWith` trim)
+   diverged in dogfood — the cursor row's content at
+   EnterPressed time differed from the same row's content at
+   tuple-finalise 175 ms later (PTY echo arriving in between),
+   so the prefix match returned false and the whole tuple
+   re-narrated. PR-F switches to a line-count signal: the
+   EnterPressed handler counts non-empty rendered rows in the
+   active tuple's output region; tuple-finalise splits
+   `tuple.OutputText` on `\n` and drops that many leading
+   lines. Robust to per-row drift because it relies on the
+   empty-row filter both sides apply uniformly.
+
+Cycle 49 plan: [`docs/CYCLE-49-PLAN.md`](docs/CYCLE-49-PLAN.md).
+
 ### Cycle 49 PR-D (2026-05-14): Prompts visible in SpeechCursor manual navigation
 
 `Ctrl+Shift+Up/Down/End` now surface `PromptStart` markers with

--- a/docs/CYCLE-49-PLAN.md
+++ b/docs/CYCLE-49-PLAN.md
@@ -36,7 +36,8 @@ that landed in Cycles 45–48 so the existing tests
 | A  | `claude/cycle49-speech-cursor-blank-collapse`                    | merged 2026-05-14 (PR #313) | SpeechCursor manual nav skips entries whose `renderEntryForManualNav` returns `None` (Newline, Overwrite, empty TextSpan, `UserInputEcho`-sourced, boundary markers without payload). `toMarker` deliberately preserves the unfiltered jump (marker jumps are explicit). Lands this plan doc. |
 | B  | `claude/cycle49-post-enter-delta-announce`                       | merged 2026-05-14 (PR #314) | `recordTransitionImpl` captures the on-screen preamble (active tuple's prompt row through cursor row) at `EnterPressed` time after a `SubPromptIdle` and writes it to `lastAnnouncedText`; tuple-finalise prefix-trim then slices the post-Enter delta from `tuple.OutputText`. |
 | C  | `claude/cycle49-review-cursor-refresh`                           | merged 2026-05-14 (PR #315) | `TerminalAutomationPeer.RaiseTextChanged()` fires `AutomationEvents.TextPatternOnTextChanged` after every Announce site so NVDA's review cursor invalidates its cached `DocumentRange` and re-pulls the latest tail. |
-| D  | `claude/cycle49-prompt-in-speechcursor-nav`                      | drafting | **Re-cut 2026-05-14** from the original "test-01 line-1" scope (which needs diagnostic-bundle data after A/B/C and stays open as the §"Open follow-ups" item below). New D scope: maintainer feedback "speech cursor should include the prompt as a separate item." Adds `SpeechCursor.renderEntryForManualNav` which decouples manual-nav rendering from `PromptPath` narration policy: `PromptStart` markers with payload always render to a `FinalDirOnly`-trimmed announce for navigation regardless of the per-shell PromptPath, so the user can navigate prompt-to-prompt in review even when auto-drive is silent on prompts. Auto-drive narration unchanged. |
+| D  | `claude/cycle49-prompt-in-speechcursor-nav`                      | merged 2026-05-14 (PR #316) | **Re-cut 2026-05-14** from the original "test-01 line-1" scope (which needs diagnostic-bundle data after A/B/C and stays open as the §"Open follow-ups" item below). New D scope: maintainer feedback "speech cursor should include the prompt as a separate item." Adds `SpeechCursor.renderEntryForManualNav` which decouples manual-nav rendering from `PromptPath` narration policy: `PromptStart` markers with payload always render to a `FinalDirOnly`-trimmed announce for navigation regardless of the per-shell PromptPath, so the user can navigate prompt-to-prompt in review even when auto-drive is silent on prompts. Auto-drive narration unchanged. |
+| F  | `claude/cycle49-subprompt-last-line-and-line-count-delta`        | drafting | Maintainer dogfood 2026-05-14 surfaced two sub-prompt-announce defects on top of the post-A/B/C build. (1) The sub-prompt announce narrated every preamble line the script printed before the prompt; NVDA reading "test-02-text-input" as "test zero two text input" mis-confused the listener. PR-F narrows the announce to the LAST non-empty line of the post-echo-strip accumulator. (2) PR-B's text-prefix-trim for the post-Enter delta failed to fire (the cursor row's content drifted between EnterPressed and tuple-finalise). PR-F replaces the prefix-trim with a line-count signal: count non-empty rows at EnterPressed; drop that many `\n`-delimited lines from `tuple.OutputText` at tuple-finalise. Robust to per-row drift. |
 | E1 | `claude/cycle49-csi-aware-userinputbuffer`                       | pending  | `UserInputBuffer` parses `CSI 2K` / `CSI nG` / bare `\r` clear-line + cursor-position sequences arriving during `Composing` so the buffer reflects the actual on-screen draft after a shell-side history recall (cmd's doskey, PSReadLine's history-search, bash readline). |
 | E2 | `claude/cycle49-history-recall-announce`                         | pending  | On `UserInputBuffer` rewrite mid-`Composing`, announce the new buffer contents via a dedicated activity ID (probably new — `pty-speak.input-assistant` per CORE-ABSTRACTION-BOUNDARY.md §"input assistant" reserved peer pane). NVDA's `MostRecent` processing supersedes prior recall announces. |
 | E3 | `claude/cycle49-draft-input-recall-entry-source`                 | pending  | Add `EntrySource.DraftInputRecall`. Recalled-buffer rewrites produce a `ContentHistory.Entry` tagged with this source, so manual nav can optionally include them but live announce + SpeechCursor AutoDrive filter them like `UserInputEcho`. Symmetric with how typed input is recorded today. Decided 2026-05-14 per maintainer answer in chat. |
@@ -65,39 +66,49 @@ per usual. NVDA-matrix walk is the cycle-level gate:
 Consolidate to a single Cycle-49-1 row in the closure-audit
 (PR-Z) per the cycle-closure-audit discipline.
 
-## Open follow-ups (need diagnostic data)
+## Open follow-ups
 
-Maintainer dogfood on the post-PR-A/B/C build (2026-05-14) surfaced
-three issues that need diagnostic data before they can be sized as
-PRs. Bundle paste pending.
+Maintainer dogfood on the post-PR-A/B/C build (2026-05-14)
+surfaced three issues. Bundle paste 2026-05-14 06:26 (preview.121)
+diagnosed each; PR-F addresses #2 + #3, #1 remains for review.
 
-1. **Test 01 missing first line.** "This is a simple echo test."
-   (script line 15) is absent from BOTH the speech narration AND
-   the review-cursor document. Substrate-level issue —
-   `ContentHistoryTextProvider.DocumentRange` materialises from
-   `state.Entries` unfiltered, so if the line isn't visible to the
-   review cursor, the bytes either didn't reach `ContentHistory`
-   or got displaced. Need grep on the bundle for "This is a
-   simple echo test" + the surrounding `ContentHistory` append
-   log to identify which.
-2. **Test 02 sub-prompt content wrong.** Maintainer hears
-   "zero c windows system…" as the first audible chunk instead of
-   "Enter your name:". The Cycle 48 post-PR-F echo-strip drops
-   content up to the first `\n` in the accumulator; this symptom
-   suggests the accumulator contains multiple preamble lines (or
-   the cmd version banner / script path) that survive the
-   single-line strip. Bundle grep "PR-E sub-prompt announce.
-   Length=" reveals what was actually narrated.
-3. **Post-Enter still narrates full output.** PR-B's
-   `capturePreambleForSubPromptResponse` should overwrite
-   `lastAnnouncedText` with the on-screen preamble at
-   EnterPressed time so the tuple-final prefix-trim slices the
-   delta. Either the capture isn't firing
-   (`awaitingSubPromptEnter` never set), the captured preamble
-   doesn't match `tuple.OutputText`'s prefix (screen-render
-   divergence), or the capture throws (logged at Warning).
-   Bundle greps "PR-B sub-prompt preamble captured" and
-   "Tuple-final prefix trim" disambiguate.
+1. **Test 01 "Line 1 of 8" missing — likely recognition, not
+   substrate.** The bundle's `CONTENT HISTORY` section shows
+   `This is a simple echo test.` IS in ContentHistory at the
+   expected position; the tuple-final announce log shows it
+   WAS narrated (`Length=266`,
+   `MsgHead==== PTYSPEAK-TEST-START: test-01-echo ===This is a simple e...`).
+   Working hypothesis: the script's "Line 1" is implicit
+   (it doesn't say "Line 1 of 8" literally — only Lines 2-7
+   are labelled, with Line 1 = `This is a simple echo test.`
+   and Line 8 = `Last line. ...`), and NVDA reading the
+   whole 266-char output as one continuous utterance makes
+   the unlabelled line easy to miss. **Remediation pending
+   maintainer confirmation**: either (a) rename the script
+   lines to be explicit ("Line 1 of 8. This is a simple
+   echo test." etc.) — purely a test-fixture change, no
+   substrate code; or (b) genuine substrate bug — would
+   need the user to confirm via review-cursor navigation
+   that the line is in fact absent. Pending response.
+2. **Test 02 sub-prompt: full preamble narrated, including
+   "test-02" pronounced "zero two".** Bundle's `PR-E
+   sub-prompt announce. Length=239` confirms the announce
+   body was the full 239-char preamble (start-marker,
+   prelude line, prompt). PR-F narrows the announce to the
+   LAST non-empty line of the accumulator (the actual
+   prompt text where the cursor is parked).
+3. **Post-Enter still narrates the full output.** Bundle
+   shows `PR-B sub-prompt preamble captured. PromptRow=16
+   CursorRow=20 Length=139` followed by
+   `Tuple-final announce. Length=220` with no
+   "Tuple-final prefix trim" log line — confirming the
+   `text.StartsWith(lastAnnouncedText)` check returned
+   false (per-row content drift in the 175 ms between
+   EnterPressed and tuple-finalise). PR-F replaces the
+   prefix-trim with line-count slicing: capture the count
+   of non-empty rows at EnterPressed; drop that many
+   `\n`-delimited lines from `tuple.OutputText` at
+   tuple-finalise. Robust to drift.
 
 ## Decisions already made
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -990,7 +990,7 @@ module Program =
         // ContentHistory seqs. Resets to "" on shell hot-switch.
         let mutable lastAnnouncedText : string = ""
 
-        // Cycle 49 PR-B — sub-prompt response watermark.
+        // Cycle 49 PR-B / PR-F — sub-prompt response watermark.
         //
         // `awaitingSubPromptEnter` flips true when SubPromptIdle
         // transitions Executing → Composing (a sub-prompt has
@@ -1001,20 +1001,30 @@ module Program =
         //
         // `capturePreambleForSubPromptResponse` is installed
         // further down (after `currentSession` enters scope) and
-        // overwrites `lastAnnouncedText` with the full on-screen
-        // content rendered from the active tuple's prompt row
-        // through the cursor row at EnterPressed time. The
-        // existing tuple-finalise prefix-trim (search for
-        // `lastAnnouncedText.Length > 0` below) then slices that
-        // preamble off `tuple.OutputText` so only the post-Enter
-        // delta gets announced. Test 02 (`set /p name=`) used to
-        // narrate the entire output from "This is the input
-        // test." down because `lastAnnouncedText` only carried
-        // the sub-prompt's own announce text (`"Enter your
-        // name:"`); the screen-rendered preamble captured here
-        // matches `tuple.OutputText`'s prefix and the
-        // existing trim fires.
+        // records the **count of non-empty rendered rows** in
+        // the active tuple's output region at EnterPressed time
+        // (sub-prompt response). The tuple-finalise announce
+        // (search for `subPromptPreambleLineCount` below) then
+        // splits `tuple.OutputText` on `\n`, drops that many
+        // leading lines, and announces only the remainder — the
+        // post-Enter delta.
+        //
+        // PR-B originally captured the preamble as a TEXT
+        // string and relied on `text.StartsWith(lastAnnouncedText)`
+        // prefix-trim. Maintainer dogfood 2026-05-14 surfaced
+        // the failure mode: the captured text and
+        // `tuple.OutputText`'s prefix could diverge by a row's
+        // worth of bytes (the cursor row's content at
+        // EnterPressed time differs from the same row's content
+        // 175 ms later at tuple-finalise time), so the
+        // StartsWith returned false and the entire output got
+        // re-announced. PR-F switches to a line-count signal,
+        // which is robust to per-row drift as long as the
+        // empty-row-filtering semantics agree (and they do —
+        // both this capture and `SessionModel.extractContent`
+        // use `String.IsNullOrEmpty` as the filter).
         let mutable awaitingSubPromptEnter : bool = false
+        let mutable subPromptPreambleLineCount : int = 0
         let mutable capturePreambleForSubPromptResponse
             : (unit -> unit) = (fun () -> ())
 
@@ -1633,20 +1643,31 @@ module Program =
                             | ShellPolicy.LineByLine -> false
                             | ShellPolicy.Off -> false)
                     if shouldAnnounce then
-                        // Cycle 48 post-PR-F (2026-05-13) —
-                        // strip the user's submitted-command
-                        // echo from the accumulator before
-                        // announcing. After EnterPressed, cmd
-                        // echoes the typed line + `\r\n`
-                        // before emitting the sub-prompt text.
-                        // Including that echo in the announce
-                        // produces the "garbled" output the
-                        // maintainer reported on test 02
-                        // (cmd echoes "set /p name=Enter your
-                        // name:\r\nEnter your name:"; we want
-                        // to announce just the second half).
-                        // Drop everything up to and including
-                        // the first `\n` in the accumulator.
+                        // Cycle 49 PR-F (2026-05-14) — announce
+                        // ONLY the last non-empty line of the
+                        // sub-prompt accumulator. The pre-PR-F
+                        // approach announced every preamble line
+                        // the script printed before the prompt:
+                        // test 02's accumulator
+                        // "=== PTYSPEAK-TEST-START... ===\n
+                        // This test prompts for a text string
+                        // and echoes it back.\nEnter your name:"
+                        // narrated all three lines, and NVDA's
+                        // word-by-word read made the embedded
+                        // "test-02" sound like "test zero two"
+                        // (the maintainer's "zero c windows
+                        // system" dogfood report). The actual
+                        // useful sub-prompt content is the LAST
+                        // line, where the cursor is parked
+                        // waiting for input. The preamble lines
+                        // remain reachable via SpeechCursor
+                        // manual review.
+                        //
+                        // The leading echo-strip (drop up to and
+                        // including the first `\n`) stays — it
+                        // removes the cmd-side echo of the user's
+                        // submitted command line that always
+                        // precedes the script's first byte.
                         let raw = outcome.AccumulatedOutput
                         let firstLf = raw.IndexOf('\n')
                         let postEchoRaw =
@@ -1654,7 +1675,15 @@ module Program =
                                 raw.Substring(firstLf + 1)
                             else
                                 raw
-                        let sanitised = AnnounceSanitiser.sanitise postEchoRaw
+                        let lastLine =
+                            let lines =
+                                postEchoRaw.Split([| '\n' |], System.StringSplitOptions.None)
+                            lines
+                            |> Array.rev
+                            |> Array.tryFind (fun line ->
+                                not (System.String.IsNullOrWhiteSpace line))
+                            |> Option.defaultValue postEchoRaw
+                        let sanitised = AnnounceSanitiser.sanitise lastLine
                         let trimmed = sanitised.Trim()
                         if not (System.String.IsNullOrWhiteSpace trimmed) then
                             let toSay =
@@ -1662,10 +1691,11 @@ module Program =
                                 else trimmed.Substring(trimmed.Length - OutputAnnounceCapChars)
                             if toSay.Length < trimmed.Length then
                                 log.LogInformation(
-                                    "PR-E sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
+                                    "PR-F sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
                                     trimmed.Length, toSay.Length, OutputAnnounceCapChars)
                             log.LogInformation(
-                                "PR-E sub-prompt announce. Length={Len}", toSay.Length)
+                                "PR-F sub-prompt announce (last line). Length={Len} AccumulatorLen={Acc}",
+                                toSay.Length, raw.Length)
                             window.TerminalSurface.Announce(toSay, ActivityIds.output)
                             // Cycle 49 PR-C — invalidate UIA
                             // Text-pattern cache so the review
@@ -1682,14 +1712,16 @@ module Program =
                                 "shell-interaction-sub-prompt"
                                 ""
                         OutputDispatcher.dispatch readyEvent
-                    // Cycle 49 PR-B — sub-prompt response
+                    // Cycle 49 PR-B / PR-F — sub-prompt response
                     // watermark bookkeeping. Track whether the
                     // most recent state change parked us in
                     // Composing-via-SubPromptIdle so the upcoming
-                    // EnterPressed can overwrite `lastAnnouncedText`
-                    // with the full on-screen preamble and the
-                    // tuple-finalise prefix-trim downstream slices
-                    // the post-Enter delta cleanly. PromptDetected
+                    // EnterPressed can record the preamble line
+                    // count (PR-F line-count slice) for the
+                    // downstream tuple-finalise to drop. PR-B's
+                    // text-prefix-trim approach was superseded
+                    // 2026-05-14 by the line-count slice (more
+                    // robust to per-row drift). PromptDetected
                     // resets the flag in case the user never
                     // responded (script bailed mid sub-prompt).
                     match outcome.Trigger with
@@ -1755,22 +1787,38 @@ module Program =
         // SessionId. None when persistence is MemoryOnly.
         sessionLogWriter <- sessionLogWriterFactory currentSession.SessionId
 
-        // Cycle 49 PR-B — install the real
+        // Cycle 49 PR-B / PR-F — install the real
         // `capturePreambleForSubPromptResponse` body now that
         // `currentSession` is in scope. recordTransitionImpl
         // (declared earlier) invokes this whenever the user
-        // presses Enter on a sub-prompt response so the
-        // tuple-finalise prefix-trim sees the full on-screen
-        // preamble in `lastAnnouncedText` and only announces the
-        // post-Enter delta.
+        // presses Enter on a sub-prompt response.
         //
-        // Runs on the UI thread (same thread the keyboard write
-        // callback and the dispatcher-timer SubPromptIdle tick
-        // run on). `screen.SnapshotRows` is thread-safe (the
-        // parser dispatches its mutations through the same
-        // dispatcher), and `currentSession` is read only here on
-        // the dispatcher thread, so no extra synchronisation
-        // beyond the existing actor-model contract is needed.
+        // PR-F (2026-05-14) — captures the **count** of
+        // non-empty rendered rows in the active tuple's output
+        // region, not the rendered preamble text. The
+        // tuple-finalise announce path then splits
+        // `tuple.OutputText` on `\n` and drops that many
+        // leading lines so only the post-Enter delta gets
+        // announced. PR-B's text-based prefix-trim approach
+        // diverged in the maintainer's 2026-05-14 dogfood:
+        // the cursor row's content at EnterPressed time
+        // differed from the same row's content at
+        // tuple-finalise 175ms later, so the StartsWith check
+        // returned false and the entire output was re-spoken.
+        // Line-count is robust to per-row content drift as
+        // long as both this capture and
+        // `SessionModel.extractContent` apply the same
+        // empty-row filter (and they do — both use
+        // `String.IsNullOrEmpty`).
+        //
+        // Runs on the UI thread (same thread the keyboard
+        // write callback and the dispatcher-timer
+        // SubPromptIdle tick run on). `screen.SnapshotRows`
+        // is thread-safe (the parser dispatches its mutations
+        // through the same dispatcher), and `currentSession`
+        // is read only here on the dispatcher thread, so no
+        // extra synchronisation beyond the existing actor-
+        // model contract is needed.
         capturePreambleForSubPromptResponse <-
             fun () ->
                 try
@@ -1785,20 +1833,19 @@ module Program =
                         cursorRow > promptRow
                         && promptRow >= 0
                         && cursorRow < snapshot.Length ->
-                        let lines = ResizeArray<string>()
                         let startRow = promptRow + 1
                         let endRow = cursorRow
+                        let mutable nonEmptyCount = 0
                         for r in startRow .. endRow do
                             if r >= 0 && r < snapshot.Length then
                                 let line = CanonicalState.renderRow snapshot r
                                 if not (System.String.IsNullOrEmpty line) then
-                                    lines.Add(line)
-                        let preamble = String.concat "\n" lines
-                        if preamble.Length > 0 then
+                                    nonEmptyCount <- nonEmptyCount + 1
+                        if nonEmptyCount > 0 then
                             log.LogInformation(
-                                "PR-B sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} Length={Len}",
-                                promptRow, cursorRow, preamble.Length)
-                            lastAnnouncedText <- preamble
+                                "PR-F sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} LineCount={Lc}",
+                                promptRow, cursorRow, nonEmptyCount)
+                            subPromptPreambleLineCount <- nonEmptyCount
                     | _ -> ()
                 with ex ->
                     log.LogWarning(
@@ -2140,17 +2187,17 @@ module Program =
                 // channel layer and trust the hotkey + log to
                 // surface the cap when needed.
                 //
-                // Cycle 49 PR-B (2026-05-14) — post-Enter delta
-                // announce: when the user responds to a sub-prompt
-                // (`set /p`, `pause`, `choice`, etc.) `lastAnnouncedText`
-                // has been overwritten at EnterPressed time by
-                // `capturePreambleForSubPromptResponse` with the
-                // full on-screen content from the active tuple's
-                // prompt row through the cursor row. The prefix-trim
-                // below then slices that preamble off
-                // `tuple.OutputText` so only the post-Enter delta
-                // (the bytes the script produced AFTER the user
-                // submitted their response) gets announced. The
+                // Cycle 49 PR-F (2026-05-14, supersedes PR-B's
+                // text-prefix-trim) — post-Enter delta announce.
+                // When the user responds to a sub-prompt (`set /p`,
+                // `pause`, `choice`, etc.) the EnterPressed
+                // handler set `subPromptPreambleLineCount` to the
+                // count of non-empty rows in the active tuple's
+                // output region at that moment. The slicing logic
+                // below splits `tuple.OutputText` on `\n`, drops
+                // that many leading lines, and announces only the
+                // remainder — the bytes the script produced
+                // AFTER the user submitted their response. The
                 // sub-prompt's own prompt text + the user's typed
                 // response are reachable via SpeechCursor manual
                 // navigation; auto-narration covers only what's
@@ -2188,16 +2235,53 @@ module Program =
                 // user explicitly wants to inspect markers.
                 match tupleFinaliseAnnounce with
                 | Some text ->
-                    let trimmed =
-                        if lastAnnouncedText.Length > 0
-                           && text.StartsWith(lastAnnouncedText, StringComparison.Ordinal) then
-                            text.Substring(lastAnnouncedText.Length)
+                    // Cycle 49 PR-F (2026-05-14) — pick the
+                    // trimming strategy based on whether this
+                    // tuple-final follows a sub-prompt response
+                    // (the EnterPressed-from-Composing case PR-B
+                    // wires).
+                    //
+                    // Sub-prompt path (`subPromptPreambleLineCount > 0`):
+                    //   line-count slice — split `text` on `\n`,
+                    //   drop the leading `n` lines (the
+                    //   preamble + sub-prompt + typed-response
+                    //   that the user has already engaged with),
+                    //   join the remainder. Robust to per-row
+                    //   content drift between EnterPressed and
+                    //   tuple-finalise.
+                    //
+                    // Otherwise (top-level tuple after a plain
+                    // command run): fall back to the existing
+                    // text prefix-trim against `lastAnnouncedText`
+                    // — it's a no-op in practice for these
+                    // tuples (`lastAnnouncedText` carries the
+                    // prior tuple's announce body, which won't
+                    // be a prefix of the new tuple's output) but
+                    // preserves the legacy code path so PR-F's
+                    // scope stays focused on the sub-prompt fix.
+                    let trimmed, trimStrategy =
+                        if subPromptPreambleLineCount > 0 then
+                            // Honour CR / CRLF / bare-LF row
+                            // separators uniformly. SessionModel's
+                            // extractContent joins with `\n`, so
+                            // a Split-on-'\n' here picks up its
+                            // line groupings 1:1.
+                            let lines =
+                                text.Split([| '\n' |], System.StringSplitOptions.None)
+                            let drop = min subPromptPreambleLineCount lines.Length
+                            let remainder = lines |> Array.skip drop
+                            String.concat "\n" remainder, "line-count"
+                        elif lastAnnouncedText.Length > 0
+                             && text.StartsWith(
+                                 lastAnnouncedText, StringComparison.Ordinal) then
+                            text.Substring(lastAnnouncedText.Length), "prefix-trim"
                         else
-                            text
+                            text, "none"
                     if System.String.IsNullOrWhiteSpace trimmed then
                         log.LogInformation(
-                            "Tuple-final announce suppressed (prefix already announced). OriginalLen={Orig} LastAnnouncedLen={Last}",
-                            text.Length, lastAnnouncedText.Length)
+                            "Tuple-final announce suppressed (prefix already announced). OriginalLen={Orig} Strategy={Strategy} SubPromptLines={Lines} LastAnnouncedLen={Last}",
+                            text.Length, trimStrategy,
+                            subPromptPreambleLineCount, lastAnnouncedText.Length)
                     else
                         let toSay =
                             if trimmed.Length <= OutputAnnounceCapChars then trimmed
@@ -2208,8 +2292,9 @@ module Program =
                                 trimmed.Length, toSay.Length, OutputAnnounceCapChars)
                         if trimmed.Length < text.Length then
                             log.LogInformation(
-                                "Tuple-final prefix trim. OriginalLen={Orig} TrimmedLen={Trim} LastAnnouncedLen={Last}",
-                                text.Length, trimmed.Length, lastAnnouncedText.Length)
+                                "Tuple-final trim. OriginalLen={Orig} TrimmedLen={Trim} Strategy={Strategy} SubPromptLines={Lines} LastAnnouncedLen={Last}",
+                                text.Length, trimmed.Length, trimStrategy,
+                                subPromptPreambleLineCount, lastAnnouncedText.Length)
                         log.LogInformation(
                             "Tuple-final announce. Length={Len}", toSay.Length)
                         window.TerminalSurface.Announce(toSay, ActivityIds.output)
@@ -2219,8 +2304,13 @@ module Program =
                         // content immediately.
                         raiseTextChanged ()
                         lastAnnouncedText <- toSay
+                    // Reset the sub-prompt line-count regardless
+                    // of trim outcome — this tuple is finalised
+                    // and the next tuple starts fresh.
+                    subPromptPreambleLineCount <- 0
                     lastAnnouncedSeq <- ContentHistory.latestSeq contentHistory
-                | None -> ()
+                | None ->
+                    subPromptPreambleLineCount <- 0
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
             |> ignore
 


### PR DESCRIPTION
## Summary

Cycle 49 PR-F. Two refinements from preview.121 dogfood (diagnostic bundle pasted 2026-05-14 06:26).

### 1. Sub-prompt announce: last non-empty line only

Pre-PR-F the sub-prompt announce narrated the entire post-echo-strip accumulator — every preamble line the script printed before the prompt. For `test-02-text-input.cmd` the accumulator carried three lines (`=== PTYSPEAK-TEST-START: test-02-text-input ===`, `This test prompts for a text string and echoes it back.`, `Enter your name:`), and NVDA reading the embedded `02` as "**zero two**" produced the maintainer's "zero c windows system" dogfood report.

PR-F narrows the announce to the LAST non-empty line of the accumulator (the actual sub-prompt text where the cursor is parked). The preceding preamble lines remain reachable via SpeechCursor manual review.

### 2. Post-Enter delta via line-count slicing

PR-B's text-prefix-trim approach (overwrite `lastAnnouncedText` with the screen-rendered preamble; `tuple.OutputText.StartsWith` trim) diverged in dogfood. Bundle confirms: `PR-B sub-prompt preamble captured. PromptRow=16 CursorRow=20 Length=139` followed by `Tuple-final announce. Length=220` with NO `Tuple-final prefix trim` log — the `StartsWith` returned false because the cursor row's content drifted between EnterPressed and tuple-finalise (175 ms apart).

PR-F switches to a line-count signal: the EnterPressed handler counts non-empty rendered rows in the active tuple's output region; tuple-finalise splits `tuple.OutputText` on `\n` and drops that many leading lines. Robust to per-row drift because both this capture and `SessionModel.extractContent` apply the same empty-row filter.

## What PR-F does NOT address

Issue #1 from the dogfood ("test 01 Line 1 of 8 missing") remains as `docs/CYCLE-49-PLAN.md` §"Open follow-ups" item 1. Bundle's `CONTENT HISTORY` section shows `This is a simple echo test.` IS in the substrate verbatim, so this is either a test-fixture-naming issue (the script's mental "Line 1" is unlabelled) or a navigation/recognition issue (NVDA reading the 266-char output as one continuous utterance makes the unlabelled first line easy to miss). Pending maintainer confirmation that the line is in fact absent from the review-cursor document.

## Test plan

- [ ] CI green on windows-latest
- [ ] NVDA dogfood: test-02-text-input — sub-prompt announce is "Enter your name:" (only); after typing a name + Enter, only "Hello, NAME! ..." + END marker narrate (no re-read of the preamble).
- [ ] Regression: plain command (e.g. `dir`) tuple-final announce unchanged.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_