### PR TITLE
ADR 0007 Phase 6a-2a: CellEvent.Appended off the canonical seal site

### DIFF
--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -2047,6 +2047,22 @@ module Program =
                 // line itself and post-single-key-response output
                 // (both filtered from the raw ContentHistory-Seq
                 // path as `UserInputEcho`; ADR 0004 §4a).
+                //
+                // ADR 0007 Phase 6a-2a — this `appendCell` call
+                // IS the canonical seal site (D8 "event-driven
+                // off the canonical seal event"). Capture the
+                // transcript length before/after so each item
+                // `appendCell` just added (0/1/2: Input then
+                // Output, whitespace-skipped, sharing one
+                // `CellId`) is published as a typed
+                // `CellEventBus.Appended` on the D9 cell
+                // pipeline, in append order. PURELY ADDITIVE: no
+                // sink renders `Appended` yet (6a-2b's focusable
+                // history list is the first subscriber), so this
+                // is CI-only with no audible change — the
+                // dogfood-validated narration path is untouched.
+                let beforeCount =
+                    SpeechCursor.cellCount speechCursor
                 SpeechCursor.appendCell
                     speechCursor
                     tuple.Id
@@ -2054,6 +2070,11 @@ module Program =
                     tuple.CommandText
                     tuple.OutputText
                     tuple.ExitCode
+                for cv in
+                    SpeechCursor.cellViewsFrom
+                        speechCursor beforeCount do
+                    CellEventBus.publish (
+                        CellEventBus.Appended cv)
             | None -> ()
 
             // Cycle 45 Commit 2 — ContentHistory + SpeechCursor

--- a/src/Terminal.Core/CellEventBus.fs
+++ b/src/Terminal.Core/CellEventBus.fs
@@ -47,14 +47,25 @@ open Microsoft.Extensions.Logging
 /// Manual-navigation path that published the event.
 module CellEventBus =
 
-    /// A typed cell event. 6a-1: `Focused` only — the user moved
-    /// the Manual cursor onto a cell (the typed `CellView` it
-    /// landed on is carried so sinks never re-derive it from
-    /// rendered text). Later cases (`Appended` 6a-2, `Operated`
-    /// Phase 6 D2, `Segment` Phase 4, `PaneSwitched` 6a-2) are
-    /// added by the phase that wires them — not pre-declared.
+    /// A typed cell event; the typed `CellView` is carried so
+    /// sinks never re-derive cell meaning from rendered text
+    /// (ADR 0008). Cases are added by the phase that wires them
+    /// (not pre-declared — D9 "single-purpose"):
+    ///
+    ///   * `Focused` (6a-1) — the user moved the Manual cursor
+    ///     onto a cell (off the four user-nav handlers).
+    ///   * `Appended` (6a-2a) — a cell item was sealed into the
+    ///     transcript (off the canonical `appendCell` seal site;
+    ///     D8's list-update event). `appendCell` adds up to two
+    ///     items per cell (Input then Output, whitespace-skipped)
+    ///     sharing one `CellId`; one `Appended` is published per
+    ///     item actually added, in append order.
+    ///
+    /// Later: `Operated` (Phase 6 D2 ops) / `Segment` (Phase 4)
+    /// / `PaneSwitched` (6a-2b) — added when their phase ships.
     type CellEvent =
         | Focused of SpeechCursor.CellView
+        | Appended of SpeechCursor.CellView
 
     let private log =
         Logger.get "Terminal.Core.CellEventBus"

--- a/src/Terminal.Core/SpeechCursor.fs
+++ b/src/Terminal.Core/SpeechCursor.fs
@@ -683,6 +683,27 @@ module SpeechCursor =
         if state.Mode = AutoDrive then
             state.CellPos <- state.CellTranscript.Count - 1
 
+    /// ADR 0007 Phase 6a-2a — number of items in the cell
+    /// transcript. Pure read-only accessor; the `CellTranscript`
+    /// field is `internal`, so the seal site (Terminal.App, not
+    /// in the `InternalsVisibleTo` set) computes the
+    /// just-appended delta via `cellCount` before / after
+    /// `appendCell` rather than reaching into the collection.
+    let cellCount (state: T) : int =
+        state.CellTranscript.Count
+
+    /// ADR 0007 Phase 6a-2a — the transcript items at indices
+    /// `[fromIndex .. Count-1]`, in order, as a list. Used at
+    /// the seal site to publish one `CellEventBus.Appended` per
+    /// item `appendCell` just added (it adds 0/1/2 items). A
+    /// negative / out-of-range `fromIndex` clamps to a safe
+    /// window (empty when `fromIndex >= Count`) so the caller
+    /// needs no bounds bookkeeping. Pure read-only.
+    let cellViewsFrom (state: T) (fromIndex: int) : CellView list =
+        let count = state.CellTranscript.Count
+        let start = max 0 fromIndex
+        [ for i in start .. count - 1 -> state.CellTranscript.[i] ]
+
     /// Project a stored `CellView` to the `(text, activityId)`
     /// pair the narration path consumes. Keeps `cellCurrent` /
     /// `cellPrevious` / `cellNext` / `cellToLatest` returning

--- a/tests/Tests.Unit/CellEventBusTests.fs
+++ b/tests/Tests.Unit/CellEventBusTests.fs
@@ -28,9 +28,14 @@ let private mkCell (seq: int64) : SpeechCursor.CellView =
       ActivityId = ActivityIds.output
       ExitCode = None }
 
-let private focusedSeq (ev: CellEventBus.CellEvent) : int64 =
+// Both cases carry the typed `CellView`; the bus contract is
+// kind-agnostic, so the helper extracts the sequence from
+// either (the OR-pattern also keeps the match exhaustive as
+// cases are added).
+let private cellSeq (ev: CellEventBus.CellEvent) : int64 =
     match ev with
-    | CellEventBus.Focused cv -> cv.CellSequence
+    | CellEventBus.Focused cv
+    | CellEventBus.Appended cv -> cv.CellSequence
 
 [<Fact>]
 let ``subscribe receives a published Focused event`` () =
@@ -38,7 +43,7 @@ let ``subscribe receives a published Focused event`` () =
     let received = ResizeArray<int64>()
     use _sub =
         CellEventBus.subscribe (fun ev ->
-            received.Add(focusedSeq ev))
+            received.Add(cellSeq ev))
     CellEventBus.publish (CellEventBus.Focused(mkCell 7L))
     Assert.Equal<int64 list>([ 7L ], List.ofSeq received)
 
@@ -48,7 +53,7 @@ let ``dispose stops further delivery`` () =
     let received = ResizeArray<int64>()
     let sub =
         CellEventBus.subscribe (fun ev ->
-            received.Add(focusedSeq ev))
+            received.Add(cellSeq ev))
     CellEventBus.publish (CellEventBus.Focused(mkCell 1L))
     sub.Dispose()
     CellEventBus.publish (CellEventBus.Focused(mkCell 2L))
@@ -59,8 +64,8 @@ let ``multiple subscribers each receive the event`` () =
     CellEventBus.clearForTests ()
     let a = ResizeArray<int64>()
     let b = ResizeArray<int64>()
-    use _sa = CellEventBus.subscribe (fun ev -> a.Add(focusedSeq ev))
-    use _sb = CellEventBus.subscribe (fun ev -> b.Add(focusedSeq ev))
+    use _sa = CellEventBus.subscribe (fun ev -> a.Add(cellSeq ev))
+    use _sb = CellEventBus.subscribe (fun ev -> b.Add(cellSeq ev))
     CellEventBus.publish (CellEventBus.Focused(mkCell 5L))
     Assert.Equal<int64 list>([ 5L ], List.ofSeq a)
     Assert.Equal<int64 list>([ 5L ], List.ofSeq b)
@@ -69,7 +74,7 @@ let ``multiple subscribers each receive the event`` () =
 let ``clearForTests drops all subscribers`` () =
     CellEventBus.clearForTests ()
     let received = ResizeArray<int64>()
-    CellEventBus.subscribe (fun ev -> received.Add(focusedSeq ev))
+    CellEventBus.subscribe (fun ev -> received.Add(cellSeq ev))
     |> ignore
     CellEventBus.clearForTests ()
     CellEventBus.publish (CellEventBus.Focused(mkCell 9L))
@@ -84,8 +89,33 @@ let ``a throwing subscriber does not break publish for the others`` () =
             raise (InvalidOperationException("sink boom")))
     use _good =
         CellEventBus.subscribe (fun ev ->
-            received.Add(focusedSeq ev))
+            received.Add(cellSeq ev))
     // publish must not propagate the subscriber exception …
     CellEventBus.publish (CellEventBus.Focused(mkCell 3L))
     // … and the well-behaved subscriber still got the event.
     Assert.Equal<int64 list>([ 3L ], List.ofSeq received)
+
+[<Fact>]
+let ``Appended events are delivered in publish order`` () =
+    CellEventBus.clearForTests ()
+    let received = ResizeArray<int64>()
+    use _sub =
+        CellEventBus.subscribe (fun ev ->
+            received.Add(cellSeq ev))
+    CellEventBus.publish (CellEventBus.Appended(mkCell 1L))
+    CellEventBus.publish (CellEventBus.Appended(mkCell 2L))
+    Assert.Equal<int64 list>([ 1L; 2L ], List.ofSeq received)
+
+[<Fact>]
+let ``one subscriber receives both Focused and Appended`` () =
+    CellEventBus.clearForTests ()
+    let kinds = ResizeArray<string>()
+    use _sub =
+        CellEventBus.subscribe (fun ev ->
+            match ev with
+            | CellEventBus.Focused _ -> kinds.Add "focused"
+            | CellEventBus.Appended _ -> kinds.Add "appended")
+    CellEventBus.publish (CellEventBus.Appended(mkCell 1L))
+    CellEventBus.publish (CellEventBus.Focused(mkCell 1L))
+    Assert.Equal<string list>(
+        [ "appended"; "focused" ], List.ofSeq kinds)

--- a/tests/Tests.Unit/SpeechCursorTests.fs
+++ b/tests/Tests.Unit/SpeechCursorTests.fs
@@ -749,6 +749,41 @@ let ``appendCell command item is trimmed`` () =
     let tc, _ = expectSome "cmd" (SpeechCursor.cellCurrent c)
     Assert.Equal("echo hi", tc)
 
+// ADR 0007 Phase 6a-2a — the pure seal-site delta accessors
+// (`cellCount` / `cellViewsFrom`) the Terminal.App seal site
+// uses to publish one `CellEventBus.Appended` per item
+// `appendCell` added (the `CellTranscript` field is `internal`,
+// so the delta is computed via these rather than reaching in).
+[<Fact>]
+let ``cellCount reflects the appended item count`` () =
+    let c = freshCursor ()
+    Assert.Equal(0, SpeechCursor.cellCount c)
+    addCell c "echo hi" "hi" // Input + Output = 2
+    Assert.Equal(2, SpeechCursor.cellCount c)
+    addCell c "cmd-only" "   " // whitespace output skipped = +1
+    Assert.Equal(3, SpeechCursor.cellCount c)
+
+[<Fact>]
+let ``cellViewsFrom slices from the index and clamps out of range`` () =
+    let c = freshCursor ()
+    addCell c "c1" "o1" // indices 0,1
+    let before = SpeechCursor.cellCount c
+    addCell c "c2" "o2" // indices 2,3
+    // The just-appended delta = exactly the second cell's items.
+    let delta = SpeechCursor.cellViewsFrom c before
+    Assert.Equal<string list>(
+        [ "c2"; "o2" ], delta |> List.map (fun v -> v.Text))
+    Assert.Equal<SpeechCursor.CellKind list>(
+        [ SpeechCursor.CellKind.Input
+          SpeechCursor.CellKind.Output ],
+        delta |> List.map (fun v -> v.Kind))
+    // From 0 = the whole transcript.
+    Assert.Equal(4, (SpeechCursor.cellViewsFrom c 0).Length)
+    // Past the end = empty (no bounds bookkeeping needed).
+    Assert.Empty(SpeechCursor.cellViewsFrom c 99)
+    // Negative clamps to 0 (the whole transcript).
+    Assert.Equal(4, (SpeechCursor.cellViewsFrom c (-5)).Length)
+
 [<Fact>]
 let ``appendCell in AutoDrive follows the latest item`` () =
     let c = freshCursor ()


### PR DESCRIPTION
## Summary

Completes the **D9 cell-event feed**: the `appendCell` seal site now publishes a typed `CellEventBus.Appended` per item it adds. This is the live source 6a-2b's focusable history list subscribes to (D8 "append is event-driven off the canonical seal event"). Pure F#, **additive, CI-only** — no sink renders `Appended` yet, so no audible change and no dogfood.

## Changes

- **`CellEventBus`**: `CellEvent` gains `Appended of CellView` (one per item `appendCell` added — 0/1/2: Input then Output, whitespace-skipped, sharing one `CellId` — in append order). Doc records the per-phase case taxonomy.
- **`SpeechCursor`**: two pure read-only accessors — `cellCount` and `cellViewsFrom`. `CellTranscript` is `internal` and Terminal.App is **not** in the `InternalsVisibleTo` set, so the seal site computes the just-appended delta via these rather than reaching into the collection — and **`appendCell`'s signature is unchanged** (no return-type change → no call-site sweep / no foot-gun across the ~14 test callers).
- **`Program.fs` seal site**: capture transcript length before/after `appendCell`, publish one `Appended` per new item. The dogfood-validated narration path (`dispatchTupleToWriter` + `appendCell`) is byte-identical.
- **Tests**: `Appended` delivery + publish-order + mixed Focused/Appended (the `cellSeq` helper is an OR-pattern so the match stays exhaustive as cases grow — guards FS0025 under `TreatWarningsAsErrors`); `cellCount` / `cellViewsFrom` slice-from-index + out-of-range + negative-clamp.

## Why this split (6a-2a vs 6a-2b)

6a-2b (the WPF history list — flat ListBox→UIA List — + the `Ctrl+Shift+Left/Right` pane switch through the `HotkeyRegistry` triple + `AppReservedHotkeys`, touching the load-bearing `OnPreviewKeyDown` contract) is the WPF/UIA-risk PR and its NVDA dogfood is the **hard D8 control-type ratification gate**. Landing the pure `Appended` feed first keeps that PR a single cohesive dogfood and keeps this step a small, locally-unverifiable-but-low-risk substrate change (no local compiler — additive, no behaviour change, every new path unit-tested).

## Test plan

- [ ] Windows build + unit tests green (new `Appended`/accessor tests; no regression to existing `SpeechCursor`/`CellEventBus` suites; seal-site compiles).
- [ ] No dogfood — `Appended` has no sink yet by construction (the D8 ratification dogfood is 6a-2b's gate; I'll send the concrete NVDA procedure when that build is CI-green).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_