### PR TITLE
fix: history-recall diagnostic logging + new-feature diagnostic convention (PR-J)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,36 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-J (2026-05-14): History-recall diagnostic logging + new-feature diagnostic convention
+
+Maintainer reported a non-deterministic "show CMD" mis-announce
+after a few cmd evaluations in the post-Cycle-49 release build.
+The leading hypothesis is that PR-I's prompt-prefix strip
+occasionally fails to match (so the full prompt-path row gets
+announced, and NVDA's TTS of `C:\path\to\current>recalledCmd`
+produces the phonemes the maintainer is hearing as "show CMD").
+PR-J adds the diagnostic signal needed to confirm or refute the
+hypothesis from a `Ctrl+Shift+D` bundle without requiring an
+on-demand repro:
+
+- Information-level log gains `Stripped={Stripped}` so an
+  always-on bundle confirms whether the prefix-strip matched.
+- New Debug-level "PR-I history-recall details" log captures
+  `PromptRow`, `Row` (full prompt row content), `PromptText`
+  (the `Composing.PromptText` the strip checked against),
+  `Stripped`, and `Announce` (the text NVDA spoke). Debug
+  level matches the existing `UserInputBuffer captured on
+  Enter: ... Text={Text}` precedent — both go to NVDA out
+  loud so no new sensitivity boundary is crossed.
+- Empty-recall branch also gets the same details log so a
+  silent recall is distinguishable from a missed code path.
+
+Also adds a new CLAUDE.md project convention: **new features
+ship with their diagnostic triggers in the same PR**, not as
+a follow-up. The convention names the minimum signal an
+announce site / state transition / screen-read should emit
+so the maintainer can triage from a bundle.
+
 ### Cycle 49 PR-I (2026-05-14): History-recall draft announce
 
 When the user presses Up / Down arrow during `Composing`, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,51 @@ Quick rule: **never log secrets**, even names — env-var names like
 announcement-bound exception messages through
 `Terminal.Core.AnnounceSanitiser.sanitise`.
 
+### New features ship with their diagnostic triggers
+
+Established 2026-05-14 after PR-I (history-recall announce)
+shipped with a thin `RowLen={RowLen} DraftLen={DraftLen}` log
+and the maintainer reported a non-deterministic mis-announce
+that the lean log couldn't localise. Required a follow-up
+PR-J just to add the diagnostic args.
+
+**Rule**: when a feature introduces a new announce site,
+state-machine transition, screen-read, or any other path
+whose behaviour the maintainer would need to triage from a
+`Ctrl+Shift+D` bundle, ship the diagnostic args **in the
+same PR**, not as a follow-up.
+
+Minimum signal for an announce site:
+
+- The **announce body** (logged at Debug if it contains user
+  data; at Information if structural). PR-I logs the
+  recalled draft text at Debug, matching the existing
+  `UserInputBuffer captured on Enter: ... Text=...` log
+  precedent — both go to NVDA out loud so no new
+  sensitivity boundary is crossed.
+- The **decision inputs** that determined the announce —
+  for PR-I the prompt row, `PromptText`, and whether the
+  prefix-strip matched. For sub-prompt announces, the
+  accumulator length + last-line vs full-body choice.
+- Counts (lengths, indices, line counts) at Information so
+  the always-on bundle has enough to confirm the path fired
+  even when Debug logging is off.
+
+Bundle-friendly format:
+
+- Use templated args (`{Foo}={Foo} {Bar}={Bar}`), not
+  interpolated strings, so the FileLogger can index them.
+- Prefix with the PR ID (`PR-I history-recall details.`)
+  so a grep on a noisy bundle quickly finds your log lines.
+- Keep templates **single-line** — multi-line bodies break
+  the grep tooling on the bundle.
+
+Test fixtures (the canonical-interactions corpus + the
+`Diagnostics → Test ...` menu items) also count as
+diagnostic triggers; if a new feature has a deterministic
+shell-side reproducer, add a test-corpus entry so the
+maintainer doesn't have to script it ad-hoc.
+
 ### App-reserved hotkey contract
 
 Canonical: [`spec/tech-plan.md`](spec/tech-plan.md) section 6 +

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4193,18 +4193,52 @@ module Program =
                                 | ValueSome t -> Some t
                                 | ValueNone -> None
                             | _ -> None
-                        let draft =
+                        let stripped =
                             match promptText with
                             | Some pt
                                 when row.StartsWith(
                                     pt, StringComparison.Ordinal) ->
-                                row.Substring(pt.Length)
-                            | _ -> row
+                                true
+                            | _ -> false
+                        let draft =
+                            if stripped then
+                                match promptText with
+                                | Some pt -> row.Substring(pt.Length)
+                                | None -> row
+                            else
+                                row
                         let trimmed = draft.Trim()
+                        // PR-J (2026-05-14) — diagnostic
+                        // logging. Maintainer reported a non-
+                        // deterministic "show CMD" mis-announce
+                        // after a few evaluations in cmd. Most
+                        // likely the prompt-prefix strip
+                        // mis-matched and the full row (path +
+                        // command) got narrated. The Debug-
+                        // level Row / PromptText / Stripped /
+                        // Announce arguments let the next
+                        // diagnostic bundle confirm which case
+                        // hit and what text NVDA spoke.
+                        //
+                        // Debug-level (not Information) so
+                        // these don't flood the bundle when
+                        // FileLogger is at Information.
+                        // Announce text is logged for parity
+                        // with `UserInputBuffer captured` —
+                        // both go to NVDA out loud so no new
+                        // sensitivity boundary is crossed.
+                        let promptTextDesc =
+                            match promptText with
+                            | Some pt -> pt
+                            | None -> "<none>"
                         if not (System.String.IsNullOrWhiteSpace trimmed) then
                             log.LogInformation(
-                                "PR-I history-recall announce. RowLen={RowLen} DraftLen={DraftLen}",
-                                row.Length, trimmed.Length)
+                                "PR-I history-recall announce. RowLen={RowLen} DraftLen={DraftLen} Stripped={Stripped}",
+                                row.Length, trimmed.Length, stripped)
+                            log.LogDebug(
+                                "PR-I history-recall details. PromptRow={PromptRow} Row={Row} PromptText={PromptText} Stripped={Stripped} Announce={Announce}",
+                                promptRow, row, promptTextDesc,
+                                stripped, trimmed)
                             window.TerminalSurface.Announce(
                                 trimmed, ActivityIds.inputAssistant)
                         else
@@ -4212,7 +4246,8 @@ module Program =
                             // history exhausted). Stay silent —
                             // narrating a blank line is noise.
                             log.LogDebug(
-                                "PR-I history-recall: empty draft, no announce.")
+                                "PR-I history-recall: empty draft, no announce. PromptRow={PromptRow} Row={Row} PromptText={PromptText} Stripped={Stripped}",
+                                promptRow, row, promptTextDesc, stripped)
                     | _ -> ()
                 with ex ->
                     log.LogWarning(


### PR DESCRIPTION
## Summary

Two-part follow-up to Cycle 49 PR-I:

### 1. Diagnostic logging for the "show CMD" mis-announce

Maintainer reported a non-deterministic mis-announce after a few cmd evaluations on the post-Cycle-49 release build: NVDA occasionally says "show CMD" instead of the recalled command, even though the screen shows the correct command. Leading hypothesis: PR-I's prompt-prefix strip in `tryAnnounceRecalledDraft` occasionally fails to match (so the full prompt-path row gets announced; NVDA's TTS of `C:\path\to\current>recalledCmd` produces phonemes the maintainer hears as "show CMD").

PR-J adds the diagnostic signal so the next `Ctrl+Shift+D` bundle confirms or refutes the hypothesis without requiring an on-demand repro:

- **Information-level log gains `Stripped={Stripped}`** so an always-on bundle confirms whether the prefix-strip matched on each recall.
- **New Debug-level `PR-I history-recall details` log** captures `PromptRow`, `Row` (the full prompt row), `PromptText` (the `Composing.PromptText` the strip checked against), `Stripped`, and `Announce` (the text NVDA spoke). Debug-level so it doesn't flood Information bundles; matches the existing `UserInputBuffer captured on Enter: ... Text={Text}` precedent — both end up audible via NVDA anyway.
- **Empty-recall branch** gets the same details log so a silent recall is distinguishable from a missed code path.

No behavior change to the announce; only logging.

### 2. New CLAUDE.md project convention

Establishes "new features ship with their diagnostic triggers in the same PR, not as a follow-up." PR-I shipping with a thin `RowLen / DraftLen` log was the precipitating gap. The convention names the minimum signal an announce site / state transition / screen-read should emit + bundle-friendly formatting rules.

## Test plan

- [ ] CI green
- [ ] Maintainer dogfood: once the build cuts, do whatever sequence triggered the bug previously, then `Ctrl+Shift+D`. Grep the bundle's FileLogger section for `PR-I history-recall`. The row text + PromptText + Stripped flag will tell us which case fired.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_