### PR TITLE
fix: ContentHistory source at first byte + sub-prompt cursor-capture gate (PR-Q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,51 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-Q (2026-05-14): ContentHistory source captured at first byte + cursor-capture gated to top-level Enter
+
+Maintainer's post-PR-P bundle (preview.128) localised two
+distinct bugs:
+
+1. **`Enter your name:` mis-tagged as `UserInputEcho`.**
+   `Source = resolveSource state` ran at TextSpan SEAL time
+   inside `sealActiveSpan`. The script's `set /p` prompt
+   (no trailing newline) accumulated bytes into the active
+   TextSpan during `Executing`, but the TextSpan didn't
+   seal until cmd went idle — by which point
+   `SubPromptIdle` had already flipped `ShellInteraction`
+   to `Composing`. The seal-time resolver returned
+   `EntrySource.UserInputEcho`. SpeechCursor's
+   `renderEntryForManualNav` filter correctly skipped the
+   entry per the tag — but the tag itself was wrong.
+   PR-Q captures the source at the FIRST byte of the
+   active TextSpan (alongside `ActiveSpanStartedAt`),
+   stores it in a new `ActiveSpanSource` field, and uses
+   it at seal. Falls back to `resolveSource` if the field
+   is unset (defensive — shouldn't happen since
+   first-byte initialises both fields atomically). Net:
+   `Enter your name:` now tags `CmdOutput` correctly and
+   becomes navigable in SpeechCursor.
+
+2. **Tuple-final no-trim regression from PR-O.** PR-O's
+   cursor-row capture in the byte-write wrapper fired on
+   EVERY Enter, including the sub-prompt-response Enter.
+   For test-02's "love" + Enter, that overwrote
+   `lastSubmittedCommandEndCursorRow` with the sub-prompt
+   input row (7) instead of the script-invocation end
+   row (4). `computePromptCommandWrapRows` then returned
+   `wrapRows = 7 - 3 + 1 = 5`, `capturePreambleForSubPromptResponse`
+   computed `startRow = 8`, range `[8, 6]` was empty,
+   `nonEmptyCount` stayed 0, no preamble-captured log
+   fired, and tuple-final fell through to no-trim —
+   narrating the ENTIRE script output from the start
+   instead of just the response delta.
+   PR-Q gates the cursor capture on `not
+   awaitingSubPromptEnter` so only top-level Enter
+   updates the saved cursor signal. Sub-prompt-response
+   Enter leaves it alone — the previously-captured
+   script-invocation cursor row stays valid for the
+   wrap-rows computation.
+
 ### Post-Cycle-49 PR-P (2026-05-14): Per-entry ContentHistory dump in diagnostic bundle
 
 Maintainer's Test D (SpeechCursor missing the `Enter your

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4559,20 +4559,38 @@ module Program =
                             // it via Up/Down (Up-arrow recall doesn't
                             // route through `UserInputBuffer` so
                             // `Capture()` underreports its length).
-                            try
-                                let _, (curRow, _), _ =
-                                    screen.SnapshotRows(0, screen.Rows)
-                                lastSubmittedCommandEndCursorRow <- curRow
-                                lastSubmittedCommandPromptRow <-
-                                    match currentSession.Active with
-                                    | Some active ->
-                                        match active.PromptRowIndex with
-                                        | Some r -> r
+                            // PR-Q follow-up (2026-05-14) — only
+                            // capture the cursor/prompt row when
+                            // this Enter is the TOP-LEVEL submit
+                            // (state Composing with the path
+                            // prompt). For a sub-prompt-response
+                            // Enter (`awaitingSubPromptEnter =
+                            // true`) the cursor row reflects the
+                            // sub-prompt input position, not the
+                            // script-invocation end — overwriting
+                            // here mis-computes wrapRows for the
+                            // tuple-final preamble capture and
+                            // silences the line-count slice
+                            // (`startRow > endRow → empty range
+                            // → preamble count stays 0 → tuple-
+                            // final falls through to no-trim`).
+                            // Maintainer bundle 2026-05-14 confirmed
+                            // this regression.
+                            if not awaitingSubPromptEnter then
+                                try
+                                    let _, (curRow, _), _ =
+                                        screen.SnapshotRows(0, screen.Rows)
+                                    lastSubmittedCommandEndCursorRow <- curRow
+                                    lastSubmittedCommandPromptRow <-
+                                        match currentSession.Active with
+                                        | Some active ->
+                                            match active.PromptRowIndex with
+                                            | Some r -> r
+                                            | None -> -1
                                         | None -> -1
-                                    | None -> -1
-                            with _ ->
-                                lastSubmittedCommandEndCursorRow <- -1
-                                lastSubmittedCommandPromptRow <- -1
+                                with _ ->
+                                    lastSubmittedCommandEndCursorRow <- -1
+                                    lastSubmittedCommandPromptRow <- -1
                             recordTransition
                                 (ShellInteraction.EnterPressed captured)
                     // Cycle 49 PR-I — history-recall announce.

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -244,6 +244,17 @@ module ContentHistory =
         /// newline / marker / idle / overwrite.
         member val internal ActiveSpanText: StringBuilder = StringBuilder() with get
         member val internal ActiveSpanStartedAt: DateTime voption = ValueNone with get, set
+        /// PR-Q (2026-05-14) — `EntrySource` captured at the
+        /// first byte of the active TextSpan. The seal-time
+        /// resolver was racy for sub-prompts: the script's
+        /// `set /p` prompt text (no trailing newline) idle-
+        /// sealed AFTER `SubPromptIdle` flipped
+        /// `ShellInteraction` to `Composing`, so the resolver
+        /// returned `UserInputEcho` even though the bytes
+        /// arrived during `Executing`. Sealing now uses this
+        /// first-byte snapshot instead. Reset to `ValueNone`
+        /// on seal/clear.
+        member val internal ActiveSpanSource: EntrySource voption = ValueNone with get, set
         member val internal LastEventAt: DateTime = DateTime.MinValue with get, set
         /// CUB deferred-resolution: same shape as Cycle 44's bare-
         /// CR + CUB fixes in `LinearTextStream`. When a `CSI N D`
@@ -582,15 +593,30 @@ module ContentHistory =
                 match state.ActiveSpanStartedAt with
                 | ValueSome t -> t
                 | ValueNone -> at
+            // PR-Q (2026-05-14) — use the source captured at the
+            // active span's FIRST byte, not the current
+            // resolver. Seal-time resolution mis-tagged
+            // `set /p` prompts as `UserInputEcho` because the
+            // idle-seal fired AFTER `SubPromptIdle` flipped
+            // `ShellInteraction` to `Composing`. Fall back to
+            // the resolver only if no first-byte source was
+            // recorded (defensive — shouldn't happen in
+            // practice since `appendFromEvent`'s first-byte
+            // branch sets it alongside `ActiveSpanStartedAt`).
+            let resolvedSource =
+                match state.ActiveSpanSource with
+                | ValueSome s -> s
+                | ValueNone -> resolveSource state
             let entry =
                 TextSpan
                     { Seq = nextSeq state
                       Text = state.ActiveSpanText.ToString()
                       StartedAt = startedAt
                       SettledAt = at
-                      Source = resolveSource state }
+                      Source = resolvedSource }
             state.ActiveSpanText.Clear() |> ignore
             state.ActiveSpanStartedAt <- ValueNone
+            state.ActiveSpanSource <- ValueNone
             state.Entries.Add(entry)
             Some entry
 
@@ -787,6 +813,13 @@ module ContentHistory =
                     // emitted until the span seals.
                     if state.ActiveSpanStartedAt.IsNone then
                         state.ActiveSpanStartedAt <- ValueSome now
+                        // PR-Q (2026-05-14) — capture the source
+                        // at the first byte. `sealActiveSpan`
+                        // consumes this snapshot, avoiding the
+                        // sub-prompt mis-tag race where idle-
+                        // seal fired AFTER `SubPromptIdle`
+                        // flipped state to `Composing`.
+                        state.ActiveSpanSource <- ValueSome (resolveSource state)
                     state.ActiveSpanText.Append(rune.ToString())
                     |> ignore
                     []
@@ -890,6 +923,7 @@ module ContentHistory =
             state.NextSeq <- 0L
             state.ActiveSpanText.Clear() |> ignore
             state.ActiveSpanStartedAt <- ValueNone
+            state.ActiveSpanSource <- ValueNone
             state.LastEventAt <- DateTime.MinValue
             state.PendingCUB <- ValueNone
             state.PendingCRDeferred <- false


### PR DESCRIPTION
## Summary

Two bugs found in maintainer's post-PR-P bundle (preview.128), shipped together since both surfaced from the same diagnostic paste.

### Bug 1: `Enter your name:` mis-tagged as `UserInputEcho` (Test D root cause)

PR-P's new per-entry dump revealed it:
```
[Seq=12 Source=UserInputEcho Kind=TextSpan Len=16 Text="Enter your name:" NavRender=None]
```

Same byte stream, three lines apart:
- Seq=8 `=== PTYSPEAK-TEST-START...` → `CmdOutput` ✓
- Seq=10 `This test prompts...` → `CmdOutput` ✓
- **Seq=12 `Enter your name:` → `UserInputEcho` ✗**

The first two end with `\n`; the third (a `set /p` prompt) does NOT. So Seq=12's TextSpan accumulates bytes during `Executing`, then idle-seals AFTER `SubPromptIdle` flips `ShellInteraction` to `Composing`. `sealActiveSpan` calls `resolveSource` at seal-time → returns `UserInputEcho`. SpeechCursor's filter correctly skipped it per the tag — but the tag was wrong.

**Fix:** capture source at FIRST byte of the active TextSpan into a new `ActiveSpanSource` field, consume at seal. Falls back to `resolveSource` if unset (defensive). Reset paths (`sealActiveSpan`, `reset`) clear the field.

### Bug 2: Tuple-final no-trim regression from PR-O

Maintainer Test B retest report: "after I hit enter on the input prompt it speaks the entire message again from the beginning rather than only what comes next." Log confirms:
```
12:13:36.766 UserInputBuffer captured on Enter: Length=4 Text=love
12:13:36.943 Tuple-final announce. Length=220  ← full output, no trim
```
NO `PR-N sub-prompt preamble captured` log between them.

PR-O captures the cursor row on EVERY Enter — including the sub-prompt-response Enter. For `love` + Enter, that overwrote `lastSubmittedCommandEndCursorRow` with the sub-prompt input row (7) instead of the script-invocation end (4). `computePromptCommandWrapRows` returned `wrapRows = 7 - 3 + 1 = 5`, `capturePreamble` computed `startRow = 8`, range `[8, 6]` was empty, `nonEmptyCount` stayed 0, tuple-final fell through to no-trim.

**Fix:** gate the cursor capture on `not awaitingSubPromptEnter`. Only top-level Enter updates the saved cursor signal; sub-prompt-response Enter leaves it alone — script-invocation cursor stays valid for wrap-rows.

## Test plan

- [ ] CI green
- [ ] Dogfood Test D: run test-02-text-input, type a name + Enter. `Ctrl+Shift+Up` past the output. NVDA narrates `Enter your name:` as a separate stop. (Bug 1 fix.)
- [ ] Dogfood Test B: after typing the name + Enter, NVDA narrates only `Hello, NAME!...` + END marker. (Bug 2 fix.)
- [ ] Regression: run echo twice, run test-01 — both narrate cleanly.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_