### PR TITLE
Cycle 52 R4a: HeuristicPromptDetector namespace purify (Core → Shell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13997,6 +13997,29 @@ tuple-final announce (sealed IOCell OutputText). Len=…` (Info),
 body at Debug, plus `R3b command-Enter watermark …`. No unit seam
 (Program.fs composition-root path).
 
+### Cycle 52 R4a (2026-05-16): HeuristicPromptDetector namespace purify (Terminal.Core → Terminal.Shell)
+
+First half of R4 (ADR 0006 R4-purify, folding the deferred R1.2 /
+R3c tail). R1.2 physically moved `HeuristicPromptDetector.fs` into
+the `Terminal.Shell` project but kept its `namespace Terminal.Core`
++ call sites ("deferred to R3 when call sites change anyway"). R4a
+completes that: the file now declares `namespace Terminal.Shell`
+with an explicit `open Terminal.Core` for the substrate types it
+consumes (Logger / PromptBoundaryData / BoundaryKind / Cell /
+CanonicalState — previously visible implicitly via the namespace),
+mirroring `CmdAdapter.fs`. The three code consumers
+(`Program.fs`, `Diagnostics.fs`, `HeuristicPromptDetectorTests.fs`)
+gain `open Terminal.Shell`. Pure behaviour-preserving relocation
+(15 +/2 −, no logic change); the Terminal.Core `///` doc-comment
+mentions of the detector are unaffected.
+
+**Maintainer-facing:** the FileLogger category for the detector
+changes `Terminal.Core.HeuristicPromptDetector` →
+`Terminal.Shell.HeuristicPromptDetector` — diagnostic-bundle greps
+that targeted the old category string must use the new one. This
+removes the last namespace-level Terminal.Core/shell-leak, setting
+up R4b (extend the portability-lint CI to *enforce* the boundary).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -194,11 +194,17 @@ list** and folds 0005's mechanism into it.
   risk; dogfood is the gate. R3c (heuristic→adapter
   physical relocation + R1.2 namespace move) remains the
   structural follow-on.
-- **R4 — purify + enforce.** Extend the existing portability-
-  lint CI job to assert `Terminal.Core` has no shell strings
-  / no WPF / no P/Invoke. **This is the enforcement that
-  structurally prevents re-leak** — the answer to "why did 51
-  cycles stay brittle".
+- **R4 — purify + enforce.** Sequenced R4a → R4b. **R4a —
+  purify (done 2026-05-16):** `HeuristicPromptDetector`
+  namespace `Terminal.Core` → `Terminal.Shell` (+ explicit
+  `open Terminal.Core`; consumers `open Terminal.Shell`;
+  logger category restrung) — the deferred R1.2 / R3c tail,
+  removing the last namespace-level shell-leak. Behaviour-
+  preserving (15 +/2 −). **R4b — enforce (next):** extend the
+  existing portability-lint CI job to assert `Terminal.Core`
+  has no shell strings / no WPF / no P/Invoke. **This is the
+  enforcement that structurally prevents re-leak** — the
+  answer to "why did 51 cycles stay brittle".
 - **R5 — PowerShell adapter** (= ADR 0005 Stage D). Full
   A/B/C/D + exit code.
 - **R6 — feature unlock** (= ADR 0005 Stage E). Per-line

--- a/src/Terminal.App/Diagnostics.fs
+++ b/src/Terminal.App/Diagnostics.fs
@@ -11,6 +11,7 @@ open PtySpeak.Views
 open Terminal.Audio
 open Terminal.Core
 open Terminal.Pty
+open Terminal.Shell
 
 /// Ctrl+Shift+D diagnostic battery.
 ///

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -15,6 +15,7 @@ open Terminal.Core
 open Terminal.Core.Channels
 open Terminal.Audio
 open Terminal.Pty
+open Terminal.Shell
 open Terminal.Accessibility
 open PtySpeak.Views
 

--- a/src/Terminal.Shell/HeuristicPromptDetector.fs
+++ b/src/Terminal.Shell/HeuristicPromptDetector.fs
@@ -1,8 +1,18 @@
-namespace Terminal.Core
+namespace Terminal.Shell
 
 open System
 open System.Text.RegularExpressions
 open Microsoft.Extensions.Logging
+// R4a (ADR 0006 R3c/R4-purify) — the heuristic detector now
+// declares its true home namespace. R1.2 physically moved the
+// file into the Terminal.Shell project but kept the
+// `Terminal.Core` namespace + call sites unchanged ("deferred to
+// R3 when call sites change anyway"). The Terminal.Core types it
+// consumes (Logger / PromptBoundaryData / BoundaryKind / Cell /
+// CanonicalState) were implicitly visible while it lived in that
+// namespace; now they need an explicit open (mirrors
+// `CmdAdapter.fs`).
+open Terminal.Core
 
 /// Tier 1.D — heuristic prompt-boundary fallback.
 ///
@@ -192,7 +202,7 @@ module HeuristicPromptDetector =
           LastEmittedPromptRowIndex = None
           RowDirtyAfterEmit = false }
 
-    let private logger = Logger.get "Terminal.Core.HeuristicPromptDetector"
+    let private logger = Logger.get "Terminal.Shell.HeuristicPromptDetector"
 
     /// Resolve the per-shell regex + stability window from
     /// the shell-key string. Returns `None` for unknown

--- a/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
+++ b/tests/Tests.Unit/HeuristicPromptDetectorTests.fs
@@ -3,6 +3,7 @@ module PtySpeak.Tests.Unit.HeuristicPromptDetectorTests
 open System
 open Xunit
 open Terminal.Core
+open Terminal.Shell
 
 // ---------------------------------------------------------------------
 // SessionModel Tier 1.D — heuristic prompt-boundary detector


### PR DESCRIPTION
## Summary

First half of **R4** (ADR 0006 R4-purify), folding the deferred R1.2 / R3c tail. R1.2 physically moved `HeuristicPromptDetector.fs` into the `Terminal.Shell` project but kept its `namespace Terminal.Core` + call sites ("deferred to R3 when call sites change anyway"). R4a completes that — the **last namespace-level Terminal.Core/shell-leak**:

- `HeuristicPromptDetector.fs`: `namespace Terminal.Core` → `namespace Terminal.Shell`, with an explicit `open Terminal.Core` for the substrate types it consumes (`Logger` / `PromptBoundaryData` / `BoundaryKind` / `Cell` / `CanonicalState` — previously visible *implicitly* because it lived in that namespace). Mirrors the established `CmdAdapter.fs` pattern.
- Logger category restrung `Terminal.Core.HeuristicPromptDetector` → `Terminal.Shell.HeuristicPromptDetector`.
- The three code consumers — `Program.fs`, `Diagnostics.fs`, `HeuristicPromptDetectorTests.fs` — gain `open Terminal.Shell`. (`SelectionDetectorTests` and all `src/Terminal.Core/*` references are doc-comments only — no code dependency, unaffected.)

Pure behaviour-preserving relocation: **49 +/7 −** (mostly the explanatory comment + CHANGELOG/ADR); zero logic change.

**Maintainer-facing:** diagnostic-bundle greps that targeted the old logger category `Terminal.Core.HeuristicPromptDetector` must now use `Terminal.Shell.HeuristicPromptDetector`. (CHANGELOG + ADR 0006 R4 status updated.)

Sets up **R4b** — extend the portability-lint CI job to *enforce* the boundary (assert `Terminal.Core` has no shell strings / WPF / P/Invoke), the structural gate ADR 0006 calls "the answer to why 51 cycles stayed brittle".

## Test plan

- [ ] CI: build+test (windows) — the real gate (no local `dotnet`). Verified twice: the rename is atomic across all 4 code files; `open Terminal.Core` restores the implicitly-visible substrate types; consumers `open Terminal.Shell`; existing `Terminal.Shell.CmdAdapter`/`SessionHost` FQ refs remain valid with the new `open`.
- [ ] CI: actionlint / markdown link / portability lint (this PR does NOT yet change the lint — that's R4b).
- [ ] No dogfood behaviour change expected (pure namespace relocation). The one observable delta is the FileLogger category string for the detector — confirm a bundle shows `Terminal.Shell.HeuristicPromptDetector` on the next dogfood.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_