### PR TITLE
fix: history-recall settle gate for rapid Up/Down tapping (PR-L)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-L (2026-05-14): History-recall settle gate
+
+Maintainer dogfood 2026-05-14 reproduced two related desyncs
+under rapid Up/Down arrow tapping:
+
+1. **Spoken text ≠ visually displayed command**: PR-I's 100 ms
+   debounced timer fires 100 ms after the last keystroke, but
+   under rapid tap cmd's response bytes (the line-rewrite for
+   each arrow press) are still arriving from the PTY when the
+   timer fires. The screen-read sees an intermediate state and
+   the announce reflects an earlier state than what's now on
+   screen. PR-L adds a settle gate: on tick, also check
+   `lastReadUtc`; if the reader has emitted bytes within the
+   last 100 ms, restart the timer instead of announcing. Only
+   when keystrokes AND incoming bytes have both been quiet for
+   100 ms does the announce fire.
+
+2. **Visually displayed command ≠ what cmd executes on Enter**:
+   This one is a user-perception race against ConPTY round-
+   trip latency — cmd processes Up/Down bytes in order and
+   atomically updates its history pointer, but the screen
+   reflects each step only after the response byte makes it
+   back through the reader. If Enter is pressed while a
+   line-rewrite is in transit, the visible frame is stale.
+   Not pty-speak's bug to fix, but PR-L's settle gate ensures
+   the SPOKEN text matches what cmd will run if Enter is
+   pressed at the moment the user hears the announce.
+
+Diagnostic log added per the PR-J CLAUDE.md convention: when
+the gate defers, `PR-L history-recall settle-gate: deferring
+(LastReadAgoMs=N)` lands at Debug.
+
 ### Post-Cycle-49 PR-K (2026-05-14): Sub-prompt screen-read + capturePreamble endRow fix
 
 Two coupled bug fixes from preview.125 dogfood of the

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4362,8 +4362,41 @@ module Program =
                         "history-recall announce failed: {Message}",
                         ex.Message)
             historyRecallTimer.Tick.Add(fun _ ->
-                historyRecallTimer.Stop()
-                tryAnnounceRecalledDraft ())
+                // PR-L (2026-05-14) — settle gate. The 100 ms
+                // timer is reset by every Up/Down keypress
+                // (debounce); on tick, also check whether PTY
+                // bytes are still flowing in. If the reader has
+                // emitted bytes within the last 100 ms, cmd's
+                // response to the recall is mid-flight; defer
+                // by restarting the timer. Otherwise the
+                // screen-read happens against a settled
+                // display.
+                //
+                // Maintainer 2026-05-14 dogfood: rapid Up/Down
+                // tapping reproduced two symptoms — (1) spoken
+                // text different from visually-displayed
+                // command, (2) visually-displayed command
+                // different from what cmd executes on Enter.
+                // Symptom (1) was my screen-read firing
+                // mid-response (cmd's line-rewrite bytes still
+                // arriving). Symptom (2) is fundamentally a
+                // user-perception race against ConPTY round-
+                // trip and isn't pty-speak's to fix — but
+                // resolving (1) means the spoken text matches
+                // what cmd will actually run if Enter is
+                // pressed at the settled moment.
+                let now = DateTimeOffset.UtcNow
+                let elapsedSinceLastRead =
+                    (now - lastReadUtc).TotalMilliseconds
+                if elapsedSinceLastRead < 100.0 then
+                    log.LogDebug(
+                        "PR-L history-recall settle-gate: deferring (LastReadAgoMs={Ms}).",
+                        elapsedSinceLastRead)
+                    historyRecallTimer.Stop()
+                    historyRecallTimer.Start()
+                else
+                    historyRecallTimer.Stop()
+                    tryAnnounceRecalledDraft ())
             let triggerHistoryRecallDebounce () =
                 // Stop + restart so rapid Up / Down keypresses
                 // coalesce to a single announce of the final state.


### PR DESCRIPTION
## Summary

Post-Cycle-49 PR-L. Maintainer dogfood 2026-05-14 reproduced two related desyncs under rapid Up/Down arrow tapping:

1. **Spoken text ≠ visually displayed command**: PR-I's 100 ms debounce fires 100 ms after the last keystroke, but cmd's response bytes (line-rewrite for each arrow press) are still arriving from the PTY when the timer fires. The screen-read sees an intermediate state.
2. **Visually displayed command ≠ what cmd executes on Enter**: A user-perception race against ConPTY round-trip latency. Not pty-speak's bug — but resolving (1) means the spoken text matches what cmd would run if Enter were pressed at the announce moment.

## Mechanism

On Tick, the gate now checks `lastReadUtc` (already tracked by `startReaderLoop`). If the reader has emitted bytes within the last 100 ms, defer by restarting the timer instead of calling `tryAnnounceRecalledDraft`. Once both keystrokes AND incoming bytes have been quiet for 100 ms, the announce fires.

No new threading or plumbing — `lastReadUtc` is already used by the heartbeat (`LastReadAgoMs`) and the dispatcher-timer ticks run on the UI thread alongside `lastReadUtc` updates.

## Test plan

- [ ] CI green
- [ ] Dogfood: press Up arrow once at cmd prompt, NVDA narrates the recalled command. Screen and announce match.
- [ ] Dogfood: rapidly tap Up/Up/Up/Down/Up/Down. Each tap during rapid sequence is silent; ONE announce fires after the tapping settles. That announce matches what's on screen at announce time.
- [ ] Dogfood: confirm bundle's FileLogger shows `PR-L history-recall settle-gate: deferring (LastReadAgoMs=N)` lines for the in-flight ticks during rapid tap (Debug log level).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_