### PR TITLE
docs(cycle51): crash-safe handoff — execution playbook + archiving discipline

### DIFF
--- a/docs/CYCLE-51-PLAYBOOK.md
+++ b/docs/CYCLE-51-PLAYBOOK.md
@@ -1,0 +1,558 @@
+# Cycle 51 execution playbook — IOCell pivot
+
+> **NEXT SESSION: THIS IS YOUR START-HERE DOCUMENT.** Read it
+> top to bottom before writing any code. It is a turn-by-turn
+> execution guide with exact `file:line` anchors, the rejected
+> thesis you must NOT re-introduce, and the bundle evidence
+> behind every decision. Companion to
+> [`adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md)
+> (the canonical decision record — read it second) and
+> [`SESSION-HANDOFF.md`](SESSION-HANDOFF.md) (the ~150-line
+> brief — read it first for the bird's-eye).
+>
+> This doc was written 2026-05-15 by the session that shipped
+> PR-V, deliberately as a crash-safe handoff. It is exhaustive
+> on purpose. When Cycle 51 ships, PR-Z marks this doc
+> HISTORICAL (banner at top + move to `docs/archive/`).
+
+## 0. STOP — three things that will waste your time if you skip them
+
+1. **The classification-by-`EntrySource` thesis is REJECTED.**
+   The original ADR draft (and the Phase 0 spike) proposed
+   walking `ContentHistory` entries and routing each to
+   command-vs-output by its `EntrySource` tag
+   (`UserInputEcho` → command, `CmdOutput` → output). **This
+   does not work.** Section 4 has the bundle proof. Do not
+   re-introduce it. The command/output split is the
+   **first-newline rule on a marker-bounded slice** — the
+   heuristic the existing extractor already ships.
+
+2. **The spike branch `spike/cycle51-iocell-substrate-exploration`
+   (`de8bf81`) is a GRAVEYARD, not a starting point.** It
+   contains the rejected classifier (`SessionModel.extractIOCell`
+   spike version), the `IOCellSpikeComparison` facade, the
+   `ContentHistory.entriesAfter` helper, and a `Cycle 51 spike
+   PR-V0.` diagnostic log in `Program.fs`. **Do NOT cherry-pick
+   anything from it.** It is pushed only so the ADR's
+   provenance reference (`de8bf81`) resolves. Work from clean
+   `main`.
+
+3. **There is no `dotnet` in the sandbox.** You cannot
+   `dotnet build` / `dotnet test` locally. Every compile error
+   is a multi-minute CI round-trip. Read each `.fs` edit twice.
+   The F# 9 gotchas in §7 have bitten this codebase repeatedly;
+   internalize them before editing F#.
+
+## 1. Where we are exactly (2026-05-15)
+
+- **`main` HEAD = `6b3ff6a`** — PR-V (ADR 0004) merged via
+  PR #332 (docs-only fast-merge on the markdown link check).
+- **Local `main` is up to date; working tree clean.**
+- **Branches**: the merged PR-V branch was deleted local +
+  remote. The spike branch is still on remote (graveyard;
+  leave it — PR-Z dispositions it).
+- **No code has changed on `main`** since `ae33bc9` except
+  the ADR docs. `SessionModel.fs`, `Program.fs`,
+  `ContentHistory.fs` on `main` are exactly the
+  Cycle-49/50 state. All line anchors in this doc are against
+  `main` at `6b3ff6a`.
+- **Cycle 51 progress**: Phase 0 (spike) ✅ done (superseded
+  by bundle analysis). PR-V ✅ merged. **PR-W is next.**
+  Then PR-W2 → PR-X → PR-Y → PR-Z.
+
+## 2. The north star (maintainer's verbatim intent)
+
+Keep these in view — they are why the pivot exists, not just
+what it does:
+
+- *"the core infrastructure is not robust enough and
+  extensible and modular enough to handle other shells"*
+- *"we need to be just handling The Computational in and out
+  in a similar way that a computational notebook such as
+  Wolfram does"*
+- *"I want to be able to have an abstraction layer on top of
+  all of this that will allow us to route each one of these
+  different events that is presently going into NVDA through
+  different channels, such as spatial audio and custom speech
+  synthesis"*
+- *"We have a ton of wonderful infrastructure in place to do
+  CI, build releases, diagnostics, and user testing scripts.
+  How do we pivot and use all of this existing tooling, but
+  get rid of the screen paradigm"*
+
+The pivot's essence: **stop using screen-row coordinates as a
+source of truth; the substrate (ContentHistory, Seq-keyed) is
+already notebook-shaped; finish trusting it and delete the
+screen-row code that fights it.** The maintainer is a
+screen-reader (NVDA) user — see §7 for the no-GUI-walks rule.
+
+## 3. The reading order before you touch code
+
+1. This doc (§0–§10).
+2. [`adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md)
+   — the canonical decision record. Especially §"Context →
+   What the substrate reliably provides", §"Decision 3",
+   §"Status notes" (the draft→revised arc), §"Migration plan"
+   (PR-W / PR-X are the load-bearing ones).
+3. [`../CLAUDE.md`](../CLAUDE.md) — runtime rules (CI-log
+   asking, no-GUI-walks, diagnostic recipes, docs-only
+   fast-merge, poll-CI-every-60s).
+4. [`../CONTRIBUTING.md`](../CONTRIBUTING.md) §"F# gotchas
+   learned in practice" — before any `.fs` edit.
+5. The four ADRs 0001–0004 if you don't already hold the
+   substrate/channel/interaction/IOCell framing.
+
+## 4. The bundle evidence (why the thesis was rejected)
+
+The maintainer's preview.135 dogfood bundle (2026-05-14,
+4-run test-04 sequence) carried a `--- ENTRIES ---` per-entry
+ContentHistory dump. Two findings, both load-bearing for the
+migration:
+
+### 4a. `EntrySource` is too coarse for command/output split
+
+From the dump (run 1 of test-04):
+
+| Seq | Source | Text | Truth |
+|----|--------|------|-------|
+| 6  | UserInputEcho | `"…test-04-yes-no…."` (typed cmd) | command ✓ |
+| 8  | CmdOutput | `=== PTYSPEAK-TEST-START …` | output ✓ |
+| 12 | CmdOutput | `Continue? [Y,N]?` | output ✓ |
+| 13 | **UserInputEcho** | `N` (the keypress) | ambiguous |
+| 15 | **UserInputEcho** | `You chose No.` | **output** ✗ |
+| 17 | **UserInputEcho** | `=== PTYSPEAK-TEST-END …` | **output** ✗ |
+
+Root cause: heuristic-only cmd emits **no CommandStart
+marker**. `ShellInteraction` therefore stays `Composing`
+almost the whole session, and the `EntrySource` resolver
+returns `UserInputEcho` for every byte that arrives in
+`Composing` — including cmd's own command OUTPUT. The dump's
+own stats line confirmed it: `Sources: UserInputEcho=70
+CmdOutput=32 CmdSubPrompt=0` — the `CmdSubPrompt` tag that
+was supposed to bracket sub-prompt output **never fired
+once** across the entire 4-run session. Even a plain
+`echo PtySpeakDiagPlain` had its echoed output (`Seq 94
+"PtySpeakDiagPlain"`) tagged `UserInputEcho`.
+
+**Conclusion**: an `EntrySource`-classifying extractor would
+push most of every cell's OUTPUT into the COMMAND field.
+Thesis dead. Use the first-newline split (cmd echoes the
+typed command, then `\r\n`, then output) on a marker-bounded
+slice — exactly what `extractContentFromContentHistory`'s
+heuristic-only arm already does and ships today.
+
+### 4b. The real haywire mechanism (what PR-X must fix)
+
+Run 4 of test-04 (the command echo wrapped because the
+script path exceeds 80 cols). Timeline from the FileLogger
+slice:
+
+```
+HeuristicPromptDetector dirty-flag set … priorRow=29  (wrapped)
+PR-I history-recall announce. RowLen=10 DraftLen=10   ← only "es-no.cmd"" announced
+UserInputBuffer captured on Enter: … Text=y[A
+PR-K sub-prompt announce. Length=16 Source=accumulator-fallback
+  (NO `PR-N sub-prompt screen-read range` log — screen-read path bailed)
+  (NO `PR-U sub-prompt preamble line count seeded` log)
+Tuple-final announce. Length=196                       ← WHOLE output
+  (NO `Tuple-final trim` log)
+```
+
+Mechanism: command echo wrapped → `subPromptScreenReader`'s
+screen-row math failed → it fell back to `accumulator-fallback`
+(text correct) → **but `PR-U`'s preamble-line-count seed is
+gated on `Source=screen`**, so it never fired →
+`subPromptPreambleLineCount` stayed `0` → the tuple-final
+trim (gated on line-count > 0) never activated → the full
+196-char output was announced instead of the ~14-char
+post-Enter delta ("You chose Yes."). That is the "things go
+completely haywire" the maintainer reported.
+
+**PR-X kills this by construction**: no screen-read, no
+`Source=screen` gate, no line-count math. A Seq watermark
+captured at EnterPressed + a Seq slice at tuple-final. See
+§6.
+
+## 5. PR-W — IOCell type + extraction simplification + schemaVersion 2
+
+**Branch**: `claude/cycle51-pr-w-iocell-type-extraction`
+(cut from fresh `main`; `git checkout main && git pull`
+first per CLAUDE.md).
+
+**Scope**: type rename + 2 new fields + promote the existing
+heuristic extractor arm to sole + delete the row-walk +
+formatter schemaVersion bump + SessionLogWriter swap +
+test rewrite + SESSION-MODEL→IOCELL-SCHEMA doc. **No
+EntrySource classifier. No spike helpers.**
+
+### 5a. Type rename + new fields — `src/Terminal.Core/SessionModel.fs`
+
+- **`SessionModel.fs:84`** `type SessionTuple =` — rename to
+  `IOCell`. Use `Edit replace_all=true` on the token
+  `SessionTuple` across the whole file (~150 sites incl.
+  `ActiveSessionTuple` — keep that name distinct;
+  rename to `ActiveIOCell`). Also sweep `Program.fs`,
+  `SessionLogWriter.fs`, `Diagnostics.fs`,
+  `tests/Tests.Unit/*` for `SessionTuple` references
+  (`grep -rn 'SessionTuple' src tests`).
+- Add the phase DU **above** the `IOCell` record:
+  ```fsharp
+  [<RequireQualifiedAccess>]
+  type IOCellPhase =
+      | Composing
+      | Executing
+      | AwaitingSubPromptResponse of subPromptText: string
+      | Sealed
+  ```
+- Add two fields to the `IOCell` record (per ADR §"In-memory
+  representation"): `CellSequence: int64` and
+  `Phase: IOCellPhase`. **Identity rule**: assign `Id` and
+  `CellSequence` at cell CREATION (the PromptStart-driven
+  `apply` transition that opens a cell), not at seal. The
+  active-cell constructor and `History`-seal path both live
+  in this file — find them via `grep -n 'Id = \|History\b'`.
+  `CellSequence` is monotonic per shell-session starting at
+  `0L`; it resets on shell-switch (same place
+  `ContentHistory.reset` is called — see Program.fs
+  `switchToShell`).
+- Every record-construction site of the old `SessionTuple`
+  must add the two fields. The compiler will flag each
+  (F# requires all record fields). Expect ~10–20 sites.
+
+### 5b. Extraction simplification — DELETE row-walk, PROMOTE heuristic arm
+
+- **`SessionModel.fs:794`** `let private
+  extractContentFromContentHistory` — this function has two
+  arms:
+  - **`SessionModel.fs:805`** `| Some promptStart, Some
+    outputStart ->` — the OSC-133 arm. **KEEP as-is.** It's
+    Seq-based and correct; cmd just doesn't exercise it.
+  - **`SessionModel.fs:816`** `| Some promptStart, None ->`
+    — the heuristic-only arm (slice from PromptStart Seq to
+    tail, trim trailing new-prompt text via `newPromptText`,
+    split on first `\n`). **This is the canonical extractor.**
+    Lines 850–875 are the proven logic.
+  - **`SessionModel.fs:876`** `| _ -> None` — the
+    no-PromptStart-Seq case. This is now the **drop-on-None**
+    contract: return `None`, the cell does NOT finalize.
+  Rename the whole function to `extractIOCell` (drop the
+  `private` only if a test needs it; otherwise keep private).
+- **`SessionModel.fs:347`** `let private extractContent` —
+  the screen-row-walk fallback. **DELETE the entire
+  function.**
+- **`SessionModel.fs:441`** `let private finalizeAndEnqueue`
+  — at **`SessionModel.fs:452-469`** the
+  `commandText, outputText, extractionPath` block does
+  `match fromLinear with Some -> … | None -> extractContent …`.
+  **Delete the `None -> extractContent …` fallback.** When
+  the thunk returns `None`, the cell drops:
+  `finalizeAndEnqueue` should return `state, None` (no tuple
+  enqueued) and log at Information
+  `IOCell dropped: no PromptStart Seq in ContentHistory.`
+  (per CLAUDE.md "new features ship with their diagnostic
+  triggers"). The `extractionPath` string local can go away
+  or collapse to a constant `"content-history"`.
+- **`SessionModel.fs:437`** has a `TODO(Cycle 39): remove the
+  linearOverride None branch + extractContent` — this PR IS
+  that removal. Delete the TODO comment too.
+- The `linearOverride` thunk plumbing in
+  `applyAndCaptureWithContentHistory`
+  (**`SessionModel.fs:888`**) stays structurally — it just
+  never has a fallback now.
+
+### 5c. Formatter — schemaVersion 1 → 2
+
+- **`SessionModel.fs:1357`** `let formatTupleAsJsonl` →
+  rename `formatIOCellAsJsonl`. Serialize the two new fields:
+  `cellSequence` (int64 JSON number) and `phase` as a tagged
+  DU object per the locked rule —
+  `{"kind":"composing"}` / `{"kind":"executing"}` /
+  `{"kind":"awaitingSubPromptResponse","subPromptText":"…"}` /
+  `{"kind":"sealed"}`.
+- **`SessionModel.fs:1137-1180`** is the locked-wire-format
+  docstring block (the "Hand-rolled (no JSON library)" notes
+  at line 1161). Update it: bump the `schemaVersion` line
+  1 → 2; document the two new fields + the `phase` tagged
+  shape; keep every other locked rule (escape policy,
+  Map-as-array, lone-surrogate-throws) verbatim.
+- **`SessionLogWriter.fs:231`** `let line =
+  SessionModel.formatTupleAsJsonl sanitised` → swap to
+  `formatIOCellAsJsonl`. Also the docstring at
+  `SessionLogWriter.fs:12` + `:53` mention
+  `formatTupleAsJsonl` — update.
+
+### 5d. Tests + docs
+
+- `tests/Tests.Unit/SessionModelTests.fs` — find cases that
+  exercised the row-walk (`extractContent`) path; rewrite to
+  assert the drop-on-None contract (no tuple finalised when
+  no PromptStart Seq). Add `IOCellPhase` serialization unit
+  tests (round-trip property tests are PR-W2, not here).
+  Any new fixture file needs a `<Compile Include=…>` in
+  `tests/Tests.Unit/Tests.Unit.fsproj`.
+- `docs/SESSION-MODEL.md` → replace with
+  `docs/IOCELL-SCHEMA.md` (same decade-stable wire-format
+  discipline, schemaVersion 2, the two new fields). Leave a
+  1-line `docs/SESSION-MODEL.md` pointer stub
+  ("Renamed to IOCELL-SCHEMA.md in Cycle 51 PR-W"). Update
+  any doc cross-links (`grep -rn 'SESSION-MODEL.md' docs`).
+- CHANGELOG.md `[Unreleased]` — append-BOTTOM entry
+  `### Cycle 51 PR-W (…)`.
+- This is NOT docs-only → full Windows CI required.
+
+## 6. PR-X — Seq-based sub-prompt narration (THE LOAD-BEARING PR)
+
+**Branch**: `claude/cycle51-pr-x-seq-subprompt-narration`.
+
+**This PR fixes the actual haywire (§4b).** Everything it
+touches is in `src/Terminal.App/Program.fs`. The replacement
+design is small; most of the work is DELETION.
+
+### 6a. The replacement design (what to build)
+
+1. **One mutable Seq watermark** replacing all the
+   line-count / cursor-row state:
+   `let mutable subPromptPreambleSeq : int64 = -1L`.
+2. **At EnterPressed** (user submits the sub-prompt
+   response): `subPromptPreambleSeq <-
+   ContentHistory.latestSeq contentHistory`. Unconditional
+   — NO `Source=screen` gate (that gate is the bug).
+3. **Sub-prompt announce** (replaces `subPromptScreenReader`):
+   `ContentHistory.sliceText contentHistory promptStartSeq
+   (ContentHistory.latestSeq contentHistory)` where
+   `promptStartSeq` is
+   `(ContentHistory.tryLatestMarker contentHistory
+   MarkerKind.PromptStart).Value.Seq`. Sanitise, announce.
+   The existing `accumulator-fallback` already proved this
+   text is correct — you're just making it the ONLY path.
+   Do **not** classify by `EntrySource` (§4a).
+4. **Tuple-final delta**: at cell-seal, announce
+   `ContentHistory.sliceText contentHistory
+   subPromptPreambleSeq System.Int64.MaxValue` minus the
+   trailing next-prompt text (reuse the existing
+   `newPromptText` tail-trim logic). No `OriginalLen` /
+   `TrimmedLen` / `Strategy=line-count` / `SubPromptLines`
+   arithmetic.
+
+### 6b. DELETE these (all in `Program.fs`, anchors vs `main`)
+
+- **`1027`** `let mutable subPromptPreambleLineCount : int`
+- **`1028`** `let mutable capturePreambleForSubPromptResponse`
+- **`1041`** `let mutable subPromptScreenReader`
+- **`1074-1076`** `lastSubmittedCommandLength` /
+  `lastSubmittedCommandEndCursorRow` /
+  `lastSubmittedCommandPromptRow`
+- **`1981`** `let computePromptCommandWrapRows`
+- **`2024`** the `subPromptScreenReader <- …` assignment
+  block (through ~`2050`, the `PR-N sub-prompt screen-read
+  range` log at `2046`)
+- **`1734`** `let screenRowsAnnounce = subPromptScreenReader ()`
+  and the `1764-1829` PR-K/PR-U announce+seed block —
+  replace with the §6a design (Seq-slice announce; the PR-K
+  truncation-to-`OutputAnnounceCapChars` at `1765` stays as
+  a cap on the new Seq-slice body).
+- **`1864`** `capturePreambleForSubPromptResponse ()` call
+  → replace with the watermark assignment (§6a item 2).
+- **`2141`** the second `subPromptPreambleLineCount <-
+  nonEmptyCount` site.
+- **`2350`** `let tupleFinaliseAnnounce` + **`2529-2605`**
+  the trim block (`Tuple-final trim` log at `2587`,
+  `subPromptPreambleLineCount <- 0` resets at `2602`/`2605`)
+  → replace with the §6a item-4 Seq-slice delta. Keep the
+  `OutputAnnounceCapChars` (800) cap at `2579-2584`.
+- **`4626`** `lastSubmittedCommandLength <-` and
+  **`4658-4668`** `lastSubmittedCommandEndCursorRow <-` /
+  `lastSubmittedCommandPromptRow <-` in the byte-write CR
+  branch — delete the captures (the values are now unused).
+- The PR-N/PR-O comment blocks around `1056-1076` and
+  `1974-2023`.
+
+### 6c. Diagnostic triggers (SHIP IN THIS PR — CLAUDE.md rule)
+
+Replace the deleted `PR-N`/`PR-U`/`Tuple-final trim` logs
+with, at Information (single-line, templated args, PR-X
+prefix so a bundle grep finds them):
+- `PR-X sub-prompt Seq-slice. PromptStartSeq={Seq}
+  LatestSeq={Seq} AnnounceLen={Len}`
+- `PR-X preamble watermark. PreambleSeq={Seq}`
+- `PR-X tuple-final delta. PreambleSeq={Seq} DeltaLen={Len}
+  TailTrimmed={Bool}`
+- the announce body at Debug (matches the existing
+  `PR-K sub-prompt announce body` precedent).
+
+### 6d. Tests
+
+Pure-F# unit tests over a `ContentHistory` fake (easy per
+PR-S's `CI-TESTING-FUTURE.md` Win 1). **Add the regression
+test for §4b**: a cell whose typed-command echo spans a wrap
+boundary still produces the correct short post-Enter delta
+(this is the exact bug the screen-row path had; the Seq
+path must pass it).
+
+## 7. PR-W2, PR-Y, PR-Z (summaries — full detail in ADR §"Migration plan")
+
+### PR-W2 — `IOCell.parseFromJsonl` round-trip reader
+
+- New `IOCell.parseFromJsonl : string -> Result<IOCell,
+  ParseError>` near `formatIOCellAsJsonl` in
+  `SessionModel.fs`. Hand-rolled (no JSON lib). Branch on
+  `schemaVersion`; `Result.Error` for `1` with a clear
+  message. **No UI surface** — internal + test only.
+- `tests/Tests.Unit/IOCellRoundTripTests.fs` (new; add
+  `<Compile Include=…>`): FsCheck
+  `forall c, parseFromJsonl (formatIOCellAsJsonl c) = Ok c`.
+  Generators cover the `IOCellPhase` + `BoundarySource` DUs,
+  `option` fields, edge strings (lone-surrogate must throw
+  on format per existing policy; reader rejects the same
+  payload as malformed).
+
+### PR-Y — Tier 1 channel routing
+
+Announce-site inventory (done this session, vs `main`):
+- **Tier 1 (~3-5 sites; refactor to
+  `OutputDispatcher.dispatch`)**: `Program.fs:1777` (PR-K
+  sub-prompt announce body — note PR-X reworks this site;
+  sequence PR-Y AFTER PR-X), `Program.fs:2645` (tuple-final
+  announce — same note), the Cycle-49 PR-I history-recall
+  announce on `ActivityIds.input-assistant` (needs a new
+  `SemanticCategory.InputAssistant` / `HistoryRecall`
+  variant), mode-change announces (alt-screen, selection,
+  shell-policy).
+- **Tier 2 (~50 sites; mechanical rename to
+  `AnnounceEmergency`)**: all `Ctrl+Shift+*` hotkeys, all
+  `Diagnostics →`/`View →` menu items + their result
+  announces, shell-switch success/failure, exception
+  fallbacks. Full list in ADR §"Decision 4".
+- New `TerminalSurface.AnnounceEmergency(msg, ?activityId)`
+  routing directly to `RaiseNotificationEvent` on
+  `pty-speak.app-affordance` — no dispatcher lookup. Lives
+  in the WPF view layer (`grep -rn 'member.*Announce'
+  src/Views src/*.xaml.cs`).
+- Channel-extensibility smoke test: a no-op `LoggingProfile`
+  recording every dispatched event proves Tier 1 routes
+  through the dispatcher.
+
+### PR-Z — closure audit (docs-only; fast-merge)
+
+Per CLAUDE.md §"Cycle closure audit". Checklist:
+- ADR 0004 Status → Accepted / Implemented (per-PR
+  Status-notes entries).
+- `CORE-ABSTRACTION-BOUNDARY.md` → point at ADR 0004 as the
+  cell-model lock; reframe §6 in IOCell terms.
+- `INTERACTION-MODEL.md` snapshot; `CANONICAL-DISPLAY-CATALOG.md`
+  cross-ref; `ARCHITECTURE.md` / `DOC-MAP.md` / `README.md`
+  module-map + feature-list.
+- `ACCESSIBILITY-TESTING.md` — add the Cycle 51 NVDA matrix
+  row (4-run test-04 + test-01 + test-02 + history-recall +
+  menu + Tier 2 emergency announce).
+- `CLAUDE.md` §"Current sequencing" — collapse the per-PR
+  breakdown to one Cycle-51 line.
+- `SESSION-HANDOFF.md` — Current state = Cycle 51 done;
+  Next stage drops the cycle-internal PRs.
+- This playbook + the spike branch: banner HISTORICAL,
+  move playbook to `docs/archive/`, delete the spike branch
+  (local + remote).
+- `grep -rn 'SessionTuple' src tests docs` must be empty
+  (rename complete). `grep -rn 'extractContent\b\|
+  subPromptScreenReader\|computePromptCommandWrapRows' src`
+  must be empty (deletions complete).
+- Tag (maintainer pushes; tag-push 403s in sandbox per
+  CLAUDE.md): stage `cycle51-iocell-shipped` in
+  `docs/CHECKPOINTS.md`.
+
+## 8. Operational protocol (every PR)
+
+- **`git checkout main && git pull origin main` BEFORE
+  cutting each PR branch** (Cycle-50 CHANGELOG-conflict
+  lesson). Branch name `claude/cycle51-pr-<x>-<slug>`.
+- **One concern per PR.** Conventional-commit messages.
+  CHANGELOG `[Unreleased]` append-BOTTOM.
+- **Create PRs via `mcp__github__create_pull_request`**
+  (auto-subscribes to webhook activity). Ready-for-review,
+  not draft.
+- **Poll CI every 60s** (webhooks unreliable here):
+  `mcp__github__pull_request_read method=get_check_runs`;
+  `Bash sleep 60 run_in_background:true` between polls; do
+  NOT poll faster or sleep longer.
+- **Docs-only PRs** (PR-Z, this playbook's PR) fast-merge
+  on the markdown link check alone — verify the file list
+  is strictly `*.md` first (`get_files`). PR-W / PR-W2 /
+  PR-X / PR-Y touch `src/`+`tests/` → full Windows CI
+  required.
+- **Standing merge rule**: CI green → squash-merge without
+  re-asking → `git checkout main && git pull` → delete
+  local+remote branch. Succinct CI announcements
+  ("all green, merging").
+- **CI failure**: ASK the maintainer for the log slice
+  (sandbox blocks the blob/api hosts; you cannot fetch
+  job logs). Tell them the exact strings to grep
+  (`error FS`, `error MSB`, `Build FAILED`, the test
+  name) + ~5–10 surrounding lines. **Do not push
+  speculative fixups.** Use `AskUserQuestion` if they may
+  be away (it phone-notifies; plain text does not).
+- **Walking-skeleton discipline**: each PR ships through
+  the maintainer's release-build NVDA dogfood before the
+  next. Don't bundle. After PR-X especially, dogfood the
+  4-run test-04 reproducer — that's the acceptance gate.
+
+## 9. F# 9 / .NET 9 gotchas that WILL bite (canonical: CONTRIBUTING.md)
+
+- **Nullness annotations at .NET boundaries** (`FS3261`).
+  `Environment.GetEnvironmentVariable`,
+  `Process.Start(ProcessStartInfo)`, `Path.GetFileName/
+  GetDirectoryName`, `StreamReader.ReadLine` return
+  nullable — annotate / `nonNull`.
+- **`let rec`** for self-referencing class-body bindings
+  (`FS0039` is misleading).
+- **`internal` not `private`** for companion-module access;
+  cross-assembly test access via
+  `[<assembly: InternalsVisibleTo("PtySpeak.Tests.Unit")>]`.
+- **DU access from C#**: `IsXxx` predicates + `.Item`/
+  `.Item1` accessors. `IOCellPhase` is consumed from F#
+  only here, but `IOCell` may be touched by the WPF C#
+  layer — check.
+- **Record literal type inference** fails when the record
+  module isn't auto-opened — annotate the binding
+  (`FS0039` at the field).
+- **Sequence-in-match-arm** under
+  `TreatWarningsAsErrors=true` — multi-statement match arms
+  generally compile (precedent exists), but if a complex
+  arm trips the offside rule, extract a named local
+  function. Watch this in the PR-X announce rework.
+- **Literal `0x1B` / NUL bytes** in test fixtures are
+  foot-guns — verify with `grep -c $'\x1b' <file>` after
+  edits. Relevant if PR-X / PR-W2 tests embed ESC bytes.
+- **No `dotnet` locally** — read each `.fs` twice; a missed
+  `let rec`/unused `open`/typo is a multi-minute CI
+  round-trip. `git diff --stat` before every commit;
+  investigate surprises before committing.
+
+## 10. The screen-reader-user constraints (NON-NEGOTIABLE)
+
+- The maintainer uses **NVDA**. **Never** propose a fix /
+  workflow that requires walking a GUI dialog tree. Give
+  keyboard/shell equivalents (`setx`, `set`, `tasklist |
+  findstr`, `taskkill`, `reg query`). If no CLI equivalent
+  exists, say so and ask.
+- **Asking for diagnostics**: don't say "open the bundle
+  and Ctrl+F" (not screen-reader-searchable). Use the
+  in-app **`Diagnostics → Grep Diagnostics`** dialog
+  (pattern; clipboard-capped 60 KB; full text to
+  `%LOCALAPPDATA%\PtySpeak\extracts\`). Tell them the exact
+  pattern (e.g. `PR-X tuple-final delta`). The NVDA
+  announce confirms size + extract path.
+- **`AskUserQuestion` phone-notifies; plain text does
+  not.** Use it for genuine design decisions / CI-log asks
+  when they may be away — NOT for status updates or
+  autonomy-contract-covered actions.
+
+## 11. If you have to stop mid-cycle
+
+Update SESSION-HANDOFF.md §"Current state" + §"Next stage"
+with: exact `main` HEAD, which PR merged last, which branch
+is in flight + its commit, what's left in the in-flight PR,
+and any CI-failure context awaiting a maintainer log paste.
+Then this playbook + the ADR carry the rest. The maintainer
+explicitly values a crash-safe handoff over finishing a
+turn — leave the next session a clean pickup, like this doc
+was left for you.

--- a/docs/DOC-MAP.md
+++ b/docs/DOC-MAP.md
@@ -24,7 +24,8 @@ navigation anchor.
 | [`docs/INSTALL.md`](INSTALL.md) | End user wanting to install the latest preview | Before first run | Step-by-step download + install + update flow with the SmartScreen workaround for unsigned previews. References `scripts/install-latest-preview.ps1` for the scripted alternative and `docs/BUILD.md` for build-from-source. |
 | [`CLAUDE.md`](../CLAUDE.md) | Claude Code agents | Every session start (auto-loaded) | Claude-runtime-specific rules (sandbox quirks, MCP behaviour, ask-for-CI-logs, webhook auto-subscribe); indexes the canonical rules in `CONTRIBUTING.md`. |
 | [`CONTRIBUTING.md`](../CONTRIBUTING.md) | Human contributors opening PRs | When opening a PR | Canonical home for: PR shape, branch naming, fixup-commit rhythm, F# / .NET 9 gotchas, accessibility non-negotiables, P/Invoke conventions. |
-| [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) | Next Claude Code session (or human picking up the work) | Session-to-session continuity | TLDR brief (~150 lines): current state, where we left off, next-stage candidates, sandbox gotchas, pointers out. Designed to stay short — historical handoff content moves to `docs/archive/` rather than accumulate here. |
+| [`docs/SESSION-HANDOFF.md`](SESSION-HANDOFF.md) | Next Claude Code session (or human picking up the work) | Session-to-session continuity | TLDR brief (≤200 lines): current state, where we left off, next-stage candidates, sandbox gotchas, pointers out. Stays short by the §"Archiving stale onboarding narrative" discipline — closed-cycle detail moves to CHANGELOG + `docs/archive/`, not accumulated here. |
+| [`docs/CYCLE-51-PLAYBOOK.md`](CYCLE-51-PLAYBOOK.md) | Next session executing the Cycle 51 IOCell pivot | Before writing any Cycle 51 code | Turn-by-turn execution guide for PR-W → PR-Z: exact `file:line` anchors, the rejected classification-by-`EntrySource` thesis (do not re-introduce), the dogfood-bundle evidence, F# gotchas, operational protocol. Companion to ADR 0004 (decisions) + SESSION-HANDOFF (bird's-eye). PR-Z marks it HISTORICAL → `docs/archive/`. |
 | [`spec/overview.md`](../spec/overview.md), [`spec/tech-plan.md`](../spec/tech-plan.md) | Architecture review | When changing design | Immutable spec: external research and stage-by-stage plan. ADR-style authorisation required for edits. |
 | [`spec/event-and-output-framework.md`](../spec/event-and-output-framework.md) | Architecture review (post-Stage-7 substrate) | When implementing sub-stages 8a-8f / 9a-9d, or when reasoning about event routing / output channels / profiles / the InputSource and OutputEvent schemas | Substrate spec for the post-Stage-7 framework cycles. Supersedes `spec/tech-plan.md` §8 / §9 in-place; reframes §10 as the first non-built-in framework consumer. Answers MAY-4.md's consolidated questions with v1 commitments (rationale + tradeoffs) on RawInput envelope, Intent layer, dispatcher, OutputEvent + Profile + Channel, threading + priority taxonomy, TOML schema. |
 | [`docs/PROJECT-PLAN-2026-05-12.md`](PROJECT-PLAN-2026-05-12.md) | Strategic planning | When planning a cycle (current) | Snapshot 2026-05-12 (post-Cycle-45c). Captures the ContentHistory/SpeechCursor substrate consolidation + candidate next cycles (45g, 45d, semantic-labels, etc.). Predecessor revisions archived under `docs/archive/pre-cycle-45/` per Track E E5 dated-snapshot discipline. |
@@ -122,3 +123,67 @@ The duplication audit that produced this file is the precedent —
 content drift compounds quickly when each session adds material to
 "the doc that feels relevant" without checking which doc owns the
 topic.
+
+## Archiving stale onboarding narrative
+
+**Problem this solves**: the living onboarding docs
+([`SESSION-HANDOFF.md`](SESSION-HANDOFF.md), the `CLAUDE.md`
+§"Current sequencing" block, and any in-flight `CYCLE-N-*.md`
+plan/playbook) accumulate per-cycle detail. A new contributor
+(human or Claude) reading a handoff that still narrates a
+three-cycles-old PR sequence as "current" wastes time
+reconstructing what is actually true now. Onboarding threads
+must describe the **present**, not the archaeology.
+
+**The rule**: a doc whose job is "where are we now / start
+here" carries only the *current* cycle in narrative form.
+The moment a cycle closes, its blow-by-blow detail moves to a
+durable record and the living doc keeps a ≤2-line pointer.
+
+**Durable records (where closed-cycle detail lives)** — these
+are append-only and never trimmed:
+
+- `CHANGELOG.md` `[Unreleased]` / released sections — the
+  canonical per-PR ship record.
+- `git log` — the commit-level truth.
+- The cycle's own `CYCLE-N-*.md` plan/playbook, marked
+  HISTORICAL and moved to `docs/archive/` by that cycle's
+  closure audit.
+- ADRs — the decision record; closure flips
+  Proposed → Accepted / Implemented rather than deleting.
+
+**The archive procedure** (run as part of every
+CLAUDE.md §"Cycle closure audit", or whenever an onboarding
+doc exceeds its size budget):
+
+1. **Identify the stale span** — any section of a living
+   onboarding doc that narrates a *closed* cycle in more than
+   a 2-line summary (per-PR tables, validation-gate
+   checklists, "next: PR-X" transitional language).
+2. **Confirm it is preserved elsewhere** — the same facts
+   must already be in CHANGELOG / git / the cycle's archived
+   plan / an ADR. Onboarding docs hold *no unique history*;
+   if a fact lives only there, move it to the right durable
+   record first, then trim.
+3. **Replace with a pointer** — collapse the span to ≤2 lines:
+   "Cycle N shipped (<PRs/commits>); detail in CHANGELOG +
+   `docs/archive/CYCLE-N-*.md`." Link the durable record.
+4. **Move (don't delete) cycle plans/playbooks** — when a
+   cycle closes, its `CYCLE-N-PLAYBOOK.md` / `CYCLE-N-PLAN.md`
+   gets a HISTORICAL banner at the top (one line: "Historical
+   — Cycle N shipped <date>; see CHANGELOG. Kept for the
+   planning↔shipped delta.") and moves to `docs/archive/`.
+   Update this DOC-MAP table + every cross-reference.
+5. **Size budgets** (enforced, not aspirational):
+   `SESSION-HANDOFF.md` ≤ 200 lines; `CLAUDE.md` §"Current
+   sequencing" ≤ one cycle's worth of bullets. Exceeding the
+   budget is the trigger to run steps 1–4 even mid-cycle.
+
+**Precedent**: `docs/archive/pre-cycle-45/` (the multi-
+thousand-line pre-Cycle-45 handoff + superseded plans),
+`CYCLE-49-PLAN.md` (HISTORICAL-bannered), and the Cycle 46
+retro (`CYCLE-46-NEXT-STEPS.md`) which is the cautionary
+tale: transitional "PR-D is next" language left un-archived
+forced later sessions to reverse-engineer the truth. The
+cost of NOT archiving is paid by every subsequent
+onboarding read.

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -11,118 +11,56 @@ previous (multi-thousand-line) handoff is at
 [`docs/archive/pre-cycle-45/SESSION-HANDOFF-pre-cycle-45c-historical.md`](archive/pre-cycle-45/SESSION-HANDOFF-pre-cycle-45c-historical.md)
 and serves the decision-trail role this file used to overload.
 
-## Current state (2026-05-14)
+## Current state (2026-05-15)
 
-**Cycle 49 fully shipped.** Eight-PR sequence (PR-A → PR-I,
-plus closure audit) refining the speech / review-cursor /
-sub-prompt narration on top of Cycle 48's `ShellInteraction`
-state machine:
+> **NEW SESSION START HERE → [`CYCLE-51-PLAYBOOK.md`](CYCLE-51-PLAYBOOK.md).**
+> That doc is the turn-by-turn execution guide (exact
+> `file:line` anchors, the rejected thesis you must not
+> re-introduce, the bundle evidence). This section is just
+> the bird's-eye; the playbook is the map.
 
-| PR   | Commit    | Scope                                                              |
-|------|-----------|--------------------------------------------------------------------|
-| #313 (PR-A) | `8242e56` | `SpeechCursor` manual nav (`Ctrl+Shift+Up/Down/End`) skips entries whose render returns `None` (Newline, Overwrite, empty TextSpan, `UserInputEcho`, boundary markers without payload). One stop per audible chunk. |
-| #314 (PR-B) | `36acad6` | Post-Enter delta announce for sub-prompt responses. Captures the on-screen preamble at `EnterPressed` so tuple-finalise only narrates the script's response. (PR-B's text-prefix-trim was later superseded by PR-F's line-count slice.) |
-| #315 (PR-C) | `1579ff7` | `TerminalAutomationPeer.RaiseTextChanged` fires after every Announce site so NVDA's review cursor invalidates its cached `DocumentRange` and re-pulls the latest tail without needing a fresh command. |
-| #316 (PR-D) | `4b315ae` | `SpeechCursor.renderEntryForManualNav` decouples manual-nav rendering from per-shell `PromptPath` policy. `PromptStart` markers with payload always surface as navigable entries (`FinalDirOnly`-trimmed) regardless of auto-drive verbosity. |
-| #317 (PR-F) | `2f8a05a` | Two refinements: (1) sub-prompt announce narrates only the LAST non-empty line of the accumulator (the actual prompt text), not every preamble line. (2) Post-Enter delta uses line-count slicing on `tuple.OutputText` instead of PR-B's text prefix-trim — robust to per-row content drift between EnterPressed and tuple-finalise. |
-| #318 (PR-G) | `335dbb9` | Removed the tuple-final `lastAnnouncedText` prefix-trim relic. Pre-PR-G it silenced duplicate-command output (running `echo hi` twice → second run silent) and produced the "unpredictable" silence pattern over a session. Only sub-prompt line-count slicing remains. |
-| #319 (PR-H) | `b9e250f` | Reshaped `test-01-echo.cmd` with explicit `Line 1 of 3` / `Line 2 of 3` / `Line 3 of 3` labels + framed intro and final messages. Maintainer recognition issue from the pre-Cycle-49 implicit Line 1 / Line 8 labelling. |
-| #320 (PR-I) | `904051c` | Up / Down arrow history-recall announce. Detects arrow byte sequences (`\x1B [ A/B`, `\x1B O A/B`), debounces 100 ms, reads the prompt row, strips the prompt-path prefix, and announces via a new `pty-speak.input-assistant` activity ID. CORE-ABSTRACTION-BOUNDARY.md §"input assistant" reserved peer pane's first concrete user. |
-| (this PR-Z) | (closure audit) | Docs sweep: SESSION-HANDOFF (this section), PROJECT-PLAN change log, CLAUDE.md sequencing, ACCESSIBILITY-TESTING matrix consolidation, CYCLE-49-PLAN HISTORICAL banner. |
-
-Cycle 48 history retained in the CHANGELOG + ADR-0003.
-
-`main` past Cycle 49 PR-I (`904051c`), with this PR-Z closure
-audit landing on top. Working tree clean; no in-flight
-branches; no pending fixups.
-
-**Validation gate**: maintainer dogfood against the post-PR-I
-release build is the gating signal. Live items verified
-2026-05-14 during cycle:
-- Simple echo (`test-01-echo`) narration ✓
-- Sub-prompt (`test-02-text-input`) prompt + post-Enter delta ✓
-- Duplicate command (e.g. `echo hi` twice) ✓
-- Menu narration (was a downstream regression of the
-  duplicate-suppression bug; resolved by PR-G/H) ✓
-- History recall via Up/Down arrow — pending release-build
-  re-test post-PR-I.
+- **`main` HEAD = `6b3ff6a`.** Working tree clean; no
+  in-flight code branches; no pending fixups. The spike
+  branch `spike/cycle51-iocell-substrate-exploration`
+  (`de8bf81`) is on remote as a **graveyard** — do not
+  cherry-pick from it (playbook §0).
+- **Cycle 51 (IOCell pivot) in flight.** Phase 0 spike ✅
+  (superseded by dogfood-bundle analysis). **PR-V (ADR
+  0004) ✅ merged** (#332, `6b3ff6a`). **PR-W is next**,
+  then PR-W2 → PR-X → PR-Y → PR-Z. Decision record:
+  [`adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md).
+- **Cycle 49 + post-49 hotfixes (PRs #313–#331) shipped**
+  through `ae33bc9`. Per-PR detail lives in
+  [`CHANGELOG.md`](../CHANGELOG.md) + `git log` +
+  [`CYCLE-49-PLAN.md`](CYCLE-49-PLAN.md) (HISTORICAL) —
+  not repeated here per the
+  [DOC-MAP §"Archiving stale onboarding narrative"](DOC-MAP.md#archiving-stale-onboarding-narrative)
+  discipline.
+- **Why the pivot**: the maintainer's 2026-05-14
+  preview.135 dogfood (4-run test-04) went "completely
+  haywire". Root cause is structural — screen-row
+  coordinates as a source of truth on a scrolling buffer.
+  The bundle also falsified the initial
+  classification-by-`EntrySource` thesis (playbook §4).
+  PR-X is the load-bearing fix.
 
 ## Next stage
 
-**Cycle 51 in flight.** Maintainer's 2026-05-14 dogfood at
-preview.134 (commit `ae33bc9`) surfaced catastrophic
-substrate failure when running `test-04-yes-no.cmd` four
-times in sequence ("things go completely haywire... not
-reading the beginning half... not reading the end... reading
-a bunch of stuff well after I've moved on"). Root cause is
-structural: Cycle 49's PR-K → PR-U all bolted screen-row-
-based extraction logic on top of a substrate
-(`ContentHistory`) that is already Seq-based and
-notebook-shaped. The fix is a pivot, not another patch.
+**Cycle 51 (IOCell pivot).** Full sequencing, exact code
+anchors, the rejected-thesis context, and the per-PR
+execution maps are in
+[`CYCLE-51-PLAYBOOK.md`](CYCLE-51-PLAYBOOK.md); the locked
+decisions are in
+[ADR 0004](adr/0004-iocell-model-for-shell-interaction.md).
+Do not re-narrate them here (DOC-MAP archiving discipline).
 
-[ADR 0004](adr/0004-iocell-model-for-shell-interaction.md)
-locks four decisions for the pivot:
-
-1. **IOCell** is the unit of shell interaction (rename of
-   `SessionModel.SessionTuple`).
-2. Sub-prompts are inline state inside the parent IOCell
-   in v1 — not nested cells.
-3. **ContentHistory** is the sole extraction substrate.
-   Screen-row coordinates are display-only post-pivot.
-   `tryLatestMarker(PromptStart) = None` → drop-the-cell.
-4. **OutputDispatcher** is the sole non-emergency channel.
-   Tier 1 (substrate-driven) flows through
-   `OutputDispatcher.dispatch`; Tier 2 (~50 app-affordance
-   call sites) is a narrow named bypass
-   (`AnnounceEmergency`).
-
-**Cycle 51 sequencing** (each PR independently CI-gated +
-NVDA-validated):
-
-- **Phase 0** spike branch
-  `spike/cycle51-iocell-substrate-exploration` (commit
-  `de8bf81`, throwaway) — diagnostic-only parallel
-  `extractIOCell` + `ContentHistory.entriesAfter` +
-  side-by-side comparison log (`Cycle 51 spike PR-V0.`).
-  **Outcome: the maintainer's preview.135 dogfood bundle
-  was analysed instead of building the spike, and it
-  falsified the classification-by-`EntrySource` thesis**
-  (no CommandStart marker in heuristic-only cmd → state
-  stays `Composing` → cmd's own output tagged
-  `UserInputEcho`; `CmdSubPrompt=0` all session). The
-  spike's classifier is rejected; spike helpers are NOT
-  carried into PR-W. See ADR 0004 §"Status notes"
-  2026-05-14 revised entry.
-- **PR-V** — this ADR 0004 + CLAUDE.md reading-order +
-  this SESSION-HANDOFF.md update. Docs-only fast-merge.
-- **PR-W** (smaller than first drafted) — IOCell type
-  rename + `Phase` / `CellSequence` fields; promote the
-  existing `extractContentFromContentHistory`
-  heuristic-only arm (marker-slice + first-newline split)
-  to the sole `extractIOCell`; delete `extractContent`
-  + the row-walk fallback; `formatIOCellAsJsonl`
-  (schemaVersion 1 → 2); SessionLogWriter swap.
-- **PR-W2** — `IOCell.parseFromJsonl` round-trip reader
-  (maintainer-only; no UI surface) + FsCheck property
-  tests.
-- **PR-X** (now the load-bearing PR — fixes the actual
-  haywire) — sub-prompt narration goes Seq-slice +
-  Seq-watermark delta, NO `Source=screen` gate (the
-  run-4 wrapped-command failure was the screen-read
-  source falling back without seeding the preamble
-  count). Delete `subPromptScreenReader`,
-  `computePromptCommandWrapRows`, cursor-row capture,
-  PR-N/PR-O/PR-U screen blocks.
-- **PR-Y** — Tier 1 channel routing audit (refactor ~3-5
-  substrate-driven Announce sites to `OutputDispatcher`;
-  rename ~50 Tier 2 sites to `AnnounceEmergency`).
-- **PR-Z** — Closure audit.
-
-**Validation gate**: maintainer release-build dogfood of
-each PR's post-merge build. Cycle 51 NVDA matrix row in
-[`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md)
-covers 4-run test-04 + test-01 + test-02 + history-recall
-+ menu narration + Tier 2 emergency announce.
+One-line state: PR-V ✅ merged → **PR-W next** → PR-W2 →
+**PR-X (the load-bearing fix)** → PR-Y → PR-Z. Each PR is
+independently CI-gated and ships through the maintainer's
+release-build NVDA dogfood; the acceptance gate for PR-X is
+the 4-run test-04 reproducer no longer going haywire. Cycle
+51 NVDA matrix row lives in
+[`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md).
 
 **Next-cycle candidates** (after Cycle 51 ships; none block
 each other):
@@ -182,9 +120,10 @@ Things a new session needs that aren't in
 
 | If you need… | Open |
 |---|---|
+| **Cycle 51 execution map (START HERE)** | [`docs/CYCLE-51-PLAYBOOK.md`](CYCLE-51-PLAYBOOK.md) |
+| Cycle 51 locked decisions | [`docs/adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md) |
 | Cycle-by-cycle trail | [`CHANGELOG.md`](../CHANGELOG.md) `[Unreleased]` |
-| Cycle 46 ADR (decision + Open Question resolutions + per-PR Status notes) | [`docs/adr/0002-uia-textedit-caret-output.md`](adr/0002-uia-textedit-caret-output.md) |
-| Cycle 46 PR-C / PR-D scoping doc (historical, now superseded by the shipped code) | [`docs/CYCLE-46-NEXT-STEPS.md`](CYCLE-46-NEXT-STEPS.md) |
+| Doc-archiving discipline | [`docs/DOC-MAP.md`](DOC-MAP.md#archiving-stale-onboarding-narrative) |
 | Active strategic plan + roadmap | [`docs/PROJECT-PLAN-2026-05-12.md`](PROJECT-PLAN-2026-05-12.md) |
 | Pre-Cycle-45 decision history | [`docs/archive/pre-cycle-45/`](archive/pre-cycle-45/) (README inside) |
 | Substrate / architecture | [`docs/CORE-ABSTRACTION-BOUNDARY.md`](CORE-ABSTRACTION-BOUNDARY.md) + [`docs/adr/0001-substrate-channel-dichotomy.md`](adr/0001-substrate-channel-dichotomy.md) |


### PR DESCRIPTION
## Summary

This session shipped **PR-V (ADR 0004, merged `6b3ff6a`)** then ran long enough to risk a context crash mid-pivot. This PR is the deliberate crash-safe handoff so a fresh session picks up cleanly. **Docs-only** → fast-merge on the markdown link check.

### 1. `docs/CYCLE-51-PLAYBOOK.md` (new — the START HERE doc)

558-line turn-by-turn execution guide for PR-W → PR-Z:
- **Exact `file:line` anchors** against `main` `6b3ff6a` for every deletion/rename/edit in PR-W (type rename, promote heuristic arm, delete `extractContent`, schemaVersion 1→2) and PR-X (the load-bearing fix: Seq watermark replacing the screen-row sub-prompt machinery).
- **The REJECTED classification-by-`EntrySource` thesis with the dogfood-bundle proof** — so the next session does not re-introduce it. (Heuristic-only cmd has no CommandStart marker → state stays `Composing` → cmd's own output tagged `UserInputEcho`; `CmdSubPrompt=0` all session.)
- **The real haywire mechanism PR-X must fix** (run-4 wrapped command → screen-read fallback → `Source=screen`-gated preamble seed never fired → full output announced).
- The spike branch `de8bf81` flagged a **graveyard** (do not cherry-pick).
- F# 9 gotchas, CI/merge/dogfood protocol, screen-reader-user constraints, the maintainer's verbatim north-star intent.

### 2. `docs/DOC-MAP.md` — documented archiving process

New "Archiving stale onboarding narrative" section under Maintenance discipline (the user asked for a documented process so old information doesn't confuse new contributors): living onboarding docs carry only the *current* cycle; closed-cycle detail moves to durable records (CHANGELOG / git / archived cycle plans / ADRs) behind a ≤2-line pointer; enforced size budgets (`SESSION-HANDOFF.md` ≤ 200 lines); the move-don't-delete archive procedure with precedents.

### 3. `docs/SESSION-HANDOFF.md` — discipline applied

Trimmed the stale Cycle-49 per-PR table + validation checklist (preserved in CHANGELOG + `CYCLE-49-PLAN.md` + git) to a 2-line pointer; Current state refreshed to 2026-05-15 / PR-V merged / PR-W next, pointing at the playbook as START HERE; Next stage collapsed (no longer duplicating the playbook). **197 → 136 lines**, back under the 200-line budget.

## Test plan

- [ ] Markdown link check passes (the only required gate for docs-only; all new internal links + the `DOC-MAP.md#archiving-stale-onboarding-narrative` anchor verified locally)
- [ ] Next session can execute PR-W from `CYCLE-51-PLAYBOOK.md` §5 without re-deriving context
- [ ] No code paths touched — Windows build not required per the docs-only fast-merge rule

🤖 https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCW33Es86Kej8vCV9edGC5)_