### PR TITLE
fix(cycle51): PR-AE — cursor-anchored prompt detection (the real root…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13851,6 +13851,37 @@ alongside the ContentHistory reset. New `SpeechCursor` cell-API
 unit tests (additive; the existing 25 Seq-engine tests are
 untouched).
 
+### Cycle 51 PR-AE (2026-05-15): cursor-anchored prompt detection (root-cause fix)
+
+The maintainer's 2026-05-15 dogfood showed garbled spoken output
+on fast typing / history recall and a progress loop that dumped
+everything at the end — and, correctly, flagged the
+fix-one-break-another pattern as a codebase-health smell. Root
+cause (single, upstream): `HeuristicPromptDetector` ignored the
+cursor and PASS 2 picked the **bottommost regex match anywhere
+on screen**. The instant the real prompt row was edited (history
+recall / fast typing) or changed by an in-place progress redraw,
+it no longer matched the bare-prompt regex, so the detector
+re-locked onto a **stale scrollback `C:\…>` row** from a prior
+command cycle, saw a different `rowIdx`, and fired a phantom
+`PromptStart` → bogus tuple finalize → garbage announce sliced
+from a stale watermark. Every recent announce-path patch
+(PR-X/Y/AB) was a downstream compensation for this unstable
+signal.
+
+Fix: PASS 2 is now **cursor-anchored** — the active prompt is the
+stable regex match on the cursor's row; a match on any other row
+is stale scrollback and is ignored (no emission when the cursor
+isn't on a clean prompt, i.e. the user is composing / output is
+streaming). When the cursor is the `(-1,-1)` unit-test sentinel
+the legacy bottommost-match selection is retained, so the
+existing detector test corpus is unaffected (zero churn); four
+additive tests pin the new behaviour. The emission gate,
+dirty-flag, logging, and state are otherwise unchanged. A
+follow-up audit should retire the now-redundant
+announce-path compensations (PR-AB; parts of PR-X/Y) once this is
+dogfood-validated.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.Core/HeuristicPromptDetector.fs
+++ b/src/Terminal.Core/HeuristicPromptDetector.fs
@@ -217,12 +217,16 @@ module HeuristicPromptDetector =
     /// boundary into `SessionModel.apply` + the active
     /// pathway's `OnPromptBoundary`.
     ///
-    /// `cursor` is captured for forward-compatibility with
-    /// the cursor-position refinement (Phase 2); Tier 1.D
-    /// doesn't use it.
+    /// `cursor` (`(row, col)`) anchors active-prompt selection
+    /// (Cycle 51 PR-AE): the prompt the user is at is the one
+    /// the cursor sits on; a regex match on any other row is
+    /// stale scrollback. When `cursor` is invalid (`row < 0` —
+    /// the `(-1,-1)` unit-test sentinel / no cursor) the legacy
+    /// bottommost-match selection is used so the pure-function
+    /// test corpus is unaffected.
     let tryDetect
             (snapshot: Cell[][])
-            (_cursor: int * int)
+            (cursor: int * int)
             (shellKey: string)
             (now: DateTime)
             (state: T)
@@ -320,20 +324,48 @@ module HeuristicPromptDetector =
                     state.LastEmittedPromptRowIndex,
                     priorRowText)
 
-            // PASS 2 — pick highest-rowIdx among stable matches,
-            // apply the row-index-aware emission gate.
+            // PASS 2 — cursor-anchored active-prompt selection,
+            // then the row-index-aware emission gate.
             let mutable emitted : PromptBoundaryData option = None
             let mutable emittedText : string option = None
             let mutable emittedRowIndex : int option = None
-            if stableMatches.Count > 0 then
-                let firstRow, firstText = stableMatches.[0]
-                let mutable bestRow = firstRow
-                let mutable bestText = firstText
-                for i in 1 .. stableMatches.Count - 1 do
-                    let candidateRow, candidateText = stableMatches.[i]
-                    if candidateRow > bestRow then
-                        bestRow <- candidateRow
-                        bestText <- candidateText
+            // Cycle 51 PR-AE (root-cause fix) — the active prompt
+            // is the one the CURSOR sits on. A regex match on any
+            // other row is stale scrollback (a bare `C:\…>` left
+            // on an earlier row from a prior command cycle still
+            // matches the regex; output flows downward). The old
+            // "bottommost match anywhere" rule re-locked onto that
+            // scrollback the instant the real prompt row was
+            // edited (history recall / fast typing) or changed by
+            // an in-place progress redraw, firing a phantom
+            // PromptStart → bogus tuple finalize → garbled
+            // announce (the maintainer's 2026-05-15 dogfood). When
+            // the cursor is invalid (`row < 0` — the (-1,-1)
+            // unit-test sentinel / no cursor) fall back to the
+            // legacy bottommost-match selection so the
+            // pure-function test corpus is unaffected.
+            let cursorRow = fst cursor
+            let bestPrompt : (int * string) option =
+                if cursorRow >= 0 && cursorRow < snapshot.Length then
+                    let mutable hit : (int * string) option = None
+                    for i in 0 .. stableMatches.Count - 1 do
+                        let r, t = stableMatches.[i]
+                        if r = cursorRow then hit <- Some (r, t)
+                    hit
+                elif stableMatches.Count = 0 then
+                    None
+                else
+                    let firstRow, firstText = stableMatches.[0]
+                    let mutable bestRow = firstRow
+                    let mutable bestText = firstText
+                    for i in 1 .. stableMatches.Count - 1 do
+                        let candidateRow, candidateText = stableMatches.[i]
+                        if candidateRow > bestRow then
+                            bestRow <- candidateRow
+                            bestText <- candidateText
+                    Some (bestRow, bestText)
+            match bestPrompt with
+            | Some (bestRow, bestText) ->
                 // Tier 1.E2.A — row-index-aware emission gate.
                 // A NEW PromptStart fires when the (text, rowIdx)
                 // pair differs from the last emitted pair OR the
@@ -390,6 +422,12 @@ module HeuristicPromptDetector =
                               MatchedRowIndex = Some bestRow }
                     emittedText <- Some bestText
                     emittedRowIndex <- Some bestRow
+            | None ->
+                // No active prompt this tick: the cursor isn't on
+                // a stable bare-prompt row (user is composing /
+                // output is streaming / only stale scrollback
+                // matched). Emitting here was the phantom bug.
+                ()
 
             let nextLastEmittedText =
                 match emittedText with

--- a/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
+++ b/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
@@ -885,3 +885,71 @@ let ``stable prompt at row 0 then prompt scrolled to row 1 emits twice`` () =
         HeuristicPromptDetector.tryDetect snap2 noCursor "cmd" (after 300) s3
     Assert.True(r2.IsSome)
     Assert.Equal(Some 1, r2.Value.MatchedRowIndex)
+
+// ---------------------------------------------------------------------
+// Cycle 51 PR-AE — cursor-anchored active-prompt selection.
+// The active prompt is the row the CURSOR sits on; a regex match
+// on any other row is stale scrollback. The legacy
+// bottommost-match path is preserved when the cursor is the
+// (-1,-1) test sentinel, so the corpus above is unaffected.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``cursor-anchored - stale scrollback prompt off the cursor row is suppressed`` () =
+    // row 0: a bare prompt left from a prior command cycle (still
+    // matches the regex). row 2: the real prompt row, but the
+    // user has typed on it so it no longer matches. Cursor on
+    // row 2. Legacy bottommost-match would re-lock onto row 0 and
+    // fire a phantom PromptStart; the cursor anchor suppresses.
+    let snap =
+        snapshotOf 3 80 [ "C:\\>"; "some output"; "C:\\>echo hi" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap (2, 11) "cmd" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap (2, 11) "cmd" (after 100) s1
+    Assert.True(r2.IsNone)
+
+[<Fact>]
+let ``cursor-anchored - legacy no-cursor path still emits on the same snapshot`` () =
+    // Differentiator: with the (-1,-1) sentinel the legacy
+    // bottommost-match path is preserved (existing corpus
+    // unaffected); only the real-cursor production path anchors.
+    let snap =
+        snapshotOf 3 80 [ "C:\\>"; "some output"; "C:\\>echo hi" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap noCursor "cmd" (after 100) s1
+    Assert.True(r2.IsSome)
+
+[<Fact>]
+let ``cursor-anchored - prompt on the cursor row emits with that row's index`` () =
+    let snap = snapshotOf 2 80 [ "prior output"; "C:\\>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap (1, 4) "cmd" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap (1, 4) "cmd" (after 100) s1
+    match r2 with
+    | Some data ->
+        Assert.Equal(Some 1, data.MatchedRowIndex)
+        Assert.Equal(Some "C:\\>", data.MatchedRowText)
+    | None -> Assert.Fail("Expected PromptStart on the cursor's prompt row")
+
+[<Fact>]
+let ``cursor-anchored - selects the cursor row's match not the bottommost`` () =
+    // Two matching prompt rows. Legacy picks bottommost (row 1,
+    // "C:\foo>"); the cursor anchor must pick the cursor's row 0.
+    let snap = snapshotOf 2 80 [ "C:\\>"; "C:\\foo>" ]
+    let detector = HeuristicPromptDetector.create ()
+    let _, s1 =
+        HeuristicPromptDetector.tryDetect snap (0, 4) "cmd" t0 detector
+    let r2, _ =
+        HeuristicPromptDetector.tryDetect snap (0, 4) "cmd" (after 100) s1
+    match r2 with
+    | Some data ->
+        Assert.Equal(Some 0, data.MatchedRowIndex)
+        Assert.Equal(Some "C:\\>", data.MatchedRowText)
+    | None -> Assert.Fail("Expected PromptStart on the cursor row")


### PR DESCRIPTION
… cause)

The 2026-05-15 dogfood (garbled fast-type/recall speech, progress loop dumping at end, speech cursor mirroring the nonsense) traces to ONE upstream defect, not seven: HeuristicPromptDetector ignored the cursor and PASS 2 picked the bottommost regex match anywhere on screen. When the real prompt row was edited (history recall / fast typing) or changed by an in-place progress redraw it stopped matching the bare-prompt regex, so the detector re-locked onto a stale scrollback "C:\...>" row, saw a different rowIdx, and fired a phantom PromptStart -> bogus tuple finalize -> garbage announce from a stale watermark. PR-X/Y/AB were all downstream compensations for this unstable signal.

Fix: PASS 2 is cursor-anchored. The active prompt is the stable regex match on the cursor's row; a match elsewhere is stale scrollback and ignored (no emission while composing / streaming). The (-1,-1) test-sentinel cursor keeps the legacy
bottommost-match path, so the existing detector test corpus is untouched (zero churn). Four additive tests pin the new behaviour. Gate / dirty-flag / logging / state otherwise unchanged. Follow-up: audit the now-redundant announce-path compensations (PR-AB; parts of PR-X/Y) after dogfood validation.

Acceptance gate: maintainer dogfood — fast-type echo hi + Enter (only "hi", no fragments), history recall, test-07 progress loop (no per-step phantom finalizes; speaks per the watermark), test sub-prompts, shell switch — no phantom PromptStart in the bundle.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

# Pull request

## Summary

<!-- One or two sentences. What changed and why. -->

## Stage / phase

<!-- Which stage of spec/tech-plan.md does this touch? "Stage 5", "Stage 8", "docs only", "infra", etc. -->

## Type of change

- [ ] feat — new functionality
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — internal restructuring, no behavior change
- [ ] test — tests added or updated
- [ ] build / ci — tooling, packaging, GitHub Actions
- [ ] chore — dependency bumps, formatting, etc.

## Accessibility checklist

For any PR that touches the parser, semantics, UI, UIA, audio, or
keyboard layers, all of these must be true. If a row does not apply,
mark it N/A.

- [ ] No new `TextChangedEvent` raised on the streaming path.
- [ ] All `RaiseNotificationEvent` / `RaiseAutomationEvent` calls are
      marshalled to the WPF Dispatcher thread.
- [ ] No NVDA modifier keys (`Insert`, `CapsLock`, numpad with NumLock
      off) are swallowed by `PreviewKeyDown`.
- [ ] Spinner-class redraws are deduplicated by row hash.
- [ ] Control characters are stripped from any string passed to
      `UiaRaiseNotificationEvent`.
- [ ] Earcons are below 180 Hz or above 1.5 kHz, ≤ 200 ms, ≤ -12 dBFS.
- [ ] WASAPI shared mode (`AudioClientShareMode.Shared`) is used; no
      exclusive-mode acquisition added.
- [ ] [`docs/ACCESSIBILITY-TESTING.md`](../docs/ACCESSIBILITY-TESTING.md)
      manual smoke-test rows for the touched stage were run against
      NVDA on a clean Windows VM, or a follow-up issue is filed if
      validation is deferred. **If this PR ships new user-visible
      behaviour that CI cannot fully verify**, also add a row to the
      matrix per the document's "Adding new manual tests" section
      (procedure, expected outcome, diagnostic decoder bullet).

## Configurability check

- [ ] If this PR introduces a hardcoded constant or fixed
      behaviour that a user might plausibly want to control later
      (font size, default shell, word-boundary algorithm,
      verbosity threshold, etc.), I have either updated the
      relevant section of
      [`docs/USER-SETTINGS.md`](../docs/USER-SETTINGS.md) or
      noted "no candidate settings introduced" below. See
      [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Consider
      configurability when iterating" for the rule.

## Screenshots and screen-reader output

<!-- Where relevant, paste NVDA Event Tracker output or describe the
     speech the user hears. Screenshots are welcome but not sufficient
     by themselves; include alt text. -->

## Changelog

- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`
      (or this PR is documentation-only and changelog is N/A).

## Related issues

<!-- "Fixes #123", "Refs #456", or "n/a". -->
