### PR TITLE
Cycle 51 PR-Z: history-recall announce reads wrapped commands whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13730,6 +13730,22 @@ commands; cleared on every top-level command Enter +
 shell hot-switch. New `PR-Y stripped already-spoken
 sub-prompt question` Information diagnostic.
 
+### Cycle 51 PR-Z (2026-05-15): history-recall announce reads wrapped commands whole
+
+Post-PR-Y dogfood: Up/Down command-recall occasionally spoke
+the wrapped tail of a long recalled command (`cho.cmd"`,
+`es-no.cmd"`) instead of the command. The recall announce read
+a single screen row at `Active.PromptRowIndex`; when a recalled
+command (a long script path) soft-wraps past `screen.Cols` the
+prompt+command spans two rows and cmd scrolls the viewport, so
+the fixed row index lands on the wrapped continuation. Fix:
+resolve the prompt row by scanning up from the cursor for the
+row that currently starts with the prompt text (robust to
+scroll), then join prompt-row..cursor-row so the wrapped
+command is read whole. Non-wrapping commands are unaffected
+(cursor row == prompt row → single row); with no prompt text
+(e.g. PowerShell) it stays on the single prompt row as before.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4127,30 +4127,74 @@ module Program =
             historyRecallTimer.Interval <- TimeSpan.FromMilliseconds(100.0)
             let tryAnnounceRecalledDraft () =
                 try
-                    let _, _, snapshot =
+                    let _, (cursorRow, _), snapshot =
                         screen.SnapshotRows(0, screen.Rows)
+                    let promptText =
+                        match shellInteraction.Current with
+                        | ShellInteraction.Composing data ->
+                            match data.PromptText with
+                            | ValueSome t -> Some t
+                            | ValueNone -> None
+                        | _ -> None
                     let promptRowOpt =
                         match currentSession.Active with
                         | Some active -> active.PromptRowIndex
                         | None -> None
-                    match promptRowOpt with
+                    // Cycle 51 PR-Z — a recalled command that
+                    // soft-wraps past `screen.Cols` (long script
+                    // paths) spans prompt-row..cursor-row, and cmd
+                    // scrolls the viewport, so a *fixed*
+                    // `PromptRowIndex` ends up pointing at the
+                    // wrapped tail (`…test-01-e` → `cho.cmd"`).
+                    // Resolve the prompt row by scanning UP from
+                    // the cursor for the row that currently starts
+                    // with the prompt text (robust to scroll);
+                    // fall back to `Active.PromptRowIndex`.
+                    let actualPromptRow =
+                        match promptText with
+                        | Some pt ->
+                            let mutable found = -1
+                            let mutable r =
+                                min cursorRow (snapshot.Length - 1)
+                            while found < 0 && r >= 0 do
+                                if (CanonicalState.renderRow snapshot r)
+                                    .StartsWith(
+                                        pt, StringComparison.Ordinal) then
+                                    found <- r
+                                r <- r - 1
+                            if found >= 0 then Some found else promptRowOpt
+                        | None -> promptRowOpt
+                    match actualPromptRow with
                     | Some promptRow when
                         promptRow >= 0 && promptRow < snapshot.Length ->
-                        let row = CanonicalState.renderRow snapshot promptRow
+                        // Join prompt-row..cursor-row so a wrapped
+                        // recall is read whole. cmd soft-wraps only
+                        // at full width, so non-final rows in the
+                        // span carry no trailing padding; the final
+                        // `.Trim()` handles the cursor row's. When
+                        // the command doesn't wrap, cursorRow ==
+                        // promptRow → single row (unchanged
+                        // behaviour). With no prompt text (e.g.
+                        // PowerShell) we can't bound the span
+                        // safely, so stay on the single prompt row.
+                        let endRow =
+                            match promptText with
+                            | Some _ ->
+                                max promptRow
+                                    (min cursorRow (snapshot.Length - 1))
+                            | None -> promptRow
+                        let row =
+                            seq {
+                                for r in promptRow .. endRow ->
+                                    CanonicalState.renderRow snapshot r }
+                            |> String.concat ""
                         // Strip the prompt-path prefix if the state
                         // machine has one. Without the strip the
                         // announce reads back the full
-                        // `C:\Users\Kyle\…\current>recalledCmd` row
+                        // `C:\Users\Kyle\…\current>recalledCmd`
                         // every time, which the user has already
                         // navigated past visually. Inspired by the
                         // sub-prompt last-line announce (PR-F).
-                        let promptText =
-                            match shellInteraction.Current with
-                            | ShellInteraction.Composing data ->
-                                match data.PromptText with
-                                | ValueSome t -> Some t
-                                | ValueNone -> None
-                            | _ -> None
                         let stripped =
                             match promptText with
                             | Some pt


### PR DESCRIPTION
## Summary

**Cycle 51 PR-Z — Issue 2 from your preview.137 dogfood.** Up/Down command-recall occasionally spoke the *wrapped tail* of a long recalled command (`cho.cmd"`, `es-no.cmd"`, "Show.cmd") instead of the command.

**Root cause (from your log):** the PR-I recall announce read a *single* screen row at `Active.PromptRowIndex` (`PromptRow=29 Row=cho.cmd" Stripped=False Announce=cho.cmd"`). A recalled long script path (≈80 chars) after the 46-char prompt exceeds 120 cols → soft-wraps to two rows, and cmd scrolls the viewport, so the fixed `PromptRowIndex` now points at the wrapped continuation, not the prompt line. Short commands (`echo 1`) don't wrap, so they were always correct.

**Fix:** resolve the prompt row by scanning *up from the cursor* for the row that currently starts with the prompt text (robust to the scroll), then join `prompt-row..cursor-row` so a wrapped recall is read whole. cmd soft-wraps only at full width, so intermediate rows carry no padding; the final `.Trim()` handles the cursor row's. **Non-wrapping commands are unaffected** (cursor row == prompt row → single row, exactly as before). With no prompt text (e.g. PowerShell) it stays on the single prompt row as before.

Single-file `Program.fs` change in `tryAnnounceRecalledDraft`; downstream PR-I/PR-J logging + the `inputAssistant` announce path are unchanged (the `Row=` Debug log now shows the joined command, which is the desired diagnostic).

Issue 1 (two-part tests not speaking the intro) is a separate code path → separate follow-up PR.

## ⚠ Manual acceptance

No unit harness for this screen-read path. CI proves compile + suite green. Real gate: your recall dogfood — Up/Down through short (`echo N`) **and** long (script-path) history; long recalls must now speak the full command, not `cho.cmd"`. The `PR-I history-recall details … Row=` line in a bundle will show the joined command.

## Test plan

- [ ] Full Windows CI green (touches `src/`).
- [ ] Dogfood: recall short + long commands via Up/Down; confirm long ones speak whole; confirm no regression on short ones; PR-X/PR-Y behaviour intact.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_