### PR TITLE
Record cmd announce-heuristic freeze decision (post-foundation-bundle)

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -168,6 +168,22 @@ replaces the misplaced Cycle-47 synthetic compensation for
 cmd. Folded into the R1–R4 foundation dogfood (matrix
 `52-R4c`); same installed preview, one NVDA pass.
 
+> **cmd announce-heuristic FREEZE (maintainer decision
+> 2026-05-16, post-`5518f5c` bundle).** The foundation
+> bundle proved the IOCell substrate is sound; every
+> remaining cmd defect (path/echo bleed under history-
+> recall, "Terminal edit Blank" on fresh launch — cmd
+> emits no banner, confirmed) is in the racy announce-
+> reconstruction layer, not the substrate. **Do not push
+> further cmd announce-heuristic patches before R5.**
+> PowerShell's native `A/B/C/D` is the clean reference;
+> cmd's announce path is rebuilt to it afterward. Full
+> rationale + evidence in
+> [ADR 0006](adr/0006-three-layer-refoundation.md)
+> §"Deferred to R6+" decision note. cmd *substrate* work
+> (R4c-class) is still fine — only the announce-heuristic
+> layer is frozen.
+
 **R5 — PowerShell adapter** (= ADR 0005 Stage D): full
 OSC-133 `A/B/C/D` + exit code via a generated profile /
 `-NoExit -Command`, as a second `Terminal.Shell` adapter.

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -295,6 +295,43 @@ list** and folds 0005's mechanism into it.
 
 ### Deferred to R6+ — the canonical-IOCell navigation / operations layer
 
+**Decision (maintainer, 2026-05-16, post-`5518f5c`
+foundation dogfood + bundle analysis): freeze cmd
+announce-heuristic work until the PowerShell clean
+reference exists.** The R1–R4 + R4c bundle proved the
+IOCell substrate is sound — `extractIOCell` produced a
+correct `CmdLen`/`OutLen` split on every command (plain,
+`dir`, test-02, test-09's seven segments); the
+`RecentTuple` dump and ContentHistory markers are clean.
+**Every remaining cmd defect lives in the announce-
+reconstruction layer on top**, not the substrate:
+- the R3d tuple-final announce slices
+  `[max(commandEnterSeq, lastAnnouncedSeq), end)` then
+  string-strips the trailing prompt using a *racy screen-
+  cursor-row snapshot*; under history-recall churn (the
+  bundle showed ~60 `PR-I history-recall` arrow-spam
+  events and a Seq-86 `"echo1 echo hidir echo hi…"`
+  accumulation) that snapshot mismatches → path/echo
+  bleed. Same byte-stream-reconstruction root cause as
+  deferral 1 below; **not a new R4c regression** (R4c only
+  made the strip reachable on the `;D` path; the racy
+  mechanism is R3c/R3d, unchanged).
+- cmd emits **no pre-prompt banner at all** (bundle: zero
+  `R3c banner announce` for cmd; PowerShell's fires with
+  the full text). "Terminal edit Blank" on fresh cmd
+  launch is the empty-document focus fallback, **not a
+  bug** — architectural for cmd. The banner *mechanism*
+  works (PowerShell proves it).
+
+Consequently: **do not push further cmd announce-heuristic
+patches pre-R5.** PowerShell's native `A/B/C/D` removes the
+reconstruction entirely and becomes the clean reference;
+cmd's announce path is then rebuilt to that shape
+(deferral 1). Continuing to patch cmd announce heuristics
+now is the documented tail-chasing loop. cmd substrate
+work (R4c-class) remains fine; only the announce-heuristic
+layer is frozen.
+
 Strategic referrals captured 2026-05-16 (maintainer
 direction, on the R4c-merge discussion). All are
 **deliberately deferred until the canonical IOCell is


### PR DESCRIPTION
## Summary

Docs-only. Records a strategic decision from the post-`5518f5c` foundation dogfood + diagnostic-bundle analysis (maintainer, 2026-05-16).

**The bundle proved the IOCell substrate is sound** — `extractIOCell` produced a correct `CmdLen`/`OutLen` split on every command (plain, `dir`, test-02, test-09's seven segments); `RecentTuple` + ContentHistory markers are clean. **Every remaining cmd defect lives in the announce-reconstruction layer**, not the substrate:

- **Path/echo bleed under history-recall churn** — the R3d tuple-final announce string-strips the trailing prompt using a racy screen-cursor-row snapshot; under arrow-spam history-recall (the bundle showed ~60 `PR-I history-recall` events + a Seq-86 garbled accumulation) the snapshot mismatches → bleed. Same byte-stream-reconstruction root cause as the existing deferral; **not a new R4c regression** (R4c only made the strip reachable on the `;D` path; the racy mechanism is R3c/R3d, unchanged).
- **cmd emits no pre-prompt banner at all** — bundle shows zero `R3c banner announce` for cmd while PowerShell's fires with the full text. "Terminal edit Blank" on fresh cmd launch is the empty-document focus fallback — architectural, **not a bug**. The banner mechanism works (PowerShell proves it).

**Decision:** freeze cmd announce-heuristic work until PowerShell's native `A/B/C/D` clean reference exists; cmd's announce path is rebuilt to it afterward (the already-deferred `stripNextPrompt` retirement). cmd *substrate* work (R4c-class) remains fine — only the announce-heuristic layer is frozen. This stops the documented tail-chasing loop.

Recorded in ADR 0006 §"Deferred to R6+" decision note + a SESSION-HANDOFF Next-stage banner so it isn't re-litigated. No code, no user-visible change.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge lane — strictly `.md`).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_