### PR TITLE
ADR 0009: Proposed → Accepted (maintainer ratified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15161,6 +15161,17 @@ ADR 0007 ship-log, CLAUDE.md reading order. **Not accepted;
 no code or schema change until ratified; independent of
 Phase 4; not in the autonomous sprint.**
 
+### Cycle 52 — ADR 0009 Accepted (2026-05-17)
+
+Doc-only. Maintainer ratified ADR 0009 ("I am happy with the
+ADR additions and you can mark those resolved"): **Proposed →
+Accepted**. Design locked (typed `CellOutcome` + disciplined
+metadata/tags + `schemaVersion 3`); **not yet implemented** —
+P-A is the independently-landable start, scheduled at the
+maintainer's call, independent of ADR 0007 Phase 4.
+Status/cross-refs updated in ADR 0009, ADR 0004 forward-note,
+ADR 0007 ship-log, CLAUDE.md reading order.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,14 +140,16 @@ before deviating.
    before any SpeechCursor / IOCell-history / channel /
    substrate work.
 9a. **[`docs/adr/0009-canonical-cell-metadata-and-typed-outcome.md`](docs/adr/0009-canonical-cell-metadata-and-typed-outcome.md)**
-   — Cycle 52 **Proposed** (2026-05-17, maintainer-requested
-   draft). Would add a typed `CellOutcome` (ADR 0008 applied:
-   honest `Indeterminate` where no signal is transported —
-   the `52-ADR7-P2c` lesson) + a disciplined (closed/bounded,
+   — Cycle 52 **Accepted** (2026-05-17, maintainer ratified).
+   Adds a typed `CellOutcome` (ADR 0008 applied: honest
+   `Indeterminate` where no signal is transported — the
+   `52-ADR7-P2c` lesson) + a disciplined (closed/bounded,
    *not* free-blob) metadata/tag facility, bumping the
    ADR 0004 wire format `schemaVersion 2 → 3`; generalises
-   ADR 0007 Phase 6b/6c. **Not accepted; no code/schema
-   change until ratified.** Read before any cell-metadata /
+   ADR 0007 Phase 6b/6c. **Accepted but NOT yet implemented**
+   — P-A (typed outcome + v3 + round-trip reader) is the
+   start, independently landable, scheduled at the
+   maintainer's call. Read before any cell-metadata /
    outcome / schema-version / tag-search work.
 10. **RFC 0001 (archived)** — Cycle 33 pivot-gate RFC, formalised
    the `LinearTextStream` substrate + streaming-emission protocol.

--- a/docs/adr/0004-iocell-model-for-shell-interaction.md
+++ b/docs/adr/0004-iocell-model-for-shell-interaction.md
@@ -493,11 +493,11 @@ schemaVersion bump.
 
 > **Forward note (2026-05-17):**
 > [ADR 0009](0009-canonical-cell-metadata-and-typed-outcome.md)
-> (**Proposed**, not accepted) would extend this same
-> hand-rolled discipline `schemaVersion 2 → 3` to add a typed
-> `CellOutcome` + a disciplined (closed/bounded, *not* free
-> blob) metadata facility. No schema change until that ADR is
-> ratified.
+> (**Accepted** 2026-05-17; not yet implemented) extends this
+> same hand-rolled discipline `schemaVersion 2 → 3` to add a
+> typed `CellOutcome` + a disciplined (closed/bounded, *not*
+> free blob) metadata facility. The v3 bump + round-trip
+> reader land together in ADR 0009 phase P-A when scheduled.
 
 ### In-memory representation
 

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -821,14 +821,15 @@ instruction, not buried in chat text.
   own CI-green PR + `52-ADR7-P*` dogfood row once Phase 4
   is unblocked.
 - **Cell metadata / typed outcome** (maintainer ask
-  2026-05-17) — drafted as
+  2026-05-17) —
   [ADR 0009](0009-canonical-cell-metadata-and-typed-outcome.md)
-  (**Proposed**). Its D5 generalises **Phase 6b**
-  kind-filtered jumps to outcome/tag-filtered search; its
-  P-B backs **Phase 6c** bookmarks; D3 ratifies the
-  D9/Phase-6a `CellId`-as-focus-key contract. Independent
-  of Phase 4; not in the autonomous sprint; no code until
-  ratified.
+  (**Accepted** 2026-05-17; not yet implemented). Its D5
+  generalises **Phase 6b** kind-filtered jumps to
+  outcome/tag-filtered search; its P-B backs **Phase 6c**
+  bookmarks; D3 ratifies the D9/Phase-6a
+  `CellId`-as-focus-key contract. Independent of Phase 4;
+  not in the autonomous sprint; P-A landable when the
+  maintainer schedules it.
 
 ## Phase 4 readiness brief (autonomous-sprint stop point, 2026-05-17)
 

--- a/docs/adr/0009-canonical-cell-metadata-and-typed-outcome.md
+++ b/docs/adr/0009-canonical-cell-metadata-and-typed-outcome.md
@@ -1,11 +1,13 @@
 # ADR 0009 — Canonical cell metadata & typed outcome (schemaVersion 3)
 
-- **Status**: **Proposed** (2026-05-17; maintainer requested
-  the design be drafted into an ADR for review — option "A".
-  **NOT accepted, NOT implemented; no schema change until
-  ratified.** Not in the autonomous-sprint scope.)
+- **Status**: **Accepted** (2026-05-17; maintainer ratified
+  — "I am happy with the ADR additions and you can mark those
+  resolved". Design is locked; **still NOT implemented** — no
+  code or schema change yet. P-A is the start (independently
+  landable; does not block or depend on ADR 0007 Phase 4).
+  Not in the autonomous-sprint scope.)
 - **Date**: 2026-05-17
-- **Deciders**: maintainer (KyleKeane) — pending ratification
+- **Deciders**: maintainer (KyleKeane) — ratified 2026-05-17
 - **Authoring item**: Cycle 52, during the ADR 0007 phase
   sprint. The maintainer asked whether the canonical cell
   history includes "a mechanism for arbitrary tags and
@@ -192,9 +194,12 @@ sequence (this slots alongside, it does not gate Phase 4).
 
 ## Status / next
 
-**Proposed 2026-05-17, awaiting maintainer ratification.**
-Drafted at maintainer request (option "A") for review — *no
-code, no schema change* until accepted. On acceptance, P-A is
-the start (independently landable; does not block or depend
-on ADR 0007 Phase 4). The autonomous sprint does **not**
-implement this.
+**Accepted 2026-05-17 (maintainer ratified).** Design locked;
+**not yet implemented** — no code or schema change has
+landed. **P-A** is the start (typed `CellOutcome` + derivation
++ `CellView` projection + `jumpToLastError` reframed +
+`schemaVersion 3` serializer & round-trip reader); it is
+independently landable and does **not** block or depend on
+ADR 0007 Phase 4. Sequencing of P-A vs the remaining ADR 0007
+phases is the maintainer's call (raise when ready). The
+autonomous sprint does **not** implement this.


### PR DESCRIPTION
## Summary

Docs-only. Maintainer ratified ADR 0009 ("I am happy with the ADR additions and you can mark those resolved"): **Proposed → Accepted**.

- ADR 0009 Status → **Accepted (2026-05-17)**; design locked, **not yet implemented** (P-A — typed `CellOutcome` + `schemaVersion 3` + round-trip reader — is the independently-landable start, scheduled at the maintainer's call, independent of ADR 0007 Phase 4).
- Cross-ref wording flipped Proposed→Accepted in: ADR 0004 forward-note, ADR 0007 ship-log, CLAUDE.md reading order, CHANGELOG.

## Test plan

- [ ] Markdown link check green (docs-only)

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_