### PR TITLE
docs: lock 6a-2b architectural conformance (maintainer deep-review 2026-05-17)

### DIFF
--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -90,6 +90,27 @@ and serves the decision-trail role this file used to overload.
 > D5a Q1/Q2/Q3 defaults for the first cut (history browse
 > = Manual-like; appends don't move focus/selection;
 > standard `ListBox` virtualisation), dogfood refines.
+> **BINDING (maintainer deep-review 2026-05-17 — see
+> [ADR 0007 6a-2b "Architectural conformance"](adr/0007-canonical-iocell-history-navigation.md)):**
+> list-item focus → screen reader announces **natively**;
+> we do **NOT** manually `Announce` items (double-speak) —
+> instead the list's focus/selection handler publishes
+> `CellEventBus.Focused` *in parallel* (universal bus still
+> fed for earcon / spatial-audio / braille / separate-
+> process sinks). SpeechCursor manual tooling stays
+> **separate** code (the #404 `Focused`-off-`runSpeechCursor*`
+> publish is the *legacy keyboard model's* source; the list
+> model's source is its own focus handler — both coexist,
+> decoupled). Core never depends on WPF (frontend
+> publishes interaction events / subscribes lifecycle
+> events via the bus contract → interface is
+> separate-process-capable). Flat list is a temporary
+> scaffold; Tree swap stays trivial (typed event → future
+> "N sub-components" earcon, no list computation). **Plus
+> an OPEN DECISION for the maintainer** (recorded in the
+> ADR, NOT a sidetrack): single universal tap-point vs.
+> `CellEventBus`-alongside-`OutputDispatcher` — gates only
+> 6a-2b's focus-handler publish target.
 > The session checkpointed here deliberately: 6a-2b is the
 > single locally-unverifiable (no NVDA / no compiler)
 > dogfood-gating PR and warrants a fresh full-rigor pass,

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -901,6 +901,86 @@ maintainer's standing instruction, not buried in chat text.
     [`docs/SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) "6a
     progress (2026-05-17)". Conservative D5a Q1/Q2/Q3 defaults
     for the first cut; dogfood refines.
+
+    **Architectural conformance — maintainer deep-review
+    2026-05-17 (binding constraints on the 6a-2b build; this
+    is the application of ADR 0008 / ADR 0004 Decision 4 /
+    D9 / ADR 0001 — the "one typed universal event stream,
+    many composable sinks; never re-derive meaning" principle
+    — to a *natively-focusable GUI* surface):**
+
+    1. **Parallel focus-marker, no double-speak.** When a list
+       item receives focus the **screen reader announces it
+       natively** via the standard UIA `ListItem` — pty-speak
+       does **NOT** manually `Announce` the item (doing so
+       double-speaks). *In parallel*, the list's
+       selection/focus-changed handler **publishes
+       `CellEventBus.Focused`** so the universal cell pipeline
+       is still fed for the non-screen-reader sinks (earcon,
+       spatial audio, braille, future peripherals / a separate
+       UI process). The native AT path and our typed-event
+       path run **side by side off the same focus change** —
+       relying on native focus for a clean SR experience must
+       not silently bypass the universal bus. The pane-switch
+       cue likewise must not re-read the focused element
+       (NVDA announces the newly focused control itself); at
+       most a brief distinct pane-change marker.
+    2. **SpeechCursor tooling stays separate code.** The
+       existing keyboard `runSpeechCursor*` manual-announce
+       feature is a **standalone** path; 6a-2b's list does
+       **not** route through it and it does **not** drive the
+       list (no two-entangled-models). The #404 `Focused`
+       publish off the `runSpeechCursor*` handlers is a
+       **transitional source for the legacy keyboard model**;
+       for the list model the authoritative `Focused` source
+       is the list's own focus handler. Both features may
+       coexist; they stay decoupled.
+    3. **Which-drives-which (resolved).** For the list model
+       the **list's native focus/selection IS the interaction
+       source**; SpeechCursor manual nav remains a separate
+       standalone keyboard feature. Neither drives the other.
+    4. **Frontend/backend separation invariant.**
+       `Terminal.Core` (incl. `CellEventBus`, `SpeechCursor`)
+       **never depends on WPF**. The frontend only (a)
+       *publishes* interaction events (focus) onto the bus and
+       (b) *subscribes* to lifecycle events (`Appended`) from
+       it. The bus is the neutral contract — so the interface
+       could later run as a **separate process** with the
+       computational core as the reliable hub. 6a-2b must not
+       introduce a core→WPF edge (portability-lint enforces
+       it) nor a complex frontend↔backend coupling.
+    5. **Forward-aligned to the Tree.** The flat `ListBox` is
+       an explicitly **temporary scaffold**; swap-to-`Tree`
+       must stay simple (typed model unchanged). Because
+       `CellEvent` carries the **typed `CellView`** (not
+       rendered text), a future Tree landing on a multi-
+       segment cell can drive a "**N sub-components**" earcon
+       by composing from the typed event — *without computing
+       over the rendered list*. 6a-2b must keep the event
+       typed and the item a projection (no logic that a Tree
+       swap would have to unpick).
+
+    **OPEN DECISION (maintainer) — single universal bus vs.
+    two typed sources.** #404 settled the cell pipeline as a
+    *dedicated* `CellEventBus` **parallel to** the byte-
+    oriented `OutputDispatcher` (rationale: typed `CellView`s
+    vs. rendered-text `OutputEvent`s; ADR 0008 "don't
+    re-derive"). That preserves the *principle* (typed
+    events, composable sinks) and is **extensible** to a
+    unified tap, but it is **not literally one bus**: an
+    auxiliary peripheral / spatial-audio sink today would
+    subscribe to *two* sources. The maintainer's vision is a
+    **single universal tap-point for every interaction + app
+    event**. Reconciliation options (not to be built as a
+    sidetrack — recorded for the maintainer to rule on before
+    6a-2b's focus dispatch is finalised): (a) accept two
+    specialised typed sources + add a thin uniform
+    aggregation/façade sink later; (b) make `CellEventBus`
+    feed `OutputDispatcher` (or vice-versa) so there is one
+    physical tap; (c) a neutral `UniversalEventBus` both
+    publish into. Decision gates only the *publish target* of
+    6a-2b's list-focus handler; the parallel-marker pattern
+    above holds regardless.
 - **Phases 4/4b/5 → 7** — sequence after Phase 6a + the
   boundary-diagnostic track (5 = intra-cell segments on the
   settled model; 7's oracle asserts it). Each lands as its


### PR DESCRIPTION
## Summary

Docs-only. Outcome of the maintainer-requested **deep review of #403–#406** against the modularity / universal-event-bus / native-focus architectural guidance. No code; no sidetrack — this aligns the *recorded 6a-2b plan* (a recent action, #406) with the future architecture, which is exactly what was asked.

**Review verdict — the `CellEventBus` core (#404/#405) is well-aligned:** it is the core-resident typed universal hub, modality-agnostic (carries typed `CellView`s, sinks compose), frontend cleanly separable (no WPF in `Terminal.Core`), and does not preclude the future Tree + "N sub-components" earcon. The one real gap was in the *recorded 6a-2b spec*, which under-specified the pivotal native-focus-vs-universal-bus interaction.

## What this locks into the canonical 6a-2b spec

1. **Parallel focus-marker, NO double-speak.** List-item focus → screen reader announces it **natively** (standard UIA `ListItem`); pty-speak does **not** manually `Announce` items. *In parallel*, the list's focus/selection handler publishes `CellEventBus.Focused` so the universal bus still feeds earcon / spatial-audio / braille / separate-process sinks. Native AT path and typed-event path run side-by-side off the same focus change.
2. **SpeechCursor tooling stays separate code.** #404's `Focused`-off-`runSpeechCursor*` is the *legacy keyboard model's* source; the list model's source is its own focus handler. Both coexist, decoupled (no two-entangled-models). **Which-drives-which resolved**: list native-focus is the interaction source for the list model.
3. **Frontend/backend separation invariant.** `Terminal.Core` never depends on WPF; the frontend only publishes interaction events / subscribes lifecycle events via the bus contract → the interface is **separate-process-capable**, core stays the reliable hub.
4. **Forward-aligned to the Tree.** Flat `ListBox` is an explicitly temporary scaffold; typed event keeps the Tree swap + future "N sub-components" earcon trivial (compose from the typed event, not list computation).
5. **Recorded OPEN DECISION (maintainer):** single universal tap-point vs. `CellEventBus`-parallel-to-`OutputDispatcher`. #404 preserves the *principle* (typed events, composable sinks) and is extensible to a unified tap, but is not literally one bus. Options (a)/(b)/(c) recorded for the maintainer to rule on — it gates **only** 6a-2b's focus-handler publish target; the parallel-marker pattern holds regardless. Captured-necessity references: ADR 0008 / ADR 0004 D4 / ADR 0007 D9 / ADR 0001.

## Test plan

- [ ] Markdown link check green (docs-only fast-merge gate).

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_