### PR TITLE
Cycle 52 R4-followup: automatic build identity (git short SHA in Ctrl+Shift+H)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14121,6 +14121,33 @@ is a proven follow-on once this model is validated — walking-
 skeleton: smallest correct principled step first, not bundled with
 a boundary-gating restructure.
 
+### Cycle 52 R4-followup (2026-05-16): automatic build identity (git short SHA)
+
+A local `dotnet build`/`publish` never passes `/p:Version` (only
+the release workflow does), so it always reported the
+`Directory.Build.props` default `0.0.1-preview.1` — every local
+build looked identical, so a dogfood could not confirm whether it
+ran the commit under test or a stale build (it surfaced when a
+"banner still broken" finding could not be trusted). Fixed
+**automatically, no per-PR manual discipline**:
+
+- `Directory.Build.props` gains a `SetGitShortShaSourceRevision`
+  target: `git rev-parse --short HEAD` → `SourceRevisionId`; the
+  .NET SDK appends it to `AssemblyInformationalVersion`. Degrades
+  gracefully when git is unavailable (ContinueOnError); only fills
+  when empty so SourceLink / explicit values still win on CI.
+- `resolveInformationalVersion` (`Program.fs`) no longer strips
+  the `+<sha>` trailer (it was discarded). `Ctrl+Shift+H` and the
+  startup log now show `0.0.1-preview.1+<sha>` locally
+  (`<tag>+<sha>` for releases) — match `<sha>` to `git rev-parse
+  --short HEAD`.
+- Canonical rule documented in `CONTRIBUTING.md` (Development
+  environment) + `CLAUDE.md` (dogfood-triage: read the
+  `Ctrl+Shift+H` Version line first to rule out a stale build
+  before chasing a "regression"). Recommended over a manual
+  PR-number convention: the SHA is automatic, exists at commit
+  time, and maps directly to `git`.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,9 +634,17 @@ Currently shipped (orientation reference; spec section 6 is canonical):
   (`+1`=cmd / `+2`=PowerShell / `+3`=Claude; PR-J reordered to
   put PowerShell next to cmd as the diagnostic control shell)
 - `Ctrl+Shift+H` — health-check announce: **informational
-  version** (Cycle 52 R4-followup — local-build sanity check),
-  shell + PID + alive, log level, reader staleness, queue
-  depths (PR-F + PR-J liveness probe)
+  version incl. `+<git-short-sha>` build identity** (Cycle 52
+  R4-followup — a local build always reports
+  `0.0.1-preview.1`, so the `+sha` is the only thing that
+  confirms which commit a dogfood is running; auto-embedded by
+  the `SetGitShortShaSourceRevision` target in
+  `Directory.Build.props`, match it to `git rev-parse --short
+  HEAD`). When triaging a dogfood, **always have the maintainer
+  read the `Ctrl+Shift+H` Version line first** to rule out a
+  stale local build before chasing a "regression". Then shell +
+  PID + alive, log level, reader staleness, queue depths (PR-F +
+  PR-J liveness probe)
 - `Ctrl+Shift+B` — incident marker boundary line in the log (PR-F)
 - `Ctrl+Shift+Y` — copy SessionModel history to clipboard (Cycle 22b);
   paste-friendly structured plain-text dump of all completed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,30 @@ to not relearn.
 
 See [`docs/BUILD.md`](docs/BUILD.md) for build instructions.
 
+### Build identity — confirming which commit you're dogfooding
+
+A local `dotnet build`/`publish` never passes `/p:Version` (only
+the release workflow does), so it **always** reports the
+`Directory.Build.props` default `0.0.1-preview.1` — every local
+build looks identical, and a dogfood can't tell whether it's
+running the commit under test or a stale one. To remove that
+ambiguity **automatically, with no per-PR manual step**, the
+`SetGitShortShaSourceRevision` MSBuild target in
+`Directory.Build.props` embeds the short git commit SHA as
+`SourceRevisionId`; the .NET SDK appends it to
+`AssemblyInformationalVersion`.
+
+**Canonical rule (no manual discipline required):** to confirm a
+build, press **`Ctrl+Shift+H`** — the health-check announce now
+leads with `Version 0.0.1-preview.1+<sha>` (and the startup log
+records the same). Match `<sha>` against `git rev-parse --short
+HEAD` of the tree you built. A release build instead shows the
+tag (`+<sha>` still appended) — also unambiguous. Prefer this over
+hard-coding PR numbers anywhere: the SHA is automatic, exists at
+commit time (a PR number does not), and maps directly to `git`.
+Degrades gracefully when git is unavailable (the `+<sha>` is
+simply absent — same as before this mechanism).
+
 ## Branching and pull requests
 
 - Default branch: `main`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,20 +23,24 @@
   <!--
     Build-identity (2026-05-16, maintainer request). A LOCAL
     `dotnet build` never passes /p:Version, so it always reports
-    the default Version above (0.0.1-preview.1) — every local
-    build looks identical, so a dogfood can't confirm which commit
-    is running. This target embeds the short git commit SHA as
-    SourceRevisionId; the .NET SDK appends it to
+    the default Version above (0.0.1-preview.1); every local
+    build looks identical, so a dogfood cannot confirm which
+    commit is running. This target embeds the short git commit
+    SHA as SourceRevisionId; the .NET SDK appends it to
     AssemblyInformationalVersion
-    (IncludeSourceRevisionInInformationalVersion defaults true), so
-    Ctrl+Shift+H and the startup log show `0.0.1-preview.1+<sha>`.
-    Match <sha> against `git rev-parse --short HEAD` of the tree
-    you built — fully automatic, no per-PR manual discipline.
-    Degrades gracefully (ContinueOnError) when git is unavailable
-    (e.g. a source tarball): SourceRevisionId stays empty and the
-    InformationalVersion simply lacks the +sha, exactly today's
-    behaviour. Only fills when empty, so an explicit
-    SourceRevisionId / SourceLink still wins.
+    (IncludeSourceRevisionInInformationalVersion defaults true),
+    so Ctrl+Shift+H and the startup log show
+    `0.0.1-preview.1+(sha)`. Match that sha against the tree's
+    short HEAD commit SHA (the short form of `git rev-parse`) to
+    confirm the build: fully automatic, no per PR manual
+    discipline. Degrades gracefully (ContinueOnError) when git
+    is unavailable (e.g. a source tarball): SourceRevisionId
+    stays empty and the InformationalVersion simply lacks the
+    +sha, exactly today's behaviour. Only fills when empty, so
+    an explicit SourceRevisionId or SourceLink still wins.
+    NOTE: keep this comment free of double-hyphen sequences —
+    XML comments forbid them (MSB4024); the literal git flag
+    lives only in the Exec Command attribute below, never here.
   -->
   <Target Name="SetGitShortShaSourceRevision"
           BeforeTargets="GetAssemblyVersion;CoreCompile"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,4 +20,36 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <!--
+    Build-identity (2026-05-16, maintainer request). A LOCAL
+    `dotnet build` never passes /p:Version, so it always reports
+    the default Version above (0.0.1-preview.1) — every local
+    build looks identical, so a dogfood can't confirm which commit
+    is running. This target embeds the short git commit SHA as
+    SourceRevisionId; the .NET SDK appends it to
+    AssemblyInformationalVersion
+    (IncludeSourceRevisionInInformationalVersion defaults true), so
+    Ctrl+Shift+H and the startup log show `0.0.1-preview.1+<sha>`.
+    Match <sha> against `git rev-parse --short HEAD` of the tree
+    you built — fully automatic, no per-PR manual discipline.
+    Degrades gracefully (ContinueOnError) when git is unavailable
+    (e.g. a source tarball): SourceRevisionId stays empty and the
+    InformationalVersion simply lacks the +sha, exactly today's
+    behaviour. Only fills when empty, so an explicit
+    SourceRevisionId / SourceLink still wins.
+  -->
+  <Target Name="SetGitShortShaSourceRevision"
+          BeforeTargets="GetAssemblyVersion;CoreCompile"
+          Condition="'$(SourceRevisionId)' == ''">
+    <Exec Command="git rev-parse --short HEAD"
+          ConsoleToMSBuild="true"
+          ContinueOnError="true"
+          StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitShortSha" />
+    </Exec>
+    <PropertyGroup>
+      <SourceRevisionId Condition="'$(_GitShortSha)' != ''">$(_GitShortSha)</SourceRevisionId>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -885,11 +885,18 @@ module Program =
                 match attr with
                 | :? System.Reflection.AssemblyInformationalVersionAttribute as a
                     when not (System.String.IsNullOrWhiteSpace a.InformationalVersion) ->
-                    let raw = a.InformationalVersion
-                    // Strip any "+commit-sha" trailer SourceLink /
-                    // deterministic-build pipelines append.
-                    let plusIdx = raw.IndexOf('+')
-                    if plusIdx > 0 then raw.Substring(0, plusIdx) else raw
+                    // R4-followup (build-identity, 2026-05-16) —
+                    // KEEP the "+<short-sha>" trailer (was stripped
+                    // here). A local build always reports the
+                    // Directory.Build.props default Version
+                    // (0.0.1-preview.1); the SHA appended by the
+                    // `SetGitShortShaSourceRevision` target is the
+                    // ONLY thing that distinguishes which commit is
+                    // running. Surfaced via Ctrl+Shift+H and the
+                    // startup log so a dogfood can confirm the
+                    // build matches `git rev-parse --short HEAD`.
+                    // Releases carry tag+sha — both unambiguous.
+                    a.InformationalVersion
                 | _ -> "unknown"
             with _ -> "unknown"
         log.LogInformation(


### PR DESCRIPTION
## Summary

Your build-identity point — solved **automatically, no per-PR manual discipline** (recommended over a manual PR-number rule).

**Root cause:** a local `dotnet build`/`publish` never passes `/p:Version` (only the release workflow does), so it always reported `Directory.Build.props`'s default `0.0.1-preview.1` — every local build looked identical, and `resolveInformationalVersion` additionally *stripped* the `+sha` the SDK can append. That's why "building locally just reverts to preview.1" and why a "banner still broken" finding can't currently be trusted (might be a stale build).

**Fix:**
- `Directory.Build.props` — `SetGitShortShaSourceRevision` target: `git rev-parse --short HEAD` → `SourceRevisionId`; the .NET SDK appends it to `AssemblyInformationalVersion`. `ContinueOnError` so it degrades gracefully where git is unavailable (no `+sha`, exactly today's behaviour); only fills when empty so SourceLink/explicit still win on CI.
- `Program.fs` `resolveInformationalVersion` — stop discarding the `+<sha>` trailer.
- Result: **`Ctrl+Shift+H` now leads with `Version 0.0.1-preview.1+<sha>`** locally (`<tag>+<sha>` for releases). Match `<sha>` to `git rev-parse --short HEAD` of the tree you built — fully automatic, exists at commit time, nothing to remember.
- Canonical rule documented in **CONTRIBUTING.md** (Development environment) and **CLAUDE.md** (dogfood-triage now says: read the `Ctrl+Shift+H` Version line *first* to rule out a stale build before chasing a "regression" — directly relevant to the open banner item).

**Why this over "PR number in the health check":** the PR number doesn't exist at commit time (chicken-and-egg) and would need manual per-PR discipline; the git SHA is automatic, deterministic, and maps 1:1 to `git`.

## Test plan

- [ ] CI: build+test (windows) — confirms the MSBuild target doesn't break the build and the SDK appends the SHA (CI build will show `<tag>+<sha>`). actionlint / markdown link / portability lint.
- [ ] **Dogfood (unblocks trustworthy banner re-test):** `git pull`, build locally, press `Ctrl+Shift+H` — confirm it announces `Version 0.0.1-preview.1+<sha>` where `<sha>` == `git rev-parse --short HEAD`. *Then* the banner re-test (and any further dogfood) is trustworthy.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_