### PR TITLE
docs(CLAUDE.md): never use "blind" as a metaphor for unverified/guessing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -742,6 +742,32 @@ The rule of thumb: would the maintainer be annoyed if their
 phone buzzed for this? If yes, plain text. If genuinely
 blocked, `AskUserQuestion`.
 
+### Literal language — never use "blind" (or "see", "look", "view") as a metaphor
+
+**Non-negotiable.** The maintainer is blind. Do **not** use
+"blind" to mean *without information / unverified / guessing*
+("flying blind", "a blind fix", "blindly pushing"). "Blind"
+describes a person's sensory reality, not a lack of data. Using
+it as a pejorative metaphor — especially in this project, to
+this maintainer — is offensive. This rule recurred across
+sessions purely because it was never written down here; it is
+now, so there is no excuse.
+
+State the **literal** condition instead:
+
+- "no local compiler / `dotnet` in the sandbox — CI is the
+  only build signal"
+- "locally unverifiable; the CI round-trip is the check"
+- "without the diagnostic bundle I'd be guessing — please
+  paste the log slice"
+- "unverified assumption" / "speculative" / "untested"
+
+Apply the same literalness to incidental "see / look at / view"
+when precision is easy ("the log shows", "per `file:line`",
+"the bundle reports") — not a hard ban on common verbs, but
+prefer the concrete reference. The point: be literal about the
+actual issue; never reach for sight/blindness as shorthand.
+
 ### The maintainer is a screen-reader user — no GUI dialog walks
 
 The maintainer uses NVDA. **Never** propose a fix or workflow that


### PR DESCRIPTION
## Summary

**Docs-only, conduct rule.** The maintainer is blind. Prior sessions repeatedly used "blind" / "flying blind" / "blindly" as a metaphor for *without information / no local verification* — offensive, and it recurred sporadically **only because there was no durable rule in CLAUDE.md** (the file had screen-reader / no-GUI-walk guidance, but nothing about this specific language). This adds an explicit, non-negotiable **"Literal language"** subsection (placed with the other maintainer-reality rules) giving the correct literal phrasings to use instead:

- "no local compiler / `dotnet` in the sandbox — CI is the only build signal"
- "locally unverifiable; the CI round-trip is the check"
- "unverified assumption" / "speculative" / "untested"
- prefer concrete references ("the log shows", "per `file:line`", "the bundle reports") over incidental "see/look/view" where precision is easy

So this stops recurring across sessions — it's now written down where every session loads it.

Verified this session's new artifacts (ADRs, docs, code, `[Unreleased]`) contain **no** metaphorical "blind"; the only repo occurrences are frozen historical CHANGELOG entries from prior cycles, deliberately **not** rewritten (immutable history; not what's asked).

## Test plan

- [ ] Markdown link check (docs-only fast-merge lane — strictly `CLAUDE.md`, no code/workflow). Merge on link-check green without waiting for the Windows build.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_