### PR TITLE
Cycle 52 P3: investigated; risky half re-scoped as deferred P3b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14478,6 +14478,29 @@ one `&&`-condition change; no user-visible change on the
 golden path; locally unverifiable (CI is the build signal).
 Playbook §5 P2 marked done.
 
+### Cycle 52 P3 (2026-05-16): investigated; safe half is a no-op, risky half re-scoped as deferred P3b
+
+Docs-only. P3 (audit-classified "safe-to-delete dead pathway
+config keys") investigated and found mis-scoped: (a) the
+**generated `config.toml` template is already clean** — it has
+no `#[pathway.stream]` / `#substrate_mode` lines (the
+maintainer's on-disk file showing them is a stale-build
+artifact; `Ctrl+Shift+E` only creates-if-missing, never
+rewrites), so that half is a no-op; (b)
+`ShellPathwayConfig.PathwayId` + `resolvePathwayForShell` +
+`[pathway.<id>]` parameter parsing are confirmed dead (no live
+`Terminal.App` consumer — grep-verified) **but entangled in
+the live `ShellPathwayConfig` record** which also carries the
+live `Verbosity` → `currentShellPolicy.Streaming/PromptPath`
+config consumed throughout `Program.fs`. Removing the dead bits
+is a surgical, wide, locally-unverifiable record/parser
+refactor of a ~1000-line core config module — deliberately not
+bundled into the P1–P5 proceed-pass (no-risky-locally-
+unverifiable-rip discipline). Re-scoped as deferred **P3b**
+(ADR 0006 §"Deferred to R6+" item 8), low priority (inert; not
+gating R6). No code change; finding + deferral recorded so a
+fresh session doesn't re-attempt the "safe delete".
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/CYCLE-52-R5-PLAYBOOK.md
+++ b/docs/CYCLE-52-R5-PLAYBOOK.md
@@ -285,14 +285,30 @@ PowerShell adapter is built against a pruned tree:
   falls back to the cmd-heuristic-era synthetic marker —
   exactly the R3a precedence principle. Comment + one
   `&&`-condition change; CI-green.
-- **P3 — dead pathway config keys (safe-to-delete).** The
-  `[pathway.<id>]` TOML schema + `pathway` key parsing in
-  [`src/Terminal.Core/Config.fs`](../src/Terminal.Core/Config.fs)
-  are parsed but unconsumed since Cycle 45c deleted the
-  pathway pipeline. Remove the parsing + deprecate the
-  schema with a one-line comment. Also drop the dead
-  `#[pathway.stream]` / `#substrate_mode` lines in the
-  generated `config.toml` template.
+- **P3 — dead pathway config keys (INVESTIGATED 2026-05-16,
+  #380; re-scoped — audit's "safe-to-delete" was
+  optimistic).** Findings: (a) the generated `config.toml`
+  template
+  ([`src/Terminal.Core/Config.fs`](../src/Terminal.Core/Config.fs)
+  :218+) is **already clean** — it has **no**
+  `#[pathway.stream]` / `#substrate_mode` lines; the
+  maintainer's on-disk file showing them is a stale-build
+  artifact (`Ctrl+Shift+E` only creates-if-missing, never
+  rewrites). So that half of P3 is a **no-op**. (b)
+  `ShellPathwayConfig.PathwayId` + `resolvePathwayForShell`
+  + the `[pathway.<id>]` parameter-table parsing are
+  confirmed **dead** (no live consumer in `Terminal.App` —
+  grep-verified) **but entangled in the live
+  `ShellPathwayConfig` record**, which also carries the
+  live `Verbosity` → `currentShellPolicy.Streaming/PromptPath`
+  config consumed throughout `Program.fs`. Removing the
+  dead field/resolver is therefore a surgical, wide-ish,
+  **locally-unverifiable** record/parser refactor — NOT a
+  clean delete. Per the "no risky locally-unverifiable rip
+  in a proceed-pass" discipline it is **re-scoped as
+  deferred P3b** (ADR 0006 §"Deferred to R6+"), not
+  bundled. Net P3 deliverable: this finding recorded; no
+  code change (nothing safe + substantial to ship).
 - **P4 — canonical-corpus ESC-byte fix (bug).**
   [`tests/fixtures/canonical-interactions.toml`](../tests/fixtures/canonical-interactions.toml):146
   (`command = "echo <ESC>[31mPtySpeakDiagRedText<ESC>[0m"`)

--- a/docs/adr/0006-three-layer-refoundation.md
+++ b/docs/adr/0006-three-layer-refoundation.md
@@ -463,6 +463,27 @@ would be premature.
    PS feature behaviour (per-line progress, prompt
    verbosity) defines the concrete scenario list has no
    signal; wire it when R6 needs PS-specific manual tests.
+8. **P3b — remove dead pathway config plumbing**
+   (investigated 2026-05-16, #380). `ShellPathwayConfig.
+   PathwayId` + `resolvePathwayForShell` + the
+   `[pathway.<id>]` parameter-table parsing in
+   `Terminal.Core/Config.fs` are confirmed dead (no live
+   `Terminal.App` consumer since Cycle 45c deleted the
+   pathway pipeline) **but entangled in the live
+   `ShellPathwayConfig` record**, which also carries the
+   live `Verbosity` → `currentShellPolicy.Streaming/
+   PromptPath` config consumed throughout `Program.fs`.
+   Removal is a surgical, wide-ish, locally-unverifiable
+   record/parser refactor of a ~1000-line core config
+   module — deliberately NOT bundled into the P1–P5
+   proceed-pass (the audit's "safe-to-delete" was
+   optimistic; the cmd announce FREEZE does not apply but
+   the no-risky-locally-unverifiable-rip discipline does).
+   Its own careful PR: extract/rename the record so the
+   live `Verbosity`/prompt-path config is preserved
+   byte-for-byte while `PathwayId`/resolver/`[pathway.*]`
+   parsing are dropped + a deprecation note added. Low
+   priority (inert; pure cleanliness); not gating R6.
 
 Each stage independently CI-gated and dogfood-validated. R1
 and R4 are the new structural gates that make the boundary


### PR DESCRIPTION
## Summary

Docs-only. **P3 — investigated; the audit's "safe-to-delete dead pathway config keys" was mis-scoped.**

Findings:
- **(a) The generated `config.toml` template is already clean** (`Config.fs:218+`) — it has **no** `#[pathway.stream]` / `#substrate_mode` lines. The maintainer's on-disk file showing them is a stale-build artifact (`Ctrl+Shift+E` only creates-if-missing, never rewrites an existing file). That half of P3 is a **no-op**.
- **(b)** `ShellPathwayConfig.PathwayId` + `resolvePathwayForShell` + `[pathway.<id>]` parameter parsing are confirmed **dead** (no live `Terminal.App` consumer — grep-verified) **but entangled in the live `ShellPathwayConfig` record**, which also carries the live `Verbosity` → `currentShellPolicy.Streaming/PromptPath` config consumed throughout `Program.fs` (the tuple-final announce gate, etc.). Removing the dead bits is a surgical, wide, **locally-unverifiable** record/parser refactor of a ~1000-line core config module — not a clean delete.

Per the no-risky-locally-unverifiable-rip discipline (no `dotnet` here; the cost of a wrong core-module change is a multi-minute CI round-trip), the surgery is **re-scoped as deferred P3b** (ADR 0006 §"Deferred to R6+" item 8) rather than bundled into the P1–P5 proceed-pass. Low priority — the code is inert; not gating R6.

No code change. The finding + deferral are recorded (playbook §5 P3, ADR 0006 item 8, CHANGELOG) so a fresh session doesn't re-attempt the "safe delete" and walk into the entangled refactor unaware.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge lane — strictly `.md`).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_