### PR TITLE
Cycle 52 R1.4: route reader loop through CmdAdapter (VtEvent seam, behaviour-identical)

### DIFF
--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -14,7 +14,6 @@ open Velopack.Sources
 open Terminal.Core
 open Terminal.Core.Channels
 open Terminal.Audio
-open Terminal.Parser
 open Terminal.Pty
 open Terminal.Accessibility
 open PtySpeak.Views
@@ -109,7 +108,7 @@ module Program =
     let private startReaderLoop
             (dispatcher: Dispatcher)
             (host: ConPtyHost)
-            (parser: Parser)
+            (adapter: Terminal.Shell.CmdAdapter)
             (screen: Screen)
             (view: TerminalView)
             (contentHistory: ContentHistory.T)
@@ -147,7 +146,7 @@ module Program =
                             let chunkTs = DateTime.UtcNow
                             for i in 0 .. chunk.Length - 1 do
                                 onByteFromPty chunkTs chunk.[i]
-                            let events = Parser.feedArray parser chunk
+                            let events = adapter.Translate chunk
                             // Cycle 45c — feed ContentHistory (the
                             // sole aural substrate post-PR-3c).
                             // `appendFromEvent` is Gate-locked so
@@ -900,7 +899,12 @@ module Program =
 
         let cts = new CancellationTokenSource()
         let screen = Screen(rows = ScreenRows, cols = ScreenCols)
-        let parser = Parser.create ()
+        // R1.4 (ADR 0006): the cmd transport adapter owns the VT
+        // parser. Behaviour-identical seam — `Translate` is a
+        // verbatim `Parser.feedArray` wrapper; created once and
+        // not reset across shell switches, exactly as the bare
+        // parser was.
+        let cmdAdapter = Terminal.Shell.CmdAdapter()
 
         // Cycle 45 — ContentHistory + SpeechCursor are the aural
         // substrate (parallel to the screen-grid + UIA surface).
@@ -4153,7 +4157,7 @@ module Program =
                 startReaderLoop
                     window.Dispatcher
                     host
-                    parser
+                    cmdAdapter
                     screen
                     window.TerminalSurface
                     contentHistory

--- a/src/Terminal.Shell/CmdAdapter.fs
+++ b/src/Terminal.Shell/CmdAdapter.fs
@@ -1,0 +1,32 @@
+namespace Terminal.Shell
+
+open Terminal.Core
+open Terminal.Parser
+
+/// The cmd-family transport adapter — R1 shape (R1.4, ADR
+/// 0006). It owns the VT parser and exposes `Translate` as a
+/// verbatim wrapper over `Parser.feedArray`, so the reader
+/// loop goes through the adapter seam with **zero behaviour
+/// change**: identical `VtEvent[]` output, same single
+/// parser instance for the process lifetime (the parser is
+/// created once and is deliberately not reset across shell
+/// switches, matching pre-R1.4 behaviour — see the
+/// `switchToShell` "Parser state is NOT reset" note in
+/// `Program.fs`).
+///
+/// `Translate` here is `byte[] -> VtEvent[]` (the live
+/// pipeline's event type). The `ShellEvent` boundary in
+/// `ShellEvent` / `IShellAdapter` is deliberately NOT used
+/// at R1 — it becomes meaningful in R2, when OSC-133 gives
+/// the adapter real prompt / command / output events to
+/// emit. R1.4 only establishes the seam.
+type CmdAdapter() =
+
+    let parser = Parser.create ()
+
+    /// Verbatim wrapper over `Parser.feedArray` — byte-for-
+    /// byte identical output to the former inline
+    /// `Parser.feedArray parser chunk` call in
+    /// `startReaderLoop`.
+    member _.Translate(bytes: byte[]) : VtEvent[] =
+        Parser.feedArray parser bytes

--- a/src/Terminal.Shell/Terminal.Shell.fsproj
+++ b/src/Terminal.Shell/Terminal.Shell.fsproj
@@ -11,6 +11,12 @@
     <Compile Include="ShellAdapter.fs" />
     <Compile Include="SessionHost.fs" />
     <!--
+      R1.4 (ADR 0006): the cmd transport adapter. Verbatim
+      VT-parser wrapper for now (byte[] -> VtEvent[]); no
+      intra-assembly dependency on the skeleton above.
+    -->
+    <Compile Include="CmdAdapter.fs" />
+    <!--
       R1.2: HeuristicPromptDetector relocated here from
       Terminal.Core (ADR 0006 — the detector leaves the core
       assembly). Pure relocation: the file still declares
@@ -34,6 +40,12 @@
       neither Pty nor Core references Shell.
     -->
     <ProjectReference Include="..\Terminal.Pty\Terminal.Pty.fsproj" />
+    <!--
+      R1.4 (ADR 0006): CmdAdapter wraps the VT parser
+      (Terminal.Parser). Acyclic: Terminal.Shell →
+      Terminal.Parser → Terminal.Core.
+    -->
+    <ProjectReference Include="..\Terminal.Parser\Terminal.Parser.fsproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

**Cycle 52 R1.4 — the byte→event hop in the live reader loop now goes through a transport adapter**, per your "VtEvent seam" choice. Zero behaviour change.

- **New `Terminal.Shell/CmdAdapter.fs`**: owns one `Parser` (`Parser.create`) and exposes `Translate : byte[] -> VtEvent[]` as a **verbatim `Parser.feedArray` wrapper**. Single parser instance for the process lifetime, not reset across shell switches — exactly the pre-R1.4 lifetime (`Program.fs` `switchToShell` deliberately does not reset parser state, `:4509-4512`).
- **`Program.fs`** (4 surgical swaps, behaviour-identical): `let parser = Parser.create ()` → `let cmdAdapter = Terminal.Shell.CmdAdapter()` (same site/lifetime); `startReaderLoop` param `(parser: Parser)` → `(adapter: Terminal.Shell.CmdAdapter)`; the single feed `Parser.feedArray parser chunk` → `adapter.Translate chunk`; call-site arg updated. `open Terminal.Parser` removed — it's now orphaned (all four code uses were exactly the ones rewired; only comment mentions remain), and CLAUDE.md flags unused opens as CI-failing.
- **`Terminal.Shell.fsproj`**: +`CmdAdapter.fs`, +`Terminal.Parser` project reference. Acyclic: `Terminal.Shell → Terminal.Parser → Terminal.Core`.

`ShellEvent` / `IShellAdapter` (R1.1) are **deliberately left untouched** as the R2 boundary — the adapter's R1 contract is `VtEvent`-based; `ShellEvent` becomes meaningful with R2's OSC-133. Byte-for-byte identical `VtEvent` stream → identical `ContentHistory` / `Screen` / announce behaviour, **no log changes**. `TreatWarningsAsErrors` accounted for (CmdAdapter opens `Terminal.Core`+`Terminal.Parser`, both used; `parser` field used by `Translate`; orphaned `open` removed from `Program.fs`).

## Test plan

- [ ] Full Windows build + test green — the decisive gate (compile correctness of the new adapter + the new project edge + the `Program.fs` reader-loop swap; existing tests unaffected since the `VtEvent` stream is identical).
- [ ] Workflow / portability lint green (`Terminal.Shell` out of the Core/Audio lint scope).
- This completes the R1 structural extraction. The **consolidated R1 behaviour-identical NVDA dogfood (one preview release) runs next, before any R2 work**, per ADR 0006 and the agreed plan.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_