### PR TITLE
ADR 0007 Phase 6b: pane-switch, visible-selection & per-cell-source corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15272,6 +15272,51 @@ with a larger font. Visual/focus-plumbing only — the UIA
 Carries a re-dogfood (`52-ADR7-P6a-fix`); Phase-6+ proceed is
 gated on it.
 
+### Cycle 52 ADR 0007 Phase 6b (2026-05-17): pane-switch + visible-selection + per-cell-source corrections
+
+Post-`52-ADR7-P6a` dogfood (longer session) surfaced three
+foundational regressions the earlier "PASSED" did not catch,
+all fixed here:
+
+- **Menu focus-trap recurred.** The menu-invoked pane switch
+  was re-trapped in the WPF `Menu` focus scope after a few
+  round-trips (synchronous `Keyboard.Focus` undone by the
+  menu's own post-close focus restore). The focus move is now
+  posted to the dispatcher at `Input` priority (runs after
+  the menu closes) and targets the selected `ListBoxItem`
+  container, not the `ListBox` shell — so a screen reader's
+  focus rectangle (NVDA's visual highlight) has a real
+  focused UIA element.
+- **Selected row had no visible highlight.** The
+  `SystemColors` brush-key override did not render on the
+  maintainer's theme. Replaced with a minimal own
+  `ListBoxItem` `ControlTemplate` that renders the
+  strong-blue selection independent of OS theme and
+  **persists when focus leaves the pane**. Both panes now
+  share one background with a strong per-panel outline
+  (single `PanelBackgroundBrush` resource — the future
+  theming swap point) and each row carries a thin bottom
+  rule for low-vision demarcation (deliberately minimal —
+  the flat list is scaffolding).
+- **`Ctrl+Shift+Left/Right` were spatially reversed.**
+  Corrected (terminal = left pane, history = right). Each
+  pane switch now publishes `CellEventBus.PaneSwitched`; a
+  distinct earcon per pane (`pane-terminal` 1600 Hz /
+  `pane-history` 2600 Hz) is the non-speech cue (the tone
+  carries which pane — ADR 0008), off the UI thread and
+  respecting the global earcon mute.
+- **Per-cell ops followed SpeechCursor, not the list.**
+  `Ctrl+Shift+C` copy / copy-command / copy-output / menu
+  rerun-input now resolve the target through a single
+  forward-declared "focused-cell source" seam, flipped to
+  the cell-history list's selected cell **by `CellId`**
+  (reorder/delete-safe). SpeechCursor stays alive for
+  navigation; full removal is a later phase.
+
+Locally unverifiable (no WPF/NVDA in the sandbox) — carries
+the re-dogfood gate `52-ADR7-P6b`; Phase-6+ proceed is gated
+on it.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -592,6 +592,43 @@ changes the ADR 0004 IOCell schema.
   operation-discovery menu. Nothing past 6a is built until
   6a's NVDA dogfood confirms the control type.
 
+  - **Phase 6a-2b corrections (2026-05-17, gate
+    `52-ADR7-P6b`).** The post-`52-ADR7-P6a` dogfood
+    surfaced three foundational regressions the earlier
+    "PASSED" note did not catch (the maintainer re-ran a
+    longer session): (1) the menu-invoked pane switch was
+    re-trapped in the WPF `Menu` focus scope after a few
+    round-trips — fixed by posting the focus move to the
+    dispatcher (after menu close) and focusing the selected
+    `ListBoxItem` container, not the `ListBox` shell, so a
+    screen reader's focus rectangle has a real focused UIA
+    element; (2) the selected row had no visible highlight
+    (the `SystemColors` brush-key override did not render
+    on the maintainer's theme) — fixed with a minimal own
+    `ListBoxItem` `ControlTemplate` that renders the
+    strong-blue selection independent of OS theme and
+    **persists when focus leaves the pane**, plus a uniform
+    panel background + strong per-panel outline + a thin
+    per-row rule (maintainer direction; deliberately minimal
+    — the flat list is scaffolding); (3) `Ctrl+Shift+
+    Left/Right` were spatially reversed — corrected (terminal
+    is the left pane, history the right) and each pane switch
+    now publishes `CellEventBus.PaneSwitched`, with a
+    distinct earcon per pane (ADR 0008: the tone carries
+    which pane).
+  - **Per-cell-operation source flip (Phase 2 / D2
+    follow-through, same gate).** `Ctrl+Shift+C` copy /
+    copy-command / copy-output / the menu rerun-input
+    resolved their target through `SpeechCursor.focusedCell`
+    — decoupled from the navigable list, so operating on a
+    *different* cell than the one the user navigated to. A
+    single forward-declared "focused-cell source" seam is
+    introduced and flipped to resolve the list's selected
+    cell **by `CellId`** (reorder/delete-safe; a list index
+    would not be). SpeechCursor stays alive for navigation;
+    its full removal in favour of the list (ADR 0007 D5a
+    intent) is a later, separate phase.
+
 - **Phase 7 — automated cell-structure diagnostics (D6).**
   Extend the existing test corpus + `Diagnostics → Test …`
   menu so each scripted scenario carries an **expected

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -930,6 +930,24 @@ module Program =
         let mutable speechCursor =
             SpeechCursor.create SpeechCursor.defaultParameters
 
+        // ADR 0007 Phase 6b (2026-05-17) — the single
+        // "focused-cell source" the per-cell operations
+        // (Ctrl+Shift+C copy / copy-command / copy-output /
+        // menu rerun-input) resolve through. SpeechCursor is
+        // being deprecated in favour of the static navigable
+        // cell-history list (ADR 0007 D5a); this seam lets the
+        // ops follow the list's selected cell *by CellId*
+        // (reorder/delete-safe — a list index would not be)
+        // without ripping SpeechCursor out yet. Default is the
+        // legacy SpeechCursor resolver; `compose()` reassigns
+        // it to the list resolver once the cell-history list is
+        // wired (below). Forward-declared `mutable` so the
+        // handlers (defined before the list) close over the
+        // seam, not the source.
+        let mutable focusedCellSource
+            : unit -> SpeechCursor.FocusedCell option =
+            fun () -> SpeechCursor.focusedCell speechCursor
+
         // Cycle 47 follow-up (2026-05-13) — idle-flush watermark.
         // Declared at compose-top alongside `contentHistory` so
         // both the boundary handler (further down in compose) and
@@ -3389,10 +3407,10 @@ module Program =
                     "Terminal.App.Program.runCopyFocusedCell"
             log.LogInformation(
                 "Ctrl+Shift+C pressed — copying the focused cell to clipboard.")
-            match SpeechCursor.focusedCell speechCursor with
+            match focusedCellSource () with
             | None ->
                 window.TerminalSurface.Announce(
-                    "No focused cell. Press Ctrl+Shift+Up or Down to focus a cell first.",
+                    "No cell selected. Press Ctrl+Shift+Right to focus the cell history, then arrow to a cell.",
                     ActivityIds.diagnostic)
             | Some cell ->
                 let parts =
@@ -3492,10 +3510,10 @@ module Program =
             log.LogInformation(
                 "Phase 2b — copying the focused cell's {Side} to clipboard.",
                 sideName)
-            match SpeechCursor.focusedCell speechCursor with
+            match focusedCellSource () with
             | None ->
                 window.TerminalSurface.Announce(
-                    "No focused cell. Press Ctrl+Shift+Up or Down to focus a cell first.",
+                    "No cell selected. Press Ctrl+Shift+Right to focus the cell history, then arrow to a cell.",
                     ActivityIds.diagnostic)
             | Some cell ->
                 match pick cell with
@@ -4408,10 +4426,10 @@ module Program =
         // bundle; logging discipline).
         let runRerunInput () : unit =
             let log = Logger.get "Terminal.App.Program.runRerunInput"
-            match SpeechCursor.focusedCell speechCursor with
+            match focusedCellSource () with
             | None ->
                 window.TerminalSurface.Announce(
-                    "No focused cell. Navigate to a command cell first.",
+                    "No cell selected. Press Ctrl+Shift+Right to focus the cell history, then arrow to a command cell.",
                     ActivityIds.diagnostic)
             | Some fc ->
                 match fc.Command with
@@ -4518,7 +4536,8 @@ module Program =
                             (sprintf "%A" cv.Kind),
                             cellHistoryItems.Count)))
                 |> ignore
-            | CellEventBus.Focused _ -> ())
+            | CellEventBus.Focused _ -> ()
+            | CellEventBus.PaneSwitched _ -> ())
         |> ignore
         // Parallel focus-marker: native SR announce + our typed
         // event. NO manual `Announce` here (double-speak).
@@ -4533,44 +4552,138 @@ module Program =
                     cell.CellSequence,
                     (sprintf "%A" cell.Kind)))
 
-        // Pane switch. Move keyboard focus only — the screen
-        // reader announces the newly-focused control natively
-        // (ADR 0007 6a-2b conformance #1: "at most a brief
-        // distinct pane-change marker"; the conservative
-        // first-cut default is no manual cue, dogfood refines).
-        // ADR 0007 Phase 6a-2b follow-up (maintainer dogfood
-        // 2026-05-17): the WPF `Menu` is its own *focus scope*.
-        // After the menu had been entered, a plain
-        // `element.Focus()` set logical focus but did not pull
-        // the **keyboard focus device** out of the Menu scope —
-        // arrows kept driving the menu, unrecoverable. Force the
-        // keyboard focus across scopes with `Keyboard.Focus`
-        // (textbook FocusScope fix; locally unverifiable — no
-        // WPF/NVDA in the sandbox — so it carries a re-dogfood,
-        // `52-ADR7-P6a-fix`). Entering the history pane also
-        // selects the latest row when nothing is selected, so
-        // there is an immediate visible + spoken anchor (the
-        // SelectionChanged handler then publishes
-        // `CellEventBus.Focused` and the screen reader announces
-        // it natively — no manual announce, conformance #1).
+        // ADR 0007 Phase 6b — per-cell ops follow the navigable
+        // list, resolved by `CellId` (reorder/delete-safe; a
+        // list index would not be). Gathers both sides of the
+        // selected row's cell from the same row-aligned
+        // projection the list renders, into the existing
+        // `SpeechCursor.FocusedCell` shape the ops already
+        // consume. Flips the compose-top seam off the
+        // SpeechCursor resolver — SpeechCursor stays alive for
+        // navigation; full removal is a later phase.
+        let listSelectedFocusedCell ()
+            : SpeechCursor.FocusedCell option =
+            let lb = window.CellHistoryList
+            let i = lb.SelectedIndex
+            if i < 0 || i >= cellHistoryCells.Count then None
+            else
+                let v = cellHistoryCells.[i]
+                let textOf (k: SpeechCursor.CellKind) =
+                    cellHistoryCells
+                    |> Seq.tryFind (fun c ->
+                        c.CellId = v.CellId && c.Kind = k)
+                    |> Option.map (fun c -> c.Text)
+                Some
+                    ({ CellId = v.CellId
+                       CellSequence = v.CellSequence
+                       Command = textOf SpeechCursor.CellKind.Input
+                       Output = textOf SpeechCursor.CellKind.Output }
+                     : SpeechCursor.FocusedCell)
+        focusedCellSource <- listSelectedFocusedCell
+
+        // ADR 0007 Phase 6a-2b — non-speech pane-switch cue.
+        // Distinct earcon per pane (ADR 0008: the tone itself
+        // carries which pane). Played off the UI thread so the
+        // focus path stays snappy; `CellEventBus.publish`
+        // already exception-guards subscribers. Respects the
+        // global earcon mute (Display → Earcons → Muted). The
+        // log line ships with the feature so a Ctrl+Shift+D
+        // bundle confirms the cue fired and which id.
+        CellEventBus.subscribe (fun ev ->
+            match ev with
+            | CellEventBus.PaneSwitched pane ->
+                let earconId =
+                    match pane with
+                    | CellEventBus.TerminalPane -> "pane-terminal"
+                    | CellEventBus.HistoryPane -> "pane-history"
+                let muted = EarconChannel.isMuted ()
+                cellPaneLog.LogInformation(
+                    "ADR 0007 Phase 6a-2b pane earcon. Pane={Pane} Muted={Muted} EarconId={EarconId}",
+                    (sprintf "%A" pane),
+                    muted,
+                    earconId)
+                if not muted then
+                    System.Threading.Tasks.Task.Run(
+                        System.Action(fun () ->
+                            EarconPlayer.play
+                                EarconPalette.defaultPalette
+                                earconId))
+                    |> ignore
+            | CellEventBus.Focused _ -> ()
+            | CellEventBus.Appended _ -> ())
+        |> ignore
+
+        // Pane switch (ADR 0007 Phase 6a-2b; revised after the
+        // 2026-05-17 dogfood — the prior synchronous
+        // `Keyboard.Focus` did not hold). Two compounding bugs
+        // were found and are fixed here:
+        //
+        //   1. Menu focus-scope steal. Invoked from the Menu
+        //      item, WPF's `Menu` is its own focus scope and
+        //      re-asserts the keyboard-focus device into itself
+        //      *after* the click handler returns — undoing a
+        //      synchronous `Keyboard.Focus` and leaving arrows
+        //      driving the menu (the recurring trap). Fix: post
+        //      the focus move to the dispatcher at `Input`
+        //      priority so it runs after the menu has fully
+        //      closed and relinquished focus.
+        //   2. Focus landed on the `ListBox`, not a
+        //      `ListBoxItem`. A screen reader's focus rectangle
+        //      (NVDA's visual highlight) wraps the element with
+        //      UIA keyboard focus; a `ListBox` whose item is
+        //      only *selected*, not *focused*, gives it nothing
+        //      to wrap and the low-vision selection reads as
+        //      absent. Fix: focus the selected `ListBoxItem`
+        //      container (generated via the item-container
+        //      generator after `ScrollIntoView` + `UpdateLayout`
+        //      so it exists under virtualization).
+        //
+        // Still no manual `Announce` — the screen reader speaks
+        // the newly-focused control natively (conformance #1);
+        // the parallel non-speech cue is the `PaneSwitched`
+        // earcon sink above. Locally unverifiable (no WPF/NVDA
+        // in the sandbox) — carries the re-dogfood gate
+        // `52-ADR7-P6b`.
+        let focusSelectedHistoryItem () : unit =
+            let lb = window.CellHistoryList
+            if lb.Items.Count > 0 && lb.SelectedIndex < 0 then
+                lb.SelectedIndex <- lb.Items.Count - 1
+            lb.Focus() |> ignore
+            Keyboard.Focus(lb :> IInputElement) |> ignore
+            let idx = lb.SelectedIndex
+            if idx >= 0 && idx < lb.Items.Count then
+                lb.ScrollIntoView(lb.Items.[idx])
+                lb.UpdateLayout()
+                match lb.ItemContainerGenerator.ContainerFromIndex(idx) with
+                | :? ListBoxItem as item ->
+                    item.Focus() |> ignore
+                    Keyboard.Focus(item :> IInputElement) |> ignore
+                | _ -> ()
         let runFocusHistoryPane () : unit =
-            if window.CellHistoryList.Items.Count > 0
-               && window.CellHistoryList.SelectedIndex < 0 then
-                window.CellHistoryList.SelectedIndex <-
-                    window.CellHistoryList.Items.Count - 1
-            window.CellHistoryList.Focus() |> ignore
-            Keyboard.Focus(window.CellHistoryList :> IInputElement)
+            window.Dispatcher.InvokeAsync(
+                System.Action(fun () ->
+                    focusSelectedHistoryItem ()
+                    CellEventBus.publish
+                        (CellEventBus.PaneSwitched CellEventBus.HistoryPane)
+                    cellPaneLog.LogInformation(
+                        "ADR 0007 Phase 6a-2b pane switch. Target={Target}",
+                        "history")),
+                System.Windows.Threading.DispatcherPriority.Input)
             |> ignore
-            cellPaneLog.LogInformation(
-                "ADR 0007 Phase 6a-2b pane switch. Target={Target}",
-                "history")
         let runFocusTerminalPane () : unit =
-            window.TerminalSurface.Focus() |> ignore
-            Keyboard.Focus(window.TerminalSurface :> IInputElement)
+            window.Dispatcher.InvokeAsync(
+                System.Action(fun () ->
+                    window.TerminalSurface.Focus() |> ignore
+                    Keyboard.Focus(
+                        window.TerminalSurface :> IInputElement)
+                    |> ignore
+                    CellEventBus.publish
+                        (CellEventBus.PaneSwitched CellEventBus.TerminalPane)
+                    cellPaneLog.LogInformation(
+                        "ADR 0007 Phase 6a-2b pane switch. Target={Target}",
+                        "terminal")),
+                System.Windows.Threading.DispatcherPriority.Input)
             |> ignore
-            cellPaneLog.LogInformation(
-                "ADR 0007 Phase 6a-2b pane switch. Target={Target}",
-                "terminal")
 
         bind HotkeyRegistry.SpeechCursorNext runSpeechCursorNext
         bind HotkeyRegistry.SpeechCursorPrevious runSpeechCursorPrevious

--- a/src/Terminal.Audio/EarconPalette.fs
+++ b/src/Terminal.Audio/EarconPalette.fs
@@ -30,8 +30,9 @@ module EarconPalette =
     /// compatibility (Phase 2).
     type EarconId = string
 
-    /// Default palette. Four entries — the audio side of the
-    /// 8d sub-stages plus the Cycle 45 ready-for-input cue.
+    /// Default palette. Six entries — the audio side of the
+    /// 8d sub-stages, the Cycle 45 ready-for-input cue, and the
+    /// ADR 0007 6a-2b pane-switch pair.
     /// - `bell-ping` (800Hz × 100ms): triggered by BEL (0x07).
     /// - `error-tone` (400Hz × 150ms): triggered by future
     ///   colour-detection (red rows). Currently unused by any
@@ -57,6 +58,15 @@ module EarconPalette =
     ///   other earcon. If the click is still disruptive, the
     ///   existing Display → Earcons → Muted toggle silences
     ///   all earcons globally; per-earcon mute is a follow-up.
+    /// - `pane-terminal` (1600Hz × 25ms) / `pane-history`
+    ///   (2600Hz × 25ms): ADR 0007 6a-2b (2026-05-17). The
+    ///   non-speech cue for the Ctrl+Shift+Left/Right pane
+    ///   switch — distinct pitches so the sound itself tells
+    ///   the user which pane took focus (terminal lower, the
+    ///   list higher), played by a CellEventBus.PaneSwitched
+    ///   sink. Click-like (0ms attack, near ready-prompt's
+    ///   character) so it never masks NVDA's native focus
+    ///   announce of the new control.
     /// All earcons stay shorter than the StreamProfile's 200ms
     /// debounce window so consecutive earcons don't overlap.
     /// Tunable in Phase 2 via TOML.
@@ -77,4 +87,12 @@ module EarconPalette =
               "ready-prompt",
               { FrequencyHz = 3000.0
                 DurationMs = 15
+                AttackMs = 0 }
+              "pane-terminal",
+              { FrequencyHz = 1600.0
+                DurationMs = 25
+                AttackMs = 0 }
+              "pane-history",
+              { FrequencyHz = 2600.0
+                DurationMs = 25
                 AttackMs = 0 } ]

--- a/src/Terminal.Core/CellEventBus.fs
+++ b/src/Terminal.Core/CellEventBus.fs
@@ -62,10 +62,25 @@ module CellEventBus =
     ///     item actually added, in append order.
     ///
     /// Later: `Operated` (Phase 6 D2 ops) / `Segment` (Phase 4)
-    /// / `PaneSwitched` (6a-2b) — added when their phase ships.
+    /// — added when their phase ships.
+    ///
+    ///   * `PaneSwitched` (6a-2b, 2026-05-17) — keyboard focus
+    ///     moved between the two top-level panes (terminal ⇄
+    ///     cell-history list). Published by the pane-switch
+    ///     handlers; the screen reader still announces the
+    ///     newly-focused control natively, so this is the
+    ///     parallel non-speech cue source — an earcon sink maps
+    ///     each `Pane` to a distinct tone (ADR 0008: the sound
+    ///     itself carries which pane). WPF-free: the pane is a
+    ///     neutral `Terminal.Core` DU, never a WPF control ref.
+    type Pane =
+        | TerminalPane
+        | HistoryPane
+
     type CellEvent =
         | Focused of SpeechCursor.CellView
         | Appended of SpeechCursor.CellView
+        | PaneSwitched of Pane
 
     let private log =
         Logger.get "Terminal.Core.CellEventBus"

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -597,20 +597,23 @@ module HotkeyRegistry =
             Key = None
             Modifiers = None
             Description = "Speech Cursor: toggle AutoDrive / Manual mode (menu-only)" }
-          // ADR 0007 Phase 6a-2b — pane switch. Left → focus
-          // the cell-history list; Right → focus the terminal.
-          // NVDA announces the newly-focused control natively;
-          // the list's own focus handler publishes
-          // CellEventBus.Focused in parallel (no manual
-          // announce — see ADR 0007 6a-2b conformance).
-          { Command = FocusHistoryPane
+          // ADR 0007 Phase 6a-2b — pane switch. Spatially
+          // correct (maintainer dogfood 2026-05-17): the
+          // terminal is the LEFT pane (Grid.Column 0), the
+          // cell-history list the RIGHT pane (Grid.Column 2),
+          // so Ctrl+Shift+Left → terminal, Ctrl+Shift+Right →
+          // history. NVDA announces the newly-focused control
+          // natively; the handlers publish
+          // CellEventBus.PaneSwitched in parallel for the
+          // non-speech (earcon) cue (ADR 0007 6a-2b conformance).
+          { Command = FocusTerminalPane
             Key = Some Left
             Modifiers = Some ctrlShift
-            Description = "Focus the cell-history pane" }
-          { Command = FocusTerminalPane
+            Description = "Focus the terminal pane (left)" }
+          { Command = FocusHistoryPane
             Key = Some Right
             Modifiers = Some ctrlShift
-            Description = "Focus the terminal pane" } ]
+            Description = "Focus the cell-history pane (right)" } ]
 
     /// Look up the default Hotkey for a command. Throws
     /// `KeyNotFoundException` if the registry is incomplete —

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -385,14 +385,38 @@
              focus between the two; the screen reader announces
              the newly-focused control natively. -->
         <Grid>
+            <!-- ADR 0007 Phase 6a-2b follow-up (maintainer
+                 direction 2026-05-17): both panes share ONE
+                 background colour, each with a strong outline,
+                 so the boundary is obvious without per-pane
+                 colour differences. `PanelBackgroundBrush` is
+                 deliberately a single resource — the one place
+                 a future high-contrast / dark-mode / user
+                 theme will swap (not built now; just kept to a
+                 single swap point). Black matches the terminal
+                 grid's own fill (TerminalView `_background`),
+                 so the panes are uniform today. -->
+            <Grid.Resources>
+                <SolidColorBrush x:Key="PanelBackgroundBrush" Color="Black" />
+                <SolidColorBrush x:Key="PanelOutlineBrush" Color="White" />
+            </Grid.Resources>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <views:TerminalView Grid.Column="0"
-                                x:Name="TerminalSurface"
-                                x:FieldModifier="public" />
+            <!-- TerminalSurface keeps its x:Name + public field
+                 modifier so the load-bearing MainWindow.xaml.cs
+                 `Loaded += TerminalSurface.Focus()` is
+                 unchanged; the Border just supplies the uniform
+                 background + strong panel outline. -->
+            <Border Grid.Column="0"
+                    Background="{StaticResource PanelBackgroundBrush}"
+                    BorderBrush="{StaticResource PanelOutlineBrush}"
+                    BorderThickness="2">
+                <views:TerminalView x:Name="TerminalSurface"
+                                    x:FieldModifier="public" />
+            </Border>
             <GridSplitter Grid.Column="1"
                           Width="4"
                           HorizontalAlignment="Center"
@@ -408,34 +432,59 @@
                  ListItem is announced natively on arrow-nav while
                  the SelectionChanged handler publishes
                  CellEventBus.Focused in parallel (no manual
-                 Announce — ADR 0007 6a-2b conformance #1). -->
+                 Announce — ADR 0007 6a-2b conformance #1).
+
+                 Selection visibility (2026-05-17 dogfood): the
+                 prior SystemColors brush-key override did not
+                 render on the maintainer's theme — the default
+                 ListBoxItem template paints its own selection
+                 element and ignores those keys. Replaced with a
+                 minimal own ControlTemplate so the strong-blue
+                 selected row renders independent of OS theme and
+                 PERSISTS when focus leaves the pane (no
+                 keyboard-focus condition — the maintainer needs
+                 the last selection still visible after
+                 Ctrl+Shift+Left). Each item also carries a thin
+                 bottom rule as a low-vision per-row demarcation.
+                 Deliberately minimal — this list is temporary
+                 scaffolding (Tree is the Phase-4/5 path), so no
+                 further styling investment. -->
             <ListBox Grid.Column="2"
                      x:Name="CellHistoryList"
                      x:FieldModifier="public"
                      SelectionMode="Single"
                      FontSize="16"
-                     Background="White"
-                     Foreground="Black"
+                     Background="{StaticResource PanelBackgroundBrush}"
+                     Foreground="White"
+                     BorderBrush="{StaticResource PanelOutlineBrush}"
+                     BorderThickness="2"
                      AutomationProperties.Name="Cell history"
                      AutomationProperties.AutomationId="pty-speak.CellHistoryList">
-                <!-- ADR 0007 Phase 6a-2b follow-up (maintainer
-                     dogfood 2026-05-17, low-vision): the list IS
-                     drawn on screen (real Grid column); make the
-                     SELECTED row obvious so a low-vision user can
-                     see where the NVDA cursor is. Recolour the
-                     selection highlight via the canonical
-                     SystemColors brush-key override (robust — does
-                     not fight the default item template) so it is
-                     high-contrast whether or not the list has
-                     keyboard focus, plus a large readable font.
-                     Visual-only: the UIA `List` semantics NVDA
-                     reads are unchanged (D8 stays ratified). -->
-                <ListBox.Resources>
-                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF0033CC" />
-                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="White" />
-                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#FF0033CC" />
-                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="White" />
-                </ListBox.Resources>
+                <ListBox.ItemContainerStyle>
+                    <Style TargetType="ListBoxItem">
+                        <Setter Property="Foreground" Value="White" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListBoxItem">
+                                    <Border x:Name="Bd"
+                                            Background="Transparent"
+                                            BorderBrush="#FF555555"
+                                            BorderThickness="0,0,0,1"
+                                            Padding="4,2">
+                                        <ContentPresenter />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Bd" Property="Background" Value="#FF0033CC" />
+                                            <Setter Property="Foreground" Value="White" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ListBox.ItemContainerStyle>
             </ListBox>
         </Grid>
     </DockPanel>

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -716,8 +716,8 @@ public class TerminalView : FrameworkElement
             // Up/Down/End rows above). NVDA collision check:
             // review-cursor defaults are the Numpad cluster;
             // Ctrl+Shift+arrow is free.
-            (Key.Left, ModifierKeys.Control | ModifierKeys.Shift, "Focus cell-history pane"),
-            (Key.Right, ModifierKeys.Control | ModifierKeys.Shift, "Focus terminal pane"),
+            (Key.Left, ModifierKeys.Control | ModifierKeys.Shift, "Focus terminal pane (left)"),
+            (Key.Right, ModifierKeys.Control | ModifierKeys.Shift, "Focus cell-history pane (right)"),
 
             // Future entries (NOT yet bound; commented for
             // forward-planning):

--- a/tests/Tests.Unit/CellEventBusTests.fs
+++ b/tests/Tests.Unit/CellEventBusTests.fs
@@ -28,14 +28,16 @@ let private mkCell (seq: int64) : SpeechCursor.CellView =
       ActivityId = ActivityIds.output
       ExitCode = None }
 
-// Both cases carry the typed `CellView`; the bus contract is
-// kind-agnostic, so the helper extracts the sequence from
-// either (the OR-pattern also keeps the match exhaustive as
-// cases are added).
+// The cell-carrying cases share the typed `CellView`; the bus
+// contract is kind-agnostic, so the helper extracts the
+// sequence from either. `PaneSwitched` carries a `Pane`, not a
+// cell — it is not exercised by these tests, so it maps to a
+// sentinel to keep the match exhaustive.
 let private cellSeq (ev: CellEventBus.CellEvent) : int64 =
     match ev with
     | CellEventBus.Focused cv
     | CellEventBus.Appended cv -> cv.CellSequence
+    | CellEventBus.PaneSwitched _ -> -1L
 
 [<Fact>]
 let ``subscribe receives a published Focused event`` () =
@@ -114,7 +116,8 @@ let ``one subscriber receives both Focused and Appended`` () =
         CellEventBus.subscribe (fun ev ->
             match ev with
             | CellEventBus.Focused _ -> kinds.Add "focused"
-            | CellEventBus.Appended _ -> kinds.Add "appended")
+            | CellEventBus.Appended _ -> kinds.Add "appended"
+            | CellEventBus.PaneSwitched _ -> ())
     CellEventBus.publish (CellEventBus.Appended(mkCell 1L))
     CellEventBus.publish (CellEventBus.Focused(mkCell 1L))
     Assert.Equal<string list>(


### PR DESCRIPTION
## Summary

Post-`52-ADR7-P6a` dogfood (longer session, 2026-05-17) surfaced four foundational regressions on the cell-history list. All fixed here:

- **Menu focus-trap recurred.** The menu-invoked pane switch was re-trapped in the WPF `Menu` focus scope after a few round-trips (synchronous `Keyboard.Focus` undone by the menu's own post-close focus restore). The focus move is now dispatcher-posted at `Input` priority (after the menu closes) and targets the selected `ListBoxItem` container, not the `ListBox` shell — so a screen reader's focus rectangle (NVDA's visual highlight) has a real focused UIA element.
- **Selected row had no visible highlight.** The `SystemColors` brush-key override did not render on the maintainer's theme. Replaced with a minimal own `ListBoxItem` `ControlTemplate` (strong-blue, theme-independent, **persists when focus leaves the pane**). Both panes now share one background with a strong per-panel outline (single `PanelBackgroundBrush` resource — the future theming swap point); each row has a thin bottom rule for low-vision demarcation (deliberately minimal — the flat list is scaffolding).
- **`Ctrl+Shift+Left/Right` were spatially reversed.** Corrected (terminal = left pane, history = right). Each switch publishes `CellEventBus.PaneSwitched`; a distinct per-pane earcon (`pane-terminal` 1600 Hz / `pane-history` 2600 Hz) is the non-speech cue (the tone carries which pane — ADR 0008), played off the UI thread and respecting the global earcon mute.
- **Per-cell ops followed SpeechCursor, not the list.** `Ctrl+Shift+C` copy / copy-command / copy-output / menu rerun-input now resolve through a single forward-declared "focused-cell source" seam, flipped to the list's selected cell **by `CellId`** (reorder/delete-safe). SpeechCursor stays alive for navigation; full removal is a later phase. (ADR 0007 Phase 6b note added.)

Net: +368 / −85 across 9 files. SpeechCursor is not removed; only the per-cell-op *source* is flipped.

## Test plan

- [ ] CI green (Windows build + unit tests; the only build signal — no local .NET in the sandbox).
- [ ] **Re-dogfood `52-ADR7-P6b`** (blocks Phase-6+ proceed):
  - [ ] `Ctrl+Shift+Right` focuses the cell-history list (right pane); `Ctrl+Shift+Left` focuses the terminal (left pane) — directions match layout.
  - [ ] Distinct earcon on each pane switch; respects Display → Earcons → Muted.
  - [ ] Repeated menu-invoked pane switches (many round-trips) — no recurring trap; arrows keep driving the focused control.
  - [ ] Sighted check: selected row is strongly highlighted and **stays** highlighted after `Ctrl+Shift+Left`; NVDA's visual focus rectangle wraps the selected item; uniform background + strong outline on both panes; per-row rule visible.
  - [ ] Navigate the list, press `Ctrl+Shift+C` / copy-command / copy-output / menu rerun-input — they act on the **navigated** cell.
- Diagnostics (paste-safe): `Alt` → Diagnostics → Grep Diagnostics → pattern `ADR 0007 Phase 6a-2b` (literal). Confirms `pane switch Target=…`, `list focus-marker Index=…`, `pane earcon …`.

Locally unverifiable (no WPF/NVDA in the sandbox) — CI is the only build check; behaviour is gated on the re-dogfood.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_