### PR TITLE
Cycle 51 PR-AD: SpeechCursor manual navigation fed from sealed IOCells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13819,6 +13819,38 @@ prompt). Switch-only — first launch keeps NVDA's focus-read, so
 no double-announce. New `PR-AC shell-switch banner` Information
 diagnostic.
 
+### Cycle 51 PR-AD (2026-05-15): SpeechCursor manual navigation fed from sealed IOCells
+
+Post-PR-AC dogfood found the Speech Cursor (Ctrl+Shift+Up/Down/
+End manual review) had no record of (3) the input command line,
+nor (1) the output produced after a single-key sub-prompt
+response — both confirmed via the review cursor, which showed
+them. Root cause (ADR 0004 §4a): SpeechCursor navigated raw
+ContentHistory entries through `renderEntryWithPolicy`, which
+unconditionally drops every `UserInputEcho`-tagged entry; the
+command echo is `UserInputEcho`, and post-single-key-response
+output is mis-tagged `UserInputEcho` because the state machine
+is `Composing` after `SubPromptIdle` with no `EnterPressed`.
+
+Per the maintainer's decision, Manual navigation is now fed from
+**sealed IOCells**: at tuple-finalize, the cell's authoritative
+`CommandText` + `OutputText` (from `SessionModel.extractIOCell`
+— post-PR-X this already excludes history-scroll redraws and
+includes post-response output) are appended to a new
+SpeechCursor cell-transcript as separate navigable items (the
+command line is its own item, per the maintainer's standing
+request). `Ctrl+Shift+Up/Down/End` now walk this transcript
+(`cellPrevious`/`cellNext`/`cellToLatest`); AutoDrive follows
+the latest, Manual mode stays put on append. The legacy
+ContentHistory-Seq engine (`Position`/`onAppend`/`next`/
+`previous`/`toLatest`/`toMarker`/`renderEntryForManualNav`) is
+**retained unchanged** for AutoDrive bookkeeping, selection-
+suspend, and the Diagnostics navigability dump — only the
+user-facing Manual gestures moved. Cleared on shell hot-switch
+alongside the ContentHistory reset. New `SpeechCursor` cell-API
+unit tests (additive; the existing 25 Seq-engine tests are
+untouched).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2012,7 +2012,17 @@ module Program =
                     contentHistory true commandEnterSeq
             currentSession <- nextSession
             match finalisedOpt with
-            | Some tuple -> dispatchTupleToWriter tuple
+            | Some tuple ->
+                dispatchTupleToWriter tuple
+                // Cycle 51 PR-AD (ADR 0004) — feed the sealed
+                // cell's authoritative command + output into the
+                // SpeechCursor transcript so Manual navigation
+                // (Ctrl+Shift+Up/Down/End) can review the command
+                // line itself and post-single-key-response output
+                // (both filtered from the raw ContentHistory-Seq
+                // path as `UserInputEcho`; ADR 0004 §4a).
+                SpeechCursor.appendCell
+                    speechCursor tuple.CommandText tuple.OutputText
             | None -> ()
 
             // Cycle 45 Commit 2 — ContentHistory + SpeechCursor
@@ -3942,64 +3952,41 @@ module Program =
         // (where the binding fires), the same thread the
         // reader-loop dispatcher actions use; serialisation
         // is preserved.
-        // Cycle 49 PR-D — manual nav renders entries via
-        // `renderEntryForManualNav` rather than `renderEntry` so
-        // `PromptStart` markers with payload announce as a
-        // FinalDirOnly-trimmed prompt (e.g. "Local>") regardless
-        // of the per-shell `PromptPath` policy. Auto-drive
-        // narration (in `SpeechCursor.onAppend`) still respects
-        // `PromptPath` so streaming doesn't become chattier.
-        let manualNavRender (entry: ContentHistory.Entry) =
-            let promptPath =
-                (SpeechCursor.getParameters speechCursor).PromptPath
-            SpeechCursor.renderEntryForManualNav promptPath entry
-
+        //
+        // Cycle 51 PR-AD (ADR 0004) — Manual navigation walks the
+        // sealed-IOCell transcript (command + output per cell),
+        // not raw ContentHistory entries. This is what lets the
+        // user review the command line itself and post-single-key
+        // -response output, both of which the legacy Seq path
+        // filtered as `UserInputEcho`. The manual-step announce
+        // keeps the `diagnostic` activity id so users can
+        // per-tag-mute explicit navigation separately from live
+        // output.
         let runSpeechCursorNext () : unit =
-            match SpeechCursor.next speechCursor contentHistory with
-            | Some entry ->
-                match manualNavRender entry with
-                | Some (text, _) ->
-                    // Manual-step announce uses a fresh activity
-                    // id so users can per-tag-mute live announces
-                    // separately from explicit navigation.
-                    window.TerminalSurface.Announce(
-                        text, ActivityIds.diagnostic)
-                | None ->
-                    window.TerminalSurface.Announce(
-                        "(no announcement for this entry)",
-                        ActivityIds.diagnostic)
+            match SpeechCursor.cellNext speechCursor with
+            | Some (text, _) ->
+                window.TerminalSurface.Announce(
+                    text, ActivityIds.diagnostic)
             | None ->
                 window.TerminalSurface.Announce(
                     "Already at the latest entry.",
                     ActivityIds.diagnostic)
 
         let runSpeechCursorPrevious () : unit =
-            match SpeechCursor.previous speechCursor contentHistory with
-            | Some entry ->
-                match manualNavRender entry with
-                | Some (text, _) ->
-                    window.TerminalSurface.Announce(
-                        text, ActivityIds.diagnostic)
-                | None ->
-                    window.TerminalSurface.Announce(
-                        "(no announcement for this entry)",
-                        ActivityIds.diagnostic)
+            match SpeechCursor.cellPrevious speechCursor with
+            | Some (text, _) ->
+                window.TerminalSurface.Announce(
+                    text, ActivityIds.diagnostic)
             | None ->
                 window.TerminalSurface.Announce(
                     "Already at the first entry.",
                     ActivityIds.diagnostic)
 
         let runSpeechCursorJumpToLatest () : unit =
-            match SpeechCursor.toLatest speechCursor contentHistory with
-            | Some entry ->
-                match manualNavRender entry with
-                | Some (text, _) ->
-                    window.TerminalSurface.Announce(
-                        text, ActivityIds.diagnostic)
-                | None ->
-                    window.TerminalSurface.Announce(
-                        "Jumped to latest entry.",
-                        ActivityIds.diagnostic)
+            match SpeechCursor.cellToLatest speechCursor with
+            | Some (text, _) ->
+                window.TerminalSurface.Announce(
+                    text, ActivityIds.diagnostic)
             | None ->
                 window.TerminalSurface.Announce(
                     "History is empty.", ActivityIds.diagnostic)
@@ -4831,6 +4818,11 @@ module Program =
                                         // dispatcher thread.
                                         ContentHistory.reset contentHistory
                                         SpeechCursor.reset speechCursor
+                                        // Cycle 51 PR-AD — the
+                                        // previous shell's cell
+                                        // transcript is no longer
+                                        // relevant after a switch.
+                                        SpeechCursor.cellReset speechCursor
                                         // Cycle 47 follow-up —
                                         // reset the idle-flush
                                         // watermark when

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -134,6 +134,30 @@ module SpeechCursor =
         /// arrives. Distinct from `Mode = Manual` (which is a
         /// user-driven switch and survives the suspension).
         member val internal SelectionSuspend: bool = false with get, set
+        /// Cycle 51 PR-AD (ADR 0004) — the sealed-IOCell
+        /// transcript that **Manual** navigation
+        /// (Ctrl+Shift+Up/Down/End) walks. Each finalised cell
+        /// contributes its authoritative `CommandText` and
+        /// `OutputText` (from `SessionModel.extractIOCell`, which
+        /// post-PR-X already excludes history-scroll redraws and
+        /// includes post-single-key-response output) as separate
+        /// navigable `(text, activityId)` items — fixing the
+        /// "speech cursor has no record of the command, nor of
+        /// the output after a single-key sub-prompt response"
+        /// reports (the raw ContentHistory entries are tagged
+        /// `UserInputEcho` and filtered by `renderEntryWithPolicy`;
+        /// ADR 0004 §4a). The legacy ContentHistory-Seq engine
+        /// (`Position`/`LastSpokenSeq`/`onAppend`/`next`/`previous`
+        /// /`toLatest`/`toMarker`) is retained unchanged for
+        /// AutoDrive bookkeeping, the Diagnostics navigability
+        /// dump, and selection-suspend — only the user-facing
+        /// Manual gestures move to this cell model.
+        member val internal CellTranscript
+            : ResizeArray<string * string> = ResizeArray() with get
+        /// Index into `CellTranscript` the Manual cursor is parked
+        /// on. -1 = before the first item (fresh / after
+        /// `cellReset`).
+        member val internal CellPos: int = -1 with get, set
 
     /// Construct a fresh cursor.
     let create (parameters: Parameters) : T =
@@ -625,3 +649,86 @@ module SpeechCursor =
         state.SelectionSuspend <- false
         // Mode is preserved across resets — the user's choice of
         // AutoDrive vs Manual survives tuple boundaries.
+
+    // -----------------------------------------------------------------
+    // Cycle 51 PR-AD (ADR 0004) — sealed-IOCell transcript: the
+    // model the user-facing Manual gestures navigate. Additive;
+    // the legacy ContentHistory-Seq engine above is untouched.
+    // -----------------------------------------------------------------
+
+    /// Append a finalised cell's authoritative command + output as
+    /// separate navigable items. Whitespace-only parts are
+    /// skipped (an empty-command Enter, or a command that printed
+    /// nothing). In AutoDrive the cursor follows the latest item;
+    /// in Manual it stays put so an in-progress review isn't
+    /// disturbed by new output (mirrors the legacy AutoDrive /
+    /// Manual append semantics).
+    let appendCell
+            (state: T)
+            (commandText: string)
+            (outputText: string)
+            : unit =
+        if not (String.IsNullOrWhiteSpace commandText) then
+            state.CellTranscript.Add(
+                (commandText.Trim(), ActivityIds.output))
+        if not (String.IsNullOrWhiteSpace outputText) then
+            state.CellTranscript.Add(
+                (outputText, ActivityIds.output))
+        if state.Mode = AutoDrive then
+            state.CellPos <- state.CellTranscript.Count - 1
+
+    /// The transcript item the Manual cursor is parked on, if any.
+    let cellCurrent (state: T) : (string * string) option =
+        if state.CellPos >= 0
+           && state.CellPos < state.CellTranscript.Count then
+            Some state.CellTranscript.[state.CellPos]
+        else
+            None
+
+    /// Step the Manual cursor to the previous (older) transcript
+    /// item. From the unparked state (-1) the first press lands on
+    /// the latest item. Returns the item, or `None` if already at
+    /// the first item / the transcript is empty.
+    let cellPrevious (state: T) : (string * string) option =
+        let count = state.CellTranscript.Count
+        if count = 0 then None
+        else
+            let target =
+                if state.CellPos < 0 then count - 1
+                else state.CellPos - 1
+            if target < 0 then None
+            else
+                state.CellPos <- target
+                Some state.CellTranscript.[target]
+
+    /// Step the Manual cursor to the next (newer) transcript item.
+    /// From the unparked state (-1) the first press lands on the
+    /// latest item. Returns the item, or `None` if already at the
+    /// latest item / the transcript is empty.
+    let cellNext (state: T) : (string * string) option =
+        let count = state.CellTranscript.Count
+        if count = 0 then None
+        else
+            let target =
+                if state.CellPos < 0 then count - 1
+                else state.CellPos + 1
+            if target >= count then None
+            else
+                state.CellPos <- target
+                Some state.CellTranscript.[target]
+
+    /// Jump the Manual cursor to the latest transcript item.
+    /// Returns it, or `None` if the transcript is empty.
+    let cellToLatest (state: T) : (string * string) option =
+        let count = state.CellTranscript.Count
+        if count = 0 then None
+        else
+            state.CellPos <- count - 1
+            Some state.CellTranscript.[count - 1]
+
+    /// Clear the cell transcript. Called on shell hot-switch
+    /// alongside `reset` (the previous shell's transcript is no
+    /// longer relevant).
+    let cellReset (state: T) : unit =
+        state.CellTranscript.Clear()
+        state.CellPos <- -1

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -772,3 +772,152 @@ let ``reset clears Position and LastSpokenSeq but preserves Mode`` () =
     Assert.Equal(-1L, cursor.Position)
     Assert.Equal(-1L, cursor.LastSpokenSeq)
     Assert.Equal(SpeechCursor.Manual, SpeechCursor.mode cursor)
+
+// ---------------------------------------------------------------------
+// Cycle 51 PR-AD (ADR 0004) — sealed-IOCell transcript that Manual
+// navigation walks. Additive to the legacy ContentHistory-Seq
+// engine (those tests above are unchanged). Pins: appendCell
+// command/output items, whitespace skip, AutoDrive-follow vs
+// Manual-stay, cellPrevious/cellNext/cellToLatest navigation +
+// boundaries, cellReset, and the Issue 1/3 scenarios (command +
+// post-response output are navigable).
+// ---------------------------------------------------------------------
+
+let private manualCursor () : SpeechCursor.T =
+    SpeechCursor.create
+        { SpeechCursor.defaultParameters with
+            InitialMode = SpeechCursor.Manual }
+
+let private expectSome (label: string) (o: (string * string) option) =
+    match o with
+    | Some (t, a) -> t, a
+    | None ->
+        Assert.True(false, sprintf "%s: expected Some, got None" label)
+        "", ""
+
+[<Fact>]
+let ``appendCell adds command then output as separate items`` () =
+    let c = freshCursor ()
+    SpeechCursor.appendCell c "echo hi" "hi"
+    // AutoDrive (default) parks on the latest item = the output.
+    let t, a = expectSome "current" (SpeechCursor.cellCurrent c)
+    Assert.Equal("hi", t)
+    Assert.Equal(ActivityIds.output, a)
+    // Previous steps to the command line (separate item).
+    let tc, _ = expectSome "prev" (SpeechCursor.cellPrevious c)
+    Assert.Equal("echo hi", tc)
+    // Nothing before the command.
+    Assert.Equal(None, SpeechCursor.cellPrevious c)
+
+[<Fact>]
+let ``appendCell skips whitespace-only command and output`` () =
+    let c = freshCursor ()
+    SpeechCursor.appendCell c "   " "real output"
+    let t, _ = expectSome "current" (SpeechCursor.cellCurrent c)
+    Assert.Equal("real output", t)
+    // Only one item (the output); no blank command item.
+    Assert.Equal(None, SpeechCursor.cellPrevious c)
+    SpeechCursor.appendCell c "cmd-only" "  "
+    let t2, _ = expectSome "latest" (SpeechCursor.cellToLatest c)
+    Assert.Equal("cmd-only", t2)
+
+[<Fact>]
+let ``appendCell command item is trimmed`` () =
+    let c = freshCursor ()
+    SpeechCursor.appendCell c "  echo hi  " "hi"
+    let _ = SpeechCursor.cellPrevious c
+    let tc, _ = expectSome "cmd" (SpeechCursor.cellCurrent c)
+    Assert.Equal("echo hi", tc)
+
+[<Fact>]
+let ``appendCell in AutoDrive follows the latest item`` () =
+    let c = freshCursor ()
+    SpeechCursor.appendCell c "one" "out1"
+    SpeechCursor.appendCell c "two" "out2"
+    let t, _ = expectSome "current" (SpeechCursor.cellCurrent c)
+    Assert.Equal("out2", t)
+
+[<Fact>]
+let ``appendCell in Manual does not move the cursor`` () =
+    let c = manualCursor ()
+    SpeechCursor.appendCell c "one" "out1"
+    // Manual: cursor stays unparked (-1) on append.
+    Assert.Equal(None, SpeechCursor.cellCurrent c)
+    // Explicit navigation still works.
+    let t, _ = expectSome "latest" (SpeechCursor.cellToLatest c)
+    Assert.Equal("out1", t)
+    SpeechCursor.appendCell c "two" "out2"
+    // Still parked on the old position (out1), not snapped to out2.
+    let t2, _ = expectSome "current" (SpeechCursor.cellCurrent c)
+    Assert.Equal("out1", t2)
+
+[<Fact>]
+let ``cellPrevious walks back then stops at first`` () =
+    let c = manualCursor ()
+    SpeechCursor.appendCell c "c1" "o1"
+    SpeechCursor.appendCell c "c2" "o2"
+    // Items: [c1; o1; c2; o2]. First Previous from unparked → latest.
+    Assert.Equal("o2", fst (expectSome "p1" (SpeechCursor.cellPrevious c)))
+    Assert.Equal("c2", fst (expectSome "p2" (SpeechCursor.cellPrevious c)))
+    Assert.Equal("o1", fst (expectSome "p3" (SpeechCursor.cellPrevious c)))
+    Assert.Equal("c1", fst (expectSome "p4" (SpeechCursor.cellPrevious c)))
+    Assert.Equal(None, SpeechCursor.cellPrevious c)
+
+[<Fact>]
+let ``cellNext walks forward then stops at latest`` () =
+    let c = manualCursor ()
+    SpeechCursor.appendCell c "c1" "o1"
+    SpeechCursor.appendCell c "c2" "o2"
+    let _ = SpeechCursor.cellToLatest c       // park on o2 (idx 3)
+    let _ = SpeechCursor.cellPrevious c       // c2
+    let _ = SpeechCursor.cellPrevious c       // o1
+    Assert.Equal("c2", fst (expectSome "n1" (SpeechCursor.cellNext c)))
+    Assert.Equal("o2", fst (expectSome "n2" (SpeechCursor.cellNext c)))
+    Assert.Equal(None, SpeechCursor.cellNext c)
+
+[<Fact>]
+let ``cellToLatest jumps to the last item`` () =
+    let c = manualCursor ()
+    SpeechCursor.appendCell c "c1" "o1"
+    SpeechCursor.appendCell c "c2" "o2"
+    let _ = SpeechCursor.cellPrevious c
+    let _ = SpeechCursor.cellPrevious c
+    let t, _ = expectSome "latest" (SpeechCursor.cellToLatest c)
+    Assert.Equal("o2", t)
+
+[<Fact>]
+let ``cell nav on empty transcript returns None`` () =
+    let c = freshCursor ()
+    Assert.Equal(None, SpeechCursor.cellCurrent c)
+    Assert.Equal(None, SpeechCursor.cellPrevious c)
+    Assert.Equal(None, SpeechCursor.cellNext c)
+    Assert.Equal(None, SpeechCursor.cellToLatest c)
+
+[<Fact>]
+let ``cellReset clears transcript and position`` () =
+    let c = freshCursor ()
+    SpeechCursor.appendCell c "c1" "o1"
+    SpeechCursor.cellReset c
+    Assert.Equal(None, SpeechCursor.cellCurrent c)
+    Assert.Equal(None, SpeechCursor.cellToLatest c)
+    // Fresh after reset.
+    SpeechCursor.appendCell c "c2" "o2"
+    Assert.Equal("o2", fst (expectSome "post" (SpeechCursor.cellCurrent c)))
+
+[<Fact>]
+let ``Issue 1 and 3 — command and post-response output are navigable`` () =
+    // test-04 shape: the IOCell's OutputText is the authoritative
+    // full output (incl. the post-single-key-response "You chose
+    // Yes." that the raw ContentHistory path mis-tags
+    // UserInputEcho). Both the command and that output must be
+    // reachable via Manual navigation.
+    let c = manualCursor ()
+    let cmd = "\"C:\\test-04-yes-no.cmd\""
+    let out =
+        "=== START ===\nThis test asks a yes/no question.\n"
+        + "Continue? [Y,N]?Y\nYou chose Yes.\n=== END ==="
+    SpeechCursor.appendCell c cmd out
+    let tOut, _ = expectSome "out" (SpeechCursor.cellToLatest c)
+    Assert.Contains("You chose Yes.", tOut)
+    let tCmd, _ = expectSome "cmd" (SpeechCursor.cellPrevious c)
+    Assert.Equal(cmd, tCmd)


### PR DESCRIPTION
## Summary

**Cycle 51 PR-AD — Issues 1 & 3 from your dogfood** (the architectural one you chose: *feed SpeechCursor from sealed IOCells*).

The Speech Cursor (Ctrl+Shift+Up/Down/End manual review) had no record of **(3)** the input command line, nor **(1)** the output after a single-key sub-prompt response — both visible in the review cursor. **Root cause (ADR 0004 §4a):** SpeechCursor navigated raw ContentHistory entries via `renderEntryWithPolicy`, which unconditionally drops every `UserInputEcho` entry; the command echo *is* `UserInputEcho`, and post-single-key-response output is **mis-tagged** `UserInputEcho` (machine is `Composing` after `SubPromptIdle`, no `EnterPressed`).

**Design (additive, lowest-risk realisation of your choice):** at tuple-finalize the sealed cell's authoritative `CommandText` + `OutputText` (from PR-X's `extractIOCell` — already excludes history-scroll redraws, includes post-response output) are appended to a **new SpeechCursor cell-transcript** as *separate* navigable items (command line is its own item, per your standing request). `Ctrl+Shift+Up/Down/End` now walk this transcript (`cellPrevious`/`cellNext`/`cellToLatest`); AutoDrive follows the latest item, Manual mode stays put on append; cleared on shell hot-switch.

**Crucially**, the legacy ContentHistory-Seq engine (`Position`/`onAppend`/`next`/`previous`/`toLatest`/`toMarker`/`renderEntryForManualNav`) is **retained unchanged** — it still serves AutoDrive bookkeeping, selection-suspend, and the Diagnostics navigability dump. Only the user-facing Manual gestures moved. This is why the existing **25 SpeechCursor Seq-engine tests are untouched** (no 70% rewrite) and the new cell API gets its own additive tests.

Files: `SpeechCursor.fs` (+cell model & API), `Program.fs` (appendCell at finalize; 3 hotkey handlers repointed; `manualNavRender` local removed since unused; `cellReset` on switch), `SpeechCursorTests.fs` (+12 cell-API tests incl. the test-04 Issue-1/3 scenario).

## ⚠ Acceptance

The cell-transcript API has **full xUnit coverage** (CI-validatable: append/skip-whitespace/trim/AutoDrive-follow/Manual-stay/prev-next-latest boundaries/reset/the Issue-1&3 test-04 scenario). The hotkey wiring is dogfood-gated.

## Test plan

- [ ] Full Windows CI green incl. new SpeechCursor cell tests + the untouched 25 legacy tests.
- [ ] Dogfood: run a few commands + test-04 (press Y). Ctrl+Shift+Up steps back: latest output → its command → prior output → prior command…; the post-"Y" output ("You chose Yes.") **is** present; Ctrl+Shift+End jumps to latest; switch shell (Ctrl+Shift+2/1) clears the transcript. Confirm AutoDrive live narration, review cursor, and PR-X/Y/Z/AA/AB/AC behaviour all intact.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_