### PR TITLE
fix: sub-prompt screen-read (OSC immune) + capturePreamble endRow (preserves post-Enter response)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-K (2026-05-14): Sub-prompt screen-read + capturePreamble endRow fix
+
+Two coupled bug fixes from preview.125 dogfood of the
+Cycle-49 sub-prompt narration:
+
+1. **Sub-prompt announce now reads the screen, not the raw
+   accumulator.** PR-F's "last non-empty line of the
+   accumulator" approach failed on the FIRST run of a `.cmd`
+   script because cmd emits an OSC title-set sequence
+   (`\x1B]0;cmd.exe - "..."\x07`) AFTER the script's prompt
+   text in the byte stream; that escape sequence ends up on
+   a line of its own in the accumulator and the
+   `Array.rev |> tryFind` reverse-scan picked it as the
+   "last" line, narrating
+   `]0;C:\WINDOWS\SYSTEM32\cmd.exe - ...` — the maintainer's
+   "show CMD"-style mishearing on first-run-only sub-prompts.
+   PR-K reads the screen rows `[Active.PromptRowIndex + 1,
+   cursorRow]` at `SubPromptIdle` instead. `Screen` already
+   absorbs OSC sequences as state changes (window-title,
+   palette, etc.) and `CanonicalState.renderRow` returns
+   only printable cell content. Side-effect win: the
+   announce now includes the full preamble — start marker,
+   intro text, prompt line — restoring the script context
+   PR-F had stripped down to just the prompt.
+
+2. **`capturePreambleForSubPromptResponse` uses
+   `endRow = cursorRow - 1`** to exclude the cursor row
+   from the non-empty-line count. The cursor row at
+   `EnterPressed` is racy — cmd can start echoing back
+   content before the recordTransition callback fires —
+   so counting it produces a too-high `LineCount` that
+   drops the user's actual post-Enter response from the
+   tuple-final announce. Maintainer dogfood log
+   2026-05-14: `LineCount=4`, dropped 4 of 5 lines,
+   leaving only the `PTYSPEAK-TEST-END` marker. With the
+   endRow fix the count is 3 and the `Hello, NAME!`
+   response line narrates correctly.
+
+Fallback: when `Active.PromptRowIndex` is `ValueNone` (e.g.
+PowerShell — the heuristic prompt detector doesn't match PS
+prompts today), the sub-prompt announce path falls back to
+the PR-F accumulator-last-line approach. PowerShell
+support stays as a separate backlog item.
+
 ### Post-Cycle-49 PR-J (2026-05-14): History-recall diagnostic logging + new-feature diagnostic convention
 
 Maintainer reported a non-deterministic "show CMD" mis-announce

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1643,47 +1643,102 @@ module Program =
                             | ShellPolicy.LineByLine -> false
                             | ShellPolicy.Off -> false)
                     if shouldAnnounce then
-                        // Cycle 49 PR-F (2026-05-14) — announce
-                        // ONLY the last non-empty line of the
-                        // sub-prompt accumulator. The pre-PR-F
-                        // approach announced every preamble line
-                        // the script printed before the prompt:
-                        // test 02's accumulator
-                        // "=== PTYSPEAK-TEST-START... ===\n
-                        // This test prompts for a text string
-                        // and echoes it back.\nEnter your name:"
-                        // narrated all three lines, and NVDA's
-                        // word-by-word read made the embedded
-                        // "test-02" sound like "test zero two"
-                        // (the maintainer's "zero c windows
-                        // system" dogfood report). The actual
-                        // useful sub-prompt content is the LAST
-                        // line, where the cursor is parked
-                        // waiting for input. The preamble lines
-                        // remain reachable via SpeechCursor
-                        // manual review.
+                        // PR-K (2026-05-14, post-Cycle-49) —
+                        // sub-prompt announce reads the SCREEN
+                        // (rows [Active.PromptRowIndex + 1,
+                        // cursorRow]) rather than the raw
+                        // accumulator's last line.
                         //
-                        // The leading echo-strip (drop up to and
-                        // including the first `\n`) stays — it
-                        // removes the cmd-side echo of the user's
-                        // submitted command line that always
-                        // precedes the script's first byte.
+                        // PR-F's accumulator-last-line approach
+                        // failed on the first run of a `.cmd`
+                        // script because cmd emits an OSC title-
+                        // set sequence (`\x1B]0;...\x07`) AFTER
+                        // the script's `Enter your name:`
+                        // prompt; that escape sequence is on a
+                        // line of its own in the byte stream and
+                        // the reverse-scan picked it as "last
+                        // non-empty line", so NVDA narrated
+                        // "]0;C:\WINDOWS\SYSTEM32\cmd.exe — ..."
+                        // (the maintainer's 2026-05-14 dogfood
+                        // "show CMD"-style mishearing). On a
+                        // second run the OSC is suppressed by
+                        // cmd (title already set) and PR-F
+                        // worked.
+                        //
+                        // The screen approach is robust: Screen
+                        // already absorbs OSC sequences as state
+                        // changes (window title, palette, etc.)
+                        // and `renderRow` returns only printable
+                        // cell content. The rendered rows from
+                        // the prompt onward give the user the
+                        // full sub-prompt preamble — start
+                        // marker, intro text, prompt line — in
+                        // the same order they appeared on
+                        // screen.
+                        //
+                        // Falls back to the PR-F accumulator
+                        // last-line approach when
+                        // `currentSession.Active.PromptRowIndex`
+                        // is unavailable (e.g. PowerShell which
+                        // the heuristic prompt detector doesn't
+                        // recognise today, so PromptRowIndex
+                        // stays ValueNone there).
                         let raw = outcome.AccumulatedOutput
-                        let firstLf = raw.IndexOf('\n')
-                        let postEchoRaw =
-                            if firstLf >= 0 && firstLf + 1 < raw.Length then
-                                raw.Substring(firstLf + 1)
-                            else
-                                raw
-                        let lastLine =
-                            let lines =
-                                postEchoRaw.Split([| '\n' |], System.StringSplitOptions.None)
-                            lines
-                            |> Array.rev
-                            |> Array.tryFind (fun line ->
-                                not (System.String.IsNullOrWhiteSpace line))
-                            |> Option.defaultValue postEchoRaw
-                        let sanitised = AnnounceSanitiser.sanitise lastLine
+                        let screenRowsAnnounce =
+                            try
+                                let _, (cursorRow, _), snapshot =
+                                    screen.SnapshotRows(0, screen.Rows)
+                                let promptRowOpt =
+                                    match currentSession.Active with
+                                    | Some active -> active.PromptRowIndex
+                                    | None -> None
+                                match promptRowOpt with
+                                | Some promptRow when
+                                    cursorRow >= promptRow + 1
+                                    && cursorRow < snapshot.Length ->
+                                    let lines = ResizeArray<string>()
+                                    for r in (promptRow + 1) .. cursorRow do
+                                        if r >= 0 && r < snapshot.Length then
+                                            let line = CanonicalState.renderRow snapshot r
+                                            if not (System.String.IsNullOrEmpty line) then
+                                                lines.Add(line)
+                                    if lines.Count > 0 then
+                                        Some (String.concat "\n" lines, promptRow, cursorRow)
+                                    else None
+                                | _ -> None
+                            with ex ->
+                                log.LogWarning(
+                                    ex,
+                                    "PR-K sub-prompt screen-read failed; falling back to accumulator. {Message}",
+                                    ex.Message)
+                                None
+                        let announceBody, source =
+                            match screenRowsAnnounce with
+                            | Some (body, _, _) -> body, "screen"
+                            | None ->
+                                // Fallback: accumulator's last
+                                // non-empty line (the pre-PR-K
+                                // behaviour). The leading echo-
+                                // strip drops the user's
+                                // submitted-command echo that
+                                // precedes the script's first
+                                // byte.
+                                let firstLf = raw.IndexOf('\n')
+                                let postEchoRaw =
+                                    if firstLf >= 0 && firstLf + 1 < raw.Length then
+                                        raw.Substring(firstLf + 1)
+                                    else
+                                        raw
+                                let lastLine =
+                                    let lines =
+                                        postEchoRaw.Split([| '\n' |], System.StringSplitOptions.None)
+                                    lines
+                                    |> Array.rev
+                                    |> Array.tryFind (fun line ->
+                                        not (System.String.IsNullOrWhiteSpace line))
+                                    |> Option.defaultValue postEchoRaw
+                                lastLine, "accumulator-fallback"
+                        let sanitised = AnnounceSanitiser.sanitise announceBody
                         let trimmed = sanitised.Trim()
                         if not (System.String.IsNullOrWhiteSpace trimmed) then
                             let toSay =
@@ -1691,11 +1746,14 @@ module Program =
                                 else trimmed.Substring(trimmed.Length - OutputAnnounceCapChars)
                             if toSay.Length < trimmed.Length then
                                 log.LogInformation(
-                                    "PR-F sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
-                                    trimmed.Length, toSay.Length, OutputAnnounceCapChars)
+                                    "PR-K sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap} Source={Source}",
+                                    trimmed.Length, toSay.Length, OutputAnnounceCapChars, source)
                             log.LogInformation(
-                                "PR-F sub-prompt announce (last line). Length={Len} AccumulatorLen={Acc}",
-                                toSay.Length, raw.Length)
+                                "PR-K sub-prompt announce. Length={Len} AccumulatorLen={Acc} Source={Source}",
+                                toSay.Length, raw.Length, source)
+                            log.LogDebug(
+                                "PR-K sub-prompt announce body. Source={Source} Announce={Announce}",
+                                source, toSay)
                             window.TerminalSurface.Announce(toSay, ActivityIds.output)
                             // Cycle 49 PR-C — invalidate UIA
                             // Text-pattern cache so the review
@@ -1832,9 +1890,35 @@ module Program =
                     | Some promptRow when
                         cursorRow > promptRow
                         && promptRow >= 0
-                        && cursorRow < snapshot.Length ->
+                        && cursorRow <= snapshot.Length ->
+                        // PR-K (2026-05-14) — endRow = cursorRow
+                        // - 1, not cursorRow. The cursor row at
+                        // EnterPressed is racy: cmd may have
+                        // already started echoing back the next
+                        // line by the time recordTransition
+                        // fires (175 ms of drift between
+                        // EnterPressed and tuple-finalise is
+                        // typical), so the cursor row's content
+                        // can include partial script output the
+                        // user hasn't heard yet. Counting it
+                        // produces a too-high LineCount that
+                        // drops the user's actual post-Enter
+                        // response from the tuple-final
+                        // announce.
+                        //
+                        // Maintainer 2026-05-14 dogfood: test
+                        // 02 captured PromptRow=3 CursorRow=7
+                        // LineCount=4; tuple-final dropped 4 of
+                        // 5 lines, leaving only the
+                        // PTYSPEAK-TEST-END marker — the
+                        // "Hello, kyle!" response line was
+                        // skipped. With endRow = cursorRow - 1
+                        // = 6, range [4,6] counts 3 (START /
+                        // intro / "Enter your name:kyle"), drop
+                        // 3 of 5, "Hello, kyle!" + END marker
+                        // narrate.
                         let startRow = promptRow + 1
-                        let endRow = cursorRow
+                        let endRow = cursorRow - 1
                         let mutable nonEmptyCount = 0
                         for r in startRow .. endRow do
                             if r >= 0 && r < snapshot.Length then
@@ -1843,8 +1927,8 @@ module Program =
                                     nonEmptyCount <- nonEmptyCount + 1
                         if nonEmptyCount > 0 then
                             log.LogInformation(
-                                "PR-F sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} LineCount={Lc}",
-                                promptRow, cursorRow, nonEmptyCount)
+                                "PR-K sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} EndRow={Er} LineCount={Lc}",
+                                promptRow, cursorRow, endRow, nonEmptyCount)
                             subPromptPreambleLineCount <- nonEmptyCount
                     | _ -> ()
                 with ex ->

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1027,6 +1027,19 @@ module Program =
         let mutable subPromptPreambleLineCount : int = 0
         let mutable capturePreambleForSubPromptResponse
             : (unit -> unit) = (fun () -> ())
+        // PR-K (2026-05-14) — sub-prompt screen-read callback.
+        // Declared here (early in compose) because
+        // `recordTransitionImpl`'s sub-prompt branch reads it,
+        // but `currentSession` is in scope only further down.
+        // The real body is installed alongside
+        // `capturePreambleForSubPromptResponse` once
+        // `currentSession` enters scope. Returns the screen-
+        // rendered preamble `[Active.PromptRowIndex + 1,
+        // cursorRow]` joined with `\n`, or `None` when
+        // `PromptRowIndex` is unavailable (e.g. PowerShell, or
+        // before the first PromptStart fires).
+        let mutable subPromptScreenReader
+            : (unit -> string option) = (fun () -> None)
 
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
@@ -1684,37 +1697,10 @@ module Program =
                         // recognise today, so PromptRowIndex
                         // stays ValueNone there).
                         let raw = outcome.AccumulatedOutput
-                        let screenRowsAnnounce =
-                            try
-                                let _, (cursorRow, _), snapshot =
-                                    screen.SnapshotRows(0, screen.Rows)
-                                let promptRowOpt =
-                                    match currentSession.Active with
-                                    | Some active -> active.PromptRowIndex
-                                    | None -> None
-                                match promptRowOpt with
-                                | Some promptRow when
-                                    cursorRow >= promptRow + 1
-                                    && cursorRow < snapshot.Length ->
-                                    let lines = ResizeArray<string>()
-                                    for r in (promptRow + 1) .. cursorRow do
-                                        if r >= 0 && r < snapshot.Length then
-                                            let line = CanonicalState.renderRow snapshot r
-                                            if not (System.String.IsNullOrEmpty line) then
-                                                lines.Add(line)
-                                    if lines.Count > 0 then
-                                        Some (String.concat "\n" lines, promptRow, cursorRow)
-                                    else None
-                                | _ -> None
-                            with ex ->
-                                log.LogWarning(
-                                    ex,
-                                    "PR-K sub-prompt screen-read failed; falling back to accumulator. {Message}",
-                                    ex.Message)
-                                None
+                        let screenRowsAnnounce = subPromptScreenReader ()
                         let announceBody, source =
                             match screenRowsAnnounce with
-                            | Some (body, _, _) -> body, "screen"
+                            | Some body -> body, "screen"
                             | None ->
                                 // Fallback: accumulator's last
                                 // non-empty line (the pre-PR-K
@@ -1877,6 +1863,43 @@ module Program =
         // is read only here on the dispatcher thread, so no
         // extra synchronisation beyond the existing actor-
         // model contract is needed.
+        // PR-K (2026-05-14) — install the real
+        // `subPromptScreenReader` body now that
+        // `currentSession` is in scope. Same threading
+        // contract as capturePreambleForSubPromptResponse:
+        // runs on the UI dispatcher thread from
+        // recordTransitionImpl, no extra synchronisation
+        // beyond the existing actor-model contract needed.
+        subPromptScreenReader <-
+            fun () ->
+                try
+                    let _, (cursorRow, _), snapshot =
+                        screen.SnapshotRows(0, screen.Rows)
+                    let promptRowOpt =
+                        match currentSession.Active with
+                        | Some active -> active.PromptRowIndex
+                        | None -> None
+                    match promptRowOpt with
+                    | Some promptRow when
+                        cursorRow >= promptRow + 1
+                        && cursorRow < snapshot.Length ->
+                        let lines = ResizeArray<string>()
+                        for r in (promptRow + 1) .. cursorRow do
+                            if r >= 0 && r < snapshot.Length then
+                                let line = CanonicalState.renderRow snapshot r
+                                if not (System.String.IsNullOrEmpty line) then
+                                    lines.Add(line)
+                        if lines.Count > 0 then
+                            Some (String.concat "\n" lines)
+                        else None
+                    | _ -> None
+                with ex ->
+                    log.LogWarning(
+                        ex,
+                        "PR-K sub-prompt screen-read failed; falling back to accumulator. {Message}",
+                        ex.Message)
+                    None
+
         capturePreambleForSubPromptResponse <-
             fun () ->
                 try


### PR DESCRIPTION
## Summary

Two coupled fixes from your preview.125 dogfood, both regressing PR-F's sub-prompt narration.

### Fix 1 — Sub-prompt announce now reads the screen rows

PR-F's "last non-empty line of the accumulator" approach failed on the **first run of a `.cmd` script** because cmd emits an OSC title-set sequence (`\x1B]0;cmd.exe - "..."\x07`) AFTER the script's prompt text. The `Array.rev |> tryFind not-whitespace` reverse-scan picked the OSC sequence as the "last" line. NVDA narrated `]0;C:\WINDOWS\SYSTEM32\cmd.exe - ...` — that's the "show CMD"-style mishearing on first-run-only sub-prompts.

Your 2026-05-14 bundle confirmed: `PR-F sub-prompt announce (last line). Length=139 ... MsgHead=]0;C:\WINDOWS\SYSTEM32\cmd.exe - "C:\Users\Kyle\AppData\Loca...` on the first run; correct `Length=16 MsgHead=Enter your name:` on the second (cmd doesn't re-emit OSC once title is set).

PR-K reads screen rows `[Active.PromptRowIndex + 1, cursorRow]` at `SubPromptIdle`. `Screen` already absorbs OSC sequences as state changes; `CanonicalState.renderRow` returns only printable cell content. The fix is bulletproof against any escape-sequence noise cmd throws into the stream.

**Side-effect win**: the announce now includes the full preamble (start marker + intro + prompt line) since they're all on visible rows. This restores the script context PR-F had stripped down to just the last line — addresses your "the script immediately prompts me without reading the intro text or test marker" complaint.

Falls back to PR-F's accumulator approach when `Active.PromptRowIndex` is `ValueNone` (e.g. PowerShell — the heuristic prompt detector doesn't match PS prompts today; tracked separately).

### Fix 2 — `capturePreambleForSubPromptResponse` uses `endRow = cursorRow - 1`

The cursor row at `EnterPressed` is racy: cmd can start echoing content before `recordTransition` fires. Counting it produces a too-high `LineCount` that drops the user's actual post-Enter response from the tuple-final announce.

Your log: `PromptRow=3 CursorRow=7 LineCount=4`. `tuple-final` dropped 4 of 5 lines, leaving only the `PTYSPEAK-TEST-END` marker — the `Hello, kyle!` response line got skipped. With `endRow = cursorRow - 1 = 6`, range `[4, 6]` counts 3 (START / intro / `Enter your name:kyle`), drop 3 of 5, `Hello, kyle!` + END marker both narrate.

### Diagnostic args

Per the PR-J CLAUDE.md convention: every PR-K log line carries `Source={Source}` so the bundle reveals whether the screen-read or accumulator-fallback path fired. Debug-level `Announce={Announce}` captures the body NVDA spoke.

## Not addressed here

- **SpeechCursor missing the `Enter your name:` chunk** (your issue #3). ContentHistory tail confirms the line IS in the substrate as a `CmdOutput` `TextSpan`, which PR-A's filter should NOT skip. Need a fresh bundle + `Ctrl+Shift+Y` SessionModel dump post-PR-K to diagnose.
- **PowerShell**. Tracked as a backlog item; needs the heuristic prompt detector taught about PS prompt patterns before the sub-prompt + history-recall paths can fire there.

## Test plan

- [ ] CI green
- [ ] Dogfood: run `test-02-text-input.cmd` from a fresh build, FIRST time. NVDA narrates: start marker, intro line, `Enter your name:` (full preamble, no "show CMD" OSC). Type a name + Enter; NVDA narrates `Hello, NAME!` + END marker.
- [ ] Dogfood: run it a second time. Same behaviour (regression check — confirms screen-read works in both runs, not just the OSC-bearing first).
- [ ] Regression: `dir`, `echo hi` — plain commands still narrate correctly.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_