### PR TITLE
Cycle 52 R4-followup: health-check reports informational version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14054,6 +14054,20 @@ mentions never trigger; verified zero violations on current `main`
 **This completes R4.** With R1 (extract the seam) + R4 (enforce
 it), the architectural boundary is structural, not disciplinary.
 
+### Cycle 52 R4-followup (2026-05-16): health-check reports the informational version
+
+`Ctrl+Shift+H` now announces (and logs to the bundle) the
+`AssemblyInformationalVersion` alongside the existing shell / PID /
+liveness / log-level / queue line — e.g. *"Pty-speak healthy.
+Version 0.0.1-preview.NN+sha. cmd shell, PID …"*. Surfaced on
+maintainer request from the R1–R4 foundation dogfood: a local
+`git pull` + build has no release-tag in the window title (unlike
+an installed preview), so there was no keyboard-only way to
+sanity-check that the running build is the intended version. Reuses
+the existing startup-log version resolver; no GUI walk (a
+screen-reader-friendly hotkey, not a Help-menu dialog). One-line
+`sprintf` extension to the existing `runHealthCheck` summary.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,9 +633,10 @@ Currently shipped (orientation reference; spec section 6 is canonical):
 - `Ctrl+Shift+1` / `+2` / `+3` — hot-switch the spawned shell
   (`+1`=cmd / `+2`=PowerShell / `+3`=Claude; PR-J reordered to
   put PowerShell next to cmd as the diagnostic control shell)
-- `Ctrl+Shift+H` — health-check announce: shell + PID + alive,
-  log level, reader staleness, queue depths (PR-F + PR-J liveness
-  probe)
+- `Ctrl+Shift+H` — health-check announce: **informational
+  version** (Cycle 52 R4-followup — local-build sanity check),
+  shell + PID + alive, log level, reader staleness, queue
+  depths (PR-F + PR-J liveness probe)
 - `Ctrl+Shift+B` — incident marker boundary line in the log (PR-F)
 - `Ctrl+Shift+Y` — copy SessionModel history to clipboard (Cycle 22b);
   paste-friendly structured plain-text dump of all completed

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2952,10 +2952,20 @@ module Program =
                     else
                         "Pty-speak healthy."
                 let aliveStr = if alive then "alive" else "dead"
+                // R4-followup (2026-05-16, maintainer request) —
+                // surface the AssemblyInformationalVersion in the
+                // Ctrl+Shift+H announce so a local `git pull` +
+                // build can be sanity-checked against the intended
+                // version without a GUI walk (the window title
+                // doesn't carry the release tag on a dev build the
+                // way an installed preview does). Reuses the
+                // startup-log resolver; also captured in the
+                // bundle via the LogInformation below.
                 let summary =
                     sprintf
-                        "%s %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256."
+                        "%s Version %s. %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256."
                         verdict
+                        (resolveInformationalVersion ())
                         currentShell.DisplayName
                         pid
                         aliveStr


### PR DESCRIPTION
## Summary

R1–R4 foundation-dogfood follow-up — finding **#5** (your explicit request). `Ctrl+Shift+H` now announces the `AssemblyInformationalVersion` in its summary line, e.g.:

> *"Pty-speak healthy. **Version 0.0.1-preview.NN+sha.** cmd shell, PID 1234 (alive), log level Information. Reader last byte 12 ms ago. Notification queue 0 of 256."*

A local `git pull` + build has no release tag in the window title (unlike an installed preview), so there was no keyboard-only way to confirm the running build is the intended version. This reuses the existing startup-log version resolver (`resolveInformationalVersion`), so it's the same string already logged at startup and now also in the `Ctrl+Shift+D` bundle (via the unchanged `LogInformation`). Answers your question directly: there was **no** existing health-check version surface — there is now, on the mechanism you suggested. Screen-reader-friendly hotkey, no Help-menu dialog walk.

One-line `sprintf` extension to `runHealthCheck`'s summary; no logic change.

## Test plan

- [ ] CI: build+test (windows) / actionlint / markdown link / portability lint.
- [ ] Dogfood: press `Ctrl+Shift+H` on this build — confirm the announce now leads with `Version <informational-version>`. On an installed preview it should match the release tag; on a local build it shows the `git describe`-style informational version so local==intended can be verified before re-running the matrix.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_