### PR TITLE
Cycle 52 R4-followup-2: spell SHA char-by-char in Ctrl+Shift+H (fixes scientific-notation read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14164,6 +14164,27 @@ full corpus pattern: `HotkeyRegistry` DU/`nameOf`/`builtIns`/
 `Diagnostics → CMD Interaction Tests → Multi-Interrupt (R3c)`
 menu item. NVDA matrix row `52-R3c-multi`.
 
+### Cycle 52 R4-followup-2 (2026-05-16): SHA spoken char-by-char in Ctrl+Shift+H
+
+Build-identity dogfood follow-up. The `+<sha>` trailer added by
+the build-identity feature is a 7-char hex commit id; tokens like
+`09321e7` match the `<digits>e<digits>` shape, so NVDA's number
+reader voiced them as scientific notation ("9321 times ten to the
+7"). `runHealthCheck` now spells the SHA character-by-character
+(space-separated) in the **spoken** summary only — NVDA reads each
+character. The startup log and the `Ctrl+Shift+D` bundle keep the
+raw `+sha` (unchanged `resolveInformationalVersion`) for
+grep/triage; this only reshapes what is voiced.
+
+Also recorded in `docs/SESSION-HANDOFF.md` the consolidated
+post-dogfood state: **#2 sub-prompt double-speech FIXED &
+maintainer-validated** (R3c watermark); **KI-R2-1 / backspace /
+Alt+F4 RESOLVED**; **#1 banner STILL OPEN** (silent post-R3c —
+needs a SHA-confirmed bundle, no re-speculation); **output-path
+either/or** and **cold-start-keyboard** tracked + deferred per
+maintainer lean (the latter explicitly *not* build-identity-caused
+— a separate window-activation/focus race).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -67,32 +67,55 @@ and serves the decision-trail role this file used to overload.
   `CHANGELOG.md` / `git log`. `CYCLE-51-PLAYBOOK.md` is
   HISTORICAL.
 
-### Known issues for the R1–R4 foundation dogfood
+### R1–R4 dogfood findings (post-maintainer-dogfood 2026-05-16)
 
-The maintainer is **batching dogfood findings** (explicit
-2026-05-16). Validate these against an installed preview of
-post-`cbf8d48` `main`:
+State after the maintainer's batched dogfood of post-`cab2a0d`
+`main`:
 
-- **KI-R2-1 — should now be GONE.** R2 dogfood (2026-05-16)
-  surfaced: after ~9 commands the echo output + next input
-  path leaked into the announce; toggling path-suppression
-  recovered it. Root cause = the PR-X `lastEnterSeq` +
-  `EndsWith(MatchedRowText)` next-prompt trim. R3b deleted
-  that path (announce = Seq-sliced IOCell `OutputText`, no
-  `EndsWith` heuristic). **Confirm the leak no longer
-  reproduces under sustained command volume.**
-- **R3b sub-prompt double-speech — watch for it.** Sub-prompt
-  cells now announce their `OutputText`, which may re-include
-  the just-spoken sub-prompt question (the accepted
-  single-step re-derivation risk; PR-Y strip deleted). Listen
-  on `test-02` (typed-Enter) / `test-04` (single-key Y/N) —
-  if the question is spoken twice, that's the R3b-followup
-  signal.
-- **Banner must still read** on a shell switch (PR-AA/AC
-  preserved through R3b).
-- **R4a logger-category change** is maintainer-facing: any
-  bundle grep that targeted `Terminal.Core.HeuristicPrompt`
-  `Detector` must now use `Terminal.Shell.…`.
+- **KI-R2-1 — RESOLVED & validated.** The volume-triggered
+  echo+next-path leak is gone (R3b deleted the PR-X
+  `lastEnterSeq`/`EndsWith` pile; R3c made the announce a
+  settled-watermark Seq-gap). Confirmed by the maintainer.
+- **#2 sub-prompt double-speech — FIXED & validated.** R3c's
+  spoken-watermark: the question is announced once in
+  real-time, then only the post-response output at finalise.
+  Maintainer confirmed ("first half until input, then only
+  the second half"). `test-09-multi-interrupt` (matrix
+  `52-R3c-multi`) pins the MULTI-incremental composition case
+  R5/R6 depend on.
+- **#1 banner — STILL OPEN (the one unresolved functional
+  regression).** Silent on fresh launch *and* shell switch,
+  even post-R3c (R3c default-armed `announceBannerOnNextPrompt`
+  + watermark-sliced `bannerAnnounce`). Root cause NOT
+  determinable by static reading (runtime ordering) — needs a
+  `Ctrl+Shift+D` bundle from a **SHA-confirmed** build,
+  grepped for `R3c banner announce` /
+  `announceBannerOnNextPrompt`. Do **not** re-speculate (two
+  wrong guesses already). Gated on the maintainer capturing
+  that bundle.
+- **Backspace-to-empty path-read — RESOLVED** (R3c watermark).
+- **Alt+F4 not closing — RESOLVED** (was the maintainer's
+  keyboard function-lock, not code).
+- **Output-path either/or — tracked, DEFERRED** (maintainer
+  lean 2026-05-16). Only with output-path announcements ON
+  (non-default): fast `echo`+Enter → path only; slow → output
+  only. Hypothesis: path-announce vs tuple-final contend under
+  NVDA same-activity supersession + speech-render timing.
+- **Cold-start keyboard — tracked, DEFERRED** (maintainer
+  decision 2026-05-16). A freshly-built EXE doesn't receive
+  keyboard until close+reopen. **NOT build-identity-caused**
+  (that's build-time metadata only). Suspected cold-start
+  window-activation / input-focus race; workaround exists
+  (relaunch). Needs narrowing (launch method? every cold
+  start vs post-build? window foregrounded?) before touching
+  the load-bearing WPF startup/focus path.
+- **SHA spoken as scientific notation — FIXED** (R4-followup-2:
+  `Ctrl+Shift+H` now spells the `+<sha>` char-by-char; the
+  startup log / bundle keep the raw `+sha` for grep).
+- **R4a logger-category change** is maintainer-facing: bundle
+  greps for the heuristic detector use
+  `Terminal.Shell.HeuristicPromptDetector` (old
+  `Terminal.Core.…` returns nothing).
 
 ## Next stage
 

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -3002,11 +3002,37 @@ module Program =
                 // way an installed preview does). Reuses the
                 // startup-log resolver; also captured in the
                 // bundle via the LogInformation below.
+                //
+                // R4-followup-2 (2026-05-16, dogfood) — the
+                // `+<sha>` trailer is a 7-char hex commit id;
+                // tokens like `09321e7` match the
+                // `<digits>e<digits>` shape so NVDA's number
+                // reader speaks them as scientific notation
+                // ("9321 times ten to the 7"). Spell the SHA out
+                // character-by-character (space-separated) in the
+                // SPOKEN summary only — NVDA then reads each
+                // character. The startup log + the
+                // `LogInformation` below keep the raw `+sha`
+                // (unchanged `resolveInformationalVersion`) for
+                // grep/triage; this only reshapes what is voiced.
+                let spokenVersion =
+                    let v = resolveInformationalVersion ()
+                    let plus = v.IndexOf('+')
+                    if plus >= 0 && plus < v.Length - 1 then
+                        let basePart = v.Substring(0, plus)
+                        let sha = v.Substring(plus + 1)
+                        let spelled =
+                            System.String.Join(
+                                " ",
+                                sha.ToCharArray() |> Array.map string)
+                        sprintf "%s build %s" basePart spelled
+                    else
+                        v
                 let summary =
                     sprintf
                         "%s Version %s. %s shell, PID %d (%s), log level %s. Reader last byte %.0f ms ago. Notification queue %d of 256."
                         verdict
-                        (resolveInformationalVersion ())
+                        spokenVersion
                         currentShell.DisplayName
                         pid
                         aliveStr


### PR DESCRIPTION
## Summary

Build-identity dogfood follow-up (your finding **A**). The `+<sha>` trailer is a 7-char hex commit id; tokens like `09321e7` match the `<digits>e<digits>` shape, so NVDA's number reader voiced them as scientific notation ("9321 times ten to the 7"). `runHealthCheck` now spells the SHA **character-by-character** (space-separated) in the **spoken** summary only — e.g. *"Version 0.0.1-preview.1 build 0 9 3 2 1 e 7"*. The startup log and the `Ctrl+Shift+D` bundle keep the raw `+sha` (`resolveInformationalVersion` unchanged) for grep/triage; this only reshapes what is voiced.

Also consolidates `docs/SESSION-HANDOFF.md` to the accurate post-dogfood state for the next session:
- **#2 sub-prompt double-speech — FIXED & you validated it** (R3c watermark); `test-09-multi-interrupt` pins the multi-incremental case.
- **KI-R2-1 / backspace / Alt+F4 — RESOLVED.**
- **#1 banner — STILL OPEN** (silent post-R3c; needs a SHA-confirmed `Ctrl+Shift+D` bundle; no re-speculation — two wrong guesses already).
- **Output-path either/or** and **cold-start-keyboard** — tracked + **deferred** per your lean (cold-start keyboard explicitly **not** build-identity-caused: a separate window-activation/focus race; workaround = relaunch).

(B / cold-start-keyboard: tracked, deferred, not fixed here — per your call.)

## Test plan

- [ ] CI: build+test (windows) — `spokenVersion` is isolated to `runHealthCheck`'s spoken summary; `String.Join(string, string[])` via explicit `Array.map string` (unambiguous overload); both `if` branches string-typed. actionlint / markdown link / portability.
- [ ] Dogfood: `Ctrl+Shift+H` — the version now reads as discrete characters ("…build zero nine three two one e seven"), no scientific notation. Startup log / bundle still show raw `0.0.1-preview.1+09321e7`.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_