### PR TITLE
ADR 0007 Phase 6b round 2: empty-list focus, panel titles, light-scheme inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15317,6 +15317,38 @@ Locally unverifiable (no WPF/NVDA in the sandbox) — carries
 the re-dogfood gate `52-ADR7-P6b`; Phase-6+ proceed is gated
 on it.
 
+### Cycle 52 ADR 0007 Phase 6b dogfood round 2 (2026-05-17): empty-list focus, panel titles, light-scheme inversion
+
+`52-ADR7-P6b` dogfood: navigation confirmed working; three UI
+items addressed:
+
+- **Empty list could not hold keyboard focus** — arrows
+  escaped to the menu. A single non-cell placeholder row
+  ("No cell history yet.") is seeded and dropped the first
+  time a real cell is appended (the list is append-only for
+  the app lifetime; row→cell lookups were already
+  bounds-checked, so a selected placeholder safely resolves
+  to "no cell").
+- **No visual orientation** — a bold title is now drawn above
+  each panel ("Terminal" / "Cell history"); decorative and
+  non-focusable, NVDA still reads the list name on focus.
+- **Colours inverted to a light scheme** (white background /
+  black text / black outline) on the maintainer's
+  low-vision-friend test machine — kept to the
+  `Panel{Background,Foreground,Outline}Brush` resources and
+  the TerminalView default-colour pair, in lock-step so the
+  panes stay uniform. Explicitly a *temporary* swap, not the
+  future theme-management framework.
+
+Flagged, deferred to the computational-accuracy stage (NOT
+list bugs — the list faithfully projects `CellEventBus.Appended`
+off the seal site): output sub-portions do not trickle live
+(ADR 0007 Phase 4, by design); the input-test produces no
+sealed command cell (ADR 0004 drop-on-None / Cycle 52
+boundary detection, upstream); cell history is not reset on
+shell hot-switch (accepted — a shell-switch marker row is the
+planned follow-up).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -435,6 +435,18 @@ verified to fully restore it on both build types.
   Cycle 51 proves the extensibility surface; the actual
   sink impls are their own projects.
 - **Velopack staleness investigation** (PR-M).
+- **Phase 6b dogfood round 2 known limitations** (2026-05-17;
+  detail in [ADR 0007](adr/0007-canonical-iocell-history-navigation.md)
+  Phase 6b note). NOT cell-history-list bugs — the list
+  faithfully projects `CellEventBus.Appended` off the seal
+  site: (a) no live output trickle (= Phase 4, by design);
+  (b) the input-test seals no command cell (ADR 0004
+  drop-on-None / Cycle 52 boundary detection, upstream); (c)
+  history not reset on shell hot-switch — accepted, the
+  planned follow-up is a shell-switch **marker row** (its own
+  change; unify the parallel-index row arrays into one typed
+  row list first — also retires the empty-list placeholder
+  hack).
 
 See [`docs/PROJECT-PLAN-2026-05-12.md`](PROJECT-PLAN-2026-05-12.md)
 for sequencing rationale + risks.

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -628,6 +628,37 @@ changes the ADR 0004 IOCell schema.
     would not be). SpeechCursor stays alive for navigation;
     its full removal in favour of the list (ADR 0007 D5a
     intent) is a later, separate phase.
+  - **6b dogfood round 2 (2026-05-17).** Navigation
+    confirmed working. Three further UI items addressed: (1)
+    an empty `ListBox` cannot hold keyboard focus (arrows
+    escaped to the menu) — a single non-cell placeholder row
+    ("No cell history yet.") is seeded and dropped on the
+    first real append; (2) a visible bold title above each
+    panel for low-vision orientation; (3) both panels'
+    colours inverted to a light scheme (white bg / black
+    text / black outline) on the maintainer's
+    low-vision-friend test machine — an explicit *temporary*
+    swap kept to the `Panel*Brush` resources + the
+    TerminalView default-colour pair, NOT the future
+    theme-management framework.
+  - **Known limitations surfaced, deferred to the
+    computational-accuracy stage (NOT list bugs).** The list
+    is a faithful projection of `CellEventBus.Appended`,
+    published only at the canonical *seal* site (`Program.fs`
+    `finalisedOpt = Some`). Consequently: (a) output
+    sub-portions do **not** trickle in live — that is ADR
+    0007 **Phase 4 (live in-flight trickle)**, deferred by
+    design; (b) the canonical input-test produces **no
+    sealed command cell** because the cell is dropped
+    upstream (ADR 0004 drop-on-None / Cycle 52
+    boundary-detection), not lost between the bus and the
+    list. Both are upstream computational-accuracy items,
+    explicitly out of scope here. (c) Cell history is **not
+    reset on shell hot-switch** — accepted as correct
+    (maintainer 2026-05-17); the planned follow-up is a
+    shell-switch **marker row** inserted into the history
+    (its own change; needs the row model unified off the
+    current parallel-index arrays first).
 
 - **Phase 7 — automated cell-structure diagnostics (D6).**
   Extend the existing test corpus + `Diagnostics → Test …`

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4505,6 +4505,20 @@ module Program =
             System.Collections.ObjectModel.ObservableCollection<string>()
         let cellHistoryCells =
             ResizeArray<SpeechCursor.CellView>()
+        // ADR 0007 Phase 6b follow-up (dogfood 2026-05-17): an
+        // empty ListBox cannot hold keyboard focus — arrows
+        // escape to the menu. Seed one non-cell placeholder row
+        // so the pane always has a focusable item; it is dropped
+        // the first time a real cell is appended (the list is
+        // append-only for the app lifetime, so it never returns
+        // to empty — no re-add path needed). Index safety: while
+        // the placeholder is the only row `cellHistoryCells` is
+        // empty, and every row→cell lookup (SelectionChanged
+        // publish, `listSelectedFocusedCell`) is already
+        // bounds-checked against `cellHistoryCells`, so a
+        // selected placeholder resolves to "no cell".
+        let cellHistoryPlaceholder = "No cell history yet."
+        let mutable cellHistoryPlaceholderPresent = false
         let cellKindLabel (k: SpeechCursor.CellKind) : string =
             match k with
             | SpeechCursor.CellKind.Input -> "Command"
@@ -4516,6 +4530,8 @@ module Program =
                 cv.Text.Replace("\r", " ").Replace("\n", " ").Trim()
             sprintf "%s: %s" (cellKindLabel cv.Kind) oneLine
         window.CellHistoryList.ItemsSource <- cellHistoryItems
+        cellHistoryItems.Add(cellHistoryPlaceholder)
+        cellHistoryPlaceholderPresent <- true
         // Subscribe the list to the canonical cell pipeline.
         // `Appended` → add a projected row (marshalled to the
         // UI thread; the publish fires on the reader/seal
@@ -4528,6 +4544,9 @@ module Program =
             | CellEventBus.Appended cv ->
                 window.Dispatcher.InvokeAsync(
                     System.Action(fun () ->
+                        if cellHistoryPlaceholderPresent then
+                            cellHistoryItems.Clear()
+                            cellHistoryPlaceholderPresent <- false
                         cellHistoryItems.Add(cellHistoryDisplay cv)
                         cellHistoryCells.Add(cv)
                         cellPaneLog.LogInformation(

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -385,37 +385,58 @@
              focus between the two; the screen reader announces
              the newly-focused control natively. -->
         <Grid>
-            <!-- ADR 0007 Phase 6a-2b follow-up (maintainer
-                 direction 2026-05-17): both panes share ONE
-                 background colour, each with a strong outline,
-                 so the boundary is obvious without per-pane
-                 colour differences. `PanelBackgroundBrush` is
-                 deliberately a single resource — the one place
-                 a future high-contrast / dark-mode / user
-                 theme will swap (not built now; just kept to a
-                 single swap point). Black matches the terminal
-                 grid's own fill (TerminalView `_background`),
-                 so the panes are uniform today. -->
+            <!-- ADR 0007 Phase 6b follow-up (maintainer dogfood
+                 2026-05-17): both panes share ONE background
+                 colour with a strong outline + a visible title
+                 above each, so a low-vision user can orient.
+                 Colours INVERTED to a light scheme (white
+                 background / black text / black outline) on the
+                 maintainer's low-vision-friend test machine —
+                 explicitly a temporary swap, NOT the future
+                 theme-management framework. `PanelBackgroundBrush`
+                 / `PanelForegroundBrush` / `PanelOutlineBrush`
+                 stay the single swap point that framework will
+                 later own. The terminal grid's own default fill
+                 / text (TerminalView `_background` + the
+                 ResolveBrush default-spec branch) are inverted
+                 in lock-step so the panes stay uniform. -->
             <Grid.Resources>
-                <SolidColorBrush x:Key="PanelBackgroundBrush" Color="Black" />
-                <SolidColorBrush x:Key="PanelOutlineBrush" Color="White" />
+                <SolidColorBrush x:Key="PanelBackgroundBrush" Color="White" />
+                <SolidColorBrush x:Key="PanelForegroundBrush" Color="Black" />
+                <SolidColorBrush x:Key="PanelOutlineBrush" Color="Black" />
             </Grid.Resources>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <!-- TerminalSurface keeps its x:Name + public field
-                 modifier so the load-bearing MainWindow.xaml.cs
-                 `Loaded += TerminalSurface.Focus()` is
-                 unchanged; the Border just supplies the uniform
-                 background + strong panel outline. -->
+            <!-- Each panel = Border (uniform bg + strong
+                 outline) → DockPanel → a docked title header +
+                 the content. TerminalSurface keeps its x:Name +
+                 public field modifier so the load-bearing
+                 MainWindow.xaml.cs `Loaded +=
+                 TerminalSurface.Focus()` is unchanged. The title
+                 Border/TextBlock is decorative (non-focusable,
+                 not in the tab order) — pure sighted
+                 orientation; NVDA still reads the list's
+                 AutomationProperties.Name on focus. -->
             <Border Grid.Column="0"
                     Background="{StaticResource PanelBackgroundBrush}"
                     BorderBrush="{StaticResource PanelOutlineBrush}"
                     BorderThickness="2">
-                <views:TerminalView x:Name="TerminalSurface"
-                                    x:FieldModifier="public" />
+                <DockPanel>
+                    <Border DockPanel.Dock="Top"
+                            BorderBrush="{StaticResource PanelOutlineBrush}"
+                            BorderThickness="0,0,0,1">
+                        <TextBlock Text="Terminal"
+                                   FontWeight="Bold"
+                                   FontSize="14"
+                                   Padding="4,2"
+                                   Foreground="{StaticResource PanelForegroundBrush}" />
+                    </Border>
+                    <views:TerminalView x:Name="TerminalSurface"
+                                        x:FieldModifier="public" />
+                </DockPanel>
             </Border>
             <GridSplitter Grid.Column="1"
                           Width="4"
@@ -434,58 +455,68 @@
                  CellEventBus.Focused in parallel (no manual
                  Announce — ADR 0007 6a-2b conformance #1).
 
-                 Selection visibility (2026-05-17 dogfood): the
-                 prior SystemColors brush-key override did not
-                 render on the maintainer's theme — the default
-                 ListBoxItem template paints its own selection
-                 element and ignores those keys. Replaced with a
-                 minimal own ControlTemplate so the strong-blue
-                 selected row renders independent of OS theme and
-                 PERSISTS when focus leaves the pane (no
-                 keyboard-focus condition — the maintainer needs
-                 the last selection still visible after
-                 Ctrl+Shift+Left). Each item also carries a thin
-                 bottom rule as a low-vision per-row demarcation.
+                 Selection visibility: the list owns a minimal
+                 ControlTemplate so the strong-blue selected row
+                 renders independent of OS theme and PERSISTS
+                 when focus leaves the pane. Blue selection +
+                 white text stays high-contrast on the inverted
+                 (white) panel. Each item carries a thin bottom
+                 rule as a low-vision per-row demarcation. The
+                 outer Border owns the panel bg + outline, so the
+                 ListBox itself is transparent / borderless.
                  Deliberately minimal — this list is temporary
-                 scaffolding (Tree is the Phase-4/5 path), so no
-                 further styling investment. -->
-            <ListBox Grid.Column="2"
-                     x:Name="CellHistoryList"
-                     x:FieldModifier="public"
-                     SelectionMode="Single"
-                     FontSize="16"
-                     Background="{StaticResource PanelBackgroundBrush}"
-                     Foreground="White"
-                     BorderBrush="{StaticResource PanelOutlineBrush}"
-                     BorderThickness="2"
-                     AutomationProperties.Name="Cell history"
-                     AutomationProperties.AutomationId="pty-speak.CellHistoryList">
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="ListBoxItem">
-                        <Setter Property="Foreground" Value="White" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="ListBoxItem">
-                                    <Border x:Name="Bd"
-                                            Background="Transparent"
-                                            BorderBrush="#FF555555"
-                                            BorderThickness="0,0,0,1"
-                                            Padding="4,2">
-                                        <ContentPresenter />
-                                    </Border>
-                                    <ControlTemplate.Triggers>
-                                        <Trigger Property="IsSelected" Value="True">
-                                            <Setter TargetName="Bd" Property="Background" Value="#FF0033CC" />
-                                            <Setter Property="Foreground" Value="White" />
-                                        </Trigger>
-                                    </ControlTemplate.Triggers>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </ListBox.ItemContainerStyle>
-            </ListBox>
+                 scaffolding (Tree is the Phase-4/5 path). -->
+            <Border Grid.Column="2"
+                    Background="{StaticResource PanelBackgroundBrush}"
+                    BorderBrush="{StaticResource PanelOutlineBrush}"
+                    BorderThickness="2">
+                <DockPanel>
+                    <Border DockPanel.Dock="Top"
+                            BorderBrush="{StaticResource PanelOutlineBrush}"
+                            BorderThickness="0,0,0,1">
+                        <TextBlock Text="Cell history"
+                                   FontWeight="Bold"
+                                   FontSize="14"
+                                   Padding="4,2"
+                                   Foreground="{StaticResource PanelForegroundBrush}" />
+                    </Border>
+                    <ListBox x:Name="CellHistoryList"
+                             x:FieldModifier="public"
+                             SelectionMode="Single"
+                             FontSize="16"
+                             Background="Transparent"
+                             Foreground="{StaticResource PanelForegroundBrush}"
+                             BorderThickness="0"
+                             AutomationProperties.Name="Cell history"
+                             AutomationProperties.AutomationId="pty-speak.CellHistoryList">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Foreground" Value="{StaticResource PanelForegroundBrush}" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListBoxItem">
+                                            <Border x:Name="Bd"
+                                                    Background="Transparent"
+                                                    BorderBrush="#FF999999"
+                                                    BorderThickness="0,0,0,1"
+                                                    Padding="4,2">
+                                                <ContentPresenter />
+                                            </Border>
+                                            <ControlTemplate.Triggers>
+                                                <Trigger Property="IsSelected" Value="True">
+                                                    <Setter TargetName="Bd" Property="Background" Value="#FF0033CC" />
+                                                    <Setter Property="Foreground" Value="White" />
+                                                </Trigger>
+                                            </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
+                </DockPanel>
+            </Border>
         </Grid>
     </DockPanel>
 </Window>

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -172,7 +172,11 @@ public class TerminalView : FrameworkElement
     /// <summary>Default background fill for the terminal grid.
     /// FrameworkElement (unlike Control / Panel) does not expose
     /// `Background` itself, so we keep our own.</summary>
-    private readonly Brush _background = Brushes.Black;
+    // Inverted to a light scheme (maintainer dogfood 2026-05-17,
+    // low-vision-friend test machine) — kept in lock-step with
+    // MainWindow.xaml PanelBackgroundBrush. Temporary; the future
+    // theme-management framework will own this.
+    private readonly Brush _background = Brushes.White;
 
     public TerminalView()
     {
@@ -1524,7 +1528,7 @@ public class TerminalView : FrameworkElement
     {
         if (spec.IsDefault)
         {
-            return isForeground ? Brushes.White : Brushes.Black;
+            return isForeground ? Brushes.Black : Brushes.White;
         }
         if (spec.IsIndexed)
         {
@@ -1536,7 +1540,7 @@ public class TerminalView : FrameworkElement
             var rgb = (ColorSpec.Rgb)spec;
             return new SolidColorBrush(Color.FromRgb(rgb.Item1, rgb.Item2, rgb.Item3));
         }
-        return isForeground ? Brushes.White : Brushes.Black;
+        return isForeground ? Brushes.Black : Brushes.White;
     }
 
     private static Brush Ansi16ToBrush(byte idx)


### PR DESCRIPTION
## Summary

Follow-up to #410 (ADR 0007 Phase 6b). The `52-ADR7-P6b` dogfood confirmed navigation works; three further UI items addressed, plus three upstream limitations flagged (not fixed — out of scope per maintainer steer):

- **Empty cell-history list could not hold keyboard focus** — arrows escaped to the menu. A single non-cell placeholder row (`No cell history yet.`) is seeded and dropped on the first real append. The list is append-only for the app lifetime, and row→cell lookups (`SelectionChanged` publish, `listSelectedFocusedCell`) were already bounds-checked against `cellHistoryCells`, so a selected placeholder safely resolves to "no cell".
- **No visual orientation for low-vision use** — a bold title is now drawn above each panel (`Terminal` / `Cell history`). Decorative: non-focusable, not in the tab order; NVDA still reads the list's `AutomationProperties.Name` on focus.
- **Colours inverted to a light scheme** (white background / black text / black outline) on the maintainer's low-vision-friend test machine — kept to the `Panel{Background,Foreground,Outline}Brush` resources and the `TerminalView` default-colour pair (`_background` + the `ResolveBrush` default-spec branch), in lock-step so the panes stay uniform. Explicitly a **temporary** swap, not the future theme-management framework.

### Flagged, deferred (NOT list bugs)

The cell-history list faithfully projects `CellEventBus.Appended`, published only at the canonical *seal* site (`Program.fs`, `finalisedOpt = Some`). So:

- Output sub-portions do **not** trickle in live → ADR 0007 **Phase 4 (live in-flight trickle)**, deferred by design.
- The canonical input-test produces **no sealed command cell** → the cell is dropped upstream (ADR 0004 drop-on-None / Cycle 52 boundary detection), not lost between bus and list.
- Cell history is **not reset on shell hot-switch** → accepted as correct (maintainer 2026-05-17). Planned follow-up: a shell-switch **marker row** — its own next change, which will unify the parallel-index row arrays into one typed row list (also retiring the placeholder hack).

Recorded in ADR 0007 Phase 6b note + SESSION-HANDOFF known-limitations.

## Test plan

- [ ] CI green (Windows build + tests; the only build signal — no local .NET in the sandbox).
- [ ] Dogfood (continues `52-ADR7-P6b`):
  - [ ] Before any command: `Ctrl+Shift+Right` focuses the cell-history pane; it shows "No cell history yet." and arrows stay in the list (no escape to the menu). NVDA announces the placeholder.
  - [ ] After the first command seals, the placeholder is gone and only real rows remain.
  - [ ] Sighted check: a clear bold title above each panel; both panels white background / black text / black outline; selected row strong blue with white text; per-row rule visible; terminal text black-on-white.
  - [ ] Per-cell ops on the placeholder row announce "no cell selected" (no crash / mis-target).

Locally unverifiable (no WPF/NVDA in the sandbox) — CI is the only build check.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_