### PR TITLE
Cycle 52 R2: cmd OSC-133 prompt integration (Option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13882,6 +13882,47 @@ follow-up audit should retire the now-redundant
 announce-path compensations (PR-AB; parts of PR-X/Y) once this is
 dogfood-validated.
 
+### Cycle 52 R2 (2026-05-16): cmd OSC-133 prompt integration (Option B)
+
+The cmd transport adapter now injects an OSC-133 shell-integration
+`prompt` template at spawn (startup **and** switch-to-cmd), so cmd
+emits PromptStart (`;A`) before the prompt path and CommandStart
+(`;B`) after it. Replaces the brittle byte-stream
+`lastEnterSeq`/first-newline heuristic with an authoritative
+shell-emitted boundary for the command/output split.
+
+Mechanism (ADR 0005/0006, **Option B** — command-line `prompt`
+injection, adapter-owned): `cmd.exe /K prompt
+$e]133;A$e\$p$g$e]133;B$e\` (unquoted — the value is space-free
+with no cmd metacharacters, sidestepping cmd's outer-quote
+stripping). Injection is gated on the resolved/target `ShellId =
+Cmd`, so claude / PowerShell spawns are byte-identical.
+
+cmd's `prompt` has no hook to emit OutputStart (`;C`) between Enter
+and command output, so per the maintainer's 2026-05-16 decision the
+consumer realises ADR 0005 §3's "implicit C":
+`SessionModel.extractIOCell` gains a third arm — PromptStart +
+CommandStart, no OutputStart — that anchors the proven PR-X
+watermark split at the shell-emitted `;B` marker (the `[A,B)`
+region is the prompt path and is excluded by construction).
+Provenance is OSC 133, not the heuristic fallback. The pre-R2
+PromptStart-only arm is byte-identical (no `CommandStart` marker
+existed pre-R2 — the heuristic detector emits only `PromptStart`),
+so no shell without the injection regresses. Exit-code (`;D`) is
+deferred (its live `%errorlevel%` can't defer through cmd's
+command-line `%`-expansion without fragile escaping; A/B is
+sufficient for the split).
+
+Diagnostics ship with the feature: an `Arm={CleanOscAC|CmdOscAB|
+Heuristic}` line per extraction and `R2 cmd OSC-133 prompt
+injection applied … Base=… Integrated=…` at both spawn seams. The
+exact command-line string is locally unverifiable (no cmd in the
+dev sandbox) — pinned by `CmdAdapterTests` and validated
+end-to-end by the cmd dogfood (ADR 0005 §4 Stage B). If the
+template needs adjustment it is a contained one-line change in
+`CmdAdapter.Osc133PromptValue`; nothing downstream depends on *how*
+cmd was told to emit OSC 133, only *that* it does.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0005-osc133-shell-integration.md
+++ b/docs/adr/0005-osc133-shell-integration.md
@@ -105,6 +105,25 @@ deletable.
      command captured at `B` is the *final* line the shell
      will run, so **history recall is correct by
      construction**.
+     - **R2 status note (2026-05-16):** implemented as
+       **Option B** (command-line `cmd.exe /K prompt …`,
+       adapter-owned — `CmdAdapter.IntegrateOsc133`), *not*
+       `setx`/env `PROMPT`. Two refinements forced by the
+       shipped consumer + cmd's `prompt` semantics:
+       (1) "OutputStart (`C`) is the implicit transition
+       after `B` + Enter" is **not** synthesised — the
+       shipped `SessionModel.extractIOCell` needs a literal
+       marker. cmd's `prompt` has no post-Enter/pre-output
+       hook, so the "implicit C" is realised **consumer-
+       side**: a new PromptStart + CommandStart
+       `extractIOCell` arm anchors the command/output split
+       at the shell-emitted `;B` marker (maintainer decision
+       2026-05-16). (2) deferred-`D;%errorlevel%` is itself
+       deferred — its live `%errorlevel%` can't defer
+       through cmd's *command-line* `%`-expansion without
+       fragile escaping; **A/B only** in R2, which is
+       sufficient for the split (the R2 gate). `;D` returns
+       when reachable without the quoting hazard.
    - **PowerShell / pwsh** — a generated `prompt` function +
      `PSConsoleHostReadLine` / PSReadLine handler emits full
      `A` / `B` / `C` / `D;$LASTEXITCODE`. Injected via

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -4,9 +4,17 @@
   architectural re-foundation. Builds on and **supersedes the
   stage list of [ADR 0005](0005-osc133-shell-integration.md)**
   (0005's OSC-133 mechanism is folded into this ADR's
-  R-stages). R1 in progress (architecture map → behaviour-
-  identical extraction). Each R-stage remains independently
-  CI- and dogfood-gated.
+  R-stages). R1 complete + maintainer-dogfood-validated
+  (#348–#352, 2026-05-16). **R2 in progress** — cmd OSC-133
+  `prompt` injection landed (ADR 0005 Stage B mechanism,
+  **Option B**: command-line `prompt`, adapter-owned); cmd
+  emits `;A`/`;B` only (no `prompt` hook for `;C`), so ADR
+  0005 §3's "implicit C" is realised **consumer-side** —
+  `SessionModel.extractIOCell` gained a PromptStart +
+  CommandStart arm anchoring the split at the shell-emitted
+  `;B` (maintainer decision 2026-05-16). cmd dogfood gate
+  pending. Each R-stage remains independently CI- and
+  dogfood-gated.
 - **Deciders:** maintainer — chose "Re-foundation ADR now" +
   "Drop MAUI consideration for now" (2026-05-15), after the
   strategic review of why 51 cycles produced brittle

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4558,6 +4558,24 @@ module Program =
                         sprintf "Cannot switch to %s: %s" shell.DisplayName safe,
                         ActivityIds.error)
                 | Ok newCmdLine ->
+                    // R2 (ADR 0005/0006, Option B) — cmd
+                    // OSC-133 prompt injection on
+                    // switch-to-cmd. Gated on the switch
+                    // target so claude / PowerShell switches
+                    // are byte-identical. The cmd transport
+                    // adapter owns the injection (ADR 0006).
+                    let newCmdLine =
+                        if target = ShellRegistry.Cmd then
+                            let integrated =
+                                Terminal.Shell.CmdAdapter.IntegrateOsc133
+                                    newCmdLine
+                            log.LogInformation(
+                                "R2 cmd OSC-133 prompt injection applied (shell-switch). Base={Base} Integrated={Integrated}",
+                                newCmdLine,
+                                integrated)
+                            integrated
+                        else
+                            newCmdLine
                     // Announce-before-launch pattern from
                     // Stage 4b's diagnostic-launcher: NVDA
                     // gets the cue into its speech queue

--- a/src/Terminal.Core/SessionModel.fs
+++ b/src/Terminal.Core/SessionModel.fs
@@ -737,49 +737,48 @@ module SessionModel =
     /// silence beats stale-scrollback garbage). There is no
     /// row-walk fallback.
     ///
-    /// Two arms:
-    ///   * PromptStart + OutputStart present (OSC 133 shell):
-    ///     clean Seq-slice split.
-    ///   * PromptStart only (heuristic-only cmd / PowerShell):
-    ///     slice PromptStart→tail, trim the trailing
-    ///     new-prompt text, split on the first newline (cmd
-    ///     echoes the typed command, then `\r\n`, then
-    ///     output). `EntrySource` is NOT consulted — the
-    ///     2026-05-14 bundle showed it mis-tags post-response
-    ///     output in heuristic-only cmd (ADR 0004 Context).
+    /// Three arms (precedence top-to-bottom):
+    ///   * PromptStart + OutputStart (literal ;C — forward-
+    ///     compatible ideal; no shell emits ;C today): clean
+    ///     Seq-slice split [A,C) / [C,tail).
+    ///   * PromptStart + CommandStart, no OutputStart (R2 cmd
+    ///     OSC-133 A/B — ADR 0005/0006, Option B): the [A,B)
+    ///     region is the prompt path; anchor the PR-X
+    ///     watermark split at the CommandStart marker so the
+    ///     typed command + output (after ;B) split cleanly.
+    ///     Shell-emitted ;B ⇒ OSC-133 provenance, NOT the
+    ///     heuristic fallback.
+    ///   * PromptStart only (no OSC 133 at all — pre-R2 cmd /
+    ///     vanilla PowerShell / claude): slice PromptStart→
+    ///     tail, trim the trailing new-prompt text, PR-X
+    ///     watermark or first-newline split. `EntrySource` is
+    ///     NOT consulted — the 2026-05-14 bundle showed it
+    ///     mis-tags post-response output in heuristic-only cmd
+    ///     (ADR 0004 Context).
     let private extractIOCell
             (history: ContentHistory.T)
             (newPromptText: string option)
             (commandEnterSeq: int64)
             : (string * string) option
             =
-        match
-            ContentHistory.tryLatestMarker
-                history ContentHistory.MarkerKind.PromptStart,
-            ContentHistory.tryLatestMarker
-                history ContentHistory.MarkerKind.OutputStart
-        with
-        | Some promptStart, Some outputStart ->
-            // OSC 133 path — shell emitted both PromptStart and
-            // OutputStart, so we have a clean (command, output)
-            // split.
-            let commandText =
-                ContentHistory.sliceText
-                    history promptStart.Seq outputStart.Seq
-            let outputText =
-                ContentHistory.sliceText
-                    history outputStart.Seq System.Int64.MaxValue
-            Some (commandText, outputText)
-        | Some promptStart, None ->
-            // Heuristic-only path (cmd / vanilla PowerShell). No
-            // OSC 133 markers.
-            let stripNextPrompt (s: string) : string =
-                match newPromptText with
-                | Some p when not (System.String.IsNullOrEmpty p)
-                              && s.EndsWith(p) ->
-                    s.Substring(0, s.Length - p.Length)
-                | _ -> s
-            if commandEnterSeq > promptStart.Seq then
+        // The trailing-next-prompt trim is shared by the
+        // heuristic split regardless of which marker anchors
+        // the slice lower bound.
+        let stripNextPrompt (s: string) : string =
+            match newPromptText with
+            | Some p when not (System.String.IsNullOrEmpty p)
+                          && s.EndsWith(p) ->
+                s.Substring(0, s.Length - p.Length)
+            | _ -> s
+        // The PR-X watermark split, parameterised by the slice
+        // lower-bound Seq. Anchored at `promptStart.Seq` it is
+        // the pre-R2 heuristic-only behaviour (byte-identical);
+        // anchored at `commandStart.Seq` it is the R2 cmd
+        // OSC-133 A/B clean split (the [A,B) prompt-path region
+        // is excluded by construction, since the lower bound is
+        // the CommandStart marker that follows the path).
+        let heuristicSplit (lowerBound: int64) : (string * string) option =
+            if commandEnterSeq > lowerBound then
                 // Cycle 51 PR-X — Seq-watermark split. The
                 // command-Enter watermark (captured at the
                 // byte-level Enter in Program.fs) is the exact
@@ -797,7 +796,7 @@ module SessionModel =
                 // wholesale into OutputText.
                 let cmdRegion =
                     ContentHistory.sliceText
-                        history promptStart.Seq commandEnterSeq
+                        history lowerBound commandEnterSeq
                 let outRegion =
                     ContentHistory.sliceText
                         history commandEnterSeq System.Int64.MaxValue
@@ -824,7 +823,7 @@ module SessionModel =
                 // keystrokes back); the rest is shell output.
                 let raw =
                     ContentHistory.sliceText
-                        history promptStart.Seq System.Int64.MaxValue
+                        history lowerBound System.Int64.MaxValue
                 let withoutNewPrompt = stripNextPrompt raw
                 let trimmed =
                     (withoutNewPrompt.TrimStart('\r', '\n'))
@@ -843,6 +842,78 @@ module SessionModel =
                         let out =
                             trimmed.Substring(nlIdx + 1)
                         Some (cmd, out)
+        let lenOf (r: (string * string) option) : int * int =
+            match r with
+            | Some (c, o) -> c.Length, o.Length
+            | None -> 0, 0
+        match
+            ContentHistory.tryLatestMarker
+                history ContentHistory.MarkerKind.PromptStart,
+            ContentHistory.tryLatestMarker
+                history ContentHistory.MarkerKind.OutputStart,
+            ContentHistory.tryLatestMarker
+                history ContentHistory.MarkerKind.CommandStart
+        with
+        | Some promptStart, Some outputStart, _ ->
+            // OSC 133 path — shell emitted both PromptStart and
+            // OutputStart, so we have a clean (command, output)
+            // split. (No shell emits a literal ;C today; this
+            // arm is the forward-compatible ideal.)
+            let commandText =
+                ContentHistory.sliceText
+                    history promptStart.Seq outputStart.Seq
+            let outputText =
+                ContentHistory.sliceText
+                    history outputStart.Seq System.Int64.MaxValue
+            logger.LogDebug(
+                "extractIOCell arm. Arm={Arm} PromptSeq={PromptSeq} OutputSeq={OutputSeq} CmdLen={CmdLen} OutLen={OutLen}",
+                "CleanOscAC",
+                promptStart.Seq,
+                outputStart.Seq,
+                commandText.Length,
+                outputText.Length)
+            Some (commandText, outputText)
+        | Some promptStart, None, Some commandStart ->
+            // R2 (ADR 0005/0006, Option B) — cmd OSC-133 A/B
+            // clean arm. cmd's `prompt`-only integration emits
+            // PromptStart (;A) before the prompt path and
+            // CommandStart (;B) after it, but has no hook to
+            // emit OutputStart (;C) between Enter and the
+            // command's output. Per the maintainer's 2026-05-16
+            // decision the consumer realises ADR 0005 §3's
+            // "implicit C": anchor the command/output split at
+            // the authoritative CommandStart marker — the [A,B)
+            // region is the prompt path, the typed command +
+            // output follow ;B. Reuses the proven PR-X watermark
+            // split (history-scroll-immune) rather than the
+            // PromptStart-only first-line heuristic. Provenance
+            // is OSC 133 (the ;B marker is shell-emitted), so
+            // this is a clean arm, not the heuristic fallback.
+            let result = heuristicSplit commandStart.Seq
+            let cl, ol = lenOf result
+            logger.LogDebug(
+                "extractIOCell arm. Arm={Arm} PromptSeq={PromptSeq} CommandSeq={CommandSeq} CommandEnterSeq={CommandEnterSeq} CmdLen={CmdLen} OutLen={OutLen}",
+                "CmdOscAB",
+                promptStart.Seq,
+                commandStart.Seq,
+                commandEnterSeq,
+                cl,
+                ol)
+            result
+        | Some promptStart, None, None ->
+            // Heuristic-only path (no OSC 133 at all — pre-R2
+            // cmd / vanilla PowerShell / claude). Byte-identical
+            // to the pre-R2 `Some promptStart, None` arm.
+            let result = heuristicSplit promptStart.Seq
+            let cl, ol = lenOf result
+            logger.LogDebug(
+                "extractIOCell arm. Arm={Arm} PromptSeq={PromptSeq} CommandEnterSeq={CommandEnterSeq} CmdLen={CmdLen} OutLen={OutLen}",
+                "Heuristic",
+                promptStart.Seq,
+                commandEnterSeq,
+                cl,
+                ol)
+            result
         | _ -> None
 
     /// Cycle 45c / 51 — ContentHistory-driven finalize. The

--- a/src/Terminal.Shell/CmdAdapter.fs
+++ b/src/Terminal.Shell/CmdAdapter.fs
@@ -30,3 +30,50 @@ type CmdAdapter() =
     /// `startReaderLoop`.
     member _.Translate(bytes: byte[]) : VtEvent[] =
         Parser.feedArray parser bytes
+
+    /// R2 (ADR 0005/0006) — the cmd `prompt` template that
+    /// emits OSC 133 shell-integration markers (Option B:
+    /// prompt-string injection; the cmd transport adapter owns
+    /// the injection per ADR 0006).
+    ///
+    /// cmd renders this template at every prompt. It emits
+    /// OSC 133 PromptStart (`;A`) before the visible path and
+    /// CommandStart (`;B`) after it. cmd has no hook to emit
+    /// OutputStart (`;C`) in the gap between Enter and the
+    /// command's output, so `SessionModel.extractIOCell`'s R2
+    /// CommandStart arm anchors the command/output split at
+    /// the `;B` marker — ADR 0005 §3's "implicit C", realised
+    /// consumer-side per the maintainer's 2026-05-16 decision.
+    ///
+    /// cmd `prompt` codes: `$e` = ESC (Win10+), `$p` = cwd,
+    /// `$g` = `>`, literal `\` = backslash. The OSC 133
+    /// terminator is ST = ESC `\` = `$e\` (the VT parser
+    /// accepts ST as well as BEL — `StateMachine.fs`). The
+    /// `\\` pairs in the F# literal are single backslashes at
+    /// runtime.
+    ///
+    /// Exit-code (`;D`) is deferred: its live `%errorlevel%`
+    /// cannot defer through cmd's command-line `%`-expansion
+    /// without fragile escaping, and A/B alone is sufficient
+    /// for the command/output split (the R2 dogfood gate).
+    static member Osc133PromptValue : string =
+        "$e]133;A$e\\$p$g$e]133;B$e\\"
+
+    /// R2 — wrap a resolved cmd command line with the OSC 133
+    /// `prompt` injection. No surrounding quotes: the value is
+    /// space-free and contains no cmd metacharacters
+    /// (`&|<>()@^`), so an unquoted `/K prompt <value>`
+    /// sidesteps cmd's nuanced outer-quote-stripping entirely.
+    ///
+    /// The exact produced string is locally unverifiable (no
+    /// cmd in the dev sandbox); it is pinned by
+    /// `CmdAdapterTests` and validated end-to-end by the cmd
+    /// dogfood (ADR 0005 §4 Stage B). If the dogfood shows the
+    /// template needs adjustment it is a contained one-line
+    /// change here — nothing downstream depends on *how* cmd
+    /// was told to emit OSC 133, only *that* it does.
+    static member IntegrateOsc133(baseCommandLine: string) : string =
+        sprintf
+            "%s /K prompt %s"
+            baseCommandLine
+            CmdAdapter.Osc133PromptValue

--- a/src/Terminal.Shell/SessionHost.fs
+++ b/src/Terminal.Shell/SessionHost.fs
@@ -96,24 +96,43 @@ type SessionHost private () =
             match ShellRegistry.tryFind ShellRegistry.Cmd with
             | Some s -> s
             | None -> failwith "Cmd not registered in ShellRegistry.builtIns"
-        match ShellRegistry.tryFind requested with
-        | None ->
-            cmdShell, "cmd.exe"
-        | Some shell ->
-            match shell.Resolve() with
-            | Ok cmdLine ->
-                shell, cmdLine
-            | Error reason ->
-                log.LogWarning(
-                    "Shell {Shell} unavailable: {Reason}. Falling back to {Fallback}.",
-                    shell.DisplayName,
-                    reason,
-                    cmdShell.DisplayName)
-                let fallbackCmd =
-                    match cmdShell.Resolve() with
-                    | Ok c -> c
-                    | Error _ -> "cmd.exe"
-                cmdShell, fallbackCmd
+        let resolvedShell, resolvedCmdLine =
+            match ShellRegistry.tryFind requested with
+            | None ->
+                cmdShell, "cmd.exe"
+            | Some shell ->
+                match shell.Resolve() with
+                | Ok cmdLine ->
+                    shell, cmdLine
+                | Error reason ->
+                    log.LogWarning(
+                        "Shell {Shell} unavailable: {Reason}. Falling back to {Fallback}.",
+                        shell.DisplayName,
+                        reason,
+                        cmdShell.DisplayName)
+                    let fallbackCmd =
+                        match cmdShell.Resolve() with
+                        | Ok c -> c
+                        | Error _ -> "cmd.exe"
+                    cmdShell, fallbackCmd
+        // R2 (ADR 0005/0006, Option B) — cmd OSC-133 prompt
+        // injection. Applied once at the single orchestration
+        // return so all three resolution outcomes
+        // (registered-miss / resolved-cmd / fallback-to-cmd)
+        // get it, and non-cmd shells (claude / PowerShell)
+        // are byte-identical. The cmd transport adapter owns
+        // the injection (ADR 0006); SessionHost only gates it
+        // on the resolved ShellId.
+        if resolvedShell.Id = ShellRegistry.Cmd then
+            let integrated =
+                CmdAdapter.IntegrateOsc133 resolvedCmdLine
+            log.LogInformation(
+                "R2 cmd OSC-133 prompt injection applied (startup). Base={Base} Integrated={Integrated}",
+                resolvedCmdLine,
+                integrated)
+            resolvedShell, integrated
+        else
+            resolvedShell, resolvedCmdLine
 
     /// Placeholder factory. Real adapter selection + spawn
     /// wiring lands in a subsequent R1 step; the constructor

--- a/src/Terminal.Shell/Terminal.Shell.fsproj
+++ b/src/Terminal.Shell/Terminal.Shell.fsproj
@@ -9,13 +9,17 @@
   <ItemGroup>
     <Compile Include="ShellEvent.fs" />
     <Compile Include="ShellAdapter.fs" />
-    <Compile Include="SessionHost.fs" />
     <!--
       R1.4 (ADR 0006): the cmd transport adapter. Verbatim
-      VT-parser wrapper for now (byte[] -> VtEvent[]); no
-      intra-assembly dependency on the skeleton above.
+      VT-parser wrapper (byte[] -> VtEvent[]) plus, since R2,
+      the OSC-133 `prompt` injection helper. Compiled BEFORE
+      SessionHost: R2 wired SessionHost.ResolveStartupShell to
+      call CmdAdapter.IntegrateOsc133, so the adapter must
+      precede the orchestration point in F# compile order. No
+      dependency on ShellEvent / ShellAdapter above.
     -->
     <Compile Include="CmdAdapter.fs" />
+    <Compile Include="SessionHost.fs" />
     <!--
       R1.2: HeuristicPromptDetector relocated here from
       Terminal.Core (ADR 0006 — the detector leaves the core

--- a/tests/Tests.Unit/CmdAdapterTests.fs
+++ b/tests/Tests.Unit/CmdAdapterTests.fs
@@ -1,0 +1,56 @@
+module PtySpeak.Tests.Unit.CmdAdapterTests
+
+open Xunit
+open Terminal.Shell
+
+// ---------------------------------------------------------------------
+// R2 (ADR 0005/0006, Option B) — cmd OSC-133 `prompt` injection.
+// ---------------------------------------------------------------------
+//
+// `CmdAdapter.IntegrateOsc133` builds the command line that makes
+// cmd emit OSC 133 PromptStart (;A) + CommandStart (;B). The exact
+// string is NOT locally verifiable — there is no cmd.exe in the dev
+// sandbox, and cmd's `prompt`-code + quoting semantics can only be
+// confirmed by the maintainer's cmd dogfood (ADR 0005 §4 Stage B).
+// These fixtures pin the string so a regression fails loudly in CI
+// long before a release+dogfood cycle is spent on it, and document
+// WHY each token is shaped the way it is.
+
+[<Fact>]
+let ``Osc133PromptValue is the A/B FinalTerm template with ST terminators`` () =
+    // cmd `prompt` codes: $e=ESC, $p=cwd, $g='>', literal '\'.
+    // OSC 133 terminator is ST = ESC '\' = `$e\`. The template
+    // emits: ;A  <visible path>  ;B. No ;C (cmd has no
+    // post-Enter/pre-output hook) and no ;D (deferred — its live
+    // %errorlevel% cannot defer through cmd's command-line
+    // %-expansion without fragile escaping).
+    let v = CmdAdapter.Osc133PromptValue
+    Assert.Equal("$e]133;A$e\\$p$g$e]133;B$e\\", v)
+    // Structural intent (fails loudly if a future edit breaks the
+    // OSC framing even if the literal above is "fixed" to match):
+    Assert.StartsWith("$e]133;A$e\\", v) // PromptStart + ST
+    Assert.EndsWith("$e]133;B$e\\", v)   // CommandStart + ST
+    Assert.Contains("$p$g", v)            // visible path + '>'
+    Assert.DoesNotContain("133;C", v)     // no OutputStart
+    Assert.DoesNotContain("133;D", v)     // no CommandFinished
+    Assert.DoesNotContain("%errorlevel%", v)
+
+[<Fact>]
+let ``IntegrateOsc133 wraps the base command line with /K prompt, unquoted`` () =
+    // No surrounding quotes: the value is space-free and has no
+    // cmd metacharacters, so `/K prompt <value>` sidesteps cmd's
+    // nuanced outer-quote-stripping entirely.
+    let integrated = CmdAdapter.IntegrateOsc133 "cmd.exe"
+    Assert.Equal(
+        "cmd.exe /K prompt $e]133;A$e\\$p$g$e]133;B$e\\",
+        integrated)
+
+[<Fact>]
+let ``IntegrateOsc133 preserves an arbitrary base path verbatim`` () =
+    // The fn is pure (the cmd-only gate lives at the SessionHost /
+    // switchToShell call sites, not here); it must not mangle a
+    // resolved base path.
+    let integrated =
+        CmdAdapter.IntegrateOsc133 "C:\\Windows\\System32\\cmd.exe"
+    Assert.StartsWith("C:\\Windows\\System32\\cmd.exe /K prompt ", integrated)
+    Assert.EndsWith(CmdAdapter.Osc133PromptValue, integrated)

--- a/tests/Tests.Unit/SessionModelTests.fs
+++ b/tests/Tests.Unit/SessionModelTests.fs
@@ -800,6 +800,60 @@ let ``CH path — OSC 133 PromptStart+OutputStart splits command vs output`` () 
     Assert.Equal(SessionModel.IOCellPhase.Sealed, cell.Phase)
 
 [<Fact>]
+let ``CH path — R2 cmd OSC-133 PromptStart+CommandStart (no OutputStart) splits at CommandStart, prompt path excluded`` () =
+    // R2 (ADR 0005/0006, Option B). cmd's prompt-only
+    // integration emits PromptStart (;A) before the prompt
+    // path and CommandStart (;B) after it, but no OutputStart
+    // (;C). The [A,B) region is the prompt path and MUST NOT
+    // leak into CommandText / OutputText — extractIOCell's R2
+    // arm anchors the command/output split at the
+    // shell-emitted CommandStart marker, not PromptStart.
+    let initial = SessionModel.create "cmd" 100
+    let history = freshHistory ()
+    let history =
+        appendHistoryMarker history t0 ContentHistory.MarkerKind.PromptStart
+    // The [A,B) prompt-path region (Seq < CommandStart →
+    // excluded by the R2 arm). Trailing newline seals it
+    // before the marker so the assertion is deterministic.
+    let history =
+        feedHistoryBytes
+            history (after 5)
+            (System.Text.Encoding.ASCII.GetBytes "C:\\dir>\n")
+    let history =
+        appendHistoryMarker
+            history (after 10) ContentHistory.MarkerKind.CommandStart
+    // After ;B: echoed command, its output, the next prompt.
+    let history =
+        feedHistoryBytes
+            history (after 15)
+            (System.Text.Encoding.ASCII.GetBytes "echo hi\nhi\nC:\\dir>")
+    let s1 =
+        SessionModel.applyWithContentHistory
+            initial
+            (boundaryWithText BoundaryKind.PromptStart t0 "C:\\dir>")
+            [||] history true (-1L)
+    let s2 =
+        SessionModel.applyWithContentHistory
+            s1 (boundary BoundaryKind.CommandStart (after 100))
+            [||] history true (-1L)
+    let _s3, finalisedOpt =
+        SessionModel.applyAndCaptureWithContentHistory
+            s2
+            (boundaryWithText
+                (BoundaryKind.CommandFinished (Some 0))
+                (after 200)
+                "C:\\dir>")
+            [||] history true (-1L)
+    Assert.True(finalisedOpt.IsSome)
+    let cell = finalisedOpt.Value
+    Assert.Equal("echo hi", cell.CommandText)
+    Assert.Equal("hi", cell.OutputText)
+    // The [A,B) prompt path must not leak into either field.
+    Assert.DoesNotContain("C:\\dir>", cell.CommandText)
+    Assert.DoesNotContain("C:\\dir>", cell.OutputText)
+    Assert.Equal(SessionModel.IOCellPhase.Sealed, cell.Phase)
+
+[<Fact>]
 let ``CH path — heuristic-only PromptStart-only slices the blob`` () =
     let initial = SessionModel.create "cmd" 100
     let _s, finalisedOpt =

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="EnvBlockTests.fs" />
     <Compile Include="ShellRegistryTests.fs" />
     <Compile Include="ShellSwitchTests.fs" />
+    <Compile Include="CmdAdapterTests.fs" />
     <Compile Include="HotkeyRegistryTests.fs" />
     <Compile Include="AppReservedHotkeysMirrorTests.fs" />
     <Compile Include="MultiStateRegistryTests.fs" />


### PR DESCRIPTION
## Summary

R2 (ADR 0005/0006) — make cmd emit OSC-133 so the command/output split comes from an **authoritative shell-emitted boundary** instead of the brittle `lastEnterSeq`/first-newline byte-stream heuristic.

**Emit side (Option B — command-line `prompt`, adapter-owned):** `CmdAdapter.IntegrateOsc133` wraps the resolved cmd command line as `cmd.exe /K prompt $e]133;A$e\$p$g$e]133;B$e\` (unquoted — space-free, no cmd metacharacters → sidesteps cmd's outer-quote-stripping). Applied at both spawn seams (`SessionHost.ResolveStartupShell` startup; `Program.fs switchToShell` switch-to-cmd), gated on `ShellId = Cmd` so claude / PowerShell spawns are **byte-identical**.

**Consume side (the maintainer's 2026-05-16 decision):** cmd's `prompt` has no hook to emit OutputStart (`;C`) between Enter and command output, and the shipped `extractIOCell` clean arm strictly needs a literal marker. So ADR 0005 §3's "implicit C" is realised **consumer-side**: `SessionModel.extractIOCell` gains a third arm — PromptStart + CommandStart, no OutputStart — that anchors the proven PR-X watermark split at the shell-emitted `;B` marker. The `[A,B)` region is the prompt path and is excluded by construction.

**No regression:** pre-R2 the heuristic detector emits only `PromptStart` (no `CommandStart` marker ever existed without OSC `;B`), so the new arm is dormant until this injection ships → the PromptStart-only arm stays byte-identical. The heuristic split body was factored into a lower-bound-parameterised local (behaviour-preserving) reused by both the new arm (anchored at `;B`) and the legacy arm (anchored at PromptStart).

**Deferred:** exit-code `;D` — its live `%errorlevel%` can't defer through cmd's command-line `%`-expansion without fragile escaping; A/B is sufficient for the split (the R2 gate).

**Diagnostics ship with the feature (CLAUDE.md):** `Arm={CleanOscAC|CmdOscAB|Heuristic}` per extraction; `R2 cmd OSC-133 prompt injection applied … Base=… Integrated=…` at both spawn seams.

**Decision trail:** the env-var-vs-command-line choice (Option B) and the cmd-`;C`-impossibility fork (consumer-side resolution) were both surfaced via `AskUserQuestion` and locked by the maintainer before implementation; ADR 0005 §3 and ADR 0006 status carry the clarification.

## Test plan

- [ ] CI: build (Windows) — the exact cmd command-line string is locally unverifiable (no cmd in the dev sandbox); `CmdAdapterTests` pins it and the structural OSC framing.
- [ ] CI: unit tests — new `extractIOCell` PromptStart+CommandStart arm test (prompt path excluded, split at `;B`); the 80+ existing callers unaffected (new arm dormant without OSC `;B`); existing OSC-133 and heuristic-only arm tests unchanged.
- [ ] **cmd dogfood (decisive, ADR 0005 §4 Stage B):** maintainer release-build — cmd prompt renders cleanly (no visible escape leakage), command/output split is correct including history-recall, diagnostic bundle shows `Arm=CmdOscAB` and the injection-applied log lines. If the `prompt` template needs adjustment it is a contained one-line change in `CmdAdapter.Osc133PromptValue` — nothing downstream depends on *how* cmd was told to emit OSC 133, only *that* it does.
- [ ] NVDA matrix Cycle 52 R2 row (post-dogfood).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_