### PR TITLE
fix: command-wrap-aware sub-prompt screen-read (PR-N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-N (2026-05-14): Command-wrap-aware sub-prompt screen-read
+
+Maintainer dogfood 2026-05-14: when a command (e.g. the
+`test-02-text-input.cmd` invocation, ~91 chars) is long
+enough that `prompt path + typed command` exceeds
+`screen.Cols`, the typed command's continuation wraps onto
+the row right after the prompt row. PR-K's sub-prompt
+screen-read started at `promptRow + 1` unconditionally, so
+the wrapped continuation row was misclassified as script
+preamble and NVDA narrated the tail of the file path
+before the script's intro and prompt text.
+
+PR-N captures `UserInputBuffer.Capture()` result's length
+at EnterPressed (`lastSubmittedCommandLength`) and uses it
+to compute `wrapRows = ceil((PromptText.Length +
+cmdLen) / screen.Cols)`. Both PR-K sub-prompt screen-read
+sites — `subPromptScreenReader` (the announce body) and
+`capturePreambleForSubPromptResponse` (the tuple-final
+line-count) — now start at `promptRow + wrapRows` instead
+of `promptRow + 1`. The wrap-continuation row(s) skip
+correctly regardless of how many visual rows the command
+spans.
+
+Diagnostic logs per the PR-J CLAUDE.md convention:
+`PR-N sub-prompt screen-read range. PromptRow=N
+WrapRows=N StartRow=N CursorRow=N LineCount=N` at Debug
+and the existing `PR-N sub-prompt preamble captured`
+Information log gains `WrapRows={WrapRows} StartRow={StartRow}`
+fields.
+
+Note: the same wrap issue can in principle affect the
+`extractContent` row-walk fallback in `SessionModel.fs`,
+but in practice the `extractContentFromContentHistory`
+linear path is used for cmd (splits on the first `\n` in
+the byte stream — invariant under visual wrap) so
+tuple-final extraction is already wrap-correct. The
+row-walk fallback only fires on shell-switch /
+finalize-incomplete edges where extraction quality is
+less critical; left as a follow-up if a real reproducer
+surfaces.
+
 ### Post-Cycle-49 PR-L (2026-05-14): History-recall settle gate
 
 Maintainer dogfood 2026-05-14 reproduced two related desyncs

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1040,6 +1040,19 @@ module Program =
         // before the first PromptStart fires).
         let mutable subPromptScreenReader
             : (unit -> string option) = (fun () -> None)
+        // PR-N (2026-05-14) — last-submitted-command length.
+        // Set in the byte-write wrapper at EnterPressed time
+        // (right before recordTransition fires). Used by the
+        // sub-prompt screen-read paths to compute how many
+        // visual rows the prompt + typed command occupy when
+        // the command wraps past `screen.Cols`. Without this,
+        // the wrapped continuation row gets misclassified as
+        // sub-prompt preamble and NVDA narrates the tail of
+        // the file path before the script's actual intro
+        // text. 0 when no command has been submitted yet (or
+        // when the buffer was empty at Enter — e.g. user
+        // pressed Enter at an empty prompt).
+        let mutable lastSubmittedCommandLength : int = 0
 
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
@@ -1870,6 +1883,43 @@ module Program =
         // runs on the UI dispatcher thread from
         // recordTransitionImpl, no extra synchronisation
         // beyond the existing actor-model contract needed.
+        // PR-N (2026-05-14) — compute the visual-row span the
+        // prompt + typed command occupies. When the command
+        // wraps past `screen.Cols`, the continuation lands on
+        // row `promptRow + 1` (and further rows). The
+        // sub-prompt screen-read paths used to start at
+        // `promptRow + 1` unconditionally — misclassifying
+        // wrap-continuation rows as script preamble and
+        // narrating the tail of the file path before the
+        // script's actual output. Maintainer 2026-05-14
+        // dogfood: 91-char script path + 47-char prompt =
+        // 138 chars on a 120-col screen → wraps to 2 rows;
+        // row `promptRow + 1` was being announced as
+        // preamble.
+        //
+        // `lastSubmittedCommandLength` is set in the byte-
+        // write wrapper at EnterPressed, so it's available
+        // by the time SubPromptIdle fires (which happens
+        // post-EnterPressed → Executing → SubPromptIdle).
+        // For top-level Composing entries before any Enter,
+        // the length is 0 and the helper returns 1 (no wrap)
+        // — correct since the prompt + nothing doesn't wrap.
+        let computePromptCommandWrapRows (promptRow: int) : int =
+            try
+                let cols = max 1 screen.Cols
+                let promptLen =
+                    match currentSession.Active with
+                    | Some active ->
+                        match active.Tuple.PromptText with
+                        | null -> 0
+                        | t -> t.Length
+                    | None -> 0
+                let cmdLen = max 0 lastSubmittedCommandLength
+                let total = promptLen + cmdLen
+                if total <= 0 then 1
+                else max 1 ((total + cols - 1) / cols)
+            with _ -> 1
+
         subPromptScreenReader <-
             fun () ->
                 try
@@ -1883,12 +1933,17 @@ module Program =
                     | Some promptRow when
                         cursorRow >= promptRow + 1
                         && cursorRow < snapshot.Length ->
+                        let wrapRows = computePromptCommandWrapRows promptRow
+                        let startRow = promptRow + wrapRows
                         let lines = ResizeArray<string>()
-                        for r in (promptRow + 1) .. cursorRow do
+                        for r in startRow .. cursorRow do
                             if r >= 0 && r < snapshot.Length then
                                 let line = CanonicalState.renderRow snapshot r
                                 if not (System.String.IsNullOrEmpty line) then
                                     lines.Add(line)
+                        log.LogDebug(
+                            "PR-N sub-prompt screen-read range. PromptRow={PromptRow} WrapRows={WrapRows} StartRow={StartRow} CursorRow={CursorRow} LineCount={LineCount}",
+                            promptRow, wrapRows, startRow, cursorRow, lines.Count)
                         if lines.Count > 0 then
                             Some (String.concat "\n" lines)
                         else None
@@ -1940,7 +1995,15 @@ module Program =
                         // intro / "Enter your name:kyle"), drop
                         // 3 of 5, "Hello, kyle!" + END marker
                         // narrate.
-                        let startRow = promptRow + 1
+                        // PR-N (2026-05-14) — skip wrap-
+                        // continuation rows. When the
+                        // command wrapped past screen.Cols,
+                        // `promptRow + 1` is the wrapped tail
+                        // of the typed command, not script
+                        // preamble. Same rationale as in
+                        // `subPromptScreenReader`.
+                        let wrapRows = computePromptCommandWrapRows promptRow
+                        let startRow = promptRow + wrapRows
                         let endRow = cursorRow - 1
                         let mutable nonEmptyCount = 0
                         for r in startRow .. endRow do
@@ -1950,8 +2013,8 @@ module Program =
                                     nonEmptyCount <- nonEmptyCount + 1
                         if nonEmptyCount > 0 then
                             log.LogInformation(
-                                "PR-K sub-prompt preamble captured. PromptRow={Pr} CursorRow={Cr} EndRow={Er} LineCount={Lc}",
-                                promptRow, cursorRow, endRow, nonEmptyCount)
+                                "PR-N sub-prompt preamble captured. PromptRow={Pr} WrapRows={Wr} StartRow={Sr} CursorRow={Cr} EndRow={Er} LineCount={Lc}",
+                                promptRow, wrapRows, startRow, cursorRow, endRow, nonEmptyCount)
                             subPromptPreambleLineCount <- nonEmptyCount
                     | _ -> ()
                 with ex ->
@@ -4430,6 +4493,14 @@ module Program =
                             shellInteractionLog.LogDebug(
                                 "UserInputBuffer captured on Enter: Length={Length} Text={Text}",
                                 captured.Length, captured)
+                            // PR-N — record the submitted-command
+                            // length so the sub-prompt screen-read
+                            // paths can compute wrap rows
+                            // (`ceil((promptLen + cmdLen) / cols)`)
+                            // and skip the wrapped-continuation
+                            // row(s) that would otherwise be
+                            // misclassified as script preamble.
+                            lastSubmittedCommandLength <- captured.Length
                             recordTransition
                                 (ShellInteraction.EnterPressed captured)
                     // Cycle 49 PR-I — history-recall announce.

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1909,10 +1909,7 @@ module Program =
                 let cols = max 1 screen.Cols
                 let promptLen =
                     match currentSession.Active with
-                    | Some active ->
-                        match active.Tuple.PromptText with
-                        | null -> 0
-                        | t -> t.Length
+                    | Some active -> active.Tuple.PromptText.Length
                     | None -> 0
                 let cmdLen = max 0 lastSubmittedCommandLength
                 let total = promptLen + cmdLen


### PR DESCRIPTION
## Summary

Post-Cycle-49 PR-N. Maintainer's hypothesis confirmed: when the typed command (e.g. `test-02-text-input.cmd` invocation, 91 chars) exceeds `screen.Cols`, the wrapped continuation lands on the row right after `promptRow`. PR-K's sub-prompt screen-read started at `promptRow + 1` unconditionally — misclassifying that row as script preamble. NVDA narrated the tail of the file path before the script's actual intro and prompt text.

Test-02 specifics: 47-char prompt path + 91-char script path = 138 chars on a 120-col screen → wraps to 2 visual rows. Row `promptRow + 1` is the wrap continuation, NOT script output.

## Mechanism

1. **Capture `lastSubmittedCommandLength` at EnterPressed.** Set in the byte-write wrapper right where `UserInputBuffer.Capture()` runs, alongside the existing `EnterPressed` transition recording.
2. **New helper `computePromptCommandWrapRows`** returns `max 1 (ceil((PromptText.Length + cmdLen) / screen.Cols))`. Defensive: returns 1 on any error / empty inputs.
3. **Both PR-K sub-prompt screen-read sites consume it.** `subPromptScreenReader` (sub-prompt announce body) and `capturePreambleForSubPromptResponse` (tuple-final preamble line-count) both now start at `promptRow + wrapRows` instead of `promptRow + 1`.

## Out of scope

The `SessionModel.extractContent` row-walk fallback has the same theoretical problem but:
- The live cmd / vanilla PowerShell path uses `extractContentFromContentHistory` which splits on `\n` in the byte stream — invariant under visual wrap, so tuple-final extraction is already wrap-correct.
- The row-walk fallback only fires on shell-switch / finalize-incomplete edges. No real reproducer for the wrap issue there yet.

Leaving as a follow-up if dogfood surfaces it.

## Diagnostic logs (per the PR-J CLAUDE.md convention)

- Debug: `PR-N sub-prompt screen-read range. PromptRow=N WrapRows=N StartRow=N CursorRow=N LineCount=N` for the announce path.
- Information: existing `PR-N sub-prompt preamble captured` log gains `WrapRows={WrapRows} StartRow={StartRow}` fields.

## Test plan

- [ ] CI green
- [ ] Dogfood: run `test-02-text-input.cmd` (long-path command that wraps). NVDA narrates the script's intro + `Enter your name:` ONLY — no leading "input.cmd"-tail noise from the wrapped continuation row.
- [ ] Dogfood: same flow at a wider window (resize to 200 cols if possible) where command doesn't wrap. Same behavior as before — wrap logic correctly computes 1 wrap-row, no regression.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_