### PR TITLE
Cycle 52 R1: record ADR 0005+0006 acceptance + architecture map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,8 @@ before deviating.
    subtractive — retires the PR-AB / PR-X/Y announce-path
    scaffolding. Read before working on prompt-boundary
    detection, the shell-spawn seam, or the announce path.
-   **Proposed, not yet accepted — no implementation until the
-   maintainer signs off on the ADR.** Its A–F stage list is
+   **Accepted 2026-05-15 (maintainer approved 0005+0006
+   together).** Its A–F stage list is
    superseded by ADR 0006's R0–R7; 0005 stays the canonical
    *mechanism* spec.
 9. **[`docs/adr/0006-three-layer-refoundation.md`](docs/adr/0006-three-layer-refoundation.md)**
@@ -101,8 +101,10 @@ before deviating.
    ADR 0005's stage list** with R0–R7 (folds OSC-133 in).
    F# kept, WPF kept, **MAUI explicitly out of scope**
    (maintainer decision 2026-05-15). Read before any
-   transport / core / channel / spawn work. **Proposed —
-   no implementation until the maintainer signs off.**
+   transport / core / channel / spawn work. **Accepted
+   2026-05-15; R1 in progress (architecture map →
+   behaviour-identical extraction). Each R-stage stays
+   independently CI- + dogfood-gated.**
 10. **RFC 0001 (archived)** — Cycle 33 pivot-gate RFC, formalised
    the `LinearTextStream` substrate + streaming-emission protocol.
    The substrate it specified was replaced by `ContentHistory` +

--- a/docs/CYCLE-52-R1-ARCHITECTURE-MAP.md
+++ b/docs/CYCLE-52-R1-ARCHITECTURE-MAP.md
@@ -1,0 +1,132 @@
+# Cycle 52 R1 — current-architecture & dependency map
+
+Evidence base for the ADR 0006 behaviour-preserving
+extraction. Distilled from a full read-only codebase survey
+(2026-05-15). Every claim carries a `file:line` anchor so R1
+edits can be made without re-deriving the map. Companion to
+[`adr/0006-three-layer-refoundation.md`](adr/0006-three-layer-refoundation.md).
+
+## Headline finding
+
+The codebase is architecturally sound at the high level
+(substrate/channel per ADR 0001, IOCell per ADR 0004, OSC-133
+decoder per ADR 0005). **The single load-bearing leak is
+`HeuristicPromptDetector` (492 LOC in `Terminal.Core`)** — it
+couples the pure core to cmd/PowerShell/Claude prompt regexes.
+`Terminal.Core` already has **zero WPF, zero P/Invoke, zero
+`Process`** (verified). So R1's job is narrow: move that one
+module out, introduce the `ShellAdapter`/`SessionHost` seam,
+change nothing observable.
+
+## Layer alignment (ADR 0006 target vs today)
+
+| ADR 0006 layer | Today | R1 action |
+|---|---|---|
+| **1 Transport** `Terminal.Shell` (new) | `HeuristicPromptDetector` in `Terminal.Core`; spawn/resolve scattered in `Program.fs`; `ShellRegistry`/`PseudoConsole`/`ConPtyHost` in `Terminal.Pty` (correctly placed) | New assembly: `ShellAdapter` iface + `SessionHost`; move `HeuristicPromptDetector` in as the cmd/PS/claude **fallback** translator; `Terminal.Pty` unchanged (P/Invoke + shell strings belong here) |
+| **2 Core** `Terminal.Core` (purify) | Already WPF/P-Invoke/Process-free. Sole leak = `HeuristicPromptDetector` | Remove that one file; keep `Osc133`, `Screen`, `ContentHistory`, `SessionModel`, `SpeechCursor`, `ShellInteraction` |
+| **3 Channel** WPF+UIA | `Terminal.Accessibility`, `Views`, `NvdaChannel`, `EarconChannel`, `FileLoggerChannel` | Untouched in R1 |
+| **Orchestration** `SessionHost` (new) | Implicit, smeared across `Program.fs` (~5.3 kLOC file) | New ~one-file host owns spawn + adapter wiring + active-session/detector/SpeechCursor state + shell-switch reset |
+
+## End-to-end data path (byte → IOCell → AT)
+
+`startReaderLoop` `Program.fs:109` reads PTY bytes → per-byte
+`onByteFromPty` `Program.fs:149` (feeds `ShellInteraction`) →
+**`Parser.feedArray` `Program.fs:150`** → `Screen.Apply`
+`Screen.fs:575‑717` (OSC-133 arm calls `Osc133.tryParse`
+`Screen.fs:674`; fires `promptBoundaryEvent` `:716`) →
+`ContentHistory.appendFromEvent` `Program.fs:161` →
+`HeuristicPromptDetector.tryDetect` `Program.fs:2467`
+(`RowsChanged`) → `promptBoundaryEvent` →
+**`handlePromptBoundary` `Program.fs:1951‑2027`** →
+`SessionModel.applyAndCaptureWithContentHistory`
+`SessionModel.fs:867‑890` → **`extractIOCell`
+`SessionModel.fs:750‑846` — the sole extractor** (OSC arm
+`:756‑772`, heuristic/Seq-watermark arm `:773‑845`, drop-on-
+None `:846`) → SpeechCursor append `Program.fs:2024` +
+`OutputDispatcher.dispatch` `Program.fs:2215` →
+`NvdaChannel.fs` → UIA caret (`Terminal.Accessibility`,
+`ContentHistoryTextRange.fs`) per ADR 0002.
+
+## Leak inventory & R4 nuance
+
+- **Must move (R1):** `HeuristicPromptDetector.fs` — shell
+  regexes `:98‑114`, per-shell stability windows `:120‑126`,
+  `shellParams` lookup `:201‑209`, `tryDetect` `:227‑340`.
+  Pure function with caller-threaded mutable state
+  (`Program.fs:2467` threads `detectorState`). Signature is
+  unchanged by the move.
+- **Acceptable — do NOT flag in R4 lint:** `Config.fs:520`
+  `knownShellKeys` (TOML validation set); `ShellPolicy.fs:133‑150`
+  per-shell policy table (pure lookup, no detection).
+  **R4 lint must scope to "no shell-pattern *detection* logic
+  / no WPF / no P-Invoke / no `Process`", not a blunt "no
+  shell substring"** — else it false-positives on config &
+  policy.
+- **Deferred tech-debt (NOT R1):** `SelectionDetector.fs:274,468`
+  hard-codes `"claude"` (Ink-box selection). Claude-specific
+  by design; relocate to a claude channel extension in R6+,
+  noted not fixed now.
+
+## R1 seams (the specific wrap points)
+
+| Function | Anchor | R1 |
+|---|---|---|
+| `Parser.feedArray` | `Program.fs:150` | call site moves behind `ShellAdapter.Translate : byte[] → ShellEvent list` (parser/Screen stay *below* the adapter) |
+| `resolveStartupShell` | `Program.fs:2813‑2889` | stays in `Program.fs`; delegates to new `SessionHost.Create(config, shellId)` |
+| `HeuristicPromptDetector` | whole file | moves to `Terminal.Shell`; adapter owns the instance + threaded state |
+| `handlePromptBoundary` | `Program.fs:1951‑2027` | stays; receives boundary via a `SessionHost` state-change event instead of the raw `promptBoundaryEvent` subscription |
+| active session / `ShellInteraction` / `SpeechCursor` / detector state / shell-switch reset (`switchToShell` `Program.fs:4790‑4910`) | — | ownership moves into `SessionHost`; `Program.fs` holds a reference and calls methods |
+
+`ShellEvent` boundary DU (ADR 0006):
+`PromptStart | CommandStart | OutputChunk of bytes |
+CommandFinished of int option | Raw of bytes`. The core
+depends only on this — never bytes/screen/shell-id.
+
+## Behaviour-identity regression net
+
+Lean on, must stay green unchanged: `SessionModelTests.fs`
+(largest — pins `extractIOCell` both arms + finalisation),
+`HeuristicPromptDetectorTests.fs` (pins detector behaviour
+across the move — signature identical, only assembly changes),
+`ContentHistoryTests.fs`, `Osc133Tests.fs`, `ScreenTests.fs`,
+`SpeechCursorTests.fs`.
+
+**Coverage gap → R1 adds insurance:** no monolithic
+"feed real bytes → assert IOCell" integration test, and the
+`SessionHost`/shell-switch compose-root wiring is dogfood-only
+today. R1 adds one end-to-end bytes→IOCell test so the
+extraction has a unit-level equality check, not only the NVDA
+dogfood.
+
+## Risks
+
+- **`Program.fs` is ~5.3 kLOC** with reader-loop / shell-
+  switch / boundary / hotkey intertwined. Mitigation: move
+  only spawn+resolve+adapter+session-state into `SessionHost`;
+  leave dispatch + hotkey handling in place.
+- **No local `dotnet`** — CI-only, multi-minute round trips.
+  Mitigation: R1 is strictly behaviour-identical; read twice
+  before push; every commit must pass the full suite; the
+  decisive gate is the maintainer NVDA dogfood (`echo hi` /
+  test-01 / history-recall narrate **identically** pre/post).
+- State is single-threaded on the WPF dispatcher (no races
+  found); detector state is caller-threaded — `SessionHost`
+  takes ownership, removing the foot-gun.
+
+## Recommended R1 commit order
+
+1. New `Terminal.Shell` assembly: `ShellAdapter` interface +
+   `ShellEvent` DU + `SessionHost` skeleton (pure addition,
+   zero behaviour change, just must compile + be referenced).
+2. Move `HeuristicPromptDetector` → `Terminal.Shell`
+   (wholesale; fix `open`s/refs; tests follow it).
+3. `Program.fs` shell resolution → `SessionHost.Create`.
+4. Rewire `startReaderLoop` to `adapter.Translate` (the cmd
+   adapter wraps the *existing* parser+heuristic path
+   verbatim — still no semantic change).
+5. Project references + add the bytes→IOCell integration test.
+6. Full suite green + **R1 behaviour-identical NVDA dogfood
+   gate** before any R2 semantic work.
+
+Each step is an independently CI-gated PR. R1 lands no OSC-133
+emitter and no precedence rule — those are R2/R3.

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -15,10 +15,11 @@ and serves the decision-trail role this file used to overload.
 
 > **NEW SESSION START HERE →
 > [`adr/0006-three-layer-refoundation.md`](adr/0006-three-layer-refoundation.md)**
-> (Proposed — the Cycle 52 re-foundation; reads ADR 0005 as
-> its mechanism spec). Cycle 51 is shipped; the
-> CYCLE-51-PLAYBOOK is now historical. Do NOT implement
-> Cycle 52 until the maintainer accepts ADR 0006.
+> (**Accepted 2026-05-15**; reads ADR 0005 as its mechanism
+> spec). Cycle 51 is shipped; the CYCLE-51-PLAYBOOK is now
+> historical. **Cycle 52 R1 in progress** — architecture map
+> then behaviour-identical extraction; each R-stage stays
+> independently CI- + dogfood-gated.
 
 - **`main` HEAD = `fa8885c`** (Cycle 51 PR-AE, #344).
 - **Cycle 51 (IOCell pivot) — SHIPPED.** PR-V (ADR 0004) →
@@ -57,9 +58,10 @@ and serves the decision-trail role this file used to overload.
   **F# kept, WPF kept, MAUI explicitly out of scope**
   (maintainer decision 2026-05-15 — channel stays an
   interface for design hygiene only). ADR 0006's R0–R7
-  supersedes ADR 0005's A–F. **Not yet accepted — no
-  implementation until the maintainer signs off on
-  ADR 0006.**
+  supersedes ADR 0005's A–F. **Accepted 2026-05-15;
+  R1 in progress** (architecture map → behaviour-identical
+  extraction; each R-stage independently CI- + dogfood-
+  gated).
 - **Cycle 49 + post-49 hotfixes (PRs #313–#331)** shipped
   earlier; detail in [`CHANGELOG.md`](../CHANGELOG.md) /
   `git log` per the
@@ -70,7 +72,7 @@ and serves the decision-trail role this file used to overload.
 
 **Cycle 52 — three-layer re-foundation.** Design + decision
 in [ADR 0006](adr/0006-three-layer-refoundation.md)
-(**Proposed**; do not implement until accepted), with
+(**Accepted 2026-05-15; R1 in progress**), with
 [ADR 0005](adr/0005-osc133-shell-integration.md) as the
 OSC-133 mechanism spec. Stages, once accepted: **R0** ADR
 (this) → **R1** extract `ShellAdapter` + `SessionHost`,

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -147,6 +147,7 @@ Things a new session needs that aren't in
 | If you need… | Open |
 |---|---|
 | **Cycle 52 re-foundation (START HERE)** | [`docs/adr/0006-three-layer-refoundation.md`](adr/0006-three-layer-refoundation.md) |
+| Cycle 52 R1 architecture/dependency map | [`docs/CYCLE-52-R1-ARCHITECTURE-MAP.md`](CYCLE-52-R1-ARCHITECTURE-MAP.md) |
 | Cycle 52 OSC-133 mechanism spec | [`docs/adr/0005-osc133-shell-integration.md`](adr/0005-osc133-shell-integration.md) |
 | Cycle 51 (shipped) locked decisions | [`docs/adr/0004-iocell-model-for-shell-interaction.md`](adr/0004-iocell-model-for-shell-interaction.md) |
 | Cycle 51 execution map (HISTORICAL) | [`docs/CYCLE-51-PLAYBOOK.md`](CYCLE-51-PLAYBOOK.md) |

--- a/docs/adr/0005-osc133-shell-integration.md
+++ b/docs/adr/0005-osc133-shell-integration.md
@@ -1,8 +1,10 @@
 # ADR 0005 — OSC 133 shell integration (the heuristic-screen-scrape exit)
 
-- **Status:** Proposed (2026-05-15). Supersedes the heuristic
+- **Status:** Accepted (2026-05-15; maintainer approved
+  ADR 0005 + ADR 0006 together). Supersedes the heuristic
   prompt-detection model as the *primary* boundary source;
   does not delete it (it becomes the fallback).
+  Implementation proceeds via ADR 0006's R0–R7 stages.
 - **Status note (2026-05-15):** the "Walking-skeleton stages"
   A–F list below is **superseded by the R0–R7 stage list in
   [ADR 0006](0006-three-layer-refoundation.md)**, which folds

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -1,9 +1,12 @@
 # ADR 0006 — Three-layer re-foundation: ShellAdapter / Session core / Accessibility channel
 
-- **Status:** Proposed (2026-05-15). The architectural
-  re-foundation. Builds on and **supersedes the stage list of
-  [ADR 0005](0005-osc133-shell-integration.md)** (0005's
-  OSC-133 mechanism is folded into this ADR's R-stages).
+- **Status:** Accepted (2026-05-15; maintainer approved). The
+  architectural re-foundation. Builds on and **supersedes the
+  stage list of [ADR 0005](0005-osc133-shell-integration.md)**
+  (0005's OSC-133 mechanism is folded into this ADR's
+  R-stages). R1 in progress (architecture map → behaviour-
+  identical extraction). Each R-stage remains independently
+  CI- and dogfood-gated.
 - **Deciders:** maintainer — chose "Re-foundation ADR now" +
   "Drop MAUI consideration for now" (2026-05-15), after the
   strategic review of why 51 cycles produced brittle


### PR DESCRIPTION
## Summary

**Cycle 52 R1 kickoff.** Records the maintainer's 2026-05-15 approval of ADR 0005 (OSC-133 mechanism) + ADR 0006 (three-layer re-foundation), and begins R1.

- ADR 0005 + ADR 0006 statuses flipped **Proposed → Accepted**.
- Dependent "Proposed / not yet accepted / do-not-implement" wording in CLAUDE.md (reading-order 8–9) and SESSION-HANDOFF (start-here callout, current-state, next-stage) updated to **"Accepted; R1 in progress"**. Each R-stage remains independently CI- and dogfood-gated per ADR 0006.

**Incoming on this same branch (one coherent R1-kickoff PR):** the rigorous current module/dependency map — ADR 0006's mandated R1 first task and the evidence base for the behaviour-preserving extraction (doubly important given no local `dotnet`; CI-only validation). It is being produced now and will land as a follow-up commit before merge.

Docs-only (`*.md`) → markdown-link-check fast lane per CLAUDE.md.

## Test plan

- [ ] Markdown link check green (only relevant gate for docs-only).
- [ ] Architecture-map commit appended, then merge.
- Subsequent R1 work (the actual `ShellAdapter`/`SessionHost` extraction) ships in separate reviewable, CI-gated slices; the R1 behaviour-identical regression dogfood is the maintainer gate before any semantic stage (R2+).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_