### PR TITLE
fix: remove tuple-final prefix-trim that silenced duplicate commands (Cycle 49 PR-G)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 49 PR-G (2026-05-14): Remove tuple-final prefix-trim against lastAnnouncedText
+
+Maintainer dogfood of preview.122 (post-PR-F) surfaced a
+"speech is unreliable and unpredictable" regression and a
+specific reproducer: running the same command twice in a row
+(e.g. `echo hi` then `echo hi`) silenced the second tuple-final
+announce. Root cause: the tuple-final code still carried a
+prefix-trim against `lastAnnouncedText` from the pre-PR-B
+sub-prompt cleanup era. Once PR-F replaced that mechanism with
+line-count slicing, the prefix-trim was a relic that ONLY
+suppressed duplicate-command output (because the new
+`tuple.OutputText` happened to start with the previous
+announce body, so the trim emptied the announce). The
+"unpredictable" pattern of silences was the same logic firing
+non-deterministically as session output accumulated matching
+prefixes.
+
+PR-G deletes the prefix-trim branch entirely; the only
+trim path for tuple-final is now PR-F's sub-prompt line-count
+slice.
+
+(An unresolved menu-right-arrow narration silence reported in
+the same dogfood is NOT addressed by PR-G — pty-speak doesn't
+touch WPF menu accessibility; that issue stays open pending
+re-test on the post-PR-G build with a log if it persists.)
+
 ### Cycle 49 PR-F (2026-05-14): sub-prompt last-line announce + line-count post-Enter slicing
 
 Two connected refinements from preview.121 dogfood:

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2235,11 +2235,24 @@ module Program =
                 // user explicitly wants to inspect markers.
                 match tupleFinaliseAnnounce with
                 | Some text ->
-                    // Cycle 49 PR-F (2026-05-14) — pick the
-                    // trimming strategy based on whether this
-                    // tuple-final follows a sub-prompt response
-                    // (the EnterPressed-from-Composing case PR-B
-                    // wires).
+                    // Cycle 49 PR-G (2026-05-14) — the only
+                    // trim path for tuple-final is the sub-prompt
+                    // line-count slice (PR-F). The legacy text
+                    // prefix-trim against `lastAnnouncedText`
+                    // was removed: it was a relic of the pre-PR-B
+                    // sub-prompt cleanup story (superseded by
+                    // PR-F's line-count), and in dogfood
+                    // 2026-05-14 it silently suppressed the
+                    // announce whenever a user ran the same
+                    // command twice in a row (the new
+                    // `tuple.OutputText` happened to start with
+                    // the previous announce body, so the trim
+                    // emptied the announce and the "no audible
+                    // output" branch fired). Removing the trim
+                    // restores correct duplicate-command behaviour
+                    // and removes the "unpredictable" silence the
+                    // maintainer reported as outputs accumulated
+                    // matching prefixes over a session.
                     //
                     // Sub-prompt path (`subPromptPreambleLineCount > 0`):
                     //   line-count slice — split `text` on `\n`,
@@ -2249,16 +2262,6 @@ module Program =
                     //   join the remainder. Robust to per-row
                     //   content drift between EnterPressed and
                     //   tuple-finalise.
-                    //
-                    // Otherwise (top-level tuple after a plain
-                    // command run): fall back to the existing
-                    // text prefix-trim against `lastAnnouncedText`
-                    // — it's a no-op in practice for these
-                    // tuples (`lastAnnouncedText` carries the
-                    // prior tuple's announce body, which won't
-                    // be a prefix of the new tuple's output) but
-                    // preserves the legacy code path so PR-F's
-                    // scope stays focused on the sub-prompt fix.
                     let trimmed, trimStrategy =
                         if subPromptPreambleLineCount > 0 then
                             // Honour CR / CRLF / bare-LF row
@@ -2271,17 +2274,13 @@ module Program =
                             let drop = min subPromptPreambleLineCount lines.Length
                             let remainder = lines |> Array.skip drop
                             String.concat "\n" remainder, "line-count"
-                        elif lastAnnouncedText.Length > 0
-                             && text.StartsWith(
-                                 lastAnnouncedText, StringComparison.Ordinal) then
-                            text.Substring(lastAnnouncedText.Length), "prefix-trim"
                         else
                             text, "none"
                     if System.String.IsNullOrWhiteSpace trimmed then
                         log.LogInformation(
-                            "Tuple-final announce suppressed (prefix already announced). OriginalLen={Orig} Strategy={Strategy} SubPromptLines={Lines} LastAnnouncedLen={Last}",
+                            "Tuple-final announce suppressed (empty after slice). OriginalLen={Orig} Strategy={Strategy} SubPromptLines={Lines}",
                             text.Length, trimStrategy,
-                            subPromptPreambleLineCount, lastAnnouncedText.Length)
+                            subPromptPreambleLineCount)
                     else
                         let toSay =
                             if trimmed.Length <= OutputAnnounceCapChars then trimmed
@@ -2292,9 +2291,9 @@ module Program =
                                 trimmed.Length, toSay.Length, OutputAnnounceCapChars)
                         if trimmed.Length < text.Length then
                             log.LogInformation(
-                                "Tuple-final trim. OriginalLen={Orig} TrimmedLen={Trim} Strategy={Strategy} SubPromptLines={Lines} LastAnnouncedLen={Last}",
+                                "Tuple-final trim. OriginalLen={Orig} TrimmedLen={Trim} Strategy={Strategy} SubPromptLines={Lines}",
                                 text.Length, trimmed.Length, trimStrategy,
-                                subPromptPreambleLineCount, lastAnnouncedText.Length)
+                                subPromptPreambleLineCount)
                         log.LogInformation(
                             "Tuple-final announce. Length={Len}", toSay.Length)
                         window.TerminalSurface.Announce(toSay, ActivityIds.output)


### PR DESCRIPTION
## Summary

Cycle 49 PR-G — fixes a "speech unreliable / unpredictable" regression from preview.122 dogfood.

### The bug

The tuple-final announce path still carried this fallback after PR-F:

```fsharp
elif lastAnnouncedText.Length > 0
     && text.StartsWith(lastAnnouncedText, StringComparison.Ordinal) then
    text.Substring(lastAnnouncedText.Length), "prefix-trim"
```

`lastAnnouncedText` carries the previous tuple's announce body. When you run the same command twice (e.g. `echo hi`, `echo hi`), the second `text` equals the first → `text.StartsWith(lastAnnouncedText)` is true → `trimmed` becomes `""` → the `IsNullOrWhiteSpace` branch suppresses the announce silently. Logged as `Tuple-final announce suppressed (prefix already announced)` but inaudible. The "unpredictable" pattern is the same logic firing non-deterministically as session outputs accumulate matching prefixes.

### The fix

Delete the prefix-trim branch entirely. The pre-PR-B reason for the trim (cleanup of sub-prompt overlap) is now handled by PR-F's line-count slicing — the prefix-trim is a pure regression vector with no remaining purpose. The line-count slice for sub-prompt response is the ONLY trim path now.

### What this does NOT address

Maintainer also reported menu right-arrow narration silence in the same dogfood. PR-F's diff doesn't touch any WPF menu accessibility — there's no plausible code-path explanation. Best speculation is UIA event-queue interaction with PR-C's `RaiseTextChanged`, but I can't confirm without a log. Stays open for re-test on the post-PR-G build; if it persists, escalate with diagnostic bundle.

## Test plan

- [ ] CI green on windows-latest
- [ ] Dogfood: run `echo hi` twice — both should narrate.
- [ ] Dogfood: run `dir` twice in a row — both should narrate.
- [ ] Regression: test-02-text-input still narrates "Hello, NAME!..." post-Enter (line-count slice unaffected).
- [ ] Menu right-arrow: re-check whether it narrates on PR-G build.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_