### PR TITLE
Capture fast-type command-echo leak as a deferral (ADR 0006 + handoff)

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -212,6 +212,22 @@ verified to fully restore it on both build types.
   exactly this); if preview.141 says only `>`, it's an R1
   regression and blocks R2. Maintainer: "not worth fixing
   now, note for later."
+- **Fast-type command-echo leak** (observed 2026-05-16,
+  post-R4c local dogfood). Fast-typing `echo hi` + hitting
+  Enter quickly speaks the command (`echo hi`) *then* the
+  output (`hi`) instead of just `hi` — the `52-R3d` fail
+  signal under the fast-type window. R3d fixed normal-paced
+  typing; the fast-type race in the `commandEnterSeq`
+  byte-watermark (± an NVDA caret-read contribution) is
+  residual. **Not an R4c regression** (R4c didn't touch the
+  command/output watermark or the caret path); same root
+  cause as the deferred BOTH-edges region-cut work — see
+  [ADR 0006](adr/0006-three-layer-refoundation.md)
+  §"Deferred to R6+" item 1 (now covers the leading
+  command/output edge, not just the trailing edge).
+  Classification rule + bundle-disambiguation recorded
+  there. Eliminated by the clean event stream (R5 `;C` /
+  the R6 cmd region-cut); **deferred, do not report as new**.
 - **`EntrySource.DraftInputRecall`** (deferred from Cycle 49
   E3) — substrate refinement; no audible bug behind it
   after PR-I's screen-read approach.

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -305,24 +305,53 @@ several of these solvable in a *whole-system* way rather
 than against cmd's quirks alone; designing them pre-R5
 would be premature.
 
-1. **Retire `stripNextPrompt` → one shell-agnostic
-   output-region cut.** Today the trailing-next-prompt edge
-   of an IOCell's output is reconstructed by string-suffix
-   subtraction (`SessionModel.extractIOCell` slices
-   `[…, Int64.MaxValue)` then strips the known prompt text)
-   — a residual reconstruction heuristic, exactly the
-   ADR-0006 anti-pattern. The clean form is a positional
-   region-cut: cmd via deferred-finalise / backtrack-insert
-   at the next `;A` Seq (the marker that isn't in
-   ContentHistory yet at `;D`-finalise time — see the R4c
-   consumer note + ADR 0005 §3 R4c); PowerShell via its
-   native `;C`/`;D`. R5 surfaces this cross-shell (the
-   `CleanOscAC` arm slices `[;C, MaxValue)` with **no**
-   strip — R5's dogfood reveals the general shape), so the
-   one model that is correct for both shells is designed
-   *then*. Until then `stripNextPrompt` stays (it works on
-   the golden path; the failure mode is output that
-   legitimately ends with text equal to the prompt path).
+1. **Retire byte-stream reconstruction on BOTH IOCell-output
+   edges → real marker boundaries.** Today *both* edges of an
+   IOCell's output region are reconstructed, not cut at a
+   marker:
+   - **Trailing edge (output / next-prompt).**
+     `SessionModel.extractIOCell` slices `[…, Int64.MaxValue)`
+     then string-strips the known prompt text
+     (`stripNextPrompt`). Failure mode: output that
+     legitimately ends with text equal to the prompt path.
+   - **Leading edge (command / output split).** cmd emits no
+     real `;C` OutputStart, so the command-vs-output split is
+     the **`commandEnterSeq` byte-level Enter watermark**, not
+     a marker. Failure mode: **fast-typing a command and
+     hitting Enter quickly races the watermark capture**, so
+     the echoed command leaks into the announce — observable
+     as "`echo hi` spoken, then `hi` spoken" instead of just
+     "`hi`" (the `52-R3d` fail signal). R3d's
+     `max(commandEnterSeq, lastAnnouncedSeq)` fixed
+     *normal-paced* typing; the **fast-type window is
+     residual** and is *not* an R4c regression (R4c changed
+     only which boundary finalises + the trailing-edge
+     augmentation; it did not touch `commandEnterSeq` or the
+     NVDA-caret path). A second contributor may be NVDA's own
+     caret-read of the echoed input line (ADR 0002 channel) —
+     a `Ctrl+Shift+D` bundle (`R3d tuple-final announce …
+     CommandEnterSeq=… FromSeq=…`) disambiguates; deferred,
+     not needed pre-R5. **Classification rule:** if a
+     *pre-R4c* preview does not show the fast-type leak but a
+     post-R4c one does, it is a regression and blocks —
+     otherwise pre-existing (the byte-watermark lineage of
+     KI-R2-1).
+
+   Both edges are the same root cause — byte-stream
+   reconstruction instead of real markers — and both have the
+   same clean form: a positional region-cut. cmd via
+   deferred-finalise / backtrack-insert at the next `;A` Seq
+   (the marker not in ContentHistory yet at `;D`-finalise
+   time — see the R4c consumer note + ADR 0005 §3 R4c) plus a
+   real command/output boundary (cmd has no `;C` hook, so
+   this is the harder half); PowerShell via its native
+   `;C`/`;D`. R5 surfaces this cross-shell (the `CleanOscAC`
+   arm slices `[;C, MaxValue)` with **no** strip — R5's
+   dogfood reveals the general shape), so the one model
+   correct for both shells is designed *then*. Until then the
+   `stripNextPrompt` + `commandEnterSeq` reconstruction stays
+   (golden path works; the two failure modes above are the
+   known residue).
 2. **Replace SpeechCursor manual history-navigation with
    canonical IOCell-history navigation + per-cell
    operations.** The SpeechCursor's navigable history and


### PR DESCRIPTION
## Summary

Docs-only. Captures a deferral surfaced in the post-R4c local dogfood (2026-05-16): **fast-typing `echo hi` + hitting Enter quickly speaks the command (`echo hi`) then the output (`hi`)** instead of just `hi` — the `52-R3d` fail signal under the fast-type window.

- **Root cause:** cmd emits no real `;C` OutputStart, so the command/output split is the `commandEnterSeq` byte-level Enter watermark, not a marker. Fast typing races the watermark capture. R3d's `max(commandEnterSeq, lastAnnouncedSeq)` fixed *normal-paced* typing; the **fast-type window is residual**. A second contributor may be NVDA's own caret-read of the echoed input line (ADR 0002 channel) — a `Ctrl+Shift+D` bundle disambiguates; not needed pre-R5.
- **Not an R4c regression:** R4c changed only which boundary finalises + the trailing-edge augmentation; it did not touch `commandEnterSeq` or the NVDA-caret path. A classification rule is recorded (pre- vs post-R4c preview) in case a regression is suspected.
- **Placement:** ADR 0006 deferral #1 broadened from "trailing-next-prompt edge only" to **both** output-region edges (leading command/output split + trailing next-prompt) — same root cause (byte-stream reconstruction vs real markers), same clean form (positional region-cut), same gate (R5's native `;C` reveals the cross-shell shape). SESSION-HANDOFF deferred list gains an observable-symptom line so it isn't re-reported as new.

No code, no user-visible change — no CHANGELOG entry.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge lane — strictly `.md` files).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_