### PR TITLE
Cycle 51 PR-AC: speak the new shell's banner on hot-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13797,6 +13797,28 @@ for the startup banner. New `PR-AB stripped fast-type command
 echo` Information diagnostic. Cleared on every top-level command
 Enter and shell hot-switch.
 
+### Cycle 51 PR-AC (2026-05-15): speak the new shell's banner on hot-switch
+
+Post-PR-AA dogfood: the startup banner is heard on first app
+launch but NOT after a Ctrl+Shift+1/2/3 shell switch (cmd ↔
+PowerShell ↔ cmd). Root cause (corrected from PR-AA's premise):
+on first launch the banner is read because NVDA reads the
+terminal document when the control first gains focus — pty-speak
+never announced it via the tuple-final path (the first
+`PromptStart` finds `Active=None`, so no cell finalises and
+`tupleFinaliseAnnounce` is `None`). On a switch the control
+already has focus, so NVDA doesn't re-read, and the same
+`Active=None` first-prompt means no announce either → silence.
+Fix: `switchToShell` sets `announceBannerOnNextPrompt`; the
+first post-switch `PromptStart` slices the freshly-reset
+ContentHistory from 0 to the new prompt, trims the trailing
+prompt path, cleans escape sequences (same as PR-AA), and speaks
+it once. The flag is consumed on that first prompt even when the
+slice is empty (a banner-less shell won't retry on the next
+prompt). Switch-only — first launch keeps NVDA's focus-read, so
+no double-announce. New `PR-AC shell-switch banner` Information
+diagnostic.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1056,6 +1056,16 @@ module Program =
         // every top-level command Enter; cleared on shell
         // hot-switch.
         let mutable lastSubmittedCommand : string = ""
+        // Cycle 51 PR-AC — set true by `switchToShell` after a
+        // shell hot-switch; consumed on the first post-switch
+        // `PromptStart` to speak the new shell's startup banner.
+        // On first app launch NVDA reads the terminal document
+        // when the control first gains focus, so the launch
+        // banner is already covered; on a switch the control
+        // already has focus and the first PromptStart finds
+        // `Active=None` (no cell finalises → no tuple-final
+        // announce), so without this the banner is silent.
+        let mutable announceBannerOnNextPrompt : bool = false
 
         // Cycle 45 Commit 2 — SpeechCursor announce callback +
         // "wake up" trigger. Defined here (very early in compose)
@@ -2178,6 +2188,40 @@ module Program =
                 | Some ContentHistory.MarkerKind.PromptStart ->
                     augmented.MatchedRowText
                 | _ -> None
+            // Cycle 51 PR-AC — the new shell's startup banner, to
+            // be spoken once on the first post-switch PromptStart.
+            // ContentHistory was reset on the switch, so slicing
+            // from 0 captures only the fresh shell's pre-prompt
+            // output (the banner). Trim the trailing prompt path
+            // and clean escape sequences exactly like the
+            // sub-prompt announce (PR-AA).
+            let bannerAnnounce =
+                if announceBannerOnNextPrompt
+                   && markerKind
+                      = Some ContentHistory.MarkerKind.PromptStart then
+                    let raw =
+                        ContentHistory.sliceText
+                            contentHistory 0L System.Int64.MaxValue
+                    let withoutPrompt =
+                        match augmented.MatchedRowText with
+                        | Some p when not (System.String.IsNullOrEmpty p)
+                                      && raw.EndsWith(p) ->
+                            raw.Substring(0, raw.Length - p.Length)
+                        | _ -> raw
+                    let lines =
+                        (AnnounceSanitiser.stripSequences withoutPrompt)
+                            .Replace("\r", "\n")
+                            .Split(
+                                [| '\n' |],
+                                System.StringSplitOptions.None)
+                        |> Array.map (fun l ->
+                            (AnnounceSanitiser.sanitise l).Trim())
+                        |> Array.filter (fun l -> l.Length > 0)
+                    let joined = (String.concat " " lines).Trim()
+                    if System.String.IsNullOrWhiteSpace joined then None
+                    else Some joined
+                else
+                    None
             let boundaryAction () =
                 // Cycle 48 PR-B (ADR 0003) — observe PromptStart
                 // for the ShellInteraction state machine
@@ -2338,6 +2382,36 @@ module Program =
                     lastAnnouncedText <- toSay
                     lastAnnouncedSeq <- ContentHistory.latestSeq contentHistory
                 | None -> ()
+                // Cycle 51 PR-AC — first post-switch PromptStart:
+                // speak the new shell's banner, and consume the
+                // flag even if the slice was empty (so a
+                // banner-less shell doesn't retry on the next
+                // prompt and narrate accumulated output as a
+                // "banner").
+                if announceBannerOnNextPrompt
+                   && markerKind
+                      = Some ContentHistory.MarkerKind.PromptStart then
+                    announceBannerOnNextPrompt <- false
+                    match bannerAnnounce with
+                    | Some banner ->
+                        let toSay =
+                            if banner.Length <= OutputAnnounceCapChars then
+                                banner
+                            else
+                                banner.Substring(0, OutputAnnounceCapChars)
+                        log.LogInformation(
+                            "PR-AC shell-switch banner announce. Length={Len}",
+                            toSay.Length)
+                        log.LogDebug(
+                            "PR-AC shell-switch banner body. Announce={Announce}",
+                            toSay)
+                        window.TerminalSurface.Announce(
+                            toSay, ActivityIds.output)
+                        raiseTextChanged ()
+                        lastAnnouncedText <- toSay
+                        lastAnnouncedSeq <-
+                            ContentHistory.latestSeq contentHistory
+                    | None -> ()
             window.Dispatcher.InvokeAsync(Action(boundaryAction))
             |> ignore
 
@@ -4785,6 +4859,12 @@ module Program =
                                         commandEnterSeq <- -1L
                                         lastSubPromptAnnounce <- ""
                                         lastSubmittedCommand <- ""
+                                        // Cycle 51 PR-AC — speak
+                                        // the new shell's banner on
+                                        // its first prompt (the
+                                        // control already has focus
+                                        // so NVDA won't re-read it).
+                                        announceBannerOnNextPrompt <- true
                                         // Cycle 48 PR-B —
                                         // ShellInteraction state
                                         // resets on shell switch


### PR DESCRIPTION
## Summary

**Cycle 51 PR-AC — Issue 4 from your dogfood.** The startup banner is heard on first app launch but **not** after a Ctrl+Shift+1/2/3 shell switch (cmd ↔ PowerShell ↔ cmd).

**Corrected root cause** (PR-AA's premise was wrong, confirmed by the log + code trace): on first launch the banner is read because **NVDA reads the terminal document when the control first gains focus** — pty-speak never announced it via the tuple-final path (the first `PromptStart` finds `Active=None`, so no cell finalises and `tupleFinaliseAnnounce` is `None`). On a switch the control **already has focus** so NVDA doesn't re-read it, and the same `Active=None` first-prompt means no tuple-final announce either → silence. (So PR-AA's `watermark=0L` change never actually drove a banner.)

**Fix:** `switchToShell` sets a switch-only `announceBannerOnNextPrompt` flag (after the existing `ContentHistory.reset` + watermark resets). The first post-switch `PromptStart` slices the freshly-reset ContentHistory `[0, tail]`, trims the trailing prompt path, and cleans escape sequences with the **same machinery as PR-AA** (`stripSequences` + per-line `sanitise` + space-join), then `Announce`s it once. The flag is consumed on that first prompt **even when the slice is empty** (so a banner-less shell doesn't retry on the next prompt and narrate accumulated output as a "banner"); a live re-check at consume time prevents double-announce if two PromptStarts queue. **Switch-only** — first launch keeps NVDA's focus-read, so no double-announce there.

Single-file `Program.fs` change. New `PR-AC shell-switch banner` Information diagnostic.

## ⚠ Manual acceptance

Announce-path internal (no unit harness — same as PR-Y/AA/AB). The escape-cleaning it reuses (`stripSequences`) is unit-tested from PR-AA. CI proves compile + suite green; behaviour is dogfood-gated.

## Test plan

- [ ] Full Windows CI green (touches `src/`).
- [ ] Dogfood: launch (banner once, not twice) → Ctrl+Shift+2 PowerShell (PowerShell banner spoken once) → Ctrl+Shift+1 cmd (Windows banner spoken once) → run a command, confirm no banner re-announced on later prompts. PR-X/Y/AA/AB behaviour intact. `PR-AC shell-switch banner` appears in the bundle on switches only.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_