### PR TITLE
Cycle 51 PR-Y: single-key sub-prompt no longer re-announces the question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13708,6 +13708,28 @@ pre-PR-X CH-path tests thread `-1L` (legacy first-newline
 path preserved). Acceptance gate: the maintainer's 4-run
 test-04 + history-scroll dogfood.
 
+### Cycle 51 PR-Y (2026-05-15): single-key sub-prompt no longer re-announces the question
+
+Post-PR-X dogfood (preview.137) found single-key Y/N
+sub-prompts (test-04) re-announce the question in the
+post-response tuple-final delta: NVDA spoke "Continue?
+[Y,N]?" at SubPromptIdle, then again as the lead of "Continue?
+[Y,N]?Y / You chose Yes. / === END ===". Root cause: a
+single-key prompt's question row has no terminating newline
+when SubPromptIdle fires, so ContentHistory hasn't sealed it
+into an entry yet — `lastEnterSeq` captured then lands on the
+newline *before* the question and the slice re-includes it
+(typed-Enter sub-prompts like test-02 escape this because the
+response Enter re-captures the watermark past the sealed
+question). Fix: remember the exact question text spoken at
+SubPromptIdle and, if the tuple-final delta begins with it,
+drop it through the first newline after it (also strips the
+inline single-key response char). Exact-match against the
+literally-spoken string — a no-op for test-02 and plain
+commands; cleared on every top-level command Enter +
+shell hot-switch. New `PR-Y stripped already-spoken
+sub-prompt question` Information diagnostic.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1031,6 +1031,17 @@ module Program =
         let mutable awaitingSubPromptEnter : bool = false
         let mutable lastEnterSeq : int64 = -1L
         let mutable commandEnterSeq : int64 = -1L
+        // Cycle 51 PR-Y — the sub-prompt question we last spoke at
+        // SubPromptIdle. For a single-key prompt (test-04 — no
+        // response Enter) the question row has no terminating
+        // newline when SubPromptIdle fires, so ContentHistory
+        // hasn't sealed it into an entry yet; `lastEnterSeq`
+        // captured then lands on the newline *before* the question
+        // and the tuple-final slice re-includes it. We strip this
+        // exact already-spoken prefix off the front of the delta.
+        // Empty when no sub-prompt is outstanding; cleared on every
+        // top-level command Enter + shell hot-switch.
+        let mutable lastSubPromptAnnounce : string = ""
 
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
@@ -1738,6 +1749,12 @@ module Program =
                             raiseTextChanged ()
                             lastAnnouncedText <- toSay
                             lastAnnouncedSeq <- ContentHistory.latestSeq contentHistory
+                            // Cycle 51 PR-Y — remember the exact
+                            // question text (pre-cap `trimmed`, so
+                            // the full prefix is available to
+                            // match) for the tuple-final
+                            // strip-already-spoken-question step.
+                            lastSubPromptAnnounce <- trimmed
                         let readyEvent =
                             OutputEvent.create
                                 SemanticCategory.ReadyForInput
@@ -2048,8 +2065,36 @@ module Program =
                             raw.Substring(0, raw.Length - p.Length)
                         | _ -> raw
                     let delta =
-                        (withoutNextPrompt.TrimStart('\r', '\n'))
-                            .TrimEnd('\r', '\n')
+                        let d =
+                            (withoutNextPrompt.TrimStart('\r', '\n'))
+                                .TrimEnd('\r', '\n')
+                        // Cycle 51 PR-Y — for a single-key
+                        // sub-prompt the watermark is stuck before
+                        // the question (the question row hadn't
+                        // sealed into a ContentHistory entry when
+                        // SubPromptIdle fired, so latestSeq pointed
+                        // at the newline before it), so the slice
+                        // re-includes the question the user already
+                        // heard. Drop the exact already-spoken
+                        // question + the inline single-key response
+                        // char, through the first newline after it.
+                        // No-op for typed-Enter sub-prompts
+                        // (test-02 — the response Enter re-captured
+                        // the watermark past the question) and for
+                        // plain commands (no outstanding question).
+                        if not (System.String.IsNullOrEmpty lastSubPromptAnnounce)
+                           && d.StartsWith(lastSubPromptAnnounce) then
+                            let nl =
+                                d.IndexOf('\n', lastSubPromptAnnounce.Length)
+                            let stripped =
+                                if nl >= 0 then
+                                    (d.Substring(nl + 1)).TrimStart('\r', '\n')
+                                else ""
+                            log.LogInformation(
+                                "PR-Y stripped already-spoken sub-prompt question. QuestionLen={QLen} RawDeltaLen={RawLen} StrippedLen={StrLen}",
+                                lastSubPromptAnnounce.Length, d.Length, stripped.Length)
+                            stripped
+                        else d
                     if System.String.IsNullOrWhiteSpace delta then None
                     else Some delta
                 | _ -> None
@@ -4266,6 +4311,10 @@ module Program =
                             if not awaitingSubPromptEnter then
                                 commandEnterSeq <-
                                     ContentHistory.latestSeq contentHistory
+                                // Cycle 51 PR-Y — a fresh top-level
+                                // command starts: any outstanding
+                                // sub-prompt question is stale.
+                                lastSubPromptAnnounce <- ""
                             shellInteractionLog.LogInformation(
                                 "PR-X preamble watermark. PreambleSeq={PreambleSeq} CommandEnterSeq={CommandEnterSeq} SubPromptResponse={SubPromptResponse}",
                                 lastEnterSeq,
@@ -4614,6 +4663,7 @@ module Program =
                                         // shell's history).
                                         lastEnterSeq <- -1L
                                         commandEnterSeq <- -1L
+                                        lastSubPromptAnnounce <- ""
                                         // Cycle 48 PR-B —
                                         // ShellInteraction state
                                         // resets on shell switch


### PR DESCRIPTION
## Summary

**Cycle 51 PR-Y — follow-up fix from the preview.137 dogfood.** Single-key Y/N sub-prompts (test-04) re-announced the question in the post-response tuple-final delta.

The log proved it:
- test-04: `PR-X sub-prompt announce … Continue? [Y,N]?` (heard once), then `PR-X tuple-final delta body. Announce=Continue? [Y,N]?Y\nYou chose Yes.\n=== …END ===` — **question spoken again**.
- test-02 (typed-Enter sub-prompt): tuple-final delta = `Hello, … letter.\n=== …END ===` — **clean, no repeat**.

**Root cause:** a single-key prompt's question row has no terminating newline when `SubPromptIdle` fires (cmd sits at it awaiting a keypress), so ContentHistory hasn't sealed it into an entry yet. `lastEnterSeq` captured then lands on the newline *before* the question (e.g. Seq 162; question is Seq 163), and the tuple-final slice `[162, tail]` re-includes it. Typed-Enter sub-prompts (test-02) escape this because the response **Enter** re-captures the watermark *after* the question sealed — single-key prompts have no response Enter.

**Fix:** store the exact question text spoken at `SubPromptIdle` (`lastSubPromptAnnounce`); at tuple-final, if the delta begins with it, drop it through the first newline after it (also removes the inline single-key response char). Exact-string match against the literally-spoken string — **a no-op for test-02 and plain commands**. Cleared on every top-level command Enter and on shell hot-switch. New `PR-Y stripped already-spoken sub-prompt question` Information diagnostic.

**Not addressed (by design / your call):** the intro/preamble ("This test asks a yes/no question…") is not announced at SubPromptIdle — you said you'd rather skip straight to the question, so that's left as-is.

## ⚠ Acceptance is manual

The strip is Program.fs announce-path internal (no unit harness). CI proves it compiles + the existing suite is green. Real gate: your dogfood — test-04 ×4 (Y/N), test-02 (typed), plain `echo`. Expected: test-04 delta = "You chose Yes./No.\n=== END ===" (no leading "Continue? [Y,N]?"); test-02 unchanged; `PR-Y stripped …` appears in the bundle on test-04 only.

## Test plan

- [ ] Full Windows CI green (touches `src/`).
- [ ] Dogfood: test-04 ×4 alternating Y/N (no question repeat), test-02 (still clean), `echo hi` ×2 (no regression), history-scroll→Enter (PR-X still good). Grep bundle for `PR-Y stripped`.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_