### PR TITLE
fix: seed sub-prompt preamble line count at SubPromptIdle for single-key prompts (PR-U)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13502,6 +13502,48 @@ Going forward, new entries land at the bottom; the
 per-entry `### Cycle N PR-X (date):` header gives the
 chronological order regardless of file position.
 
+### Post-Cycle-49 PR-U (2026-05-14): Seed sub-prompt preamble line count at SubPromptIdle for single-key sub-prompts
+
+Maintainer test-04 (yes/no via `choice`) dogfood 2026-05-14:
+after pressing `Y`, NVDA narrated the entire 184-char script
+output (START + intro + `Continue? [Y,N]?Y` + `You chose Yes.`
++ END) instead of just `You chose Yes.` + END.
+
+Root cause: `choice` is a single-key sub-prompt — cmd
+consumes the `Y` byte directly without requiring `Enter`.
+The byte-write wrapper never sees `0x0D`, so no EnterPressed
+transition fires, so `capturePreambleForSubPromptResponse`
+never runs, so `subPromptPreambleLineCount` stays at 0, so
+tuple-final's line-count strategy falls through to "no
+trim". The state-machine log confirms:
+`Composing(prompt=..., single-key=true)` — the state-
+machine knows it's single-key but the line-count signal
+isn't wired into that path.
+
+PR-U also seeds `subPromptPreambleLineCount` at SubPromptIdle
+time using the count of non-empty lines in the screen-read
+announce body. For typed-input sub-prompts (test-02),
+`capturePreambleForSubPromptResponse` continues to OVERRIDE
+this seed on EnterPressed with the cursor-row count (finer
+grained, accounts for typed response on the prompt row).
+For single-key sub-prompts where no EnterPressed fires, the
+SubPromptIdle seed drives tuple-final correctly. Only
+seeds when `source = "screen"`; the accumulator-fallback
+path's line layout may not match `tuple.OutputText`'s.
+
+Diagnostic log per the PR-J convention: new Information-
+level `PR-U sub-prompt preamble line count seeded at
+SubPromptIdle. LineCount=N Source=screen` confirms the seed
+fired.
+
+(Adjacent maintainer complaint about `Continue? [Y,N]?` not
+being heard — bundle disagrees: the sub-prompt announce
+body at 13:17:52 includes "Continue? [Y,N]?" in the
+124-char announce. Likely NVDA's TTS dropped or cut off
+mid-sentence since `AnnounceSanitiser.sanitise` strips `\n`
+from the announce body. Worth a follow-up if it persists
+post-PR-U.)
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1775,6 +1775,59 @@ module Program =
                                 "PR-K sub-prompt announce body. Source={Source} Announce={Announce}",
                                 source, toSay)
                             window.TerminalSurface.Announce(toSay, ActivityIds.output)
+                            // PR-U (2026-05-14) — for single-key
+                            // sub-prompts (`choice` / `pause`)
+                            // there's no EnterPressed transition
+                            // when the user submits the response
+                            // (the byte is consumed by cmd
+                            // directly without `\r`), so
+                            // `capturePreambleForSubPromptResponse`
+                            // never fires and
+                            // `subPromptPreambleLineCount`
+                            // stays at 0 — tuple-final falls
+                            // through to no-trim and the whole
+                            // script output gets re-narrated.
+                            // Maintainer's test-04 dogfood
+                            // 2026-05-14 reproduced this:
+                            // pressed `Y` to `Continue? [Y,N]?`,
+                            // tuple-final spoke the full
+                            // 184-char output.
+                            //
+                            // Fix: at SubPromptIdle (here),
+                            // count the non-empty lines in the
+                            // screen-read announce body and
+                            // seed `subPromptPreambleLineCount`.
+                            // For typed-input sub-prompts
+                            // (test-02),
+                            // `capturePreambleForSubPromptResponse`
+                            // will OVERRIDE this count on
+                            // EnterPressed using its cursor-row
+                            // signal — which is finer-grained
+                            // and accounts for the user's
+                            // typed response on the prompt
+                            // row. For single-key sub-prompts,
+                            // no EnterPressed → the seed
+                            // count drives tuple-final
+                            // correctly.
+                            //
+                            // Only seed when `source = "screen"`;
+                            // the accumulator-fallback path's
+                            // line layout may not match
+                            // tuple.OutputText's line shape
+                            // (the accumulator has raw bytes
+                            // including OSC sequences and
+                            // partial wraps).
+                            if source = "screen" then
+                                let lineCount =
+                                    announceBody.Split([| '\n' |], System.StringSplitOptions.None)
+                                    |> Array.filter (fun l ->
+                                        not (System.String.IsNullOrWhiteSpace l))
+                                    |> Array.length
+                                if lineCount > 0 then
+                                    subPromptPreambleLineCount <- lineCount
+                                    log.LogInformation(
+                                        "PR-U sub-prompt preamble line count seeded at SubPromptIdle. LineCount={Lc} Source={Source}",
+                                        lineCount, source)
                             // Cycle 49 PR-C — invalidate UIA
                             // Text-pattern cache so the review
                             // cursor picks up the sub-prompt


### PR DESCRIPTION
## Summary

Maintainer test-04 (yes/no via `choice`) dogfood 2026-05-14: after pressing `Y`, NVDA narrated the entire 184-char script output (START + intro + `Continue? [Y,N]?Y` + `You chose Yes.` + END) instead of just `You chose Yes.` + END.

## Root cause

`choice` is a **single-key sub-prompt** — cmd consumes the `Y` byte directly, no `Enter` required. The byte-write wrapper never sees `0x0D`, so no `EnterPressed` transition fires, so `capturePreambleForSubPromptResponse` never runs, so `subPromptPreambleLineCount` stays at 0, so tuple-final's line-count strategy falls through to no-trim.

The state-machine knows it's single-key (`Composing(prompt=..., single-key=true)` in the log) — but the line-count signal isn't wired into that path.

## Fix

Seed `subPromptPreambleLineCount` at `SubPromptIdle` time using the count of non-empty lines in the screen-read announce body.

- **Typed-input sub-prompts (test-02)**: `capturePreambleForSubPromptResponse` continues to OVERRIDE this seed on `EnterPressed` with its cursor-row count (finer grained — accounts for the user's typed response on the prompt row).
- **Single-key sub-prompts (test-04)**: no `EnterPressed` fires → the SubPromptIdle seed drives tuple-final correctly.

Only seeds when `source = "screen"` (the screen-read path); the accumulator-fallback path's line layout may not match `tuple.OutputText`'s.

## Diagnostic log (per PR-J convention)

New Information-level log:
```
PR-U sub-prompt preamble line count seeded at SubPromptIdle. LineCount=N Source=screen
```

## Adjacent observation (not addressed by this PR)

Maintainer also reported `Continue? [Y,N]?` not being heard during the first chunk. Bundle disagrees — the sub-prompt announce body at `13:17:52` includes the full text in 124 chars. Likely NVDA's TTS dropped or cut off mid-sentence since `AnnounceSanitiser.sanitise` strips `\n` from the announce body, leaving NVDA no natural pause cue between the three logical lines. If it persists post-PR-U, worth a follow-up to either keep newlines in the announce or split into multiple `Announce()` calls per logical line.

## Test plan

- [ ] CI green
- [ ] Dogfood: run `test-04-yes-no`, press `Y`. NVDA narrates ONLY `You chose Yes.` + END marker. No re-narration of the script preamble or `Continue? [Y,N]?`.
- [ ] Regression: run `test-02-text-input`, type a name + Enter. Behavior unchanged from PR-R (typed-input path overrides the SubPromptIdle seed via `capturePreambleForSubPromptResponse`).

https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_