### PR TITLE
fix: include cursor row in sub-prompt preamble count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ title, body, and Velopack `Setup.exe` + nupkg + `RELEASES` files.
 
 ## [Unreleased]
 
+### Post-Cycle-49 PR-R (2026-05-14): Include cursor row in sub-prompt preamble count
+
+Maintainer post-PR-Q dogfood: after typing the sub-prompt
+response + Enter, NVDA narrates `Enter your name:love`
+followed by the script's post-Enter response, instead of
+JUST the post-Enter response. The user has already engaged
+with the prompt+response line (heard the prompt
+pre-Enter, typed the response themselves) and shouldn't
+hear it again.
+
+Root cause: PR-K's `endRow = cursorRow - 1` in
+`capturePreambleForSubPromptResponse`. PR-K added the
+`-1` in 2026-05-14 to compensate for an over-count that
+was actually a wrap-row miscount (PR-N has since fixed
+that properly via the `wrapRows` skip at `startRow`). Now
+the `-1` excludes the cursor row, which IS the row
+carrying the sub-prompt prompt + user's typed response —
+the line that should be counted as preamble.
+
+PR-R reverts to `endRow = cursorRow`. With PR-N's
+`wrapRows` skip in `startRow`, the count comes out to 3
+for the canonical test-02 case (START + intro +
+prompt:response), which drops 3 of the 5 OutputText
+lines, leaving the post-Enter response + END marker —
+exactly what the user wants to hear.
+
 ### Post-Cycle-49 PR-Q (2026-05-14): ContentHistory source captured at first byte + cursor-capture gated to top-level Enter
 
 Maintainer's post-PR-P bundle (preview.128) localised two

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2050,9 +2050,31 @@ module Program =
                         // of the typed command, not script
                         // preamble. Same rationale as in
                         // `subPromptScreenReader`.
+                        //
+                        // PR-R (2026-05-14) — endRow = cursorRow,
+                        // not cursorRow - 1. PR-K's `cursorRow -
+                        // 1` was patching what was actually a
+                        // wrap-row miscount, fixed properly in
+                        // PR-N. With wrap rows correctly skipped
+                        // by `startRow = promptRow + wrapRows`,
+                        // the cursor row IS the row carrying
+                        // the sub-prompt + user's typed response
+                        // (e.g. "Enter your name:love"). The
+                        // user has already engaged with that
+                        // line — sub-prompt announce read it
+                        // pre-Enter, user typed the response —
+                        // so the line should count as preamble
+                        // and drop from tuple-final. Pre-PR-R,
+                        // the line wasn't counted, so tuple-
+                        // final re-narrated "Enter your
+                        // name:love" before the script's
+                        // post-Enter response. Maintainer
+                        // 2026-05-14: "I hear the prompt for
+                        // the input along with the value that
+                        // I input."
                         let wrapRows = computePromptCommandWrapRows promptRow
                         let startRow = promptRow + wrapRows
-                        let endRow = cursorRow - 1
+                        let endRow = cursorRow
                         let mutable nonEmptyCount = 0
                         for r in startRow .. endRow do
                             if r >= 0 && r < snapshot.Length then


### PR DESCRIPTION
Post-Cycle-49 PR-R. Maintainer post-PR-Q dogfood: after typing sub-prompt response + Enter, NVDA narrates "Enter your name:love" followed by the script's post-Enter response, instead of JUST the post-Enter response.

PR-K's endRow = cursorRow - 1 was patching what was actually a wrap-row miscount (since fixed properly in PR-N's wrapRows skip at startRow). With PR-N in place, the -1 excludes the cursor row — which IS the row
carrying the sub-prompt + user's typed response, the line that should drop from tuple-final.

PR-R reverts to endRow = cursorRow. For test-02 the count is now 3 (START + intro + prompt:response), drops 3 of 5 OutputText lines, leaves response + END marker.

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
