### PR TITLE
Cycle 52 R1.3: move startup shell-resolution into SessionHost (behaviour-identical)

### DIFF
--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2811,82 +2811,14 @@ module Program =
         // Setting `[startup] default_shell = "cmd"` in the TOML
         // wins over the env var.
         let resolveStartupShell () : ShellRegistry.Shell * string =
-            let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
-            // Distinguish "unset" from "set to garbage" so the
-            // log line is actionable. `null` / empty / whitespace
-            // is the common case (no env var set); a non-empty
-            // unrecognised value is a typo or stale config and
-            // earns a warning. Extracted to a helper so the
-            // arm body of `parseEnvVar`'s `None` case stays a
-            // single expression — F# 9 + `TreatWarningsAsErrors`
-            // can be brittle about sequence-in-match-arm
-            // shapes, and the helper sidesteps that risk.
-            let logIfUnrecognised () : unit =
-                match envVar with
-                | null -> ()
-                | v when System.String.IsNullOrWhiteSpace(v) -> ()
-                | v ->
-                    log.LogWarning(
-                        "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude, powershell, pwsh.",
-                        v)
-            // Cycle 19 — TOML config takes precedence. When set,
-            // we use it directly without consulting the env
-            // var. The Config-side parser already validated the
-            // value against `knownShellKeys`; here we just map
-            // `string → ShellId` via `parseEnvVar`.
-            let configShell =
-                match Config.resolveDefaultShell config with
-                | Some shellKey ->
-                    match ShellRegistry.parseEnvVar shellKey with
-                    | Some id ->
-                        log.LogInformation(
-                            "Startup shell resolved from [startup] default_shell = \"{Shell}\" (overriding PTYSPEAK_SHELL).",
-                            shellKey)
-                        Some id
-                    | None ->
-                        // Defensive — Config-side parser already
-                        // filtered against `knownShellKeys`, so this
-                        // arm shouldn't fire. Log + fall through.
-                        log.LogWarning(
-                            "Config: [startup] default_shell = \"{Shell}\" passed schema validation but parseEnvVar rejected it; falling through to PTYSPEAK_SHELL.",
-                            shellKey)
-                        None
-                | None -> None
-            let requested =
-                match configShell with
-                | Some id -> id
-                | None ->
-                    match ShellRegistry.parseEnvVar envVar with
-                    | Some id -> id
-                    | None ->
-                        logIfUnrecognised ()
-                        ShellRegistry.Cmd
-            // `tryFind` only returns None for ids not registered in
-            // `builtIns`; both Cmd and Claude are registered, so this
-            // is unreachable for the requested id, but the cmd-fallback
-            // is shared with the resolution-failure branch below.
-            let cmdShell =
-                match ShellRegistry.tryFind ShellRegistry.Cmd with
-                | Some s -> s
-                | None -> failwith "Cmd not registered in ShellRegistry.builtIns"
-            match ShellRegistry.tryFind requested with
-            | None ->
-                cmdShell, "cmd.exe"
-            | Some shell ->
-                match shell.Resolve() with
-                | Ok cmdLine ->
-                    shell, cmdLine
-                | Error reason ->
-                    log.LogWarning(
-                        "Shell {Shell} unavailable: {Reason}. Falling back to {Fallback}.",
-                        shell.DisplayName,
-                        reason,
-                        cmdShell.DisplayName)
-                    let fallbackCmd =
-                        match cmdShell.Resolve() with
-                        | Ok c -> c
-                        | Error _ -> "cmd.exe"
-                    cmdShell, fallbackCmd
+            // R1.3 (ADR 0006): the shell-resolution decision now
+            // lives in the single orchestration point. This is a
+            // behaviour-identical delegation — same precedence
+            // (TOML → env → cmd), same log templates (emitted via
+            // the same `log` instance, so category + structured
+            // args are byte-identical), same fallback semantics.
+            // See src/Terminal.Shell/SessionHost.fs.
+            Terminal.Shell.SessionHost.ResolveStartupShell(config, log)
 
         let chosenShell, commandLine = resolveStartupShell ()
         log.LogInformation(

--- a/src/Terminal.Shell/SessionHost.fs
+++ b/src/Terminal.Shell/SessionHost.fs
@@ -1,19 +1,119 @@
 namespace Terminal.Shell
 
+open System
+open Microsoft.Extensions.Logging
+open Terminal.Core
+open Terminal.Pty
+
 /// The single orchestration point (ADR 0006). It will select
 /// a shell adapter, own the active session / detector /
 /// SpeechCursor state, wire the adapter's `ShellEvent` stream
 /// to the session core, and own shell-switch reset — the
 /// logic currently smeared across `Terminal.App/Program.fs`.
 ///
-/// R1.1 introduces the type and reserves the seam only. The
-/// wiring is moved out of `Program.fs` in later R1 steps (see
+/// R1.1 introduced the type and reserved the seam. R1.3 gives
+/// it its first real responsibility: the startup
+/// shell-resolution decision (`ResolveStartupShell`), lifted
+/// verbatim from `Program.fs` so behaviour is identical (same
+/// precedence, same log templates emitted through the
+/// passed-in `ILogger`, same fallback). Adapter selection /
+/// reader-loop wiring move here in later R1 steps (see
 /// `docs/CYCLE-52-R1-ARCHITECTURE-MAP.md` §"Recommended R1
-/// commit order", steps 3–4). Until then this is
-/// intentionally inert, so R1.1 stays a pure,
-/// zero-behaviour-change addition: nothing constructs or
-/// depends on it yet.
+/// commit order").
 type SessionHost private () =
+
+    /// Resolve the shell to spawn at startup. Behaviour-
+    /// identical extraction of the former `Program.fs`
+    /// `resolveStartupShell` closure (ADR 0006 — the single
+    /// orchestration point owns shell selection).
+    ///
+    /// Precedence (highest → lowest): `[startup] default_shell`
+    /// TOML → `PTYSPEAK_SHELL` env var → cmd built-in default.
+    /// Use case: maintainer has `PTYSPEAK_SHELL=claude` set
+    /// from prior testing + wants cmd as durable default
+    /// without manipulating env vars; `[startup]
+    /// default_shell = "cmd"` wins over the env var.
+    ///
+    /// `log` is the caller's existing logger instance, so the
+    /// emitted category + templates are byte-identical to the
+    /// pre-R1.3 output (the diagnostic bundle greps these).
+    static member ResolveStartupShell(config: Config.Config, log: ILogger) : ShellRegistry.Shell * string =
+        let envVar = Environment.GetEnvironmentVariable("PTYSPEAK_SHELL")
+        // Distinguish "unset" from "set to garbage" so the
+        // log line is actionable. `null` / empty / whitespace
+        // is the common case (no env var set); a non-empty
+        // unrecognised value is a typo or stale config and
+        // earns a warning. Extracted to a helper so the
+        // arm body of `parseEnvVar`'s `None` case stays a
+        // single expression — F# 9 + `TreatWarningsAsErrors`
+        // can be brittle about sequence-in-match-arm
+        // shapes, and the helper sidesteps that risk.
+        let logIfUnrecognised () : unit =
+            match envVar with
+            | null -> ()
+            | v when System.String.IsNullOrWhiteSpace(v) -> ()
+            | v ->
+                log.LogWarning(
+                    "PTYSPEAK_SHELL=\"{Value}\" not recognised; falling back to cmd.exe. Recognised values: cmd, claude, powershell, pwsh.",
+                    v)
+        // Cycle 19 — TOML config takes precedence. When set,
+        // we use it directly without consulting the env
+        // var. The Config-side parser already validated the
+        // value against `knownShellKeys`; here we just map
+        // `string → ShellId` via `parseEnvVar`.
+        let configShell =
+            match Config.resolveDefaultShell config with
+            | Some shellKey ->
+                match ShellRegistry.parseEnvVar shellKey with
+                | Some id ->
+                    log.LogInformation(
+                        "Startup shell resolved from [startup] default_shell = \"{Shell}\" (overriding PTYSPEAK_SHELL).",
+                        shellKey)
+                    Some id
+                | None ->
+                    // Defensive — Config-side parser already
+                    // filtered against `knownShellKeys`, so this
+                    // arm shouldn't fire. Log + fall through.
+                    log.LogWarning(
+                        "Config: [startup] default_shell = \"{Shell}\" passed schema validation but parseEnvVar rejected it; falling through to PTYSPEAK_SHELL.",
+                        shellKey)
+                    None
+            | None -> None
+        let requested =
+            match configShell with
+            | Some id -> id
+            | None ->
+                match ShellRegistry.parseEnvVar envVar with
+                | Some id -> id
+                | None ->
+                    logIfUnrecognised ()
+                    ShellRegistry.Cmd
+        // `tryFind` only returns None for ids not registered in
+        // `builtIns`; both Cmd and Claude are registered, so this
+        // is unreachable for the requested id, but the cmd-fallback
+        // is shared with the resolution-failure branch below.
+        let cmdShell =
+            match ShellRegistry.tryFind ShellRegistry.Cmd with
+            | Some s -> s
+            | None -> failwith "Cmd not registered in ShellRegistry.builtIns"
+        match ShellRegistry.tryFind requested with
+        | None ->
+            cmdShell, "cmd.exe"
+        | Some shell ->
+            match shell.Resolve() with
+            | Ok cmdLine ->
+                shell, cmdLine
+            | Error reason ->
+                log.LogWarning(
+                    "Shell {Shell} unavailable: {Reason}. Falling back to {Fallback}.",
+                    shell.DisplayName,
+                    reason,
+                    cmdShell.DisplayName)
+                let fallbackCmd =
+                    match cmdShell.Resolve() with
+                    | Ok c -> c
+                    | Error _ -> "cmd.exe"
+                cmdShell, fallbackCmd
 
     /// Placeholder factory. Real adapter selection + spawn
     /// wiring lands in a subsequent R1 step; the constructor

--- a/src/Terminal.Shell/Terminal.Shell.fsproj
+++ b/src/Terminal.Shell/Terminal.Shell.fsproj
@@ -27,6 +27,13 @@
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <ProjectReference Include="..\Terminal.Core\Terminal.Core.fsproj" />
+    <!--
+      R1.3 (ADR 0006): SessionHost.ResolveStartupShell consumes
+      ShellRegistry (Terminal.Pty). Dependency direction stays
+      acyclic: Terminal.Shell → Terminal.Pty → Terminal.Core;
+      neither Pty nor Core references Shell.
+    -->
+    <ProjectReference Include="..\Terminal.Pty\Terminal.Pty.fsproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

**Cycle 52 R1.3 — first real responsibility for the orchestration point** (R1 architecture-map step 3 / ADR 0006). The startup shell-selection decision moves out of `Program.fs` into `SessionHost`.

**Behaviour-identical by construction:**
- `SessionHost.ResolveStartupShell(config, log)` is the former `Program.fs` `resolveStartupShell` closure body, lifted **verbatim** — same `[startup] default_shell` → `PTYSPEAK_SHELL` → cmd precedence, same defensive fallbacks, same log message templates and structured arg names.
- `Program.fs` keeps the `resolveStartupShell` closure **signature and its single call site unchanged**; only the body changes, to a one-line delegation. The caller's existing `log` instance is passed through, so the emitted logger category (`Terminal.App.Program`) and templates are **byte-identical** to pre-R1.3 output — the `Ctrl+Shift+D` diagnostic bundle greps these exact strings, so identical logs = identical observable behaviour.
- `Terminal.Shell.fsproj` gains a `Terminal.Pty` project reference (`SessionHost` consumes `ShellRegistry`). Dependency graph stays **acyclic**: `Terminal.Shell → Terminal.Pty → Terminal.Core`; neither `Pty` nor `Core` references `Shell`.

No runtime behaviour change: identical shell chosen, identical command line, identical logs. `TreatWarningsAsErrors` accounted for (4 opens, all used; nullness on `Environment.GetEnvironmentVariable`/`parseEnvVar` preserved verbatim from the code that already compiled in `Terminal.App`).

Portability-lint unaffected (`Terminal.Shell` is out of its `Terminal.Core`/`Terminal.Audio` scope; nothing banned added to `Core`).

## Test plan

- [ ] Full Windows build + test green — the decisive gate (compile correctness of the extracted member + the new project edge; existing tests unaffected since the result/logs are identical).
- [ ] Workflow / portability lint green.
- No NVDA dogfood for R1.3 alone (behaviour-identical by construction). The **consolidated R1 behaviour-identical NVDA dogfood runs before R2** via one preview release, per ADR 0006 and the agreed plan — not per sub-step.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_