### PR TITLE
ADR 0007 Phase 6a-1: canonical typed CellEventBus + cell.focused wiring

### DIFF
--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4263,11 +4263,29 @@ module Program =
         // keeps the `diagnostic` activity id so users can
         // per-tag-mute explicit navigation separately from live
         // output.
+        // ADR 0007 D9 / Phase 6a-1 — emit the typed `Focused`
+        // cell event on the canonical cell pipeline
+        // (`CellEventBus`) after a successful user navigation.
+        // PURELY ADDITIVE: the dogfood-validated direct announce
+        // in each handler below is untouched and byte-identical;
+        // no sink renders this event yet (6a-2's history list is
+        // the first subscriber), so 6a-1 is CI-only with no
+        // audible change. `cellCurrentView` resolves the typed
+        // cell the cursor just landed on — every nav accessor
+        // sets `CellPos` to it on a `Some`, so this is `Some`
+        // exactly when navigation moved (no event on the
+        // edge/empty `None`, where focus did not move).
+        let publishCellFocused () : unit =
+            match SpeechCursor.cellCurrentView speechCursor with
+            | Some cv -> CellEventBus.publish (CellEventBus.Focused cv)
+            | None -> ()
+
         let runSpeechCursorNext () : unit =
             match SpeechCursor.cellNext speechCursor with
             | Some (text, _) ->
                 window.TerminalSurface.Announce(
                     text, ActivityIds.diagnostic)
+                publishCellFocused ()
             | None ->
                 window.TerminalSurface.Announce(
                     "Already at the latest entry.",
@@ -4278,6 +4296,7 @@ module Program =
             | Some (text, _) ->
                 window.TerminalSurface.Announce(
                     text, ActivityIds.diagnostic)
+                publishCellFocused ()
             | None ->
                 window.TerminalSurface.Announce(
                     "Already at the first entry.",
@@ -4288,6 +4307,7 @@ module Program =
             | Some (text, _) ->
                 window.TerminalSurface.Announce(
                     text, ActivityIds.diagnostic)
+                publishCellFocused ()
             | None ->
                 window.TerminalSurface.Announce(
                     "History is empty.", ActivityIds.diagnostic)
@@ -4311,6 +4331,7 @@ module Program =
                     landedSeq)
                 window.TerminalSurface.Announce(
                     text, ActivityIds.diagnostic)
+                publishCellFocused ()
             | None ->
                 // ADR 0007 Phase 2c follow-up (2026-05-17,
                 // maintainer dogfood). Exit-code failure

--- a/src/Terminal.Core/CellEventBus.fs
+++ b/src/Terminal.Core/CellEventBus.fs
@@ -1,0 +1,105 @@
+namespace Terminal.Core
+
+open System
+open Microsoft.Extensions.Logging
+
+/// ADR 0007 D9 / Phase 6a-1 — the canonical, modality-agnostic
+/// cell-event stream.
+///
+/// D9 locks that cell lifecycle / navigation / operation events
+/// are first-class **typed** semantic events on one canonical
+/// pipeline, with many composable sinks (speech, earcon, future
+/// braille, the Phase 6a history list) — speech is not primary
+/// with the rest bolted on. This module is that pipeline for the
+/// cell layer: a single typed `CellEvent` published to N
+/// subscribers. It is the cell-layer instance of ADR 0001's
+/// substrate/channel dichotomy + ADR 0004 Decision 4 ("one
+/// canonical unambiguous event stream, many sinks"); it runs
+/// *parallel to*, not squeezed into, the byte-oriented
+/// `OutputDispatcher` (cell events carry typed `CellView`s, not
+/// rendered-text `OutputEvent`s — a sink must never re-derive
+/// cell meaning from rendered output: ADR 0008).
+///
+/// Resolution of the ADR 0007 open decision "`pty-speak.cell.*`
+/// ActivityId taxonomy / cell pipeline shape (Phase 6a / D9)":
+/// the canonical cell pipeline is *this dedicated typed bus*
+/// (not an `OutputDispatcher` route). The `pty-speak.cell.*`
+/// `ActivityIds` are the per-event routing / NVDA-per-tag-config
+/// tags a sink applies when it renders one. Settled here in 6a
+/// per the ADR's "settle when 6a wires the first event".
+///
+/// Scope discipline (walking-skeleton): 6a-1 defines the
+/// contract + the bus + wires the lowest-risk real publication
+/// (`Focused`, off the existing user-nav handlers — additive,
+/// the dogfood-validated direct announce is untouched). The
+/// `Appended` seal event (the D8 list's update mechanism) and
+/// the WPF list subscriber land in 6a-2, where their audible /
+/// AT effect is dogfood-validated together (the D8 control-type
+/// ratification gate). Only the case a shipped phase wires is
+/// declared.
+///
+/// The subscriber registry mirrors
+/// `OutputDispatcher.installEventTap` exactly (token-keyed map
+/// under a lock, `IDisposable` unsubscribe, snapshot-then-fire)
+/// so the concurrency reasoning is identical and already
+/// battle-tested. `publish` is exception-guarded: a throwing
+/// sink (a UI-thread marshal in 6a-2, say) must never break the
+/// Manual-navigation path that published the event.
+module CellEventBus =
+
+    /// A typed cell event. 6a-1: `Focused` only — the user moved
+    /// the Manual cursor onto a cell (the typed `CellView` it
+    /// landed on is carried so sinks never re-derive it from
+    /// rendered text). Later cases (`Appended` 6a-2, `Operated`
+    /// Phase 6 D2, `Segment` Phase 4, `PaneSwitched` 6a-2) are
+    /// added by the phase that wires them — not pre-declared.
+    type CellEvent =
+        | Focused of SpeechCursor.CellView
+
+    let private log =
+        Logger.get "Terminal.Core.CellEventBus"
+
+    let private gate: obj = obj ()
+    let mutable private nextToken: int = 0
+    let mutable private subscribers: Map<int, CellEvent -> unit> =
+        Map.empty
+
+    /// Subscribe to every published `CellEvent` until the
+    /// returned `IDisposable` is disposed. Token-keyed so
+    /// disposing one subscription cannot remove another even
+    /// when callers pass identical (capture-free) lambdas.
+    let subscribe (handler: CellEvent -> unit) : IDisposable =
+        let token =
+            lock gate (fun () ->
+                let t = nextToken
+                nextToken <- t + 1
+                subscribers <- subscribers |> Map.add t handler
+                t)
+        { new IDisposable with
+            member _.Dispose () =
+                lock gate (fun () ->
+                    subscribers <- subscribers |> Map.remove token) }
+
+    /// Fire all current subscribers for one event. The map is
+    /// snapshotted under the lock so a concurrent
+    /// subscribe/dispose cannot mutate the collection mid-fire;
+    /// each subscriber is invoked outside the lock and guarded
+    /// so one throwing sink neither aborts the others nor
+    /// propagates back into the (navigation) caller.
+    let publish (event: CellEvent) : unit =
+        let snapshot = lock gate (fun () -> subscribers)
+        snapshot
+        |> Map.iter (fun _ handler ->
+            try
+                handler event
+            with ex ->
+                log.LogDebug(
+                    ex,
+                    "CellEventBus subscriber threw; continuing.") )
+
+    /// Test isolation — drop all subscribers and reset the
+    /// token counter. Mirrors `EarconChannel.clearForTests`.
+    let clearForTests () : unit =
+        lock gate (fun () ->
+            subscribers <- Map.empty
+            nextToken <- 0)

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -45,6 +45,12 @@
       Placed after ShellPolicy so both deps are in scope.
     -->
     <Compile Include="SpeechCursor.fs" />
+    <!--
+      ADR 0007 D9 / Phase 6a-1 — the canonical typed cell-event
+      bus. Depends only on `SpeechCursor.CellView`; placed
+      immediately after SpeechCursor.fs so that dep is in scope.
+    -->
+    <Compile Include="CellEventBus.fs" />
     <Compile Include="SelectionDetector.fs" />
     <Compile Include="Config.fs" />
     <Compile Include="EarconChannel.fs" />

--- a/src/Terminal.Core/Types.fs
+++ b/src/Terminal.Core/Types.fs
@@ -534,3 +534,33 @@ module ActivityIds =
     /// ActivityId so consecutive presses dedupe at the
     /// NVDA-channel layer.
     let processCleanup = "pty-speak.process-cleanup"
+
+    /// ADR 0007 D9 / Phase 6a — the canonical, modality-agnostic
+    /// cell-event family. Cell lifecycle / navigation / operation
+    /// events flow as typed `CellEventBus.CellEvent`s; the
+    /// `pty-speak.cell.*` ids are the unambiguous, single-purpose
+    /// routing/per-tag-config tags a sink (speech / earcon /
+    /// future braille / the Phase 6a history list) uses when it
+    /// renders one — distinct from a cell's *content* ActivityId
+    /// (`output`), exactly as `shellSwitch` / `inputAssistant`
+    /// are distinct from streaming output. The full planned set
+    /// (ADR 0007 "`pty-speak.cell.*` ActivityId taxonomy" open
+    /// decision, settled here in 6a — kept single-purpose, grown
+    /// per phase): `cell.focused` (6a-1, user navigated the
+    /// Manual cursor to a cell), `cell.appended` (6a-2, a cell
+    /// sealed into the transcript — the D8 list's update event),
+    /// later `cell.operated` (Phase 6 D2 ops) / `cell.segment`
+    /// (Phase 4) / `cell.pane` (6a-2 pane switch). Only the ids
+    /// a shipped phase wires are defined; speculative ones are
+    /// not pre-declared (ADR 0007 D9 "keep ids unambiguous and
+    /// single-purpose"; the guideline "don't build beyond what
+    /// the task requires").
+    ///
+    /// 6a-1 wires `cell.focused` only. No sink renders it yet —
+    /// the existing dogfood-validated Manual-nav direct announce
+    /// (`runSpeechCursor*` → `Announce(text, diagnostic)`) is
+    /// untouched and stays byte-identical; the typed event is
+    /// emitted in parallel for 6a-2's list (and future
+    /// composable sinks) to subscribe to, so 6a-1 ships CI-only
+    /// (no audible change → no dogfood).
+    let cellFocused = "pty-speak.cell.focused"

--- a/tests/Tests.Unit/CellEventBusTests.fs
+++ b/tests/Tests.Unit/CellEventBusTests.fs
@@ -1,0 +1,91 @@
+module PtySpeak.Tests.Unit.CellEventBusTests
+
+open System
+open Xunit
+open Terminal.Core
+
+// ---------------------------------------------------------------------
+// ADR 0007 D9 / Phase 6a-1 — CellEventBus contract tests.
+// ---------------------------------------------------------------------
+//
+// Pins the canonical typed cell-event bus:
+//
+//   * a subscriber receives published events
+//   * disposing the subscription stops delivery
+//   * multiple subscribers each receive every event
+//   * clearForTests drops all subscribers (test isolation)
+//   * a throwing subscriber neither aborts the others nor
+//     propagates back into the publishing (navigation) caller
+//
+// No WPF / no sink rendering — 6a-1 is the pure pipeline; the
+// first real subscriber (the history list) lands in 6a-2.
+
+let private mkCell (seq: int64) : SpeechCursor.CellView =
+    { CellId = Guid.NewGuid()
+      CellSequence = seq
+      Kind = SpeechCursor.CellKind.Output
+      Text = sprintf "cell-%d" seq
+      ActivityId = ActivityIds.output
+      ExitCode = None }
+
+let private focusedSeq (ev: CellEventBus.CellEvent) : int64 =
+    match ev with
+    | CellEventBus.Focused cv -> cv.CellSequence
+
+[<Fact>]
+let ``subscribe receives a published Focused event`` () =
+    CellEventBus.clearForTests ()
+    let received = ResizeArray<int64>()
+    use _sub =
+        CellEventBus.subscribe (fun ev ->
+            received.Add(focusedSeq ev))
+    CellEventBus.publish (CellEventBus.Focused(mkCell 7L))
+    Assert.Equal<int64 list>([ 7L ], List.ofSeq received)
+
+[<Fact>]
+let ``dispose stops further delivery`` () =
+    CellEventBus.clearForTests ()
+    let received = ResizeArray<int64>()
+    let sub =
+        CellEventBus.subscribe (fun ev ->
+            received.Add(focusedSeq ev))
+    CellEventBus.publish (CellEventBus.Focused(mkCell 1L))
+    sub.Dispose()
+    CellEventBus.publish (CellEventBus.Focused(mkCell 2L))
+    Assert.Equal<int64 list>([ 1L ], List.ofSeq received)
+
+[<Fact>]
+let ``multiple subscribers each receive the event`` () =
+    CellEventBus.clearForTests ()
+    let a = ResizeArray<int64>()
+    let b = ResizeArray<int64>()
+    use _sa = CellEventBus.subscribe (fun ev -> a.Add(focusedSeq ev))
+    use _sb = CellEventBus.subscribe (fun ev -> b.Add(focusedSeq ev))
+    CellEventBus.publish (CellEventBus.Focused(mkCell 5L))
+    Assert.Equal<int64 list>([ 5L ], List.ofSeq a)
+    Assert.Equal<int64 list>([ 5L ], List.ofSeq b)
+
+[<Fact>]
+let ``clearForTests drops all subscribers`` () =
+    CellEventBus.clearForTests ()
+    let received = ResizeArray<int64>()
+    CellEventBus.subscribe (fun ev -> received.Add(focusedSeq ev))
+    |> ignore
+    CellEventBus.clearForTests ()
+    CellEventBus.publish (CellEventBus.Focused(mkCell 9L))
+    Assert.Empty(received)
+
+[<Fact>]
+let ``a throwing subscriber does not break publish for the others`` () =
+    CellEventBus.clearForTests ()
+    let received = ResizeArray<int64>()
+    use _bad =
+        CellEventBus.subscribe (fun _ ->
+            raise (InvalidOperationException("sink boom")))
+    use _good =
+        CellEventBus.subscribe (fun ev ->
+            received.Add(focusedSeq ev))
+    // publish must not propagate the subscriber exception …
+    CellEventBus.publish (CellEventBus.Focused(mkCell 3L))
+    // … and the well-behaved subscriber still got the event.
+    Assert.Equal<int64 list>([ 3L ], List.ofSeq received)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -74,6 +74,7 @@
     -->
     <Compile Include="ContentHistoryTests.fs" />
     <Compile Include="SpeechCursorTests.fs" />
+    <Compile Include="CellEventBusTests.fs" />
     <!--
       Cycle 48 PR-B (ADR 0003) — ShellInteraction state machine
       pure-function tests. Slot after ContentHistory because the


### PR DESCRIPTION
## Summary

First walking-skeleton slice of **Phase 6a** (the cell-history interface, pulled forward by the #403 re-sequencing). Establishes the **D9 canonical typed cell-event pipeline** as pure Terminal.Core substrate, with zero WPF and **no audible change** — CI-only, no dogfood.

**Settles the ADR 0007 open decision "`pty-speak.cell.*` ActivityId taxonomy / cell pipeline shape (Phase 6a / D9)":** the canonical cell pipeline is a *dedicated typed bus* (`CellEventBus`), not an `OutputDispatcher` route — one typed `CellEvent`, N composable sinks (speech / earcon / future braille / the Phase 6a list), running parallel to the byte-oriented `OutputDispatcher`. Cell events carry typed `CellView`s so a sink never re-derives cell meaning from rendered text (ADR 0008). This is the cell-layer instance of ADR 0001 substrate/channel + ADR 0004 D4. *(The canonical ADR open-decision text update follows as a separate docs concern — recorded here to keep this PR one-concern/code-only; the ADR explicitly anticipated "settle when 6a wires the first event".)*

## Changes

- **`ActivityIds`** (`Types.fs`): `pty-speak.cell.focused`. Doc names the full planned taxonomy (`focused` 6a-1 · `appended` 6a-2 · later `operated`/`segment`/`pane`); only the shipped-phase id is declared (D9 "single-purpose"; no speculative ids).
- **`CellEventBus.fs`** (new): `CellEvent` DU (`Focused` only — later cases added by the phase that wires them), token-keyed `subscribe`/`publish` mirroring `OutputDispatcher.installEventTap` **exactly** (same proven concurrency reasoning), `publish` exception-guarded so a throwing sink can't abort the others or propagate into the navigation caller, `clearForTests` for isolation.
- **`Program.fs`**: a local `publishCellFocused` helper publishes `CellEvent.Focused` off the four user-nav handlers (Next / Previous / JumpToLatest / JumpToLastError). **Purely additive** — the dogfood-validated direct `Announce(text, diagnostic)` is byte-identical; published only on a real focus move (`Some`), never on the edge/empty `None`.
- **Unit tests** (`CellEventBusTests.fs`): deliver / dispose-stops-delivery / multi-subscriber / `clearForTests` isolation / throwing-sink does not break others.
- `.fsproj` compile entries (`CellEventBus.fs` after `SpeechCursor.fs` — its only dep; `CellEventBusTests.fs` after `SpeechCursorTests.fs`).

## Why this split

6a-2 (the focusable WPF list — flat **ListBox→UIA List** per D8's "deliberately-flat first cut" conditional, segments deferred to Phase 4/5 — + `cell.appended` seal event + the `Ctrl+Shift+Left/Right` pane switch) carries the WPF/UIA risk and **its NVDA dogfood is the hard D8 control-type ratification gate**. Isolating the pure D9 contract here keeps that PR's audible/AT surface a single coherent dogfood, and keeps 6a-1 a CI-only, no-audible-change substrate step (no local compiler — small, verifiable, revertible).

## Test plan

- [ ] Windows build + unit tests green (new `CellEventBusTests` + no regression to `SpeechCursorTests`; the four nav handlers compile with the additive publish).
- [ ] No dogfood — 6a-1 has no sink and no audible change by construction (the D8 ratification dogfood is 6a-2's gate; I'll send the concrete NVDA procedure when that build is CI-green).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_