### PR TITLE
feat: announce history-recall draft on Up/Down arrow (Cycle 49 PR-I)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Cycle 49 PR-I (2026-05-14): History-recall draft announce
+
+When the user presses Up / Down arrow during `Composing`, the
+shell (cmd's doskey, PowerShell's PSReadLine, bash readline)
+rewrites the on-screen input line to display the previous /
+next command from its history. Before PR-I, pty-speak's
+`UserInputBuffer` only tracked OUTGOING keystrokes — the
+shell-side rewrite bypassed it silently and NVDA never heard
+what was now sitting in the input line.
+
+PR-I detects the Up / Down arrow byte sequences in the byte-
+write wrapper (`\x1B [ A/B` normal mode, `\x1B O A/B`
+application / DECCKM mode), starts a 100 ms debounced
+`DispatcherTimer`, and on tick reads the current prompt row
+from `screen.SnapshotRows`. The row content is stripped of
+the `Composing.PromptText` prefix where present (so the
+announce is just the recalled draft, not the path) and
+narrated through a new `pty-speak.input-assistant` activity
+ID — separate from `pty-speak.output` so users can mute /
+per-tag-configure draft announces independently of command
+output.
+
+Rapid Up / Down keypresses (the user scrolling through
+history) coalesce: the timer restart drops the prior pending
+announce, so only the FINAL state narrates.
+
+CORE-ABSTRACTION-BOUNDARY.md §"input assistant" reserved
+peer pane is the conceptual home for this channel; PR-I is
+the first concrete user of it.
+
 ### Cycle 49 PR-H (2026-05-14): Reshape test-01-echo for explicit line counting
 
 `scripts/cmd-tests/test-01-echo.cmd` reshaped per maintainer

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4141,7 +4141,94 @@ module Program =
                     (fun _ -> lastReadUtc <- DateTimeOffset.UtcNow)
                     (fun ts b -> ShellInteraction.observeByte shellInteraction ts b)
                     cts.Token
-            window.TerminalSurface.SetPtyHost(
+
+        // Cycle 49 PR-I — history-recall draft announce.
+        //
+        // When the user presses Up / Down arrow during Composing,
+        // the shell (cmd's doskey, PowerShell's PSReadLine, bash
+        // readline) rewrites the on-screen input line to display
+        // the previous / next command from its history. The PTY
+        // bytes the shell sends to perform the rewrite (clear-
+        // line CSI sequences, cursor-position resets, the
+        // recalled-command bytes) flow through the reader thread
+        // into Screen but bypass `UserInputBuffer`'s byte-stream
+        // tracking — `UserInputBuffer` watches OUTGOING bytes
+        // (user keystrokes to PTY) and so doesn't see the shell-
+        // side rewrite.
+        //
+        // The fix here doesn't try to reverse-engineer the shell's
+        // rewrite protocol (CSI 2K, CSI nG, bare `\r`, etc. vary
+        // per shell). Instead: when the byte-write wrapper sees
+        // an Up / Down arrow keystroke going OUT to the PTY,
+        // schedule a debounced read of the current prompt row
+        // (100 ms after the last Up / Down — the typical PTY
+        // round-trip + render budget) and announce whatever the
+        // input line now reads as. Rapid Up / Down spam coalesces
+        // to a single announce of the final state.
+        let historyRecallTimer = DispatcherTimer()
+        historyRecallTimer.Interval <- TimeSpan.FromMilliseconds(100.0)
+        let tryAnnounceRecalledDraft () =
+            try
+                let _, _, snapshot =
+                    screen.SnapshotRows(0, screen.Rows)
+                let promptRowOpt =
+                    match currentSession.Active with
+                    | Some active -> active.PromptRowIndex
+                    | None -> None
+                match promptRowOpt with
+                | Some promptRow when
+                    promptRow >= 0 && promptRow < snapshot.Length ->
+                    let row = CanonicalState.renderRow snapshot promptRow
+                    // Strip the prompt-path prefix if the state
+                    // machine has one. Without the strip the
+                    // announce reads back the full
+                    // `C:\Users\Kyle\…\current>recalledCmd` row
+                    // every time, which the user has already
+                    // navigated past visually. Inspired by the
+                    // sub-prompt last-line announce (PR-F).
+                    let promptText =
+                        match shellInteraction.Current with
+                        | ShellInteraction.Composing data ->
+                            match data.PromptText with
+                            | ValueSome t -> Some t
+                            | ValueNone -> None
+                        | _ -> None
+                    let draft =
+                        match promptText with
+                        | Some pt
+                            when row.StartsWith(
+                                pt, StringComparison.Ordinal) ->
+                            row.Substring(pt.Length)
+                        | _ -> row
+                    let trimmed = draft.Trim()
+                    if not (System.String.IsNullOrWhiteSpace trimmed) then
+                        log.LogInformation(
+                            "PR-I history-recall announce. RowLen={RowLen} DraftLen={DraftLen}",
+                            row.Length, trimmed.Length)
+                        window.TerminalSurface.Announce(
+                            trimmed, ActivityIds.inputAssistant)
+                    else
+                        // Empty recall (shell offered no history /
+                        // history exhausted). Stay silent —
+                        // narrating a blank line is noise.
+                        log.LogDebug(
+                            "PR-I history-recall: empty draft, no announce.")
+                | _ -> ()
+            with ex ->
+                log.LogWarning(
+                    ex,
+                    "history-recall announce failed: {Message}",
+                    ex.Message)
+        historyRecallTimer.Tick.Add(fun _ ->
+            historyRecallTimer.Stop()
+            tryAnnounceRecalledDraft ())
+        let triggerHistoryRecallDebounce () =
+            // Stop + restart so rapid Up / Down keypresses
+            // coalesce to a single announce of the final state.
+            historyRecallTimer.Stop()
+            historyRecallTimer.Start()
+
+        window.TerminalSurface.SetPtyHost(
                 Action<byte[]>(fun bytes ->
                     // Cycle 48 PR-D (ADR 0003) — byte-stream-
                     // driven UserInputBuffer maintenance + Enter
@@ -4170,6 +4257,26 @@ module Program =
                                 captured.Length, captured)
                             recordTransition
                                 (ShellInteraction.EnterPressed captured)
+                    // Cycle 49 PR-I — history-recall announce.
+                    // Detect Up/Down arrow keystrokes the user
+                    // is sending to the shell; cmd's doskey /
+                    // PSReadLine / bash readline will replace
+                    // the on-screen input line with the
+                    // recalled command. Schedule a debounced
+                    // read of the prompt row + announce so the
+                    // user hears what was just inserted.
+                    //
+                    // Cursor-key encoding (`KeyEncoding.fs`):
+                    //   Normal mode      `\x1B [ A/B` (3 bytes)
+                    //   App / DECCKM     `\x1B O A/B` (3 bytes)
+                    // Modifier-augmented forms (Shift+Up etc.)
+                    // are 6+ bytes and not history-recall; we
+                    // ignore them.
+                    if bytes.Length = 3
+                       && bytes.[0] = 0x1Buy
+                       && (bytes.[1] = 0x5Buy || bytes.[1] = 0x4Fuy)
+                       && (bytes.[2] = 0x41uy || bytes.[2] = 0x42uy) then
+                        triggerHistoryRecallDebounce ()
                     host.WriteBytes(bytes)),
                 Action<int, int>(fun cols rows ->
                     // Resize is best-effort: a transient failure

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4142,93 +4142,93 @@ module Program =
                     (fun ts b -> ShellInteraction.observeByte shellInteraction ts b)
                     cts.Token
 
-        // Cycle 49 PR-I — history-recall draft announce.
-        //
-        // When the user presses Up / Down arrow during Composing,
-        // the shell (cmd's doskey, PowerShell's PSReadLine, bash
-        // readline) rewrites the on-screen input line to display
-        // the previous / next command from its history. The PTY
-        // bytes the shell sends to perform the rewrite (clear-
-        // line CSI sequences, cursor-position resets, the
-        // recalled-command bytes) flow through the reader thread
-        // into Screen but bypass `UserInputBuffer`'s byte-stream
-        // tracking — `UserInputBuffer` watches OUTGOING bytes
-        // (user keystrokes to PTY) and so doesn't see the shell-
-        // side rewrite.
-        //
-        // The fix here doesn't try to reverse-engineer the shell's
-        // rewrite protocol (CSI 2K, CSI nG, bare `\r`, etc. vary
-        // per shell). Instead: when the byte-write wrapper sees
-        // an Up / Down arrow keystroke going OUT to the PTY,
-        // schedule a debounced read of the current prompt row
-        // (100 ms after the last Up / Down — the typical PTY
-        // round-trip + render budget) and announce whatever the
-        // input line now reads as. Rapid Up / Down spam coalesces
-        // to a single announce of the final state.
-        let historyRecallTimer = DispatcherTimer()
-        historyRecallTimer.Interval <- TimeSpan.FromMilliseconds(100.0)
-        let tryAnnounceRecalledDraft () =
-            try
-                let _, _, snapshot =
-                    screen.SnapshotRows(0, screen.Rows)
-                let promptRowOpt =
-                    match currentSession.Active with
-                    | Some active -> active.PromptRowIndex
-                    | None -> None
-                match promptRowOpt with
-                | Some promptRow when
-                    promptRow >= 0 && promptRow < snapshot.Length ->
-                    let row = CanonicalState.renderRow snapshot promptRow
-                    // Strip the prompt-path prefix if the state
-                    // machine has one. Without the strip the
-                    // announce reads back the full
-                    // `C:\Users\Kyle\…\current>recalledCmd` row
-                    // every time, which the user has already
-                    // navigated past visually. Inspired by the
-                    // sub-prompt last-line announce (PR-F).
-                    let promptText =
-                        match shellInteraction.Current with
-                        | ShellInteraction.Composing data ->
-                            match data.PromptText with
-                            | ValueSome t -> Some t
-                            | ValueNone -> None
-                        | _ -> None
-                    let draft =
-                        match promptText with
-                        | Some pt
-                            when row.StartsWith(
-                                pt, StringComparison.Ordinal) ->
-                            row.Substring(pt.Length)
-                        | _ -> row
-                    let trimmed = draft.Trim()
-                    if not (System.String.IsNullOrWhiteSpace trimmed) then
-                        log.LogInformation(
-                            "PR-I history-recall announce. RowLen={RowLen} DraftLen={DraftLen}",
-                            row.Length, trimmed.Length)
-                        window.TerminalSurface.Announce(
-                            trimmed, ActivityIds.inputAssistant)
-                    else
-                        // Empty recall (shell offered no history /
-                        // history exhausted). Stay silent —
-                        // narrating a blank line is noise.
-                        log.LogDebug(
-                            "PR-I history-recall: empty draft, no announce.")
-                | _ -> ()
-            with ex ->
-                log.LogWarning(
-                    ex,
-                    "history-recall announce failed: {Message}",
-                    ex.Message)
-        historyRecallTimer.Tick.Add(fun _ ->
-            historyRecallTimer.Stop()
-            tryAnnounceRecalledDraft ())
-        let triggerHistoryRecallDebounce () =
-            // Stop + restart so rapid Up / Down keypresses
-            // coalesce to a single announce of the final state.
-            historyRecallTimer.Stop()
-            historyRecallTimer.Start()
+            // Cycle 49 PR-I — history-recall draft announce.
+            //
+            // When the user presses Up / Down arrow during Composing,
+            // the shell (cmd's doskey, PowerShell's PSReadLine, bash
+            // readline) rewrites the on-screen input line to display
+            // the previous / next command from its history. The PTY
+            // bytes the shell sends to perform the rewrite (clear-
+            // line CSI sequences, cursor-position resets, the
+            // recalled-command bytes) flow through the reader thread
+            // into Screen but bypass `UserInputBuffer`'s byte-stream
+            // tracking — `UserInputBuffer` watches OUTGOING bytes
+            // (user keystrokes to PTY) and so doesn't see the shell-
+            // side rewrite.
+            //
+            // The fix here doesn't try to reverse-engineer the shell's
+            // rewrite protocol (CSI 2K, CSI nG, bare `\r`, etc. vary
+            // per shell). Instead: when the byte-write wrapper sees
+            // an Up / Down arrow keystroke going OUT to the PTY,
+            // schedule a debounced read of the current prompt row
+            // (100 ms after the last Up / Down — the typical PTY
+            // round-trip + render budget) and announce whatever the
+            // input line now reads as. Rapid Up / Down spam coalesces
+            // to a single announce of the final state.
+            let historyRecallTimer = DispatcherTimer()
+            historyRecallTimer.Interval <- TimeSpan.FromMilliseconds(100.0)
+            let tryAnnounceRecalledDraft () =
+                try
+                    let _, _, snapshot =
+                        screen.SnapshotRows(0, screen.Rows)
+                    let promptRowOpt =
+                        match currentSession.Active with
+                        | Some active -> active.PromptRowIndex
+                        | None -> None
+                    match promptRowOpt with
+                    | Some promptRow when
+                        promptRow >= 0 && promptRow < snapshot.Length ->
+                        let row = CanonicalState.renderRow snapshot promptRow
+                        // Strip the prompt-path prefix if the state
+                        // machine has one. Without the strip the
+                        // announce reads back the full
+                        // `C:\Users\Kyle\…\current>recalledCmd` row
+                        // every time, which the user has already
+                        // navigated past visually. Inspired by the
+                        // sub-prompt last-line announce (PR-F).
+                        let promptText =
+                            match shellInteraction.Current with
+                            | ShellInteraction.Composing data ->
+                                match data.PromptText with
+                                | ValueSome t -> Some t
+                                | ValueNone -> None
+                            | _ -> None
+                        let draft =
+                            match promptText with
+                            | Some pt
+                                when row.StartsWith(
+                                    pt, StringComparison.Ordinal) ->
+                                row.Substring(pt.Length)
+                            | _ -> row
+                        let trimmed = draft.Trim()
+                        if not (System.String.IsNullOrWhiteSpace trimmed) then
+                            log.LogInformation(
+                                "PR-I history-recall announce. RowLen={RowLen} DraftLen={DraftLen}",
+                                row.Length, trimmed.Length)
+                            window.TerminalSurface.Announce(
+                                trimmed, ActivityIds.inputAssistant)
+                        else
+                            // Empty recall (shell offered no history /
+                            // history exhausted). Stay silent —
+                            // narrating a blank line is noise.
+                            log.LogDebug(
+                                "PR-I history-recall: empty draft, no announce.")
+                    | _ -> ()
+                with ex ->
+                    log.LogWarning(
+                        ex,
+                        "history-recall announce failed: {Message}",
+                        ex.Message)
+            historyRecallTimer.Tick.Add(fun _ ->
+                historyRecallTimer.Stop()
+                tryAnnounceRecalledDraft ())
+            let triggerHistoryRecallDebounce () =
+                // Stop + restart so rapid Up / Down keypresses
+                // coalesce to a single announce of the final state.
+                historyRecallTimer.Stop()
+                historyRecallTimer.Start()
 
-        window.TerminalSurface.SetPtyHost(
+            window.TerminalSurface.SetPtyHost(
                 Action<byte[]>(fun bytes ->
                     // Cycle 48 PR-D (ADR 0003) — byte-stream-
                     // driven UserInputBuffer maintenance + Enter

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -441,6 +441,15 @@ module ActivityIds =
     /// processing for shell-switch announcements separately
     /// from streaming output.
     let shellSwitch = "pty-speak.shell-switch"
+    /// Input-assistant pane (CORE-ABSTRACTION-BOUNDARY.md §
+    /// "input assistant" reserved peer pane). Cycle 49 PR-I
+    /// announces history-recall draft rewrites here — when the
+    /// user presses Up or Down arrow and cmd's doskey / shell's
+    /// history feature replaces the on-screen input line, the
+    /// new draft contents narrate via this activity ID. Tagged
+    /// separately so users can mute / per-tag-configure draft
+    /// announcements without affecting command output.
+    let inputAssistant = "pty-speak.input-assistant"
 
     /// Debug-logging toggle announcements (Stage 7-followup
     /// PR-E `Ctrl+Shift+G`). Emits "Debug logging on." /


### PR DESCRIPTION
## Summary

Cycle 49 PR-I. When the user presses Up / Down arrow during `Composing`, cmd's doskey / PSReadLine / bash readline rewrites the on-screen input line to show the previous / next command from history. Pre-PR-I that rewrite was silent — `UserInputBuffer` only tracks OUTGOING keystrokes and never saw the shell-side replacement.

PR-I makes the rewrite audible.

## Mechanism

1. **Byte-pattern detection.** The byte-write wrapper inspects each `bytes[]` going to the PTY. A 3-byte payload of `\x1B [ A/B` (normal mode) or `\x1B O A/B` (application / DECCKM mode) is the unmodified Up / Down arrow per `KeyEncoding.fs`. Modifier-augmented forms (Shift+Up etc.) are 6+ bytes and ignored.
2. **100 ms debounced `DispatcherTimer`.** A single timer instance starts on detection and restarts on subsequent detections so rapid Up / Down spam coalesces to one announce of the FINAL state (the user scrolling through history hears the destination, not every step).
3. **On tick: read + strip + announce.** `screen.SnapshotRows` reads the current prompt row; if `shellInteraction.Current` is `Composing` with `PromptText`, the row's prompt-path prefix is stripped so the announce is just the recalled draft (not the full `C:\Users\…\current>recalledCmd` row, which the user has already navigated past visually).
4. **New `pty-speak.input-assistant` activity ID.** Separate from `pty-speak.output` so users can mute / per-tag-configure draft announces independently of command output. CORE-ABSTRACTION-BOUNDARY.md §"input assistant" reserved peer pane is the conceptual home; PR-I is the first concrete user.

Empty drafts (shell offered no history) stay silent — narrating a blank line is noise.

## What this does NOT do

- No backwards rewrite of `UserInputBuffer` to reflect the recalled content (the deferred `EntrySource.DraftInputRecall` work). The buffer continues to track outgoing keystrokes only; subsequent typing after a recall behaves as if starting fresh from the user's view, which is acceptable for the common "press Up then Enter" flow but may be surprising for "press Up then backspace+retype." Promote to a follow-up if dogfood surfaces the issue.

## Test plan

- [ ] CI green on windows-latest.
- [ ] Dogfood: in cmd, run `echo hi`, then press Up arrow. NVDA narrates "echo hi" (or similar) via the new activity ID.
- [ ] Dogfood: press Up arrow several times rapidly through a long history. Only the final draft narrates.
- [ ] Dogfood: press Up arrow with no history available (fresh shell). Silent (no blank-line announce).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_