### PR TITLE
ADR 0007 Phase 6b: shell-switch marker row + row-model unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15349,6 +15349,26 @@ boundary detection, upstream); cell history is not reset on
 shell hot-switch (accepted — a shell-switch marker row is the
 planned follow-up).
 
+### Cycle 52 ADR 0007 Phase 6b: shell-switch marker row + row-model unification (2026-05-17)
+
+Shell hot-switch (`Ctrl+Shift+1/2/3`) now appends a marker
+notice row ("Shell switched to <name>.") to the cell history,
+so the transcript stays continuous while the shell boundary is
+visible and screen-reader-announced (accepted maintainer
+decision: the history is deliberately not reset on switch).
+
+Landed with a small row-model unification that makes notice
+rows clean rather than an index hack: the parallel
+`cellHistoryItems` (display strings) + `cellHistoryCells`
+(shorter `CellView` array + bounds-check) pair is replaced by
+`cellHistoryItems` + `cellHistoryRows : ResizeArray<CellView
+option>` kept strictly 1:1 — `Some cv` for a cell row, `None`
+for a non-cell notice row. The empty-state placeholder is now
+just the first notice row through the same path; per-cell ops
+on any notice row resolve to "no cell" and publish no
+`Focused` event. No behaviour change to cell rows; NVDA still
+reads each row as a standard ListItem.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -441,12 +441,13 @@ verified to fully restore it on both build types.
   faithfully projects `CellEventBus.Appended` off the seal
   site: (a) no live output trickle (= Phase 4, by design);
   (b) the input-test seals no command cell (ADR 0004
-  drop-on-None / Cycle 52 boundary detection, upstream); (c)
-  history not reset on shell hot-switch — accepted, the
-  planned follow-up is a shell-switch **marker row** (its own
-  change; unify the parallel-index row arrays into one typed
-  row list first — also retires the empty-list placeholder
-  hack).
+  drop-on-None / Cycle 52 boundary detection, upstream).
+  (c) history not reset on shell hot-switch — accepted;
+  **shipped** a shell-switch **marker notice row** with the
+  row-model unification (`cellHistoryRows` = one
+  `CellView option` collection 1:1 with the displayed items;
+  retired the parallel-array + placeholder hack). (a)/(b)
+  remain the open computational-accuracy items.
 
 See [`docs/PROJECT-PLAN-2026-05-12.md`](PROJECT-PLAN-2026-05-12.md)
 for sequencing rationale + risks.

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -655,10 +655,16 @@ changes the ADR 0004 IOCell schema.
     list. Both are upstream computational-accuracy items,
     explicitly out of scope here. (c) Cell history is **not
     reset on shell hot-switch** — accepted as correct
-    (maintainer 2026-05-17); the planned follow-up is a
-    shell-switch **marker row** inserted into the history
-    (its own change; needs the row model unified off the
-    current parallel-index arrays first).
+    (maintainer 2026-05-17); **shipped**: a shell-switch
+    **marker notice row** ("Shell switched to <name>.") is
+    appended so the transcript stays continuous while the
+    boundary is visible + screen-reader-announced. This
+    landed with the row-model unification: `cellHistoryRows`
+    is now a single `CellView option` collection strictly
+    1:1 with the displayed items (`Some` = cell, `None` =
+    notice), retiring the earlier shorter-parallel-array +
+    bounds-check hack and folding the empty-state placeholder
+    into the same notice mechanism.
 
 - **Phase 7 — automated cell-structure diagnostics (D6).**
   Extend the existing test corpus + `Diagnostics → Test …`

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -4488,11 +4488,13 @@ module Program =
         //    type ratified 2026-05-17); the item is a typed
         //    projection so the Tree swap stays trivial.
         //
-        // Item display is single-line ("<Kind>: <text>"); the
-        // parallel `cellHistoryCells` keeps each row's typed
-        // `CellView` so `SelectionChanged` can publish the
-        // typed event (sinks never re-derive from text —
-        // ADR 0008).
+        // Item display is single-line ("<Kind>: <text>" for
+        // cells, verbatim for notice rows). `cellHistoryRows`
+        // is strictly 1:1 with `cellHistoryItems`: `Some cv`
+        // for a real cell row (so `SelectionChanged` publishes
+        // the typed event — sinks never re-derive from text,
+        // ADR 0008), `None` for a non-cell notice row
+        // (empty-state placeholder / shell-switch marker).
         // Diagnostic triggers (ship-with-the-feature rule):
         // counts/enums only, never cell text (logging
         // discipline) — so a `Ctrl+Shift+D` bundle confirms
@@ -4503,22 +4505,31 @@ module Program =
             Logger.get "Terminal.App.Program.CellHistoryPane"
         let cellHistoryItems =
             System.Collections.ObjectModel.ObservableCollection<string>()
-        let cellHistoryCells =
-            ResizeArray<SpeechCursor.CellView>()
+        // Kept strictly index-aligned with `cellHistoryItems`
+        // (one entry per visible row): a real cell row carries
+        // `Some cv`; a non-cell *notice* row (the empty-state
+        // placeholder, or a shell-switch marker) carries `None`.
+        // One aligned collection (vs. the earlier shorter
+        // parallel array + bounds-check hack) is what lets a
+        // notice row sit anywhere without misaligning row→cell
+        // lookups.
+        let cellHistoryRows =
+            ResizeArray<SpeechCursor.CellView option>()
         // ADR 0007 Phase 6b follow-up (dogfood 2026-05-17): an
         // empty ListBox cannot hold keyboard focus — arrows
-        // escape to the menu. Seed one non-cell placeholder row
-        // so the pane always has a focusable item; it is dropped
-        // the first time a real cell is appended (the list is
-        // append-only for the app lifetime, so it never returns
-        // to empty — no re-add path needed). Index safety: while
-        // the placeholder is the only row `cellHistoryCells` is
-        // empty, and every row→cell lookup (SelectionChanged
-        // publish, `listSelectedFocusedCell`) is already
-        // bounds-checked against `cellHistoryCells`, so a
-        // selected placeholder resolves to "no cell".
+        // escape to the menu. Seed one placeholder notice row so
+        // the pane always has a focusable item; it is dropped
+        // the first time any real row (cell or notice) is added.
         let cellHistoryPlaceholder = "No cell history yet."
         let mutable cellHistoryPlaceholderPresent = false
+        // Shared so the Appended path and the notice path drop
+        // the placeholder identically (both run on the UI
+        // thread, so the shared mutable is serialised).
+        let dropPlaceholderIfPresent () : unit =
+            if cellHistoryPlaceholderPresent then
+                cellHistoryItems.Clear()
+                cellHistoryRows.Clear()
+                cellHistoryPlaceholderPresent <- false
         let cellKindLabel (k: SpeechCursor.CellKind) : string =
             match k with
             | SpeechCursor.CellKind.Input -> "Command"
@@ -4531,6 +4542,7 @@ module Program =
             sprintf "%s: %s" (cellKindLabel cv.Kind) oneLine
         window.CellHistoryList.ItemsSource <- cellHistoryItems
         cellHistoryItems.Add(cellHistoryPlaceholder)
+        cellHistoryRows.Add(None)
         cellHistoryPlaceholderPresent <- true
         // Subscribe the list to the canonical cell pipeline.
         // `Appended` → add a projected row (marshalled to the
@@ -4544,11 +4556,9 @@ module Program =
             | CellEventBus.Appended cv ->
                 window.Dispatcher.InvokeAsync(
                     System.Action(fun () ->
-                        if cellHistoryPlaceholderPresent then
-                            cellHistoryItems.Clear()
-                            cellHistoryPlaceholderPresent <- false
+                        dropPlaceholderIfPresent ()
                         cellHistoryItems.Add(cellHistoryDisplay cv)
-                        cellHistoryCells.Add(cv)
+                        cellHistoryRows.Add(Some cv)
                         cellPaneLog.LogInformation(
                             "ADR 0007 Phase 6a-2b list append. CellSeq={CellSeq} Kind={Kind} Count={Count}",
                             cv.CellSequence,
@@ -4562,14 +4572,16 @@ module Program =
         // event. NO manual `Announce` here (double-speak).
         window.CellHistoryList.SelectionChanged.Add(fun _ ->
             let i = window.CellHistoryList.SelectedIndex
-            if i >= 0 && i < cellHistoryCells.Count then
-                let cell = cellHistoryCells.[i]
-                CellEventBus.publish (CellEventBus.Focused cell)
-                cellPaneLog.LogInformation(
-                    "ADR 0007 Phase 6a-2b list focus-marker. Index={Index} CellSeq={CellSeq} Kind={Kind}",
-                    i,
-                    cell.CellSequence,
-                    (sprintf "%A" cell.Kind)))
+            if i >= 0 && i < cellHistoryRows.Count then
+                match cellHistoryRows.[i] with
+                | Some cell ->
+                    CellEventBus.publish (CellEventBus.Focused cell)
+                    cellPaneLog.LogInformation(
+                        "ADR 0007 Phase 6a-2b list focus-marker. Index={Index} CellSeq={CellSeq} Kind={Kind}",
+                        i,
+                        cell.CellSequence,
+                        (sprintf "%A" cell.Kind))
+                | None -> ())
 
         // ADR 0007 Phase 6b — per-cell ops follow the navigable
         // list, resolved by `CellId` (reorder/delete-safe; a
@@ -4584,21 +4596,46 @@ module Program =
             : SpeechCursor.FocusedCell option =
             let lb = window.CellHistoryList
             let i = lb.SelectedIndex
-            if i < 0 || i >= cellHistoryCells.Count then None
+            if i < 0 || i >= cellHistoryRows.Count then None
             else
-                let v = cellHistoryCells.[i]
-                let textOf (k: SpeechCursor.CellKind) =
-                    cellHistoryCells
-                    |> Seq.tryFind (fun c ->
-                        c.CellId = v.CellId && c.Kind = k)
-                    |> Option.map (fun c -> c.Text)
-                Some
-                    ({ CellId = v.CellId
-                       CellSequence = v.CellSequence
-                       Command = textOf SpeechCursor.CellKind.Input
-                       Output = textOf SpeechCursor.CellKind.Output }
-                     : SpeechCursor.FocusedCell)
+                match cellHistoryRows.[i] with
+                | None -> None
+                | Some v ->
+                    let textOf (k: SpeechCursor.CellKind) =
+                        cellHistoryRows
+                        |> Seq.choose id
+                        |> Seq.tryFind (fun c ->
+                            c.CellId = v.CellId && c.Kind = k)
+                        |> Option.map (fun c -> c.Text)
+                    Some
+                        ({ CellId = v.CellId
+                           CellSequence = v.CellSequence
+                           Command = textOf SpeechCursor.CellKind.Input
+                           Output = textOf SpeechCursor.CellKind.Output }
+                         : SpeechCursor.FocusedCell)
         focusedCellSource <- listSelectedFocusedCell
+
+        // ADR 0007 Phase 6b (dogfood 2026-05-17) — non-cell
+        // *notice* rows. The cell history is intentionally NOT
+        // reset on shell hot-switch (maintainer 2026-05-17);
+        // instead a marker row is appended so the transcript
+        // stays continuous while the shell boundary is visible
+        // and screen-reader-announced (the row is a standard
+        // ListItem). Notice rows carry `None` in
+        // `cellHistoryRows`, so per-cell ops on them resolve to
+        // "no cell" and no `Focused` event is published.
+        // UI-thread marshalled (ObservableCollection affinity),
+        // mirroring the Appended path.
+        let appendHistoryNotice (text: string) : unit =
+            window.Dispatcher.InvokeAsync(
+                System.Action(fun () ->
+                    dropPlaceholderIfPresent ()
+                    cellHistoryItems.Add(text)
+                    cellHistoryRows.Add(None)
+                    cellPaneLog.LogInformation(
+                        "ADR 0007 Phase 6b history notice appended. Count={Count}",
+                        cellHistoryItems.Count)))
+            |> ignore
 
         // ADR 0007 Phase 6a-2b — non-speech pane-switch cue.
         // Distinct earcon per pane (ADR 0008: the tone itself
@@ -5505,6 +5542,17 @@ module Program =
                                         // pathway, not the
                                         // pre-switch shell's.
                                         currentShellId <- shell.Id
+                                        // ADR 0007 Phase 6b — the
+                                        // cell history is not
+                                        // reset on hot-switch
+                                        // (maintainer 2026-05-17);
+                                        // drop a marker notice row
+                                        // so the shell boundary is
+                                        // visible + announced.
+                                        appendHistoryNotice
+                                            (sprintf
+                                                "Shell switched to %s."
+                                                shell.DisplayName)
                                         // SessionModel Tier 1.C —
                                         // per-shell-session
                                         // recreation (per Q5


### PR DESCRIPTION
## Summary

Implements the shell-switch marker you asked for, plus the small row-model unification it needs to be clean.

- **Shell-switch marker row.** `Ctrl+Shift+1/2/3` hot-switch now appends a marker notice row — `Shell switched to <name>.` — to the cell history (on the successful spawn, UI-thread marshalled). The history is deliberately **not** reset (your accepted decision); the marker keeps the transcript continuous while making the shell boundary visible and screen-reader-announced (it's a standard ListItem, so NVDA reads it on arrow-nav).
- **Row-model unification (the enabling cleanup).** The fragile pair — `cellHistoryItems` (display strings) + a *shorter* `cellHistoryCells` (`CellView` array relying on bounds-checks for non-cell rows) — is replaced by `cellHistoryItems` + `cellHistoryRows : ResizeArray<CellView option>` kept **strictly 1:1**: `Some cv` = cell row, `None` = non-cell notice row. This is what lets a notice row sit anywhere without misaligning row→cell lookups. The empty-state placeholder (#411) is now just the first notice row through the same shared `dropPlaceholderIfPresent` path — the index hack is retired. Per-cell ops on any notice row resolve to "no cell"; no `Focused` event is published for notice rows.

No behaviour change to real cell rows (display, NVDA announce, per-cell ops, pane-switch focus all unchanged). Item 3 (output not appearing for the input-test) remains flagged/deferred — confirmed upstream seal/boundary, not a list bug; docs unchanged on that.

## Test plan

- [ ] CI green (Windows build + tests — only build signal; no local .NET).
- [ ] Dogfood (continues `52-ADR7-P6b`):
  - [ ] Switch shells with `Ctrl+Shift+1/2/3`: a "Shell switched to <name>." row appears in the cell history; prior rows are preserved (not reset); NVDA announces the marker row when arrowed to.
  - [ ] Switching shells before any command: the "No cell history yet." placeholder is replaced by the marker (not duplicated).
  - [ ] Real command cells still append/display/announce as before; `Ctrl+Shift+C` / copy-command / copy-output / rerun still act on the navigated **cell** row; selecting a marker row → ops announce "no cell selected".
  - [ ] Pane switch + selection highlight + light scheme unchanged from #411.

Locally unverifiable (no WPF/NVDA in the sandbox) — CI is the only build check.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_