### PR TITLE
CLAUDE.md: CI-failure log requests must use AskUserQuestion (phone surface)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,19 +189,30 @@ requests". Quick reminders:
 ### CI failures — ask for the log, don't guess
 
 When a CI check fails on a PR, **ask the user to paste the relevant
-log slice** rather than guessing at the failure cause. The local
-sandbox blocks `productionresultssa*.blob.core.windows.net` and
-`api.github.com`, so you cannot fetch CI run logs directly via
-`WebFetch` or `curl` — both 403. The GitHub MCP tools don't return
-job logs either. Without the user's paste, any fix is inferred from
-the diff alone — which produces unfocused fixup commits that may
-miss the real issue. PR #132 demonstrated the failure mode: two
-speculative fixes (`Process.Start` nullness + sequence-in-match-arm
-refactor) were both wrong; the actual cause was an `FS0039`
-record-label resolution issue only visible in the build log.
+log slice** rather than guessing at the failure cause. **This
+request MUST be made via the `AskUserQuestion` tool, never plain
+text** — `AskUserQuestion` pushes a phone notification so the
+maintainer is alerted even away from the desk; a plain-text request
+sits silently in the transcript and stalls the loop (maintainer
+instruction 2026-05-16, after several CI-log asks were sent as plain
+text). This is **not a judgment call about whether the maintainer
+seems present** — always use `AskUserQuestion` for a CI-failure log
+request. Frame the question with the failing-job URL + the exact
+strings to search (screen-reader-friendly, see below) as the
+question/options text. The local sandbox blocks
+`productionresultssa*.blob.core.windows.net` and `api.github.com`,
+so you cannot fetch CI run logs directly via `WebFetch` or `curl` —
+both 403. The GitHub MCP tools don't return job logs either.
+Without the user's paste, any fix is inferred from the diff alone —
+which produces unfocused fixup commits that may miss the real issue.
+PR #132 demonstrated the failure mode: two speculative fixes
+(`Process.Start` nullness + sequence-in-match-arm refactor) were
+both wrong; the actual cause was an `FS0039` record-label
+resolution issue only visible in the build log.
 
 **Request format — the maintainer uses a screen reader.** Long
-logs aren't `Ctrl+F`-searchable on a screen reader. Either:
+logs aren't `Ctrl+F`-searchable on a screen reader. In the
+`AskUserQuestion` body, either:
 
 - Ask for the full log paste and grep server-side via `Bash`
   against the pasted content, OR
@@ -209,10 +220,13 @@ logs aren't `Ctrl+F`-searchable on a screen reader. Either:
   (`error FS`, `error MSB`, `Failed!`, `Build FAILED`, the test
   name) and request the surrounding 5–10 lines.
 
-The second option is usually faster for the maintainer. If the
-user isn't around, queue the question and wait. **Do not push
-speculative fixups** — the cost of one wrong fix is multiple
-minutes of wasted CI cycle plus a noisier git history.
+The second option is usually faster for the maintainer. **Do not
+push speculative fixups** — the cost of one wrong fix is multiple
+minutes of wasted CI cycle plus a noisier git history. (A flaky
+run is the exception to "investigate the diff": if the failure is
+unrelated to the change — infra/runner/network flake — a re-run
+clears it; the maintainer may just say "flaky, green now", in
+which case proceed to merge.)
 
 ### Diagnostic logs — request chunks via the in-app menu
 
@@ -735,8 +749,11 @@ Use `AskUserQuestion` when:
   proceed (e.g. "preserve vs drop history-recall entries in
   ContentHistory" — answered 2026-05-14 via this surface).
 - A CI failure log slice is needed (per "CI failures — ask for
-  the log" rule above) and the maintainer may be away from the
-  desk.
+  the log" rule above). **Always** — not conditioned on whether
+  the maintainer seems present. Plain-text CI-log requests
+  stalled the loop several times on 2026-05-16; the maintainer
+  explicitly asked that these always come through
+  `AskUserQuestion` so the phone buzzes.
 - The MCP server has disconnected and the manual PR-create
   fallback needs the maintainer to open a compare URL.
 - Anything ambiguous in the user's instructions that genuinely


### PR DESCRIPTION
## Summary

Docs-only (CLAUDE.md). Codifies the maintainer's 2026-05-16 instruction: **CI-failure log requests must go through `AskUserQuestion`** (which pushes a phone notification), never plain text (which sits silently in the transcript and stalls the loop).

- §"CI failures — ask for the log": the request **MUST** be made via `AskUserQuestion`, **not a judgment call** about whether the maintainer seems present. Frame the failing-job URL + exact search strings as the question body. Added an explicit **flaky-run exception** (unrelated infra/runner/network flake → a re-run clears it; "flaky, green now" → proceed to merge — exactly what just happened on #377).
- §"`AskUserQuestion` is the maintainer's phone-notification surface": the CI-log bullet changed from the hedged "and the maintainer may be away from the desk" to "**Always** — not conditioned on whether the maintainer seems present", with the dated rationale.

No code.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge lane — strictly `.md`).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_