### PR TITLE
feat(diagnostics): per-entry ContentHistory dump in bundle (PR-P)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,39 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-P (2026-05-14): Per-entry ContentHistory dump in diagnostic bundle
+
+Maintainer's Test D (SpeechCursor missing the `Enter your
+name:` chunk) couldn't be localised from the existing
+bundle: the aggregate `Stats:` line gives totals but the
+per-entry view — Seq / Kind / Source / Text — was only in
+the sibling `content-history-<ts>.txt` reconstruction
+file, and even there the SpeechCursor manual-nav verdict
+wasn't computed alongside.
+
+PR-P adds a new `--- ENTRIES (last 200 with SpeechCursor
+verdict) ---` subsection inside the existing `--- CONTENT
+HISTORY (last 64KB) ---` bundle section. One line per
+entry:
+
+```
+[Seq=N Source=X Kind=Y ... NavRender=Some(Len=N Activity=A Text="...")/None]
+```
+
+Control characters are escape-printed (`\n`, `\r`, `\t`,
+`\x1B`, `\xNN`) so a wrapped row stays on one bundle line.
+Text payloads are truncated to 80 chars for paste-
+friendliness; the full reconstruction stays in the sibling
+file. Capped at the last 200 entries; pre-cap entries
+elide with a leading `... (M earlier entries omitted)` line.
+
+The new dump answers "is this entry CmdOutput?", "does
+SpeechCursor's `renderEntryForManualNav` filter return
+None for this entry?", "where exactly does the entry
+chain break for the missing chunk?" — without requiring a
+separate `Ctrl+Shift+Y` SessionModel dump or a debug-level
+log walk.
+
 ### Post-Cycle-49 PR-O (2026-05-14): Cursor-row-based wrap detection for history-recalled commands
 
 Maintainer Test B dogfood 2026-05-14: first run of test-02

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -923,27 +923,24 @@ module Diagnostics =
             if total <= cap then 0
             else total - cap
         let truncate (s: string) (n: int) : string =
-            if isNull s then ""
-            elif s.Length <= n then s
+            if s.Length <= n then s
             else (s.Substring(0, n)) + "..."
         let escape (s: string) : string =
-            if isNull s then ""
-            else
-                // Replace control chars with their escape forms so
-                // a single-line entry stays single-line in the
-                // bundle. NewLine -> \n literal, etc.
-                let sb = System.Text.StringBuilder(s.Length + 4)
-                for ch in s do
-                    let code = int ch
-                    if ch = '\n' then sb.Append("\\n") |> ignore
-                    elif ch = '\r' then sb.Append("\\r") |> ignore
-                    elif ch = '\t' then sb.Append("\\t") |> ignore
-                    elif code = 0x1B then sb.Append("\\x1B") |> ignore
-                    elif code < 0x20 || code = 0x7F then
-                        sb.AppendFormat("\\x{0:X2}", code) |> ignore
-                    elif ch = '"' then sb.Append("\\\"") |> ignore
-                    else sb.Append(ch) |> ignore
-                sb.ToString()
+            // Replace control chars with their escape forms so
+            // a single-line entry stays single-line in the
+            // bundle. NewLine -> \n literal, etc.
+            let sb = System.Text.StringBuilder(s.Length + 4)
+            for ch in s do
+                let code = int ch
+                if ch = '\n' then sb.Append("\\n") |> ignore
+                elif ch = '\r' then sb.Append("\\r") |> ignore
+                elif ch = '\t' then sb.Append("\\t") |> ignore
+                elif code = 0x1B then sb.Append("\\x1B") |> ignore
+                elif code < 0x20 || code = 0x7F then
+                    sb.AppendFormat("\\x{0:X2}", code) |> ignore
+                elif ch = '"' then sb.Append("\\\"") |> ignore
+                else sb.Append(ch) |> ignore
+            sb.ToString()
         let describeEntry (e: ContentHistory.Entry) : string =
             let seq = ContentHistory.entrySeq e
             let source =
@@ -971,7 +968,7 @@ module Diagnostics =
                         | None -> ""
                     sprintf "Kind=Marker MarkerKind=%A%s" d.Kind payload
                 | ContentHistory.Spinner d ->
-                    sprintf "Kind=Spinner Frame=\"%s\"" (escape (truncate d.Frame 40))
+                    sprintf "Kind=Spinner Frames=%d LatestText=\"%s\"" d.FrameCount (escape (truncate d.LatestText 40))
             // SpeechCursor manual-nav verdict (PR-D's
             // renderEntryForManualNav). Using FinalDirOnly to
             // match the typical run-time PromptPath; if the

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -898,6 +898,108 @@ module Diagnostics =
             (sourceTally ContentHistory.EntrySource.BoundaryMarker)
             (sourceTally ContentHistory.EntrySource.Unknown)
 
+    /// PR-P (2026-05-14) — per-entry ContentHistory dump for the
+    /// diagnostic bundle. The aggregate `Stats:` line gives totals
+    /// but a SpeechCursor-style question ("why isn't entry X
+    /// navigable?") needs per-entry visibility. Returns a multi-
+    /// line block — one entry per line — with Seq, Kind, Source,
+    /// the rendered text or payload (truncated for paste-
+    /// friendliness), and the SpeechCursor manual-nav verdict
+    /// (`NavRender=Some/None`). Capped at the last
+    /// `maxEntries` entries so the bundle stays paste-safe;
+    /// pre-cap entries elide via a leading "... (M earlier
+    /// entries omitted)" line.
+    ///
+    /// Format per line (one entry):
+    /// `[Seq=N Kind=X Source=Y Text="..." NavRender=Some/None]`
+    let internal formatContentHistoryEntries
+            (history: ContentHistory.T)
+            (maxEntries: int)
+            : string =
+        let entries = ContentHistory.snapshot history
+        let total = entries.Length
+        let cap = max 0 maxEntries
+        let start =
+            if total <= cap then 0
+            else total - cap
+        let truncate (s: string) (n: int) : string =
+            if isNull s then ""
+            elif s.Length <= n then s
+            else (s.Substring(0, n)) + "..."
+        let escape (s: string) : string =
+            if isNull s then ""
+            else
+                // Replace control chars with their escape forms so
+                // a single-line entry stays single-line in the
+                // bundle. NewLine -> \n literal, etc.
+                let sb = System.Text.StringBuilder(s.Length + 4)
+                for ch in s do
+                    let code = int ch
+                    if ch = '\n' then sb.Append("\\n") |> ignore
+                    elif ch = '\r' then sb.Append("\\r") |> ignore
+                    elif ch = '\t' then sb.Append("\\t") |> ignore
+                    elif code = 0x1B then sb.Append("\\x1B") |> ignore
+                    elif code < 0x20 || code = 0x7F then
+                        sb.AppendFormat("\\x{0:X2}", code) |> ignore
+                    elif ch = '"' then sb.Append("\\\"") |> ignore
+                    else sb.Append(ch) |> ignore
+                sb.ToString()
+        let describeEntry (e: ContentHistory.Entry) : string =
+            let seq = ContentHistory.entrySeq e
+            let source =
+                match ContentHistory.entrySource e with
+                | ContentHistory.EntrySource.UserInputEcho -> "UserInputEcho"
+                | ContentHistory.EntrySource.CmdOutput -> "CmdOutput"
+                | ContentHistory.EntrySource.CmdSubPrompt -> "CmdSubPrompt"
+                | ContentHistory.EntrySource.ShellPrompt -> "ShellPrompt"
+                | ContentHistory.EntrySource.BoundaryMarker -> "BoundaryMarker"
+                | _ -> "Unknown"
+            let kindAndPayload =
+                match e with
+                | ContentHistory.TextSpan d ->
+                    sprintf "Kind=TextSpan Len=%d Text=\"%s\""
+                        d.Text.Length (escape (truncate d.Text 80))
+                | ContentHistory.Newline _ ->
+                    "Kind=Newline"
+                | ContentHistory.Overwrite d ->
+                    sprintf "Kind=Overwrite ReplacesSeq=%d Text=\"%s\""
+                        d.ReplacesSeq (escape (truncate d.Text 80))
+                | ContentHistory.Marker d ->
+                    let payload =
+                        match d.Payload with
+                        | Some p -> sprintf " Payload=\"%s\"" (escape (truncate p 80))
+                        | None -> ""
+                    sprintf "Kind=Marker MarkerKind=%A%s" d.Kind payload
+                | ContentHistory.Spinner d ->
+                    sprintf "Kind=Spinner Frame=\"%s\"" (escape (truncate d.Frame 40))
+            // SpeechCursor manual-nav verdict (PR-D's
+            // renderEntryForManualNav). Using FinalDirOnly to
+            // match the typical run-time PromptPath; if the
+            // shipped PromptPath differs the verdict for
+            // PromptStart markers may differ in production but
+            // the rest of the entries are PromptPath-invariant.
+            let navVerdict =
+                try
+                    match
+                        SpeechCursor.renderEntryForManualNav
+                            ShellPolicy.FinalDirOnly e
+                    with
+                    | Some (text, activity) ->
+                        sprintf "NavRender=Some(Len=%d Activity=%s Text=\"%s\")"
+                            text.Length activity
+                            (escape (truncate text 60))
+                    | None -> "NavRender=None"
+                with ex ->
+                    sprintf "NavRender=ERROR(%s)" ex.Message
+            sprintf "[Seq=%d Source=%s %s %s]" seq source kindAndPayload navVerdict
+        let lines = ResizeArray<string>()
+        if start > 0 then
+            lines.Add(sprintf "... (%d earlier entries omitted; full reconstruction in the sibling content-history file)" start)
+        for i in start .. (total - 1) do
+            lines.Add(describeEntry entries.[i])
+        if lines.Count = 0 then "(no entries)"
+        else String.concat "\n" lines
+
     // ---------------------------------------------------------------
     // Cycle 25b — diagnostic-dump bundle
     // ---------------------------------------------------------------
@@ -1645,8 +1747,21 @@ module Diagnostics =
                     let statsHeader =
                         try formatContentHistoryStats history
                         with _ -> "(ContentHistory stats unavailable)"
+                    // PR-P (2026-05-14) — per-entry dump for the
+                    // SpeechCursor-verdict question. Capped at
+                    // 200 entries — sufficient for a multi-test
+                    // session and fits comfortably under the
+                    // 60 KB clipboard cap.
+                    let entriesDump =
+                        try formatContentHistoryEntries history 200
+                        with _ -> "(ContentHistory entries unavailable)"
                     let contentHistorySection =
-                        sprintf "(source: %s)\n%s\n%s" historySiblingPath statsHeader tailText
+                        sprintf
+                            "(source: %s)\n%s\n--- ENTRIES (last 200 with SpeechCursor verdict) ---\n%s\n--- TAIL (rendered) ---\n%s"
+                            historySiblingPath
+                            statsHeader
+                            entriesDump
+                            tailText
 
                     let bundle =
                         formatDiagnosticBundle


### PR DESCRIPTION
## Summary

Post-Cycle-49 PR-P. Adds a per-entry ContentHistory dump to the `Ctrl+Shift+D` diagnostic bundle so SpeechCursor entry-level questions are answerable from a single paste.

Maintainer's Test D (SpeechCursor missing the `Enter your name:` chunk) couldn't be localised from the existing bundle — the aggregate `Stats:` line gives totals but the per-entry view (Seq / Kind / Source / Text / SpeechCursor manual-nav verdict) wasn't available without `Ctrl+Shift+Y` + the sibling reconstruction file + a debug-log walk.

## What the new section looks like

Inside `--- CONTENT HISTORY (last 64KB) ---`, a new subsection:

```
--- ENTRIES (last 200 with SpeechCursor verdict) ---
[Seq=0 Source=BoundaryMarker Kind=Marker MarkerKind=PromptStart Payload="C:\Users\..." NavRender=Some(Len=N Activity=pty-speak.output Text="...")]
[Seq=1 Source=UserInputEcho Kind=TextSpan Len=4 Text="kyle" NavRender=None]
[Seq=2 Source=CmdOutput Kind=TextSpan Len=16 Text="Enter your name:" NavRender=Some(Len=16 Activity=pty-speak.output Text="Enter your name:")]
... (M earlier entries omitted; full reconstruction in the sibling content-history file)
```

Each entry line is single-line — control characters (`\n`, `\r`, `\t`, `\x1B`, `\xNN`) escape-printed, text truncated to 80 chars, payload to 60 chars in the NavRender verdict. Capped at the last 200 entries to stay paste-friendly under the 60 KB clipboard cap. The full reconstruction stays in the sibling `content-history-<ts>.txt` file.

## Verdict semantics

`NavRender` comes from `SpeechCursor.renderEntryForManualNav` with `ShellPolicy.FinalDirOnly` (the default manual-nav prompt-path mode). `Some(...)` = entry IS navigable via `Ctrl+Shift+Up/Down/End`. `None` = entry is filtered.

For the Test D question — "why isn't `Enter your name:` navigable?" — we'd expect to see a line like:
```
[Seq=N Source=CmdOutput Kind=TextSpan Len=16 Text="Enter your name:" NavRender=Some(...)]
```

If `NavRender=None` shows up there, the filter has a bug. If the entry's `Source` is `UserInputEcho` instead of `CmdOutput`, the source-resolver mis-tagged it. If the entry is **missing entirely** from the dump, ContentHistory didn't see those bytes (a substrate issue).

## Test plan

- [ ] CI green
- [ ] After merge + build, you press `Ctrl+Shift+D` and paste the bundle. The new `--- ENTRIES (last 200 with SpeechCursor verdict) ---` subsection appears between `Stats:` and `--- TAIL (rendered) ---`.
- [ ] Run test-02, type a name + Enter, then press `Ctrl+Shift+D`. Bundle includes the per-entry list. I can localise Test D from that paste directly.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_