### PR TITLE
Cycle 52 R3a: OSC-133 precedence — mute heuristic once seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13923,6 +13923,36 @@ template needs adjustment it is a contained one-line change in
 `CmdAdapter.Osc133PromptValue`; nothing downstream depends on *how*
 cmd was told to emit OSC 133, only *that* it does.
 
+### Cycle 52 R3a (2026-05-16): OSC-133 precedence — mute heuristic once seen
+
+First half of R3 (ADR 0005 Stage C / ADR 0006 R3) — the
+**precedence** rule. Once an `BoundarySource.Osc133` boundary is
+observed in a shell session, the `HeuristicPromptDetector`'s
+synthetic boundaries are no longer dispatched (`handlePromptBoundary`
+sets a per-session `oscSeenThisSession` latch; `runDetector` mutes
+the heuristic when set). This stops the regex detector from
+competing with the authoritative shell-emitted markers — the root
+cause of the announce-path compensation pile and a contributor to
+KI-R2-1.
+
+Per-shell-session and **reset only on shell-switch** (the
+`switchToShell` `Ok newHost` block), *not* on alt-screen: a
+cmd→claude switch must keep the heuristic (claude emits no OSC); a
+cmd→cmd switch re-mutes on the new session's first OSC boundary;
+alt-screen toggles don't end the session so the latch persists. The
+heuristic detector itself still ticks (state stays warm) — only its
+*dispatch* is gated, so the change is a pure suppression with no
+detector-state divergence.
+
+Diagnostics ship with it: a one-time Information transition log
+(`R3a precedence: first OSC-133 boundary observed …`) marks the
+regime change in any always-on bundle; per-occurrence Debug logs
+(`R3a: muted heuristic boundary …`) detail suppressed boundaries on
+demand. No unit seam (Program.fs composition-root mutable, like the
+shell-switch coordinator) — dogfood-gated, the diagnostic logs are
+the triage surface. The PR-X/Y/AA/AB announce-path compensation
+*deletion* is the separate R3b PR.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -165,7 +165,20 @@ list** and folds 0005's mechanism into it.
 - **R3 — precedence + scaffolding deletion** (= ADR 0005
   Stage C). "Once OSC133 seen, mute heuristic" *inside the
   adapter*; delete the PR-AB / PR-X / PR-Y announce-path
-  compensations from the core.
+  compensations from the core. **Sequenced R3a → R3b**
+  (one-concern-per-PR / walking-skeleton): **R3a — precedence
+  (in progress, 2026-05-16):** per-shell-session
+  `oscSeenThisSession` latch mutes the heuristic dispatch once
+  an `Osc133` boundary is seen (reset on shell-switch, not
+  alt-screen). Implemented at the current Program.fs detector
+  call site; relocating the gate physically *inside*
+  `CmdAdapter` (with the deferred R1.2 heuristic-namespace
+  move) is a structural follow-on (R3c / R4-purify), behaviour
+  first per the R1 precedent. **R3b — scaffolding deletion
+  (next):** delete the PR-X/Y/AA/AB announce-path
+  compensations and make the tuple-final announce
+  marker/Seq-driven like R2's `;B`-anchored `extractIOCell`
+  arm (the natural fix-home for KI-R2-1).
 - **R4 — purify + enforce.** Extend the existing portability-
   lint CI job to assert `Terminal.Core` has no shell strings
   / no WPF / no P/Invoke. **This is the enforcement that

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -1892,6 +1892,20 @@ module Program =
         let mutable promptDetector : HeuristicPromptDetector.T =
             HeuristicPromptDetector.create ()
 
+        // R3a (ADR 0005/0006) — precedence: once an OSC-133
+        // boundary has been observed in the current shell
+        // session, the heuristic detector is muted (its
+        // synthetic boundaries are no longer dispatched). This
+        // stops the regex detector from fighting the
+        // authoritative shell-emitted markers — the root cause
+        // of the announce-path compensation pile. Per-shell-
+        // session: set by `handlePromptBoundary` on the first
+        // `BoundarySource.Osc133`, reset by `switchToShell`
+        // (NOT on alt-screen — the shell keeps emitting OSC
+        // across alt-screen toggles). Mutated on the same
+        // notification-consumer thread as `promptDetector`.
+        let mutable oscSeenThisSession : bool = false
+
         // Cycle 29b — selection-prompt detector. Same actor-
         // model contract as `promptDetector`: mutated on the
         // PathwayPump worker thread, captured by closures that
@@ -1957,6 +1971,22 @@ module Program =
                 (snapshot: Cell[][])
                 : unit
                 =
+            // R3a (ADR 0005/0006) — precedence latch. Any
+            // OSC-133-sourced boundary proves the shell emits
+            // shell-integration markers; from here on the
+            // heuristic detector is muted for this shell
+            // session (see `runDetector`). One-time
+            // transition log so a bundle shows exactly when
+            // the session went OSC-authoritative.
+            match boundary.Source with
+            | BoundarySource.Osc133 ->
+                if not oscSeenThisSession then
+                    oscSeenThisSession <- true
+                    log.LogInformation(
+                        "R3a precedence: first OSC-133 boundary observed; heuristic detector now muted for this shell session. Shell={Shell} Kind={Kind}",
+                        shellIdToConfigKey currentShellId,
+                        sprintf "%A" boundary.Kind)
+            | _ -> ()
             // SessionModel Tier 1.E — PromptText augmentation.
             // Heuristic boundaries arrive with `MatchedRowText`
             // already populated (the detector renders the row
@@ -2475,6 +2505,20 @@ module Program =
             // SessionModel.apply for finalize-time content
             // extraction.
             match boundary with
+            | Some data when oscSeenThisSession ->
+                // R3a (ADR 0005/0006) — OSC-133 is
+                // authoritative for this shell session;
+                // suppress the heuristic boundary so the
+                // regex detector can't corrupt the
+                // shell-emitted marker stream. Debug-level
+                // (off by default; the Information transition
+                // log in handlePromptBoundary already marks
+                // the regime change in an always-on bundle).
+                log.LogDebug(
+                    "R3a: muted heuristic boundary (OSC-133 authoritative this session). Shell={Shell} Kind={Kind} Source={Source}",
+                    shellKey,
+                    sprintf "%A" data.Kind,
+                    sprintf "%A" data.Source)
             | Some data -> handlePromptBoundary data snapshot
             | None -> ()
             // Cycle 29b — also drive the SelectionDetector on
@@ -4748,6 +4792,18 @@ module Program =
                                         promptDetector <-
                                             HeuristicPromptDetector.reset
                                                 promptDetector
+                                        // R3a (ADR 0005/0006)
+                                        // — new shell session:
+                                        // re-arm the heuristic
+                                        // until the new shell's
+                                        // first OSC-133 (a
+                                        // cmd→claude switch has
+                                        // no OSC and MUST keep
+                                        // the heuristic; a
+                                        // cmd→cmd switch re-mutes
+                                        // on the first new-session
+                                        // OSC boundary).
+                                        oscSeenThisSession <- false
                                         // Cycle 29b — companion
                                         // reset on shell-switch
                                         // so a stale candidate


### PR DESCRIPTION
## Summary

First half of **R3** (ADR 0005 Stage C / ADR 0006 R3) — the **precedence** rule, sequenced R3a → R3b per one-concern-per-PR.

Once an `BoundarySource.Osc133` boundary is observed in a shell session, the `HeuristicPromptDetector`'s synthetic boundaries are no longer dispatched:

- **Latch:** `handlePromptBoundary` sets a per-shell-session `oscSeenThisSession` on the first `BoundarySource.Osc133` (one-time Information transition log).
- **Gate:** `runDetector` mutes the heuristic dispatch while the latch is set (per-occurrence Debug log). The detector still **ticks** (state stays warm) — only its *dispatch* is gated, so there's no detector-state divergence, just suppression.
- **Reset:** only in `switchToShell`'s `Ok newHost` block (new shell session), **not** on alt-screen. cmd→claude keeps the heuristic (claude emits no OSC); cmd→cmd re-mutes on the new session's first OSC; alt-screen toggles don't end the session so the latch persists.

This stops the regex detector from competing with the authoritative shell-emitted markers — the root cause of the announce-path compensation pile and a contributor to **KI-R2-1** (the volume-triggered path-leak you flagged in the R2 dogfood). Its full fix is the R3b compensation deletion.

**Why no unit test:** the gate is composition-root mutable state in `Program.fs` (same class as the shell-switch coordinator, which `ShellSwitchTests` documents as unreachable from the unit-test environment). Dogfood-gated; the diagnostic logs are the triage surface (CLAUDE.md: new state/transition ships with its diagnostics).

**Scope note:** physically relocating the gate *inside* `CmdAdapter` (with the deferred R1.2 heuristic-namespace move) is a structural follow-on (R3c / R4-purify) — behaviour first per the R1 precedent. ADR 0006 R3 status updated to record the R3a→R3b sequencing.

## Test plan

- [ ] CI: build+test (windows) — pure additive Program.fs change (one mutable + a latch + a guarded match arm + a reset); no signature/type changes, no test impact.
- [ ] CI: actionlint / markdown link / portability lint.
- [ ] **Dogfood (decisive):** in cmd, confirm the diagnostic bundle shows the one-time `R3a precedence: first OSC-133 boundary observed …` line and that heuristic-driven mis-announces stop once OSC is seen (this is the KI-R2-1-adjacent behaviour — expect the path-leak to be *reduced* but fully resolved only by R3b). Switch cmd→claude and confirm claude still narrates (heuristic re-armed). Switch cmd→cmd and confirm it re-mutes.
- [ ] NVDA matrix Cycle 52 R3a row (post-dogfood).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_