### PR TITLE
Cycle 51 PR-AA: speak the full sub-prompt preamble + restore the startup banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13746,6 +13746,35 @@ command is read whole. Non-wrapping commands are unaffected
 (cursor row == prompt row → single row); with no prompt text
 (e.g. PowerShell) it stays on the single prompt row as before.
 
+### Cycle 51 PR-AA (2026-05-15): speak the full sub-prompt preamble + restore the startup banner
+
+Post-PR-Y/Z dogfood found two "first part not spoken" gaps:
+(1) two-part tests (user-input, numeric, yes/no, pause) spoke
+only the question, not the intro ("This test asks…", "Enter a
+number:"); (2) switching to cmd no longer read the startup
+banner ("Microsoft Windows [Version …]").
+
+(1) PR-X took only the accumulator's last non-empty line
+because the raw byte accumulator carries an OSC window-title
+sequence whose printable body (`]0;…\foo.cmd"`) survives the
+lone-ESC `AnnounceSanitiser.sanitise` as spoken garbage. New
+`AnnounceSanitiser.stripSequences` strips whole CSI / OSC
+(BEL- or ST-terminated) / two-char-ESC sequences (full xUnit
+coverage); the sub-prompt announce now strips sequences, splits
+into visible lines, and speaks the whole preamble + question.
+Only the question line is stored for PR-Y's post-response strip
+(the tuple-final slice begins at the question, never the
+preamble, so PR-Y still matches).
+
+(2) PR-X's `when lastEnterSeq >= 0L` tuple-final guard
+suppressed every announce before the first command Enter —
+including the shell startup / post-switch banner. The slice
+watermark now defaults to `0L` when no command Enter has
+happened yet, so the banner is spoken; normal commands use the
+command-Enter watermark unchanged. New `PR-AA sub-prompt
+announce` Information diagnostic (replaces `PR-X sub-prompt
+announce`).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1699,47 +1699,58 @@ module Program =
                         // recognise today, so PromptRowIndex
                         // stays ValueNone there).
                         let raw = outcome.AccumulatedOutput
-                        // Cycle 51 PR-X — the sub-prompt announce
-                        // is the accumulator's last non-empty line
-                        // (the question itself). The screen-row
-                        // sub-prompt reader path is DELETED
-                        // (ADR 0004 — screen rows are display-only);
-                        // the 2026-05-15 dogfood confirmed this
-                        // accumulator text is the correct question
-                        // ("Continue? [Y,N]?" / "Enter your name:"
-                        // / "Enter a number:"). The leading
-                        // echo-strip drops the user's
-                        // submitted-command echo that precedes the
-                        // script's first byte.
-                        let announceBody =
-                            let firstLf = raw.IndexOf('\n')
-                            let postEchoRaw =
-                                if firstLf >= 0 && firstLf + 1 < raw.Length then
-                                    raw.Substring(firstLf + 1)
-                                else
-                                    raw
-                            postEchoRaw.Split(
-                                [| '\n' |], System.StringSplitOptions.None)
-                            |> Array.rev
-                            |> Array.tryFind (fun line ->
-                                not (System.String.IsNullOrWhiteSpace line))
-                            |> Option.defaultValue postEchoRaw
-                        let sanitised = AnnounceSanitiser.sanitise announceBody
-                        let trimmed = sanitised.Trim()
+                        // Cycle 51 PR-AA — speak the FULL preamble
+                        // + question, not just the question line.
+                        // PR-X took only the accumulator's last
+                        // non-empty line because the raw byte
+                        // accumulator carries an OSC window-title
+                        // sequence whose printable body
+                        // (`]0;…\foo.cmd"`) survives the lone-ESC
+                        // `sanitise` as spoken garbage. Strip whole
+                        // ANSI/OSC *sequences* first, then split
+                        // into visible lines and speak them all —
+                        // the maintainer asked for the intro
+                        // context ("This test asks…", "Enter a
+                        // number:") that last-line-only dropped.
+                        let lines =
+                            (AnnounceSanitiser.stripSequences raw)
+                                .Replace("\r", "\n")
+                                .Split(
+                                    [| '\n' |],
+                                    System.StringSplitOptions.None)
+                            |> Array.map (fun l ->
+                                (AnnounceSanitiser.sanitise l).Trim())
+                            |> Array.filter (fun l -> l.Length > 0)
+                        // The question/prompt is the last non-empty
+                        // line (PR-X's proven extraction). Kept
+                        // separately for PR-Y's post-response
+                        // strip, which matches the tuple-final
+                        // delta — that slice begins at the
+                        // question, never at the preamble.
+                        let questionLine =
+                            if lines.Length > 0 then
+                                lines.[lines.Length - 1]
+                            else
+                                ""
+                        // Single-line utterance (space-joined):
+                        // RaiseNotificationEvent's displayString is
+                        // single-line by contract and the embedded
+                        // controls are already gone.
+                        let trimmed = (String.concat " " lines).Trim()
                         if not (System.String.IsNullOrWhiteSpace trimmed) then
                             let toSay =
                                 if trimmed.Length <= OutputAnnounceCapChars then trimmed
                                 else trimmed.Substring(trimmed.Length - OutputAnnounceCapChars)
                             if toSay.Length < trimmed.Length then
                                 log.LogInformation(
-                                    "PR-X sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
+                                    "PR-AA sub-prompt announce truncated. OriginalLen={Orig} CappedLen={Capped} Cap={Cap}",
                                     trimmed.Length, toSay.Length, OutputAnnounceCapChars)
                             log.LogInformation(
-                                "PR-X sub-prompt announce. Length={Len} AccumulatorLen={Acc}",
-                                toSay.Length, raw.Length)
+                                "PR-AA sub-prompt announce. Length={Len} Lines={Lines} AccumulatorLen={Acc}",
+                                toSay.Length, lines.Length, raw.Length)
                             log.LogDebug(
-                                "PR-X sub-prompt announce body. Announce={Announce}",
-                                toSay)
+                                "PR-AA sub-prompt announce body. Question={Question} Announce={Announce}",
+                                questionLine, toSay)
                             window.TerminalSurface.Announce(toSay, ActivityIds.output)
                             // Cycle 49 PR-C — invalidate UIA
                             // Text-pattern cache so the review
@@ -1749,12 +1760,15 @@ module Program =
                             raiseTextChanged ()
                             lastAnnouncedText <- toSay
                             lastAnnouncedSeq <- ContentHistory.latestSeq contentHistory
-                            // Cycle 51 PR-Y — remember the exact
-                            // question text (pre-cap `trimmed`, so
-                            // the full prefix is available to
-                            // match) for the tuple-final
-                            // strip-already-spoken-question step.
-                            lastSubPromptAnnounce <- trimmed
+                            // Cycle 51 PR-Y — store ONLY the
+                            // question line (not the full
+                            // preamble+question). The tuple-final
+                            // slice begins at the question
+                            // (watermark sits just before it),
+                            // never at the preamble, so the
+                            // post-response strip must match the
+                            // question alone.
+                            lastSubPromptAnnounce <- questionLine
                         let readyEvent =
                             OutputEvent.create
                                 SemanticCategory.ReadyForInput
@@ -2054,10 +2068,23 @@ module Program =
             // `commandEnterSeq`).
             let tupleFinaliseAnnounce =
                 match finalisedOpt, currentShellPolicy.Streaming with
-                | Some _, ShellPolicy.TupleFinalOnly when lastEnterSeq >= 0L ->
+                | Some _, ShellPolicy.TupleFinalOnly ->
+                    // Cycle 51 PR-AA — when no command Enter has
+                    // happened yet (`lastEnterSeq < 0L`) the
+                    // finalising cell is the shell's startup /
+                    // post-switch banner ("Microsoft Windows
+                    // [Version …]"); slice from the start (0L) so
+                    // it gets spoken. PR-X's `>= 0L` guard
+                    // suppressed it entirely (regression the
+                    // maintainer caught: "when I switched to
+                    // command prompt it no longer reads the
+                    // banner"). Normal commands use the
+                    // command-Enter watermark, unchanged.
+                    let watermark =
+                        if lastEnterSeq >= 0L then lastEnterSeq else 0L
                     let raw =
                         ContentHistory.sliceText
-                            contentHistory lastEnterSeq System.Int64.MaxValue
+                            contentHistory watermark System.Int64.MaxValue
                     let withoutNextPrompt =
                         match augmented.MatchedRowText with
                         | Some p when not (System.String.IsNullOrEmpty p)

--- a/src/Terminal.Core/AnnounceSanitiser.fs
+++ b/src/Terminal.Core/AnnounceSanitiser.fs
@@ -67,6 +67,66 @@ module AnnounceSanitiser =
                         sb.Append(ch) |> ignore
                 sb.ToString()
 
+    /// Cycle 51 PR-AA — strip whole ANSI/VT escape *sequences*
+    /// (not just the lone ESC byte `sanitise` removes) so a
+    /// multi-line announce sourced from a raw byte accumulator
+    /// doesn't speak the surviving printable body of an OSC
+    /// window-title sequence (e.g. `]0;C:\WINDOWS\…\foo.cmd"`,
+    /// whose `ESC` and `BEL` `sanitise` drops but whose body
+    /// text it keeps). Handled:
+    ///   * CSI: `ESC '['` … final byte 0x40..0x7E
+    ///   * OSC: `ESC ']'` … terminated by BEL (0x07) or ST
+    ///     (`ESC '\'`)
+    ///   * other two-char `ESC <byte>` sequences (`ESC ( B`,
+    ///     `ESC =`, …): drop `ESC` + the following byte
+    /// A trailing lone `ESC` (no following byte) is dropped.
+    /// Lone C0/C1/DEL controls are NOT stripped here — chain
+    /// `sanitise` (single-line) or split on `\n` first
+    /// (multi-line) as the caller needs.
+    let stripSequences (s: string | null) : string =
+        if isNull s then ""
+        else
+            let s = nonNull s
+            let n = s.Length
+            if n = 0 then s
+            else
+                let sb = StringBuilder(n)
+                let mutable i = 0
+                while i < n do
+                    let c = s.[i]
+                    if c = '\u001B' then
+                        if i + 1 >= n then
+                            i <- n
+                        else
+                            match s.[i + 1] with
+                            | '[' ->
+                                i <- i + 2
+                                while i < n
+                                      && not (s.[i] >= '@'
+                                              && s.[i] <= '~') do
+                                    i <- i + 1
+                                if i < n then i <- i + 1
+                            | ']' ->
+                                i <- i + 2
+                                let mutable fin = false
+                                while i < n && not fin do
+                                    if s.[i] = '\u0007' then
+                                        i <- i + 1
+                                        fin <- true
+                                    elif s.[i] = '\u001B'
+                                         && i + 1 < n
+                                         && s.[i + 1] = '\\' then
+                                        i <- i + 2
+                                        fin <- true
+                                    else
+                                        i <- i + 1
+                            | _ ->
+                                i <- i + 2
+                    else
+                        sb.Append(c) |> ignore
+                        i <- i + 1
+                sb.ToString()
+
     /// Cycle 47 follow-up (2026-05-13) — bundle-friendly variant
     /// of `sanitise` that preserves the three "useful whitespace"
     /// control characters: `\n` (0x0A), `\r` (0x0D), and `\t`

--- a/tests/Tests.Unit/AnnounceSanitiserTests.fs
+++ b/tests/Tests.Unit/AnnounceSanitiserTests.fs
@@ -138,3 +138,70 @@ let ``sanitiseForBundle preserves non-BMP Unicode`` () =
     let emoji = "\U0001F600"
     let input = sprintf "before %s\nafter" emoji
     Assert.Equal(input, AnnounceSanitiser.sanitiseForBundle input)
+
+// ---------------------------------------------------------------------
+// stripSequences: Cycle 51 PR-AA — strip whole ANSI/VT escape
+// SEQUENCES (CSI / OSC / two-char ESC), not just the lone ESC
+// byte. Used by the sub-prompt announce so a multi-line preamble
+// sourced from the raw byte accumulator doesn't speak the
+// surviving printable body of an OSC window-title sequence.
+// Must NOT strip lone C0 controls (\n / \r) — the caller splits
+// on \n after this and chains `sanitise` per line.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``stripSequences empty returns empty`` () =
+    Assert.Equal("", AnnounceSanitiser.stripSequences "")
+
+[<Fact>]
+let ``stripSequences null returns empty`` () =
+    Assert.Equal("", AnnounceSanitiser.stripSequences null)
+
+[<Fact>]
+let ``stripSequences leaves plain text unchanged`` () =
+    let s = "Continue? [Y,N]?"
+    Assert.Equal(s, AnnounceSanitiser.stripSequences s)
+
+[<Fact>]
+let ``stripSequences removes CSI colour sequences`` () =
+    let input = "a\x1B[31mb\x1B[0mc"
+    Assert.Equal("abc", AnnounceSanitiser.stripSequences input)
+
+[<Fact>]
+let ``stripSequences removes BEL-terminated OSC title and keeps body after`` () =
+    // The real test-04 shape: OSC set-title then the script's
+    // first output line, BEL between them.
+    let input =
+        "\x1B]0;C:\\WINDOWS\\SYSTEM32\\cmd.exe - foo.cmd\x07=== PTYSPEAK-TEST-START ==="
+    Assert.Equal(
+        "=== PTYSPEAK-TEST-START ===",
+        AnnounceSanitiser.stripSequences input)
+
+[<Fact>]
+let ``stripSequences removes ST-terminated OSC`` () =
+    let input = "x\x1B]0;the title\x1B\\y"
+    Assert.Equal("xy", AnnounceSanitiser.stripSequences input)
+
+[<Fact>]
+let ``stripSequences removes two-char ESC sequence`` () =
+    let input = "a\x1B(Bb"
+    Assert.Equal("ab", AnnounceSanitiser.stripSequences input)
+
+[<Fact>]
+let ``stripSequences drops a trailing lone ESC`` () =
+    Assert.Equal("abc", AnnounceSanitiser.stripSequences "abc\x1B")
+
+[<Fact>]
+let ``stripSequences preserves newlines and carriage returns`` () =
+    // Critical: the multi-line sub-prompt announce splits on \n
+    // AFTER stripSequences, so \n / \r must survive here.
+    let input = "line1\r\nline2\nline3"
+    Assert.Equal(input, AnnounceSanitiser.stripSequences input)
+
+[<Fact>]
+let ``stripSequences cleans the full test-04 sub-prompt accumulator shape`` () =
+    let input =
+        "\n\x1B]0;C:\\WINDOWS\\SYSTEM32\\cmd.exe - \"C:\\test-04.cmd\"\x07=== PTYSPEAK-TEST-START: test-04-yes-no ===\r\nThis test asks a yes/no question. Press Y or N (no Enter needed).\r\nContinue? [Y,N]?"
+    let expected =
+        "\n=== PTYSPEAK-TEST-START: test-04-yes-no ===\r\nThis test asks a yes/no question. Press Y or N (no Enter needed).\r\nContinue? [Y,N]?"
+    Assert.Equal(expected, AnnounceSanitiser.stripSequences input)

--- a/tests/Tests.Unit/AnnounceSanitiserTests.fs
+++ b/tests/Tests.Unit/AnnounceSanitiserTests.fs
@@ -184,7 +184,11 @@ let ``stripSequences removes ST-terminated OSC`` () =
 
 [<Fact>]
 let ``stripSequences removes two-char ESC sequence`` () =
-    let input = "a\x1B(Bb"
+    // `ESC =` (DECKPAM) is a genuine two-char sequence: the
+    // stripper drops `ESC` + the single following byte. (A
+    // 3-byte form like `ESC ( B` correctly leaves its 3rd byte —
+    // by design; see the stripSequences docstring.)
+    let input = "a\x1B=b"
     Assert.Equal("ab", AnnounceSanitiser.stripSequences input)
 
 [<Fact>]


### PR DESCRIPTION
## Summary

**Cycle 51 PR-AA — Issue 1 + the "banner" follow-up from your dogfood.** Two "first part not spoken" gaps:

1. **Two-part tests speak only the question, not the intro.** PR-X's sub-prompt announce takes only the accumulator's *last* non-empty line. It does that because the raw byte accumulator carries an OSC window-title sequence whose **printable body survives** `AnnounceSanitiser.sanitise` (it strips the ESC byte, not `]0;C:\WINDOWS\…cmd"`). New **`AnnounceSanitiser.stripSequences`** strips whole CSI / OSC (BEL- or ST-terminated) / two-char-ESC sequences (**full xUnit coverage** — incl. the exact test-04 accumulator shape). The sub-prompt announce now strips sequences → splits into visible lines → speaks the **whole preamble + question**. Only the *question line* is stored for PR-Y's post-response strip (the tuple-final slice begins at the question, never the preamble, so PR-Y still matches — verified against your log: watermark sits at the newline before the question).

2. **Switching to cmd no longer reads the startup banner** (you flagged this). PR-X's `when lastEnterSeq >= 0L` tuple-final guard suppressed *every* announce before the first command Enter — including the shell startup / post-switch banner. The slice watermark now defaults to `0L` when no command Enter has happened yet, so the banner ("Microsoft Windows [Version …]") is spoken. Normal commands use the command-Enter watermark, unchanged.

Both are the same theme (output preceding a user Enter was being dropped) and the same announce code path, so they're one PR with one commit. New `PR-AA sub-prompt announce` Information diagnostic.

Rebased onto PR-Z; the `stripSequences` source uses explicit ``/`` escapes (no literal control bytes — verified, per the CONTRIBUTING foot-gun).

## ⚠ Manual acceptance

The escape stripper is **fully unit-tested** (CI-validatable). The Program.fs announce wiring is dogfood-gated. Expected on your re-test:
- **test-02 / test-04 / numeric / pause**: hear the intro line(s) **and** the question (e.g. "This test asks a yes/no question. Press Y or N (no Enter needed). Continue? [Y,N]?") — not just the question.
- **test-04 post-response**: still "You chose Yes./No. + END" (PR-Y intact — it stores the question line only).
- **Switch to cmd** (Ctrl+Shift+1): the Windows banner is spoken again.
- No OSC/title garbage ("]0;C:\WINDOWS…") in any announce.

## Test plan

- [ ] Full Windows CI green incl. new `stripSequences` xUnit tests.
- [ ] Dogfood: test-02/04/numeric/pause (intro + question spoken), test-04 ×2 (PR-Y still strips question post-response), shell-switch to cmd (banner spoken), plain `echo` + history-scroll (PR-X/PR-Z intact), no OSC garbage.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_