### PR TITLE
ADR 0007 re-sequencing: Phase 6a pulled forward; open decisions A/B/C resolved

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -22,16 +22,30 @@ and serves the decision-trail role this file used to overload.
 > surfaced and recorded (not patched, FREEZE): ADR 0006
 > §"Deferred to R6+" item 1 **"Tracked variant 1"**
 > (command-line-edit input/output desync) and **"Tracked
-> variant 2"** (clean-command argument truncation). **The
-> sprint deliberately STOPPED at Phase 4** — it is a
-> multi-stage architecture decision (segment model cascades
-> into 5/7/6a) with a maintainer-Claude-dogfood-gated open
-> decision; see
-> [ADR 0007 "Phase 4 readiness brief"](adr/0007-canonical-iocell-history-navigation.md)
-> for the resolved (granularity) vs maintainer-gated
-> (Claude interplay; segments↔sealed-cell model) decisions
-> and the one-word unblock ("C1, proceed"). Phase 6a's
-> NVDA dogfood remains the hard D8 ratification gate.
+> variant 2"** (clean-command argument truncation).
+> **RE-SEQUENCED 2026-05-17 (maintainer-ratified) — this
+> supersedes the earlier "STOPPED at Phase 4 / one-word
+> unblock (C1, proceed)" framing.** The maintainer
+> re-sequenced rather than just unblocking 4a:
+> **Phase 6a (the cell-history interface scaffolding) is
+> pulled forward and STARTS NOW** on cmd/PowerShell —
+> decoupled from the segment model; it depends only on D1+D2
+> (both shipped) and renders fine with imperfect cell
+> boundaries (an orthogonal, already-tracked concern).
+> Open decisions: **C = C1 ratified** (keep both live
+> `ProgressSegment`s + the sealed `Output`) **+** a
+> first-class **differentiable-`CellKind` / cell-history
+> filtering** requirement; **A deferred** (granularity is a
+> Phase-4-implementation detail, not now); **B + Claude
+> complexity deferred**, folded into a new
+> **boundary-diagnostic-capture track** (timestamped record
+> of every shell/Claude-CLI event → analyse boundary signals
+> from data, cmd/PowerShell first). Order:
+> **Phase 6a now → boundary-diagnostic track → Phase 4/4b/5
+> → Phase 6b+ filtering / Phase 7 oracle.** Canonical detail:
+> [ADR 0007 § Re-sequencing amendment — 2026-05-17](adr/0007-canonical-iocell-history-navigation.md#re-sequencing-amendment-2026-05-17-maintainer-ratified).
+> Phase 6a's NVDA dogfood remains the hard D8 ratification
+> gate.
 > Original recovery brief continues below.
 
 > **NEW / RECOVERED SESSION START HERE →
@@ -65,11 +79,13 @@ and serves the decision-trail role this file used to overload.
 > / D8 standard UIA control, `Tree`-rec, 6a-dogfood-gated /
 > D9 cell events on the canonical pipeline). D9's principle
 > elevated to **[ADR 0008](adr/0008-maximal-semantic-surfacing.md)**
-> (Accepted). **Implementation in progress: full Phase 0…7,
-> each its own PR + dogfood. Phase 0 = delete the 7 dead Seq
-> functions (net-subtractive, no audible change) — STARTS
-> NOW.** Next = Phase 0 → 1…7 → R6d (PS-diagnostics submenu)
-> → R7 (claude + closure).**
+> (Accepted). **Implementation: Phase 0→3 shipped CI-green;
+> re-sequenced 2026-05-17 (see the top banner) — Phase 6a now
+> → boundary-diagnostic track → Phase 4/4b/5 → Phase 6b+ /
+> Phase 7**, then R6d (PS-diagnostics submenu) → R7 (claude +
+> closure). *(Superseded next-step text — the top
+> 2026-05-17 banner is authoritative; this line kept for
+> recovery context.)*
 > The maintainer-flagged "prompt announce interrupts the
 > output read" is parked as ADR 0006 §"Deferred to R6+"
 > item 10 (NOT addressed now, maintainer's call). The cmd

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -576,9 +576,12 @@ changes the ADR 0004 IOCell schema.
   section markers; the operation-discovery menu surfaces) —
   each validated against real navigation feel once the basic
   list works, not built speculatively. Largest channel-side
-  change; sequenced last because it depends on the typed
+  change; ~~sequenced last because it depends on the typed
   model (D1), the per-cell ops (D2 — items host them), and
-  the segment model (Phases 4–5) being settled. Splits into
+  the segment model (Phases 4–5) being settled~~ **— amended
+  2026-05-17: 6a is decoupled from the segment model and
+  pulled forward; it depends only on D1 + D2 (both shipped).
+  See § Re-sequencing amendment 2026-05-17.** Splits into
   sub-phases: **6a** basic control (D8: `TreeView`/UIA `Tree`
   primary, `ListBox`/UIA `List` fallback) + `Ctrl+Shift+
   Left/Right` pane switch + the D9 `pty-speak.cell.*` event
@@ -637,12 +640,19 @@ changes the ADR 0004 IOCell schema.
 - **ProgressSegment granularity** (Phase 4): one segment per
   idle-flush chunk vs coalesced cadence. Tie to ADR 0006
   deferred item 9 (queue-and-coalesce); must not regress the
-  R3c/R3e watermark composition.
+  R3c/R3e watermark composition. **DEFERRED (amendment
+  2026-05-17): not a now-decision; the one-per-idle-flush
+  default stands to be revisited at Phase 4 implementation,
+  informed by the boundary-diagnostic capture.**
 - **Claude `IdleFlushMs = None` interplay** (Phase 4):
   Claude emits no idle-flush boundary today. Either derive
   `ProgressSegment` boundaries from Claude's own
   newline/turn structure, or revisit `IdleFlushMs` for
-  Claude. Decide in Phase 4 with a Claude dogfood.
+  Claude. ~~Decide in Phase 4 with a Claude dogfood.~~
+  **SUBSUMED (amendment 2026-05-17) into the
+  boundary-diagnostic-capture track; Claude explicitly
+  deferred until cmd/PowerShell interface + methodology
+  settled.**
 - **rerun-input safety** (Phase 3): **RESOLVED 2026-05-17
   (maintainer, post-`52-ADR7-P3` dogfood).** The shipped
   two-step arm/confirm was the conservative reading; the
@@ -801,13 +811,15 @@ self-check the agent runs, with only a thin audible-delivery
 confirmation left to the maintainer — so the walking-skeleton
 loop gets materially cheaper as the phases progress.
 
-**Implementation order**: Phase 0 (delete the dead Seq
-engine — net-subtractive, no audible change, the single-model
-precondition) starts immediately as its own PR; Phases 1→7
-follow, each gated by its own CI + dogfood. CI failures and
-essential blocking questions are raised via `AskUserQuestion`
-(phone notification), per the maintainer's standing
-instruction, not buried in chat text.
+**Implementation order**: Phase 0 → 1 → 2 → 3 shipped
+CI-green. **Re-sequenced 2026-05-17** (see
+[§ Re-sequencing amendment](#re-sequencing-amendment-2026-05-17-maintainer-ratified)):
+**Phase 6a now → boundary-diagnostic track → Phase 4/4b/5 →
+Phase 6b+ / Phase 7**, each gated by its own CI + dogfood
+(6a's NVDA dogfood = the hard D8 control-type ratification
+gate). CI failures and essential blocking questions are
+raised via `AskUserQuestion` (phone notification), per the
+maintainer's standing instruction, not buried in chat text.
 
 **Ship log (per-phase, updated as phases land):**
 
@@ -848,26 +860,27 @@ instruction, not buried in chat text.
   test-script insertion uses; `InjectCommand` deleted as
   dead code). Re-dogfood row `52-ADR7-P3` (new behaviour)
   pending.
-- **Phase 4** — **autonomous-sprint stop point (2026-05-17).**
-  NOT implemented. Phase 4's deliverable is inherently the
-  in-flight live-feed integration *and* the
-  ProgressSegment↔sealed-cell model relationship — a
-  multi-stage architecture decision (Phases 5/7/6a build on
-  the segment model) — *and* one of its open decisions (the
-  Claude `IdleFlushMs = None` interplay) explicitly requires
-  a maintainer Claude dogfood that the agent cannot run.
-  Per the standing "don't decide multi-stage architecture
-  unilaterally" rule, the agent stopped here rather than
-  guess a cascading foundation. See **"Phase 4 readiness
-  brief"** below for the resolved/blocked open decisions and
-  the proposed 4a/4b split.
-- **Phases 5 → 7** — gated behind Phase 4's segment model
-  being settled (5 = intra-cell segments on it; 7's oracle
-  asserts it; 6a depends on D1+D2+segment-model). The
-  Phase 6a NVDA dogfood remains the **hard D8 control-type
-  ratification gate** regardless. Each will land as its
-  own CI-green PR + `52-ADR7-P*` dogfood row once Phase 4
-  is unblocked.
+- **Phase 4** — **deferred by the 2026-05-17 re-sequencing
+  amendment** (was the autonomous-sprint stop point). Open
+  decision A's default stands to be revisited here; B is
+  subsumed into the new boundary-diagnostic-capture track;
+  **C is RESOLVED — C1** + the differentiable-kind / filtering
+  requirement. Phase 4/4b/5 now sequence *after* Phase 6a +
+  the boundary-diagnostic track. See
+  [§ Re-sequencing amendment](#re-sequencing-amendment-2026-05-17-maintainer-ratified)
+  (it supersedes the "Phase 4 readiness brief" below, which is
+  retained as the decision trail).
+- **Phase 6a** — **pulled forward; STARTS NOW** per the
+  re-sequencing amendment. Decoupled from the segment model;
+  depends only on D1 + D2 (both shipped). Kind-generic
+  focusable history list (D8) + `Ctrl+Shift+Left/Right` pane
+  switch + the D9 `pty-speak.cell.*` event family, on existing
+  cmd/PowerShell cells. Its NVDA dogfood remains the **hard
+  D8 control-type ratification gate**.
+- **Phases 4/4b/5 → 7** — sequence after Phase 6a + the
+  boundary-diagnostic track (5 = intra-cell segments on the
+  settled model; 7's oracle asserts it). Each lands as its
+  own CI-green PR + `52-ADR7-P*` dogfood row.
 - **Cell metadata / typed outcome** (maintainer ask
   2026-05-17) —
   [ADR 0009](0009-canonical-cell-metadata-and-typed-outcome.md)
@@ -880,6 +893,20 @@ instruction, not buried in chat text.
   maintainer schedules it.
 
 ## Phase 4 readiness brief (autonomous-sprint stop point, 2026-05-17)
+
+> **⚠ SUPERSEDED 2026-05-17 by
+> [§ Re-sequencing amendment](#re-sequencing-amendment-2026-05-17-maintainer-ratified).**
+> Retained as the decision trail (the delta between this
+> proposal and the ratified re-sequencing is itself a useful
+> artifact, per the project's mark-historical-don't-delete
+> discipline). Things this brief says that are now untrue:
+> "Phase 4 is the deliberate stop / one word ('C1, proceed')
+> unblocks 4a" — the maintainer instead re-sequenced (Phase 6a
+> pulled forward; A deferred; B folded into the
+> boundary-diagnostic track; C = C1 + a differentiable-kind /
+> filtering requirement). Read the amendment for the live
+> plan; the A/B/C analysis below remains accurate as the
+> *input* to that decision.
 
 Phases 0–3 shipped CI-green this sprint (2a/2b dogfood
 feature-PASSED; 2c/3 dogfood rows pending). Phase 4 is the
@@ -950,3 +977,151 @@ guessed live-feed integration and no compiler/dogfood
 feedback is exactly the half-finished speculative scaffolding
 the guidelines forbid. One word from the maintainer ("C1,
 proceed") unblocks 4a immediately.
+
+## Re-sequencing amendment 2026-05-17 (maintainer-ratified)
+
+The maintainer reviewed the Phase 4 readiness brief and,
+rather than simply unblocking 4a, **re-sequenced the plan**.
+Verbatim intent (2026-05-17): keep every piece of the
+interaction and tag each with a clearly-differentiable kind so
+the user can *skip or filter* segments in the interface; take a
+comprehensive, timestamped diagnostic record of every event
+from each shell (the Claude Code CLI especially — spinner +
+time-interval chunks into an ongoing thread) so boundary
+markers are derived from real signal analysis, not guesswork;
+**focus cmd + PowerShell first and get the cell-history
+interface + navigation scaffolding in place before engaging
+other-shell (Claude) boundary complexity.** The maintainer
+explicitly asked whether the interface can be scaffolded now
+even with imperfect cell boundaries — it can (rationale
+below) — and confirmed "proceed with autonomy" (2026-05-17).
+This amendment is the ratified record; it does **not** change
+the IOCell data model (ADR 0004 stands) or D1–D9/D5a.
+
+### Open decisions A / B / C — resolved by this amendment
+
+- **A — ProgressSegment granularity — DEFERRED, not a
+  now-decision.** The maintainer's question ("do you really
+  need this right now?") is correct: granularity only bites
+  when segment *generation* is implemented (Phase 4), which
+  this amendment defers behind the interface scaffolding and
+  the boundary-diagnostic track. The brief's conservative
+  default (one segment per idle-flush chunk; no new coalescing
+  layer; cannot regress the R3c/R3e watermark) **stands as the
+  default to revisit at Phase 4 implementation**, informed by
+  the boundary-diagnostic capture — not decided now.
+
+- **B — Claude `IdleFlushMs = None` interplay — remains
+  blocked, now subsumed into the boundary-diagnostic track.**
+  Claude's complexity (spinner + interval chunks into an
+  ongoing thread) is **explicitly deferred** until the
+  cmd/PowerShell interface and the boundary-determination
+  methodology are settled. The B1-vs-B2 dogfood the brief
+  asked for is replaced by — and folded into — the
+  comprehensive event-capture track defined below: the
+  capture *is* the analysis B needs, done from recorded
+  signal rather than a single listen-and-report pass.
+
+- **C — ProgressSegment ↔ sealed-cell model — RESOLVED:
+  C1, with an added differentiable-kind / filtering
+  requirement.** The maintainer ratified **C1** (keep both:
+  the immutable live-trickle `ProgressSegment`s *and* the
+  sealed consolidated `Output` — `appendCell` untouched, zero
+  regression to Phases 0–3 and the dogfood-validated
+  narration). Added requirement: `ProgressSegment` **must be
+  a clearly-differentiable `CellKind`** so the interface can
+  let the user skip it, or later choose to show / hide it, or
+  show only the final result. This is satisfiable **by
+  construction** — `CellKind.ProgressSegment` is already a
+  distinct case in D1's discriminator, separate from
+  `Input` / `Output` / `SubPromptExchange`. Consequently:
+
+  > **Cell-history filtering is elevated to a first-class
+  > requirement.** The pipeline keeps and distinctly tags
+  > everything; the *interface* decides what to show. Filter
+  > axes: by `CellKind` (e.g. hide `ProgressSegment`, show
+  > only `Input`/`Output`, "final result only"), and — once
+  > [ADR 0009](0009-canonical-cell-metadata-and-typed-outcome.md)
+  > lands — by `CellOutcome` / tag. This is the same surface
+  > as **Phase 6b** kind-filtered jumps and **ADR 0009 D5**
+  > outcome/tag-filtered search; they are now drawn together
+  > under one explicit requirement rather than treated as
+  > independent niceties. No model change is needed for it —
+  > only that the list (Phase 6a) is built kind-generically
+  > (it renders *any* `CellView` by `Kind`), which the
+  > re-sequencing requires anyway.
+
+### The interface scaffolding is decoupled from boundary correctness
+
+The original Phase 6 description sequenced 6a "last because it
+depends on the typed model (D1), the per-cell ops (D2), **and
+the segment model (Phases 4–5) being settled**." The middle
+clause was conservative over-coupling. Phase 6a — the
+focusable cell-history list control (D8), the
+`Ctrl+Shift+Left/Right` pane switch, and the D9
+`pty-speak.cell.*` event family — depends only on **D1
+(Phase 1, shipped)** and **D2 (Phase 2, shipped)**. It renders
+*any* `CellView` by its `Kind`; `ProgressSegment` is simply
+another kind it will render once segments exist. **Imperfect
+cell boundaries do not block it**: a mis-split cell still
+renders, is still navigable, still hosts per-cell ops — the
+boundary bugs are an orthogonal, already-tracked track (ADR
+0006 §"Deferred to R6+" item 1 variants 1 & 2), and improving
+them later only improves the *content inside* an
+already-working list, with no interface rework. **No extra
+exemplars are needed for the interface component itself** —
+it is structural (a standard UIA control bound to
+`CellTranscript` + the pane-switch gesture + cell events).
+The hard **D8 control-type NVDA-dogfood ratification gate is
+unchanged**: nothing past 6a is built until 6a's dogfood
+confirms `Tree` (or falls back to `List`).
+
+### New work item — boundary-diagnostic-capture track
+
+The maintainer's diagnostic-record idea is adopted as a
+**distinct track**, parallel to / after the interface
+scaffolding and feeding Phase 4 + Phase 7:
+
+> Capture a comprehensive, high-resolution-**timestamped**
+> record of every event observed from each shell transport
+> (and the Claude Code CLI) — bytes/chunks in, idle-flush
+> ticks, OSC-133 boundaries, state-machine transitions,
+> announce sends, seal events — with whatever metadata is
+> available, so reliable **begin/end-of-evaluation** signals
+> are determined by *analysing real recorded signal*, not
+> inferred by ear. **cmd / PowerShell first** (the clean
+> OSC-133 reference); **Claude deferred** until the interface
+> and the methodology on the simpler shells are settled.
+
+This is the ADR-0008-aligned, D6-oracle-feeding successor to
+"the maintainer eventually notices it sounds wrong": it turns
+boundary determination into a data exercise. Its **detailed
+design** (exact event set, capture format, the offline /
+in-app analysis surface, retention) is itself a scoped work
+item to be specified when the track is taken up — **recorded
+here, deliberately not built speculatively now** (per the
+half-finished-scaffolding guideline). It graduates to its own
+ADR if it grows past a tracked work item.
+
+### Net implementation order (supersedes the brief's "C1, proceed → 4a")
+
+1. **Phase 6a — interface scaffolding, NOW.** Kind-generic
+   focusable history list (D8 `Tree`-primary / `List`-fallback)
+   + `Ctrl+Shift+Left/Right` pane switch + the D9
+   `pty-speak.cell.*` event family on the canonical pipeline,
+   on existing cmd/PowerShell `Input`/`Output` cells. Its NVDA
+   dogfood **is** the D8 control-type ratification gate.
+2. **Boundary-diagnostic-capture track** — parallel/after;
+   cmd/PowerShell first, Claude deferred.
+3. **Phase 4 / 4b / 5 — segment model**, layered into the
+   now-proven list, informed by the capture (A's default
+   revisited here; B decided from recorded signal).
+4. **Phase 6b+ filtering** (kind / outcome / tag) layered on
+   6a per the elevated first-class requirement; **Phase 7
+   oracle** asserts the settled segment structure.
+
+Phases 0–3 status in the Ship log is unchanged. The cmd
+announce-heuristic FREEZE is unaffected (this is the
+navigation / interface / channel layer). Phase 6a starts
+immediately as its own CI-gated PR + NVDA dogfood under the
+walking-skeleton discipline.


### PR DESCRIPTION
## Summary

Records the maintainer-ratified re-sequencing of the ADR 0007 phase plan (2026-05-17). Docs-only — no code change. The maintainer re-sequenced rather than just unblocking Phase 4a; this PR makes the canonical docs read one coherent truth.

- **C — RESOLVED: C1** (keep both the immutable live-trickle `ProgressSegment`s *and* the sealed consolidated `Output`; `appendCell` untouched, zero regression to Phases 0–3) **+** `ProgressSegment` stays a clearly-differentiable `CellKind` (already true in D1's discriminator). **Cell-history filtering (by kind / outcome / tag) elevated to a first-class requirement**, drawing Phase 6b kind-filtered jumps and ADR 0009 D5 together under one explicit requirement.
- **A — DEFERRED.** ProgressSegment granularity is a Phase-4-implementation detail, not needed now; the conservative one-per-idle-flush default stands to be revisited then, informed by the diagnostic capture.
- **B — SUBSUMED.** Claude `IdleFlushMs` interplay + Claude complexity (spinner + interval chunks) explicitly deferred; folded into a new **boundary-diagnostic-capture track** (high-resolution timestamped record of every shell/Claude-CLI event → analyse boundary signals from recorded data; cmd/PowerShell first).
- **Phase 6a decoupled + pulled forward.** The original "depends on the segment model (Phases 4–5)" coupling was conservative over-coupling; 6a depends only on shipped **D1 + D2**, renders any `CellView` by `Kind`, and works fine with imperfect (already-tracked) cell boundaries. The hard **D8 NVDA-dogfood control-type ratification gate is unchanged**.

New order: **Phase 6a now → boundary-diagnostic track → Phase 4/4b/5 → Phase 6b+ filtering / Phase 7 oracle.**

## Changes

- `docs/adr/0007-canonical-iocell-history-navigation.md` — new dated `§ Re-sequencing amendment 2026-05-17 (maintainer-ratified)`; surgical pointers in the Phase 6 description, ship log, Implementation order, and open-decisions list; superseded-banner on the Phase 4 readiness brief (retained as decision trail per the mark-historical-don't-delete discipline).
- `docs/SESSION-HANDOFF.md` — top 2026-05-17 banner rewritten to the re-sequenced plan; the stale "Phase 0 → 1…7 / one-word unblock (C1, proceed)" next-step lines corrected so the next session reads one truth.

No CHANGELOG entry: internal planning re-sequence, not a user-visible change. ADR 0004 IOCell data model + D1–D9/D5a unchanged. cmd announce-heuristic FREEZE unaffected.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge gate; internal anchor `#re-sequencing-amendment-2026-05-17-maintainer-ratified` reconciled across all cross-references with a punctuation-clean heading).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_