### PR TITLE
Cycle 52 R5a: adapter-selection seam (behaviour-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14308,6 +14308,36 @@ by the cmd dogfood (NVDA matrix `52-R4c`, folded into the
 R1–R4 foundation dogfood). ADR 0005 §3 R4c status note + ADR
 0006 R4c stage.
 
+### Cycle 52 R5a (2026-05-16): adapter-selection seam (behaviour-identical; foundation sign-off received)
+
+First step after the maintainer's R1–R4+R4c foundation
+dogfood sign-off. Recon corrected the playbook's R5a premise:
+the transport is already shell-agnostic except the OSC-133
+injection (already `ShellId`-gated at two sites);
+`CmdAdapter.Translate` is a verbatim VT-parser wrapper; the
+full `IShellAdapter` (Spawn/WriteInput) is a large
+**non**-behaviour-identical refactor (spawn is
+`ConPtyHost.start`-direct, input `host.WriteBytes`-direct) —
+deferred to R6. Maintainer chose "literal R5a seam first".
+
+R5a is therefore the **thin selection layer**, not full
+`IShellAdapter` adoption: a single
+`SessionHost.Osc133IntegratorFor : ShellRegistry.ShellId ->
+(string -> string)` selector (cmd → `CmdAdapter.Integrate-
+Osc133`; every other shell → identity) replacing the two
+inline `if = Cmd` OSC-133 gates (`SessionHost.Resolve-
+StartupShell` startup + `Program.fs` `switchToShell`).
+**Byte-identical including logs:** the cmd-only "R2 cmd
+OSC-133 … applied" line still fires exactly when cmd; the
+single shared VT parser is still not reset across shell
+switches; spawn/input paths untouched. Centralises the
+per-`ShellId` dispatch so **R5b adds PowerShell in exactly
+one arm**. Pinned by two `CmdAdapterTests` facts
+(`Osc133IntegratorFor` Cmd-wraps / non-cmd-identity — the
+non-cmd assertion flips deliberately when R5b lands). No
+user-visible change. Playbook §4 R5a updated to the realized
+scope + the recon correction (full `IShellAdapter` = R6).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/CYCLE-52-R5-PLAYBOOK.md
+++ b/docs/CYCLE-52-R5-PLAYBOOK.md
@@ -112,13 +112,32 @@ interface's `ShellEvent list` (CmdAdapter.fs:19 — "`ShellEvent`
 a real seam-wiring step. Sequenced (mirror the R1 "extract
 the seam, zero behaviour change" discipline):
 
-- **R5a — wire the adapter-selection seam, behaviour-
-  identical.** Make `CmdAdapter` implement `IShellAdapter`
-  (or introduce a thin selection layer), change
-  `startReaderLoop` + `SessionHost`/`switchToShell` to pick
-  the adapter by `ShellRegistry.ShellId`. **No PowerShell
-  yet.** cmd path byte-identical; CI + a quick dogfood gate
-  it (R1 precedent). This de-risks R5b.
+- **R5a — adapter-selection seam, behaviour-identical
+  (DONE — maintainer chose "literal R5a seam first"
+  2026-05-16; recon-corrected scope).** Recon finding: the
+  transport is already shell-agnostic *except* the OSC-133
+  injection (already `ShellId`-gated at two sites);
+  `CmdAdapter.Translate` is a verbatim `Parser.feedArray`
+  wrapper; the full `IShellAdapter` (Spawn/WriteInput) is a
+  big **non**-behaviour-identical refactor because spawn is
+  `ConPtyHost.start`-direct and input `host.WriteBytes`-
+  direct. So R5a is the **thin selection layer**, NOT full
+  `IShellAdapter` adoption: a single
+  `SessionHost.Osc133IntegratorFor : ShellId -> (string ->
+  string)` selector (cmd → `CmdAdapter.IntegrateOsc133`;
+  else → `id`) replacing the two inline `if = Cmd` gates
+  (`SessionHost.ResolveStartupShell` + `Program.fs`
+  `switchToShell`). **Byte-identical incl. logs** (the
+  cmd-only "R2 cmd OSC-133 … applied" line still fires
+  exactly when cmd; the single shared VT parser is NOT
+  reset across shell switches — unchanged; spawn/input
+  untouched). Pinned by `CmdAdapterTests`
+  (`Osc133IntegratorFor` dispatch). **R5b adds the
+  PowerShell arm in that ONE selector.** The full
+  `IShellAdapter` (Spawn/WriteInput/`ShellEvent`-Translate)
+  is the **R6** target, not R5 — the "Full IShellAdapter
+  now" option was explicitly rejected (large, non-
+  behaviour-identical, R6-class).
 - **R5b — `PowerShellAdapter`.** New
   `src/Terminal.Shell/PowerShellAdapter.fs` mirroring
   `CmdAdapter` (owns one `Parser.create()`; the parser is

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4636,18 +4636,25 @@ module Program =
                     // target so claude / PowerShell switches
                     // are byte-identical. The cmd transport
                     // adapter owns the injection (ADR 0006).
+                    // R5a (ADR 0006) — route the per-shell
+                    // OSC-133 injection through the single
+                    // selection seam (`SessionHost.Osc133-
+                    // IntegratorFor`) instead of an inline
+                    // `if = Cmd` gate. Byte-identical: cmd
+                    // wraps + logs exactly as before; non-cmd
+                    // is identity + no log (the pre-R5a `else`).
+                    // R5b adds the PowerShell arm in the
+                    // selector, not here.
                     let newCmdLine =
+                        let integrated =
+                            (Terminal.Shell.SessionHost.Osc133IntegratorFor
+                                target) newCmdLine
                         if target = ShellRegistry.Cmd then
-                            let integrated =
-                                Terminal.Shell.CmdAdapter.IntegrateOsc133
-                                    newCmdLine
                             log.LogInformation(
                                 "R2 cmd OSC-133 prompt injection applied (shell-switch). Base={Base} Integrated={Integrated}",
                                 newCmdLine,
                                 integrated)
-                            integrated
-                        else
-                            newCmdLine
+                        integrated
                     // Announce-before-launch pattern from
                     // Stage 4b's diagnostic-launcher: NVDA
                     // gets the cue into its speech queue

--- a/src/Terminal.Shell/SessionHost.fs
+++ b/src/Terminal.Shell/SessionHost.fs
@@ -124,16 +124,51 @@ type SessionHost private () =
         // shells (claude / PowerShell) are byte-identical. The
         // cmd transport adapter owns the injection (ADR 0006);
         // SessionHost only gates it on the resolved ShellId.
+        let integrated =
+            (SessionHost.Osc133IntegratorFor resolvedShell.Id)
+                resolvedCmdLine
+        // Behaviour-identical: the cmd-specific log fires
+        // exactly when it did pre-R5a (cmd only). R5b adds a
+        // distinct PowerShell injection log alongside its
+        // `Osc133IntegratorFor` arm, so this cmd line stays
+        // stable + greppable in the diagnostic bundle.
         if resolvedShell.Id = ShellRegistry.Cmd then
-            let integrated =
-                CmdAdapter.IntegrateOsc133 resolvedCmdLine
             log.LogInformation(
                 "R2 cmd OSC-133 prompt injection applied (startup). Base={Base} Integrated={Integrated}",
                 resolvedCmdLine,
                 integrated)
-            resolvedShell, integrated
-        else
-            resolvedShell, resolvedCmdLine
+        resolvedShell, integrated
+
+    /// R5a (ADR 0006 / [`docs/CYCLE-52-R5-PLAYBOOK.md`]) — the
+    /// shell-adapter SELECTION seam. The ONLY shell-specific
+    /// transport behaviour wired today is the OSC-133
+    /// command-line injection: cmd wraps via
+    /// `CmdAdapter.IntegrateOsc133`; every other shell is
+    /// identity — **byte-identical to the pre-R5a `else`
+    /// branch** at both spawn sites (startup
+    /// `ResolveStartupShell` + `Program.fs` `switchToShell`).
+    /// Centralised at the single orchestration point so the
+    /// per-`ShellId` dispatch lives in ONE place and **R5b
+    /// adds PowerShell in exactly this one arm**.
+    ///
+    /// Deliberately NOT the full `IShellAdapter` (Spawn /
+    /// WriteInput / byte→`ShellEvent` Translate): spawn stays
+    /// `ConPtyHost.start`-direct, input `host.WriteBytes`-
+    /// direct, and the single shared VT parser is NOT reset
+    /// across shell switches (all unchanged — behaviour-
+    /// identical, the R1 discipline). Broadening this toward
+    /// the full `IShellAdapter` contract is the R6 target;
+    /// rationale + the recon that corrected the R5a scope are
+    /// in the playbook.
+    static member Osc133IntegratorFor
+            (shellId: ShellRegistry.ShellId)
+            : string -> string
+            =
+        match shellId with
+        | ShellRegistry.Cmd ->
+            (fun cmdLine -> CmdAdapter.IntegrateOsc133 cmdLine)
+        | _ ->
+            (fun cmdLine -> cmdLine)
 
     /// Placeholder factory. Real adapter selection + spawn
     /// wiring lands in a subsequent R1 step; the constructor

--- a/tests/Tests.Unit/CmdAdapterTests.fs
+++ b/tests/Tests.Unit/CmdAdapterTests.fs
@@ -51,6 +51,44 @@ let ``IntegrateOsc133 wraps the base command line with /K prompt, unquoted`` () 
         "cmd.exe /K prompt $e]133;D$e\\$e]133;A$e\\$p$g$e]133;B$e\\",
         integrated)
 
+// ---------------------------------------------------------------------
+// R5a (ADR 0006) — the shell-adapter SELECTION seam.
+// `SessionHost.Osc133IntegratorFor` centralises the per-ShellId
+// OSC-133 injection dispatch that was previously inlined as an
+// `if = Cmd` gate at the two spawn sites. R5a is byte-identical:
+// cmd wraps exactly like `CmdAdapter.IntegrateOsc133`; every
+// other shell is identity (the pre-R5a `else`). These pin the
+// dispatch so R5b adding the PowerShell arm is a deliberate,
+// test-visible change (this `DoesNotContain "133"` flips then).
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``Osc133IntegratorFor Cmd wraps exactly like CmdAdapter.IntegrateOsc133`` () =
+    let integ =
+        Terminal.Shell.SessionHost.Osc133IntegratorFor
+            Terminal.Pty.ShellRegistry.Cmd
+    Assert.Equal(
+        Terminal.Shell.CmdAdapter.IntegrateOsc133 "cmd.exe",
+        integ "cmd.exe")
+    Assert.Equal(
+        "cmd.exe /K prompt $e]133;D$e\\$e]133;A$e\\$p$g$e]133;B$e\\",
+        integ "cmd.exe")
+
+[<Fact>]
+let ``Osc133IntegratorFor non-cmd is identity (byte-identical pre-R5a)`` () =
+    // R5b will replace the PowerShell arm; until then every
+    // non-cmd shell returns its command line unchanged — exactly
+    // the pre-R5a `else` branch at both spawn sites.
+    let psI =
+        Terminal.Shell.SessionHost.Osc133IntegratorFor
+            Terminal.Pty.ShellRegistry.PowerShell
+    let clI =
+        Terminal.Shell.SessionHost.Osc133IntegratorFor
+            Terminal.Pty.ShellRegistry.Claude
+    Assert.Equal("powershell.exe", psI "powershell.exe")
+    Assert.DoesNotContain("133", psI "powershell.exe")
+    Assert.Equal("claude", clI "claude")
+
 [<Fact>]
 let ``IntegrateOsc133 preserves an arbitrary base path verbatim`` () =
     // The fn is pure (the cmd-only gate lives at the SessionHost /


### PR DESCRIPTION
## Summary

Cycle 52 **R5a — adapter-selection seam (behaviour-identical)**. First step after the maintainer's R1–R4+R4c foundation dogfood sign-off.

Recon corrected the playbook's R5a premise: the transport is already shell-agnostic *except* the OSC-133 injection (already `ShellId`-gated at two sites); `CmdAdapter.Translate` is a verbatim `Parser.feedArray` wrapper; the full `IShellAdapter` (`Spawn`/`WriteInput`) is a large **non-behaviour-identical** refactor (spawn is `ConPtyHost.start`-direct, input `host.WriteBytes`-direct) — that's the **R6** target, explicitly not R5. Maintainer chose "literal R5a seam first".

So R5a is the **thin selection layer**, not full `IShellAdapter` adoption:

- New `SessionHost.Osc133IntegratorFor : ShellRegistry.ShellId -> (string -> string)` — `Cmd` → `CmdAdapter.IntegrateOsc133`; every other shell → identity.
- Replaces the two inline `if = Cmd` OSC-133 gates: `SessionHost.ResolveStartupShell` (startup) + `Program.fs` `switchToShell` (hot-switch).
- **Byte-identical including logs:** the cmd-only `"R2 cmd OSC-133 … applied"` line still fires exactly when cmd (non-cmd: identity transform, no log — the pre-R5a `else`). The single shared VT parser is still **not** reset across shell switches; spawn/input paths untouched.
- Centralises the per-`ShellId` dispatch so **R5b adds PowerShell in exactly one arm**.
- Pinned by two `CmdAdapterTests` facts: `Osc133IntegratorFor Cmd` wraps exactly like `CmdAdapter.IntegrateOsc133`; non-cmd is identity (the `DoesNotContain "133"` assertion flips deliberately when R5b lands).

Playbook §4 R5a updated to the realized scope + the recon correction (full `IShellAdapter` = R6). CHANGELOG entry added. No user-visible change; locally unverifiable (CI is the build signal — full Windows build/test required since this touches `.fs`).

## Test plan

- [ ] CI green (build + unit tests on windows-latest — the only build signal; verifies the F# selector + the two refactored gate sites compile and the `Osc133IntegratorFor` pins pass).
- [ ] Quick cmd dogfood at R5 start (NVDA): fresh launch + a shell switch cmd→claude→cmd still behave byte-identically (the seam is transparent); the `R2 cmd OSC-133 … applied` log still appears for cmd in the `Ctrl+Shift+D` bundle, absent for claude.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_