### PR TITLE
Cycle 51 PR-W2: IOCell.parseFromJsonl round-trip reader

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -19,16 +19,33 @@ and serves the decision-trail role this file used to overload.
 > re-introduce, the bundle evidence). This section is just
 > the bird's-eye; the playbook is the map.
 
-- **`main` HEAD = `6b3ff6a`.** Working tree clean; no
-  in-flight code branches; no pending fixups. The spike
-  branch `spike/cycle51-iocell-substrate-exploration`
+- **`main` HEAD = `87f3773`** (Cycle 51 PR-W, #334). The
+  spike branch `spike/cycle51-iocell-substrate-exploration`
   (`de8bf81`) is on remote as a **graveyard** — do not
   cherry-pick from it (playbook §0).
 - **Cycle 51 (IOCell pivot) in flight.** Phase 0 spike ✅
   (superseded by dogfood-bundle analysis). **PR-V (ADR
-  0004) ✅ merged** (#332, `6b3ff6a`). **PR-W is next**,
-  then PR-W2 → PR-X → PR-Y → PR-Z. Decision record:
+  0004) ✅ merged** (#332). **PR-W ✅ merged** (#334,
+  `87f3773`) — IOCell rename + `IOCellPhase`/`CellSequence`,
+  ContentHistory as the sole extractor with drop-on-None,
+  schemaVersion-2 wire format, `IOCELL-SCHEMA.md`. **PR-W2
+  in flight** (`IOCell.parseFromJsonl` round-trip reader).
+  Then PR-X → PR-Y → PR-Z. Decision record:
   [`adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md).
+- **⚠ PR-W NOT dogfood-validated.** The walking-skeleton
+  release-build NVDA dogfood gate (playbook §8) was **not
+  performed** — the maintainer was unavailable for manual
+  testing and explicitly authorised carrying forward to
+  PR-W2 without it (2026-05-15). PR-W is a type/extraction/
+  schema change with no new announce site, so the
+  outstanding check is a *regression* dogfood (cmd
+  `echo hi` / test-01 still narrate via the now-sole
+  ContentHistory path; "loud silence" not garbage when a
+  cell lacks a PromptStart Seq). **This gate, plus the
+  per-PR gates for W2 onward, must be swept before PR-X's
+  4-run test-04 acceptance gate is meaningful.** Track in
+  the Cycle 51 [`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md)
+  row at PR-Z.
 - **Cycle 49 + post-49 hotfixes (PRs #313–#331) shipped**
   through `ae33bc9`. Per-PR detail lives in
   [`CHANGELOG.md`](../CHANGELOG.md) + `git log` +
@@ -54,12 +71,16 @@ decisions are in
 [ADR 0004](adr/0004-iocell-model-for-shell-interaction.md).
 Do not re-narrate them here (DOC-MAP archiving discipline).
 
-One-line state: PR-V ✅ merged → **PR-W next** → PR-W2 →
-**PR-X (the load-bearing fix)** → PR-Y → PR-Z. Each PR is
-independently CI-gated and ships through the maintainer's
-release-build NVDA dogfood; the acceptance gate for PR-X is
-the 4-run test-04 reproducer no longer going haywire. Cycle
-51 NVDA matrix row lives in
+One-line state: PR-V ✅ → PR-W ✅ (merged, **dogfood
+deferred**) → **PR-W2 in flight** → **PR-X (the
+load-bearing fix)** → PR-Y → PR-Z. Each PR is independently
+CI-gated and is *supposed* to ship through the maintainer's
+release-build NVDA dogfood before the next; PR-W's was
+deferred per maintainer instruction (see ⚠ above). The
+acceptance gate for PR-X is the 4-run test-04 reproducer no
+longer going haywire — that gate presumes the deferred
+PR-W/W2 dogfoods get swept first. Cycle 51 NVDA matrix row
+lives in
 [`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md).
 
 **Next-cycle candidates** (after Cycle 51 ships; none block

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -1375,3 +1375,332 @@ module SessionModel =
         sb.Append('}') |> ignore
         sb.Append('\n') |> ignore
         sb.ToString()
+
+    // -----------------------------------------------------------------
+    // Cycle 51 PR-W2 — round-trip reader. Hand-rolled (no JSON
+    // library; matches the Cycle 24b serializer discipline). The
+    // exact inverse of `formatIOCellAsJsonl`. No user-facing
+    // surface — exercised only by the FsCheck round-trip property
+    // + deterministic edge tests. ADR 0004 §"Round-trip
+    // discipline": branches on `schemaVersion` (only 2 in v1;
+    // `Error` for anything else); any future schema change that
+    // isn't round-trip-faithful fails CI immediately.
+    // -----------------------------------------------------------------
+
+    /// Why a JSONL line could not be parsed back into an `IOCell`.
+    type IOCellParseError =
+        /// `schemaVersion` was present but not the supported value
+        /// (2 in v1). One-way migration per ADR 0004 — v1 and v2
+        /// are mutually unreadable.
+        | UnsupportedSchemaVersion of int
+        /// The line was not a well-formed v2 IOCell record
+        /// (structural error, missing/!typed field, bad timestamp
+        /// / guid / number, or a lone UTF-16 surrogate — the
+        /// reader rejects the same payload the serializer refuses
+        /// to emit).
+        | Malformed of string
+
+    exception JsonParseException of string
+
+    type private JsonValue =
+        | JNull
+        | JStr of string
+        | JNum of string
+        | JObj of (string * JsonValue) list
+        | JArr of JsonValue list
+
+    /// Minimal recursive-descent JSON value parser. Only the
+    /// productions `formatIOCellAsJsonl` emits (object, array,
+    /// string, integer number, `null`) are recognised — booleans
+    /// and floats are intentionally absent. Raises
+    /// `JsonParseException` on any structural problem.
+    let private parseJson (s: string) : JsonValue =
+        let n = s.Length
+        let mutable i = 0
+        let fail (msg: string) : 'a = raise (JsonParseException msg)
+        let peek () = if i < n then s.[i] else ' '
+        let skipWs () =
+            while i < n
+                  && (s.[i] = ' ' || s.[i] = '\t'
+                      || s.[i] = '\n' || s.[i] = '\r') do
+                i <- i + 1
+        let expect (c: char) : unit =
+            if i < n && s.[i] = c then i <- i + 1
+            else fail (sprintf "expected '%c' at index %d" c i)
+        let hasLoneSurrogate (str: string) : bool =
+            let mutable k = 0
+            let mutable bad = false
+            while k < str.Length && not bad do
+                let ch = str.[k]
+                if System.Char.IsHighSurrogate ch then
+                    if k + 1 < str.Length
+                       && System.Char.IsLowSurrogate str.[k + 1]
+                    then k <- k + 2
+                    else bad <- true
+                elif System.Char.IsLowSurrogate ch then bad <- true
+                else k <- k + 1
+            bad
+        let parseStr () : string =
+            expect '"'
+            let sb = System.Text.StringBuilder()
+            let mutable fin = false
+            while not fin do
+                if i >= n then fail "unterminated string"
+                let c = s.[i]
+                if c = '"' then
+                    i <- i + 1
+                    fin <- true
+                elif c = '\\' then
+                    i <- i + 1
+                    if i >= n then fail "dangling escape"
+                    let e = s.[i]
+                    i <- i + 1
+                    match e with
+                    | '"' -> sb.Append('"') |> ignore
+                    | '\\' -> sb.Append('\\') |> ignore
+                    | '/' -> sb.Append('/') |> ignore
+                    | 'b' -> sb.Append('\b') |> ignore
+                    | 'f' -> sb.Append('\f') |> ignore
+                    | 'n' -> sb.Append('\n') |> ignore
+                    | 'r' -> sb.Append('\r') |> ignore
+                    | 't' -> sb.Append('\t') |> ignore
+                    | 'u' ->
+                        if i + 4 > n then fail "truncated \\u escape"
+                        let hex = s.Substring(i, 4)
+                        i <- i + 4
+                        let mutable code = 0
+                        if System.Int32.TryParse(
+                            hex,
+                            System.Globalization.NumberStyles.HexNumber,
+                            jsonInvariant,
+                            &code)
+                        then sb.Append(char code) |> ignore
+                        else fail "invalid \\u hex"
+                    | _ -> fail "unknown string escape"
+                else
+                    sb.Append(c) |> ignore
+                    i <- i + 1
+            let result = sb.ToString()
+            if hasLoneSurrogate result then
+                fail "lone UTF-16 surrogate in string"
+            result
+        let rec parseValue () : JsonValue =
+            skipWs ()
+            if i >= n then fail "unexpected end of input"
+            else
+                match s.[i] with
+                | '"' -> JStr (parseStr ())
+                | '{' -> parseObj ()
+                | '[' -> parseArr ()
+                | 'n' ->
+                    if i + 4 <= n && s.Substring(i, 4) = "null" then
+                        i <- i + 4
+                        JNull
+                    else fail "expected null"
+                | c when c = '-' || (c >= '0' && c <= '9') ->
+                    let start = i
+                    if s.[i] = '-' then i <- i + 1
+                    while i < n && s.[i] >= '0' && s.[i] <= '9' do
+                        i <- i + 1
+                    if i = start || (i = start + 1 && s.[start] = '-') then
+                        fail "malformed number"
+                    JNum (s.Substring(start, i - start))
+                | _ -> fail (sprintf "unexpected char at index %d" i)
+        and parseObj () : JsonValue =
+            expect '{'
+            skipWs ()
+            let items = ResizeArray<string * JsonValue>()
+            if peek () = '}' then
+                i <- i + 1
+            else
+                let mutable go = true
+                while go do
+                    skipWs ()
+                    let k = parseStr ()
+                    skipWs ()
+                    expect ':'
+                    let v = parseValue ()
+                    items.Add((k, v))
+                    skipWs ()
+                    if peek () = ',' then i <- i + 1
+                    elif peek () = '}' then
+                        i <- i + 1
+                        go <- false
+                    else fail "expected ',' or '}' in object"
+            JObj (List.ofSeq items)
+        and parseArr () : JsonValue =
+            expect '['
+            skipWs ()
+            let items = ResizeArray<JsonValue>()
+            if peek () = ']' then
+                i <- i + 1
+            else
+                let mutable go = true
+                while go do
+                    let v = parseValue ()
+                    items.Add(v)
+                    skipWs ()
+                    if peek () = ',' then i <- i + 1
+                    elif peek () = ']' then
+                        i <- i + 1
+                        go <- false
+                    else fail "expected ',' or ']' in array"
+            JArr (List.ofSeq items)
+        let v = parseValue ()
+        skipWs ()
+        if i <> n then fail "trailing content after JSON value"
+        v
+
+    /// Parse one JSONL line (the exact output of
+    /// `formatIOCellAsJsonl`, with or without its trailing `\n`)
+    /// back into an `IOCell`. Hand-rolled inverse; total (never
+    /// throws — all failures surface as `Result.Error`).
+    let parseFromJsonl (line: string) : Result<IOCell, IOCellParseError> =
+        try
+            let trimmed =
+                if line.EndsWith("\n") then
+                    line.Substring(0, line.Length - 1)
+                else line
+            match parseJson trimmed with
+            | JObj fields ->
+                let get (k: string) : JsonValue =
+                    match
+                        List.tryFind (fun (kk, _) -> kk = k) fields
+                    with
+                    | Some (_, v) -> v
+                    | None ->
+                        raise (JsonParseException (sprintf "missing field '%s'" k))
+                let field (obj: (string * JsonValue) list) (k: string) : JsonValue =
+                    match List.tryFind (fun (kk, _) -> kk = k) obj with
+                    | Some (_, v) -> v
+                    | None ->
+                        raise (JsonParseException (sprintf "missing field '%s'" k))
+                let asStr (j: JsonValue) : string =
+                    match j with
+                    | JStr x -> x
+                    | _ -> raise (JsonParseException "expected a string")
+                let asInt (j: JsonValue) : int =
+                    match j with
+                    | JNum x ->
+                        (try System.Int32.Parse(x, jsonInvariant)
+                         with _ -> raise (JsonParseException "expected int32"))
+                    | _ -> raise (JsonParseException "expected a number")
+                let asInt64 (j: JsonValue) : int64 =
+                    match j with
+                    | JNum x ->
+                        (try System.Int64.Parse(x, jsonInvariant)
+                         with _ -> raise (JsonParseException "expected int64"))
+                    | _ -> raise (JsonParseException "expected a number")
+                let sv = asInt (get "schemaVersion")
+                if sv <> JsonlSchemaVersion then
+                    Error (UnsupportedSchemaVersion sv)
+                else
+                    let parseTs (str: string) : DateTime =
+                        DateTime.ParseExact(
+                            str,
+                            "yyyy-MM-ddTHH:mm:ss.fffffffZ",
+                            jsonInvariant,
+                            System.Globalization.DateTimeStyles.AssumeUniversal
+                            ||| System.Globalization.DateTimeStyles.AdjustToUniversal)
+                    let optTs (j: JsonValue) : DateTime option =
+                        match j with
+                        | JNull -> None
+                        | JStr x -> Some (parseTs x)
+                        | _ -> raise (JsonParseException "expected timestamp|null")
+                    let optStr (j: JsonValue) : string option =
+                        match j with
+                        | JNull -> None
+                        | JStr x -> Some x
+                        | _ -> raise (JsonParseException "expected string|null")
+                    let optInt (j: JsonValue) : int option =
+                        match j with
+                        | JNull -> None
+                        | JNum _ -> Some (asInt j)
+                        | _ -> raise (JsonParseException "expected int|null")
+                    let phase =
+                        match get "phase" with
+                        | JObj pf ->
+                            (match asStr (field pf "kind") with
+                             | "composing" -> IOCellPhase.Composing
+                             | "executing" -> IOCellPhase.Executing
+                             | "sealed" -> IOCellPhase.Sealed
+                             | "awaitingSubPromptResponse" ->
+                                 IOCellPhase.AwaitingSubPromptResponse
+                                     (asStr (field pf "subPromptText"))
+                             | other ->
+                                 raise (JsonParseException
+                                     (sprintf "unknown phase kind '%s'" other)))
+                        | _ -> raise (JsonParseException "phase is not an object")
+                    let boundaryOf (name: string) : BoundaryKind =
+                        match name with
+                        | "PromptStart" -> BoundaryKind.PromptStart
+                        | "CommandStart" -> BoundaryKind.CommandStart
+                        | "OutputStart" -> BoundaryKind.OutputStart
+                        // The serializer emits the payload-less
+                        // name; the exit code lives on ExitCode,
+                        // not here. Canonical reconstruction.
+                        | "CommandFinished" -> BoundaryKind.CommandFinished None
+                        | other ->
+                            raise (JsonParseException
+                                (sprintf "unknown boundary '%s'" other))
+                    let sourceOf (j: JsonValue) : BoundarySource =
+                        match j with
+                        | JObj sf ->
+                            (match asStr (field sf "kind") with
+                             | "Osc133" -> BoundarySource.Osc133
+                             | "HeuristicClaudeInkBox" ->
+                                 BoundarySource.HeuristicClaudeInkBox
+                             | "HeuristicPromptRegex" ->
+                                 BoundarySource.HeuristicPromptRegex
+                                     (asInt (field sf "stabilityMs"))
+                             | other ->
+                                 raise (JsonParseException
+                                     (sprintf "unknown source kind '%s'" other)))
+                        | _ -> raise (JsonParseException "source is not an object")
+                    let sources =
+                        match get "sources" with
+                        | JArr arr ->
+                            arr
+                            |> List.map (fun e ->
+                                match e with
+                                | JObj ef ->
+                                    boundaryOf (asStr (field ef "boundary")),
+                                    sourceOf (field ef "source")
+                                | _ ->
+                                    raise (JsonParseException
+                                        "sources entry is not an object"))
+                            |> Map.ofList
+                        | _ -> raise (JsonParseException "sources is not an array")
+                    let extraParams =
+                        match get "extraParams" with
+                        | JObj ef ->
+                            ef
+                            |> List.map (fun (k, v) -> k, asStr v)
+                            |> Map.ofList
+                        | _ ->
+                            raise (JsonParseException
+                                "extraParams is not an object")
+                    let cell : IOCell =
+                        { Id = System.Guid.Parse(asStr (get "id"))
+                          CellSequence = asInt64 (get "cellSequence")
+                          CommandId = optStr (get "commandId")
+                          Phase = phase
+                          ShellId = asStr (get "shellId")
+                          PromptStartedAt =
+                              parseTs (asStr (get "promptStartedAt"))
+                          CommandStartedAt = optTs (get "commandStartedAt")
+                          OutputStartedAt = optTs (get "outputStartedAt")
+                          CommandFinishedAt = optTs (get "commandFinishedAt")
+                          PromptText = asStr (get "promptText")
+                          CommandText = asStr (get "commandText")
+                          OutputText = asStr (get "outputText")
+                          ExitCode = optInt (get "exitCode")
+                          Sources = sources
+                          ExtraParams = extraParams }
+                    Ok cell
+            | _ ->
+                Error (Malformed "top-level value is not a JSON object")
+        with
+        | JsonParseException msg -> Error (Malformed msg)
+        | :? System.FormatException as ex -> Error (Malformed ex.Message)
+        | :? System.OverflowException as ex -> Error (Malformed ex.Message)

--- a/tests/Tests.Unit/IOCellRoundTripTests.fs
+++ b/tests/Tests.Unit/IOCellRoundTripTests.fs
@@ -1,0 +1,313 @@
+module PtySpeak.Tests.Unit.IOCellRoundTripTests
+
+open System
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// Cycle 51 PR-W2 — IOCell JSONL round-trip discipline (ADR 0004).
+// ---------------------------------------------------------------------
+//
+// `SessionModel.parseFromJsonl` is the hand-rolled inverse of
+// `SessionModel.formatIOCellAsJsonl`. The headline guarantee is
+//
+//     forall c, parseFromJsonl (formatIOCellAsJsonl c) = Ok c
+//
+// exercised below by a seeded generative test over many IOCells
+// covering the IOCellPhase + BoundarySource DUs, option fields,
+// Map fields, and escape-triggering strings, plus deterministic
+// edge cases.
+//
+// NOTE: the playbook suggested FsCheck for the property. The
+// repo pins FsCheck.Xunit 3.x but has zero precedent for its
+// (reorganised-in-3.x) Gen/Arb/custom-Arbitrary API, and there
+// is no local F# compiler here — guessing the 3.x generator
+// surface blind is an expensive CI round-trip for no
+// behavioural gain. A fixed-seed System.Random generator gives
+// the same forall-style coverage, deterministic/reproducible
+// failures, and uses only the Xunit surface every other test
+// here uses. Flagged in the PR body for maintainer review.
+//
+// Control chars in fixtures are built with `char 0xNN`
+// (ASCII-only source): raw NUL/ESC/DEL bytes in .fs source get
+// silently stripped by tooling (CONTRIBUTING foot-gun).
+
+// ---------------------------------------------------------------------
+// Seeded generators (deterministic; no FsCheck dependency)
+// ---------------------------------------------------------------------
+
+let private nul = string (char 0x00)
+let private soh = string (char 0x01)
+let private esc = string (char 0x1b)
+let private del = string (char 0x7f)
+
+/// Fragments that are each a complete UTF-16 unit (BMP char or
+/// a full surrogate PAIR) — concatenation can never produce a
+/// lone surrogate (which the serializer refuses to emit).
+/// Weighted toward characters that exercise every escape branch.
+let private fragments : string[] =
+    [| "a"; "b"; "X"; "7"; " "; "/"; "é"; "ß"          // plain / passthrough
+       "\""; "\\"; "\n"; "\r"; "\t"; "\b"; "\f"             // named escapes
+       nul; soh; esc; del                                   // control / DEL
+       "👋" |]                                                // valid surrogate PAIR
+
+let private genStr (rnd: Random) : string =
+    let count = rnd.Next(0, 13)
+    let sb = System.Text.StringBuilder()
+    for _ in 1 .. count do
+        sb.Append(fragments.[rnd.Next(0, fragments.Length)]) |> ignore
+    sb.ToString()
+
+let private genOpt (rnd: Random) (g: Random -> 'a) : 'a option =
+    if rnd.Next(0, 10) < 3 then None else Some (g rnd)
+
+/// UTC DateTime with full 100ns-tick precision (the wire format
+/// is `.fffffffZ`, lossless from Windows ticks). Day capped at
+/// 28 to dodge month-length edges; year stays 4-digit.
+let private genUtc (rnd: Random) : DateTime =
+    DateTime(
+        rnd.Next(1, 10000),
+        rnd.Next(1, 13),
+        rnd.Next(1, 29),
+        rnd.Next(0, 24),
+        rnd.Next(0, 60),
+        rnd.Next(0, 60),
+        DateTimeKind.Utc)
+        .AddTicks(int64 (rnd.Next(0, 10000000)))
+
+let private genInt64 (rnd: Random) : int64 =
+    match rnd.Next(0, 5) with
+    | 0 -> 0L
+    | 1 -> -1L
+    | 2 -> Int64.MaxValue
+    | 3 -> Int64.MinValue
+    | _ -> int64 (rnd.Next(0, 1000000))
+
+let private genInt (rnd: Random) : int =
+    match rnd.Next(0, 5) with
+    | 0 -> 0
+    | 1 -> -1
+    | 2 -> Int32.MaxValue
+    | 3 -> Int32.MinValue
+    | _ -> rnd.Next(-1000, 1001)
+
+let private genPhase (rnd: Random) : SessionModel.IOCellPhase =
+    match rnd.Next(0, 4) with
+    | 0 -> SessionModel.IOCellPhase.Composing
+    | 1 -> SessionModel.IOCellPhase.Executing
+    | 2 -> SessionModel.IOCellPhase.Sealed
+    | _ -> SessionModel.IOCellPhase.AwaitingSubPromptResponse (genStr rnd)
+
+let private genSource (rnd: Random) : BoundarySource =
+    match rnd.Next(0, 3) with
+    | 0 -> BoundarySource.Osc133
+    | 1 -> BoundarySource.HeuristicPromptRegex (rnd.Next(0, 100000))
+    | _ -> BoundarySource.HeuristicClaudeInkBox
+
+/// Sources keys are drawn from the four payload-less boundary
+/// forms. `CommandFinished` is canonicalised to `None` — the
+/// serializer emits the payload-less name (the exit code lives
+/// on `ExitCode`), so only `CommandFinished None` round-trips
+/// by construction.
+let private genSources (rnd: Random) : Map<BoundaryKind, BoundarySource> =
+    let keys =
+        [ BoundaryKind.PromptStart
+          BoundaryKind.CommandStart
+          BoundaryKind.OutputStart
+          BoundaryKind.CommandFinished None ]
+    keys
+    |> List.choose (fun k ->
+        if rnd.Next(0, 2) = 0 then Some (k, genSource rnd) else None)
+    |> Map.ofList
+
+let private genExtraParams (rnd: Random) : Map<string, string> =
+    let count = rnd.Next(0, 5)
+    [ for _ in 1 .. count -> (genStr rnd, genStr rnd) ]
+    |> Map.ofList
+
+let private genIOCell (rnd: Random) : SessionModel.IOCell =
+    { Id = Guid.NewGuid()
+      CellSequence = genInt64 rnd
+      CommandId = genOpt rnd genStr
+      Phase = genPhase rnd
+      ShellId = genStr rnd
+      PromptStartedAt = genUtc rnd
+      CommandStartedAt = genOpt rnd genUtc
+      OutputStartedAt = genOpt rnd genUtc
+      CommandFinishedAt = genOpt rnd genUtc
+      PromptText = genStr rnd
+      CommandText = genStr rnd
+      OutputText = genStr rnd
+      ExitCode = genOpt rnd genInt
+      Sources = genSources rnd
+      ExtraParams = genExtraParams rnd }
+
+// ---------------------------------------------------------------------
+// The round-trip property
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``parseFromJsonl (formatIOCellAsJsonl c) = Ok c for 1000 generated cells`` () =
+    let rnd = Random(20260515)   // fixed seed -> reproducible
+    for iteration in 1 .. 1000 do
+        let c = genIOCell rnd
+        let line = SessionModel.formatIOCellAsJsonl c
+        match SessionModel.parseFromJsonl line with
+        | Ok back ->
+            if back <> c then
+                Assert.Fail(
+                    sprintf
+                        "round-trip mismatch at iteration %d\nexpected: %A\nactual:   %A"
+                        iteration c back)
+        | Error e ->
+            Assert.Fail(
+                sprintf
+                    "round-trip parse failed at iteration %d: %A\ncell: %A"
+                    iteration e c)
+
+// ---------------------------------------------------------------------
+// Deterministic edge coverage
+// ---------------------------------------------------------------------
+
+let private mkCell : SessionModel.IOCell =
+    { Id = Guid.Parse("11111111-2222-3333-4444-555555555555")
+      CellSequence = 0L
+      CommandId = None
+      Phase = SessionModel.IOCellPhase.Sealed
+      ShellId = "cmd"
+      PromptStartedAt = DateTime(2026, 5, 9, 14, 23, 45, DateTimeKind.Utc)
+      CommandStartedAt = None
+      OutputStartedAt = None
+      CommandFinishedAt = None
+      PromptText = "C:\\>"
+      CommandText = ""
+      OutputText = ""
+      ExitCode = None
+      Sources = Map.empty
+      ExtraParams = Map.empty }
+
+let private rt (c: SessionModel.IOCell) : SessionModel.IOCell =
+    match SessionModel.parseFromJsonl (SessionModel.formatIOCellAsJsonl c) with
+    | Ok back -> back
+    | Error e -> failwithf "expected Ok, got Error %A" e
+
+[<Fact>]
+let ``minimal cell round-trips`` () =
+    Assert.Equal(mkCell, rt mkCell)
+
+[<Fact>]
+let ``every IOCellPhase round-trips`` () =
+    for p in
+        [ SessionModel.IOCellPhase.Composing
+          SessionModel.IOCellPhase.Executing
+          SessionModel.IOCellPhase.Sealed
+          SessionModel.IOCellPhase.AwaitingSubPromptResponse "Continue? [Y,N]?" ] do
+        let c = { mkCell with Phase = p }
+        Assert.Equal(c, rt c)
+
+[<Fact>]
+let ``escape-heavy strings round-trip verbatim`` () =
+    let tricky =
+        "quote=\" backslash=\\ nl=\n cr=\r tab=\t bs=\b ff=\f "
+        + "nul=" + nul + " soh=" + soh + " esc=" + esc + " del=" + del
+        + " slash=/ unicode=café emoji=👋"
+    let c =
+        { mkCell with
+            CommandId = Some tricky
+            ShellId = tricky
+            PromptText = tricky
+            CommandText = tricky
+            OutputText = tricky
+            Phase = SessionModel.IOCellPhase.AwaitingSubPromptResponse tricky
+            ExtraParams = Map.ofList [ tricky, tricky; "k2", "v2" ] }
+    Assert.Equal(c, rt c)
+
+[<Fact>]
+let ``option fields round-trip None and Some`` () =
+    let someEverything =
+        { mkCell with
+            CommandId = Some "aid-42"
+            CommandStartedAt =
+                Some (DateTime(2026, 5, 9, 14, 23, 45, 50, DateTimeKind.Utc))
+            OutputStartedAt =
+                Some (DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            CommandFinishedAt =
+                Some (DateTime(9999, 12, 28, 23, 59, 59, DateTimeKind.Utc)
+                          .AddTicks(9999999L))
+            ExitCode = Some -1 }
+    Assert.Equal(someEverything, rt someEverything)
+    Assert.Equal(mkCell, rt mkCell)   // the all-None baseline
+
+[<Fact>]
+let ``Sources with every boundary + source variant round-trips`` () =
+    let c =
+        { mkCell with
+            Sources =
+                Map.ofList
+                    [ BoundaryKind.PromptStart, BoundarySource.Osc133
+                      BoundaryKind.CommandStart,
+                          BoundarySource.HeuristicPromptRegex 250
+                      BoundaryKind.OutputStart,
+                          BoundarySource.HeuristicClaudeInkBox
+                      BoundaryKind.CommandFinished None,
+                          BoundarySource.HeuristicPromptRegex 0 ] }
+    Assert.Equal(c, rt c)
+
+[<Fact>]
+let ``exitCode extremes round-trip`` () =
+    for code in [ 0; -1; 127; Int32.MaxValue; Int32.MinValue ] do
+        let c = { mkCell with ExitCode = Some code }
+        Assert.Equal(c, rt c)
+
+[<Fact>]
+let ``CellSequence extremes round-trip`` () =
+    for n in [ 0L; -1L; 42L; Int64.MaxValue; Int64.MinValue ] do
+        let c = { mkCell with CellSequence = n }
+        Assert.Equal(c, rt c)
+
+// ---------------------------------------------------------------------
+// Rejection paths
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``schemaVersion 1 is rejected with UnsupportedSchemaVersion`` () =
+    let v2 = SessionModel.formatIOCellAsJsonl mkCell
+    let v1 = v2.Replace("\"schemaVersion\":2,", "\"schemaVersion\":1,")
+    match SessionModel.parseFromJsonl v1 with
+    | Error (SessionModel.UnsupportedSchemaVersion 1) -> ()
+    | other ->
+        Assert.Fail(sprintf "expected UnsupportedSchemaVersion 1, got %A" other)
+
+[<Fact>]
+let ``structurally malformed input is rejected with Malformed`` () =
+    for bad in
+        [ "not json at all"
+          "{"
+          "{}"                                  // missing schemaVersion
+          "[1,2,3]"                             // not an object
+          "{\"schemaVersion\":2}"               // missing the rest
+          "{\"schemaVersion\":\"two\"}" ] do    // schemaVersion not a number
+        match SessionModel.parseFromJsonl bad with
+        | Error (SessionModel.Malformed _) -> ()
+        | other ->
+            Assert.Fail(sprintf "expected Malformed for %s, got %A" bad other)
+
+[<Fact>]
+let ``a lone UTF-16 surrogate is refused by the writer and rejected by the reader`` () =
+    let lone = String([| char 0xD800 |])   // lone high surrogate
+    Assert.Throws<InvalidOperationException>(fun () ->
+        SessionModel.formatIOCellAsJsonl { mkCell with OutputText = lone }
+        |> ignore)
+    |> ignore
+    let payload = "{\"schemaVersion\":2,\"x\":\"" + lone + "\"}"
+    match SessionModel.parseFromJsonl payload with
+    | Error (SessionModel.Malformed _) -> ()
+    | other -> Assert.Fail(sprintf "expected Malformed, got %A" other)
+
+[<Fact>]
+let ``trailing newline from the formatter is tolerated`` () =
+    let line = SessionModel.formatIOCellAsJsonl mkCell
+    Assert.EndsWith("\n", line)
+    match SessionModel.parseFromJsonl line with
+    | Ok back -> Assert.Equal(mkCell, back)
+    | Error e -> Assert.Fail(sprintf "expected Ok, got %A" e)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="SessionPersistenceTests.fs" />
     <Compile Include="SessionSanitiserTests.fs" />
     <Compile Include="SessionModelJsonlTests.fs" />
+    <Compile Include="IOCellRoundTripTests.fs" />
     <Compile Include="SessionLogWriterTests.fs" />
     <Compile Include="HeuristicPromptDetectorTests.fs" />
     <Compile Include="SelectionDetectorTests.fs" />


### PR DESCRIPTION
## Summary

Cycle 51 PR-W2 (ADR 0004 §"Round-trip discipline", playbook §7).

- **`SessionModel.parseFromJsonl : string -> Result<IOCell, IOCellParseError>`** — a hand-rolled (no JSON library; matches the Cycle 24b serializer discipline) recursive-descent parser, the exact inverse of `formatIOCellAsJsonl`. Lives next to the serializer in `SessionModel.fs`. **No user-facing surface** — internal + test only.
  - Branches on `schemaVersion`: only `2` accepted; `Error (UnsupportedSchemaVersion n)` otherwise (one-way migration per ADR 0004).
  - Structural / type / bad-timestamp / bad-guid / **lone-surrogate** problems → `Error (Malformed _)` (the reader rejects the same payload the serializer refuses to emit). Total — never throws.
- **`tests/Tests.Unit/IOCellRoundTripTests.fs`** (new; added to fsproj): the `forall c, parseFromJsonl (formatIOCellAsJsonl c) = Ok c` guarantee over a fixed-seed generator covering the `IOCellPhase` + `BoundarySource` DUs, `option` fields, `Map` fields, and escape-triggering strings (incl. NUL/ESC/DEL via `char 0xNN`, surrogate-pair emoji, quotes/backslash/named escapes), plus deterministic edge + rejection cases (schemaVersion-1 rejection, malformed input, lone-surrogate refuse/reject pairing, trailing-newline tolerance).

## ⚠ Two flagged deviations (please review)

1. **PR-W was NOT dogfood-validated.** The walking-skeleton release-build NVDA dogfood gate (playbook §8) was not performed — you were unavailable for manual testing and authorised carrying forward to PR-W2 without it. `docs/SESSION-HANDOFF.md` "Current state" now records this as an **outstanding gate** that, together with the per-PR gates for W2 onward, must be swept before PR-X's 4-run test-04 acceptance gate is meaningful. PR-W introduced no new announce site, so the outstanding check is a *regression* dogfood.
2. **The round-trip property uses a fixed-seed `System.Random` generator, not FsCheck.Xunit's custom-`Arbitrary` API.** The playbook suggested FsCheck; the repo pins FsCheck.Xunit 3.x but has **zero precedent** for its (reorganised-in-3.x) `Gen`/`Arb`/custom-`Arbitrary` surface, and there is no local F# compiler in this environment — guessing the 3.x generator API blind is an expensive CI round-trip for no behavioural gain. The seeded generator gives the same `forall`-style coverage with deterministic, reproducible failures, using only the Xunit surface every other test here uses. Happy to convert to FsCheck if you'd rather; flagging per the no-silent-deviation rule.

## Test plan

- [ ] Full Windows CI (touches `src/` + `tests/` — not docs-only): build + xUnit suite green, including the 1000-iteration round-trip property and the rejection-path tests.
- [ ] Maintainer release-build dogfood — N/A for behaviour (no UI surface; reader is internal/test-only), but folds into the deferred PR-W/W2 regression-dogfood sweep tracked in SESSION-HANDOFF before PR-X.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_