### PR TITLE
Cycle 51 PR-AB: strip fast-type command echo from the tuple-final delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13775,6 +13775,28 @@ command-Enter watermark unchanged. New `PR-AA sub-prompt
 announce` Information diagnostic (replaces `PR-X sub-prompt
 announce`).
 
+### Cycle 51 PR-AB (2026-05-15): strip fast-type command echo from the tuple-final delta
+
+Post-PR-AA dogfood: typing a command (e.g. `echo hi`) fast and
+hitting Enter without a pause occasionally narrated extra
+content — fragments of the command word or a repeated argument
+— with no corresponding record in the review/speech cursor.
+Root cause: `lastEnterSeq` is captured synchronously at the CR
+keystroke, but a fast-typed command's echo round-trips through
+the PTY and lands in ContentHistory at Seq > lastEnterSeq, so
+the tuple-final slice `[lastEnterSeq, tail]` begins with the
+command-echo line instead of the output (typing slowly lets the
+echo settle below the watermark first, so it never reproduced
+before). Fix: capture the submitted command text
+(`UserInputBuffer.Capture()`) at the CR keystroke and, at
+tuple-final, strip that exact already-on-screen command line off
+the front of the delta through the first newline after it — the
+same shape as PR-Y's sub-prompt-question strip, applied after
+it. No-op when the user typed slowly, for sub-prompt deltas, and
+for the startup banner. New `PR-AB stripped fast-type command
+echo` Information diagnostic. Cleared on every top-level command
+Enter and shell hot-switch.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1042,6 +1042,20 @@ module Program =
         // Empty when no sub-prompt is outstanding; cleared on every
         // top-level command Enter + shell hot-switch.
         let mutable lastSubPromptAnnounce : string = ""
+        // Cycle 51 PR-AB — the just-submitted top-level command
+        // text (UserInputBuffer.Capture() at the CR keystroke).
+        // `lastEnterSeq` is captured synchronously at CR; when
+        // the user types fast and hits Enter, cmd's echo of the
+        // command round-trips through the PTY and lands in
+        // ContentHistory at Seq > lastEnterSeq, so the tuple-final
+        // slice `[lastEnterSeq, tail]` begins with the command
+        // echo line instead of the output. We strip that exact
+        // already-on-screen command line off the front of the
+        // delta (same shape as PR-Y's question strip). Empty when
+        // no top-level command is outstanding; overwritten on
+        // every top-level command Enter; cleared on shell
+        // hot-switch.
+        let mutable lastSubmittedCommand : string = ""
 
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
@@ -2109,19 +2123,48 @@ module Program =
                         // (test-02 — the response Enter re-captured
                         // the watermark past the question) and for
                         // plain commands (no outstanding question).
-                        if not (System.String.IsNullOrEmpty lastSubPromptAnnounce)
-                           && d.StartsWith(lastSubPromptAnnounce) then
+                        let afterQuestion =
+                            if not (System.String.IsNullOrEmpty lastSubPromptAnnounce)
+                               && d.StartsWith(lastSubPromptAnnounce) then
+                                let nl =
+                                    d.IndexOf('\n', lastSubPromptAnnounce.Length)
+                                let stripped =
+                                    if nl >= 0 then
+                                        (d.Substring(nl + 1)).TrimStart('\r', '\n')
+                                    else ""
+                                log.LogInformation(
+                                    "PR-Y stripped already-spoken sub-prompt question. QuestionLen={QLen} RawDeltaLen={RawLen} StrippedLen={StrLen}",
+                                    lastSubPromptAnnounce.Length, d.Length, stripped.Length)
+                                stripped
+                            else d
+                        // Cycle 51 PR-AB — fast-type race: when the
+                        // user types a command quickly and hits
+                        // Enter, the CR watermark is captured before
+                        // cmd's echo of the command round-trips
+                        // through the PTY, so the slice leads with
+                        // the command line, not its output. Drop
+                        // that exact already-on-screen command echo
+                        // through the first newline after it. No-op
+                        // when the user typed slowly (echo Seq <
+                        // watermark → slice already starts at the
+                        // output) and for sub-prompt deltas (the
+                        // command echo is far before the watermark).
+                        if not (System.String.IsNullOrEmpty lastSubmittedCommand)
+                           && afterQuestion.StartsWith(lastSubmittedCommand) then
                             let nl =
-                                d.IndexOf('\n', lastSubPromptAnnounce.Length)
+                                afterQuestion.IndexOf(
+                                    '\n', lastSubmittedCommand.Length)
                             let stripped =
                                 if nl >= 0 then
-                                    (d.Substring(nl + 1)).TrimStart('\r', '\n')
+                                    (afterQuestion.Substring(nl + 1))
+                                        .TrimStart('\r', '\n')
                                 else ""
                             log.LogInformation(
-                                "PR-Y stripped already-spoken sub-prompt question. QuestionLen={QLen} RawDeltaLen={RawLen} StrippedLen={StrLen}",
-                                lastSubPromptAnnounce.Length, d.Length, stripped.Length)
+                                "PR-AB stripped fast-type command echo. CmdLen={CmdLen} PreStripLen={PreLen} StrippedLen={StrLen}",
+                                lastSubmittedCommand.Length,
+                                afterQuestion.Length, stripped.Length)
                             stripped
-                        else d
+                        else afterQuestion
                     if System.String.IsNullOrWhiteSpace delta then None
                     else Some delta
                 | _ -> None
@@ -4386,6 +4429,12 @@ module Program =
                                 // command starts: any outstanding
                                 // sub-prompt question is stale.
                                 lastSubPromptAnnounce <- ""
+                                // Cycle 51 PR-AB — remember the
+                                // command text so the tuple-final
+                                // delta can strip its echo if the
+                                // fast-type race put it inside the
+                                // slice window.
+                                lastSubmittedCommand <- captured.Trim()
                             shellInteractionLog.LogInformation(
                                 "PR-X preamble watermark. PreambleSeq={PreambleSeq} CommandEnterSeq={CommandEnterSeq} SubPromptResponse={SubPromptResponse}",
                                 lastEnterSeq,
@@ -4735,6 +4784,7 @@ module Program =
                                         lastEnterSeq <- -1L
                                         commandEnterSeq <- -1L
                                         lastSubPromptAnnounce <- ""
+                                        lastSubmittedCommand <- ""
                                         // Cycle 48 PR-B —
                                         // ShellInteraction state
                                         // resets on shell switch


### PR DESCRIPTION
## Summary

**Cycle 51 PR-AB — Issue 2 from your dogfood.** Typing a command fast and hitting Enter without a pause occasionally narrated extra content (fragments of the command word, a repeated argument), with **no record in the review/speech cursor** — confirming it's a transient announce artifact, not substrate corruption.

**Root cause (confirmed by code trace):** `lastEnterSeq` is captured *synchronously at the CR keystroke* (`writePtyBytes` wrapper), but cmd's echo of a fast-typed command round-trips through the PTY and lands in ContentHistory at `Seq > lastEnterSeq`. The tuple-final slice `[lastEnterSeq, tail]` then begins with the command-echo line, not the output. Typing **slowly** lets the echo settle *below* the watermark before Enter, so the slice starts cleanly at the output — which is why it only reproduces under fast typing.

**Fix:** capture the submitted command (`UserInputBuffer.Capture()`, already computed at the CR branch) into `lastSubmittedCommand`; at tuple-final, after PR-Y's sub-prompt-question strip, if the delta begins with that exact command text, drop it through the first newline after it. **Same proven shape as PR-Y's strip**, applied second. No-op when:
- the user typed slowly (echo Seq < watermark → slice already starts at output → delta doesn't lead with the command),
- it's a sub-prompt delta (command echo is far before the watermark; PR-Y path),
- it's the startup banner (no command Enter → `lastSubmittedCommand` empty).

Cleared on every top-level command Enter and on shell hot-switch (alongside the other watermarks).

Single-file `Program.fs` change; PR-Y/PR-AA/PR-X paths preserved (PR-Y logic untouched, just renamed its result `afterQuestion` and chained PR-AB after it). New `PR-AB stripped fast-type command echo` Information diagnostic.

## ⚠ Manual acceptance

Announce-path internal (no unit harness — same as PR-Y/PR-AA). CI proves compile + suite green. Real gate: your fast-type dogfood.

## Test plan

- [ ] Full Windows CI green (touches `src/`).
- [ ] Dogfood: `echo hi` typed **fast** + Enter → announces only "hi" (no `echo`/`hi` fragments); typed **slow** → still "hi"; test-02/04 sub-prompts (PR-Y intact); history-scroll + banner (PR-X/PR-AA intact). `PR-AB stripped fast-type command echo` appears in the bundle only on the fast-type case.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_