### PR TITLE
docs(cycle52): R1 close-out — status, dogfood ops, known issue

### DIFF
--- a/docs/CYCLE-52-R1-ARCHITECTURE-MAP.md
+++ b/docs/CYCLE-52-R1-ARCHITECTURE-MAP.md
@@ -113,20 +113,39 @@ dogfood.
   found); detector state is caller-threaded — `SessionHost`
   takes ownership, removing the foot-gun.
 
-## Recommended R1 commit order
+## R1 commit order — as shipped
 
-1. New `Terminal.Shell` assembly: `ShellAdapter` interface +
-   `ShellEvent` DU + `SessionHost` skeleton (pure addition,
-   zero behaviour change, just must compile + be referenced).
-2. Move `HeuristicPromptDetector` → `Terminal.Shell`
-   (wholesale; fix `open`s/refs; tests follow it).
-3. `Program.fs` shell resolution → `SessionHost.Create`.
-4. Rewire `startReaderLoop` to `adapter.Translate` (the cmd
-   adapter wraps the *existing* parser+heuristic path
-   verbatim — still no semantic change).
-5. Project references + add the bytes→IOCell integration test.
-6. Full suite green + **R1 behaviour-identical NVDA dogfood
-   gate** before any R2 semantic work.
+1. ✅ **R1.1 (#348)** New `Terminal.Shell` assembly:
+   `IShellAdapter` interface + `ShellEvent` DU +
+   `SessionHost` skeleton (inert, zero behaviour change).
+2. ✅ **R1.2 (#349)** `HeuristicPromptDetector` →
+   `Terminal.Shell`, wholesale. Kept `namespace
+   Terminal.Core` (no caller churn); detector leaves the
+   *Core assembly*. Namespace rename deferred to R3.
+3. ✅ **R1.3 (#350)** `Program.fs` shell-resolution →
+   `SessionHost.ResolveStartupShell(config, log)`, verbatim;
+   `Program.fs` delegates with the same `log` instance →
+   byte-identical logs.
+4. ✅ **R1.4 (#351)** `startReaderLoop` routed through
+   `CmdAdapter`. Per the maintainer's 2026-05-16 decision
+   this is a **`VtEvent` seam** — `CmdAdapter.Translate :
+   byte[] → VtEvent[]` is a verbatim `Parser.feedArray`
+   wrapper. `ShellEvent`/`IShellAdapter` (R1.1) are
+   **deliberately left as the R2 boundary**; they only
+   become meaningful with R2's OSC-133. (The original plan's
+   "bytes→IOCell integration test" was not added — the
+   `VtEvent`-stream identity + the full unit suite + the
+   consolidated dogfood are the behaviour-identity net;
+   revisit a dedicated integration test in R2 when the
+   event stream actually changes.)
+5. ▶ **R1 gate (next):** one consolidated behaviour-
+   identical NVDA dogfood from an **installed preview
+   release** (preview.143 @ `66ab95d`), in the maintainer's
+   normal environment — **not** a dev `dotnet run`/`publish`
+   build (unreliable NVDA UIA-notification delivery on the
+   RDP/VM). Acceptance: narrates identically to preview.141
+   (residual heuristic bugs included — that *is* behaviour-
+   identity). Then R2.
 
-Each step is an independently CI-gated PR. R1 lands no OSC-133
-emitter and no precedence rule — those are R2/R3.
+Each step shipped as an independently CI-gated PR. R1 landed
+no OSC-133 emitter and no precedence rule — those are R2/R3.

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -17,11 +17,12 @@ and serves the decision-trail role this file used to overload.
 > [`adr/0006-three-layer-refoundation.md`](adr/0006-three-layer-refoundation.md)**
 > (**Accepted 2026-05-15**; reads ADR 0005 as its mechanism
 > spec). Cycle 51 is shipped; the CYCLE-51-PLAYBOOK is now
-> historical. **Cycle 52 R1 in progress** — architecture map
-> then behaviour-identical extraction; each R-stage stays
-> independently CI- + dogfood-gated.
+> historical. **Cycle 52 R1 (R1.1–R1.4) complete & merged
+> (#347–#351)**; the gate before any R2 work is one
+> consolidated behaviour-identical NVDA dogfood
+> (preview.143), in progress.
 
-- **`main` HEAD = `fa8885c`** (Cycle 51 PR-AE, #344).
+- **`main` HEAD = `66ab95d`** (Cycle 52 R1.4, #351).
 - **Cycle 51 (IOCell pivot) — SHIPPED.** PR-V (ADR 0004) →
   PR-W / PR-W2 (IOCell + schemaVersion-2 + round-trip
   reader) → then the dogfood-driven sequence **PR-X**
@@ -58,10 +59,19 @@ and serves the decision-trail role this file used to overload.
   **F# kept, WPF kept, MAUI explicitly out of scope**
   (maintainer decision 2026-05-15 — channel stays an
   interface for design hygiene only). ADR 0006's R0–R7
-  supersedes ADR 0005's A–F. **Accepted 2026-05-15;
-  R1 in progress** (architecture map → behaviour-identical
-  extraction; each R-stage independently CI- + dogfood-
-  gated).
+  supersedes ADR 0005's A–F. **Accepted 2026-05-15; R1
+  (R1.1–R1.4) complete & merged** (#347 map+acceptance →
+  #348 R1.1 `Terminal.Shell` skeleton → #349 R1.2
+  `HeuristicPromptDetector` out of the Core assembly →
+  #350 R1.3 shell-resolution → `SessionHost` → #351 R1.4
+  reader loop through `CmdAdapter`, the **VtEvent** seam).
+  All behaviour-identical by construction + CI-green. Per
+  maintainer's 2026-05-16 choice the R1 adapter contract is
+  `VtEvent`-based; `ShellEvent`/`IShellAdapter` (R1.1) stay
+  untouched as the R2 boundary (meaningful with OSC-133).
+  The R1 gate is **one consolidated behaviour-identical
+  NVDA dogfood** (preview.143) before any R2 — not
+  per-substep.
 - **Cycle 49 + post-49 hotfixes (PRs #313–#331)** shipped
   earlier; detail in [`CHANGELOG.md`](../CHANGELOG.md) /
   `git log` per the
@@ -83,14 +93,43 @@ purify `Terminal.Core` + portability-lint enforcement (the
 structural anti-re-leak gate) → **R5** PowerShell adapter →
 **R6** feature unlock (per-line progress, prompt-verbosity
 fix, clean SpeechCursor) → **R7** claude adapter decision +
-Cycle closure audit. Each stage independently CI-gated +
-dogfood-validated. R1 + R4 are the structural gates; R2's
-cmd OSC-133 dogfood is the first semantic proof. NVDA matrix
-rows per stage in
+Cycle closure audit. **R0 + R1 (R1.1–R1.4) done & merged**
+(#347–#351); **next = the consolidated R1 NVDA dogfood
+(preview.143), then R2.** R1 + R4 are the structural gates;
+R2's cmd OSC-133 dogfood is the first semantic proof. NVDA
+matrix rows per stage in
 [`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md).
+
+**Dogfood operations (Cycle 52 R1, learned 2026-05-15/16).**
+Run R-stage dogfoods from an **installed preview release**
+(`gh release create vX --target main --prerelease …` →
+`scripts\install-latest-preview.ps1 -Tag vX`), **not** a dev
+`dotnet run`/`publish` build — the dev-host process has
+unreliable NVDA UIA-notification delivery on the RDP/VM and
+burned ~an hour of false "regression" chasing. **NVDA
+UIA-notification wedge:** after heavy app start/stop churn,
+NVDA can stop voicing UIA Notification events (output /
+diagnostics) while still speaking *menus* (native focus
+tracking). This is an environment artifact, not a code
+regression — **restart NVDA** (reboot the VM if that fails);
+verified to fully restore it on both build types.
 
 **Deferred (independent; revisit after Cycle 52):**
 
+- **Backspace-to-empty announces the full input path**
+  (observed 2026-05-16, preview.143 R1 dogfood prep). At a
+  prompt, hold backspace until the line is empty: deleting
+  the **last** character now narrates the entire input path
+  (`C:\…\Terminal.App>`) instead of just `>`. Repro: new
+  line, type `1`, backspace. Suspected **pre-existing**
+  (announce-path / PR-I history-recall prefix-strip, Cycle
+  49 era — untouched by R1; R1.1–R1.4 don't touch the
+  announce path). **Classify during the R1 dogfood:** if
+  preview.141 shows the same, it's pre-existing → R2
+  backlog (the OSC-133/clean-SpeechCursor work targets
+  exactly this); if preview.141 says only `>`, it's an R1
+  regression and blocks R2. Maintainer: "not worth fixing
+  now, note for later."
 - **`EntrySource.DraftInputRecall`** (deferred from Cycle 49
   E3) — substrate refinement; no audible bug behind it
   after PR-I's screen-read approach.


### PR DESCRIPTION
## Summary

Docs-only R1 close-out. R1.1–R1.4 are merged & CI-green (#348–#351); this records the state coherently for the next session and bottles today's hard-won operational knowledge.

- **`SESSION-HANDOFF.md`**: `main` HEAD → `66ab95d`; "R1 in progress" → **"R1 (R1.1–R1.4) complete & merged"**; the R1 gate is **one consolidated behaviour-identical NVDA dogfood (preview.143) before R2** (not per-substep); records that the R1 adapter contract is `VtEvent`-based and `ShellEvent`/`IShellAdapter` stay as the untouched R2 boundary.
- **Dogfood operations note** (the ~hour we lost today): run R-stage dogfoods from an **installed preview release**, not a dev `dotnet run`/`publish` build (unreliable NVDA UIA-notification delivery on the RDP/VM); if announcements go silent while *menus still speak*, that's the NVDA UIA-notification wedge from app start/stop churn — **restart NVDA**, it's not a code regression.
- **Deferred/known issue**: backspace-to-empty at a prompt narrates the full input path instead of just `>` (observed today). Suspected pre-existing announce-path wart (R1 didn't touch the announce path); recorded with repro + the plan to classify it via the preview.141 A/B during the R1 dogfood (pre-existing → R2 backlog; else R1 regression blocking R2). Maintainer asked to note for later, not fix now.
- **`CYCLE-52-R1-ARCHITECTURE-MAP.md`**: R1 commit order annotated as-shipped — R1.4 = `VtEvent` seam per the maintainer's choice; the originally-planned bytes→IOCell integration test is explicitly deferred to R2 (when the event stream actually changes), with the `VtEvent`-identity + unit suite + consolidated dogfood as the R1 behaviour-identity net.

## Test plan

- [ ] Markdown link check green (the only relevant gate; strictly docs-only — two `.md` files).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_