### PR TITLE
ADR 0007 Phase 6b: menu reorganization (Terminal/Cell History/Window)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15369,6 +15369,36 @@ on any notice row resolve to "no cell" and publish no
 `Focused` event. No behaviour change to cell rows; NVDA still
 reads each row as a standard ListItem.
 
+### Cycle 52 ADR 0007 Phase 6b: menu reorganization (2026-05-17)
+
+Maintainer-directed menu restructure (XAML-only — every
+actionable item is wired by `x:Name`, never by tree position,
+so this is a single-file edit):
+
+- **New top-level `Terminal`** menu; the `Shell` menu
+  (Cmd / PowerShell / Claude) is now a submenu of it.
+- **`Window`** (Close Window / Exit) moved from a top-level
+  menu to a submenu of `Interface`.
+- **New top-level `Cell History`** menu (name matches the
+  cell-history panel title), grouped into `Navigation`,
+  `Focused Cell Operations`, and `Output and Session`. The
+  real wired items (copy focused cell / command / output,
+  rerun focused input, last output, copy session history,
+  announce session log path) moved here out of the old
+  `Interface › Output History` submenu.
+- **SpeechCursor discipline**: `Jump to Last Error` is a
+  SpeechCursor navigation command, so it moved into
+  `Interface › Speech Cursor` with the rest of that set. The
+  `Pane` focus commands stay under `Interface › Pane` (main
+  UI navigation, not cell-history navigation).
+- **`(not yet implemented)` placeholders**: disabled,
+  unwired menu entries sketching the ideal comprehensive
+  op-set (cell navigation, per-cell operations, session
+  export) — a clear target for the later ADR 0007 D2 /
+  Phase 6 cell-operation + navigation work.
+
+No behaviour change to any existing wired command.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0007-canonical-iocell-history-navigation.md
+++ b/docs/adr/0007-canonical-iocell-history-navigation.md
@@ -665,6 +665,18 @@ changes the ADR 0004 IOCell schema.
     notice), retiring the earlier shorter-parallel-array +
     bounds-check hack and folding the empty-state placeholder
     into the same notice mechanism.
+  - **Menu reorganization (2026-05-17).** A top-level "Cell
+    History" menu (matching the panel title) now groups the
+    per-cell ops under Navigation / Focused Cell Operations /
+    Output and Session; SpeechCursor commands are disciplined
+    under Interface › Speech Cursor; Shell nested under a new
+    Terminal top-level; Window under Interface. The
+    `(not yet implemented)` disabled placeholders in that
+    menu are the **living sketch of the ideal D2 / Phase 6
+    op-set** (cell navigation, per-cell operations, session
+    export) — an early, low-cost stand-in for the Phase 6d
+    operation-discovery menu and a concrete target for the
+    later phases. XAML-only (items wired by `x:Name`).
 
 - **Phase 7 — automated cell-structure diagnostics (D6).**
   Extend the existing test corpus + `Diagnostics → Test …`

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -27,27 +27,40 @@
              (c) <MenuItem x:Name="MenuItem_<NewCmd>" /> here.
              Compose's reflection-driven wiring auto-picks it up.
 
-             Top-level mnemonics: _Shell, _View, _Data,
-             Dia_gnostics, _Help (all unique; non-conflicting with
-             AppReservedHotkeys's Ctrl+Shift+letter gestures since
-             different modifier sets are different gestures).
+             Top-level mnemonics: _Terminal, _Interface,
+             _Cell History, Dia_gnostics, _Help (all unique;
+             non-conflicting with AppReservedHotkeys's
+             Ctrl+Shift+letter gestures since different modifier
+             sets are different gestures).
 
-             Future menus (Window, Display, Preferences/Settings)
-             will slot in cleanly per the maintainer's
-             extensibility directive (see PROJECT-PLAN-2026-05-09.md). -->
+             Cycle 52 Phase 6b (2026-05-17) reorg: Shell nested
+             under a new Terminal top-level; the standalone
+             Window menu nested under Interface; the
+             cell-history command set promoted to its own
+             top-level "Cell History" (matches the panel title),
+             grouped Navigation / Focused Cell Operations /
+             Output and Session. "(not yet implemented)" entries
+             are disabled placeholders sketching the ideal
+             comprehensive op-set for later phases. The whole
+             reorg is XAML-only — every actionable item is wired
+             by x:Name (reflection + explicit handlers in
+             compose()), never by tree position — so menu
+             structure stays a single-file edit. -->
         <Menu DockPanel.Dock="Top"
               AutomationProperties.Name="Application menu"
               AutomationProperties.AutomationId="pty-speak.AppMenu">
-            <MenuItem Header="_Shell">
-                <MenuItem x:Name="MenuItem_SwitchToCmd"
-                          x:FieldModifier="public"
-                          Header="_Cmd" />
-                <MenuItem x:Name="MenuItem_SwitchToPowerShell"
-                          x:FieldModifier="public"
-                          Header="_PowerShell" />
-                <MenuItem x:Name="MenuItem_SwitchToClaude"
-                          x:FieldModifier="public"
-                          Header="C_laude" />
+            <MenuItem Header="_Terminal">
+                <MenuItem Header="_Shell">
+                    <MenuItem x:Name="MenuItem_SwitchToCmd"
+                              x:FieldModifier="public"
+                              Header="_Cmd" />
+                    <MenuItem x:Name="MenuItem_SwitchToPowerShell"
+                              x:FieldModifier="public"
+                              Header="_PowerShell" />
+                    <MenuItem x:Name="MenuItem_SwitchToClaude"
+                              x:FieldModifier="public"
+                              Header="C_laude" />
+                </MenuItem>
             </MenuItem>
             <!-- Cycle 27 — multi-state menu paradigm. The two
                  children are parent menu items whose sub-items
@@ -100,6 +113,14 @@
                     <MenuItem x:Name="MenuItem_SpeechCursorToggleMode"
                               x:FieldModifier="public"
                               Header="Toggle _Mode (AutoDrive / Manual)" />
+                    <!-- Cycle 52 Phase 6b — jump-to-last-error is
+                         a SpeechCursor navigation command, so it
+                         lives here with the rest of the
+                         SpeechCursor set (moved out of the old
+                         Output History submenu). -->
+                    <MenuItem x:Name="MenuItem_JumpToLastError"
+                              x:FieldModifier="public"
+                              Header="Jump to Last _Error" />
                 </MenuItem>
                 <!-- ADR 0007 Phase 6a-2b — pane switch. Menu-
                      surfaced for discoverability (the maintainer's
@@ -153,21 +174,87 @@
                               x:FieldModifier="public"
                               Header="Fina_l Dir On Change, Silent When Same" />
                 </MenuItem>
-                <!-- Cycle 48 post-PR-F (2026-05-13) — infrastructure
-                     items (open data folder, edit config) lifted
-                     from the old Data submenu to Interface direct
-                     level per maintainer feedback. They're not
-                     about command output; they're about where
-                     pty-speak's app data lives. The
-                     last-command + session-history items kept
-                     together under "Output History". -->
+                <!-- Cycle 52 Phase 6b (2026-05-17) — open data
+                     folder + edit config stay at Interface level
+                     (where pty-speak's app data lives). The
+                     last-command / session-history /
+                     per-cell-operation items moved OUT to the
+                     new top-level "Cell History" menu; Window
+                     nested here (was a top-level sibling). -->
                 <MenuItem x:Name="MenuItem_OpenDataFolder"
                           x:FieldModifier="public"
                           Header="Open _Data Folder" />
                 <MenuItem x:Name="MenuItem_OpenConfig"
                           x:FieldModifier="public"
                           Header="Edit _Config" />
-                <MenuItem Header="Output _History">
+                <!-- Cycle 28 — Window items are menu-only (no
+                     HotkeyRegistry accelerator). Close Window's
+                     InputGestureText="Alt+F4" is purely visual
+                     (the OS-level Alt+F4 is handled by WPF Window
+                     natively). Cycle 52 Phase 6b: nested under
+                     Interface (was its own top-level menu). -->
+                <MenuItem Header="_Window">
+                    <MenuItem x:Name="MenuItem_CloseWindow"
+                              x:FieldModifier="public"
+                              Header="_Close Window"
+                              InputGestureText="Alt+F4" />
+                    <MenuItem x:Name="MenuItem_ExitApp"
+                              x:FieldModifier="public"
+                              Header="E_xit" />
+                </MenuItem>
+            </MenuItem>
+<!-- Cycle 52 Phase 6b (2026-05-17) — "Cell History"
+                 promoted to its own top-level menu (matches the
+                 cell-history panel title). Real wired items keep
+                 their x:Name (relocated only; compose() wiring
+                 is by-name, unaffected). "(not yet implemented)"
+                 entries are disabled placeholders (no x:Name, no
+                 wiring) sketching the ideal comprehensive op-set
+                 — a clear target for the later cell-operation /
+                 navigation phases (ADR 0007 D2 / Phase 6). -->
+            <MenuItem Header="_Cell History">
+                <MenuItem Header="_Navigation">
+                    <!-- Cell-history-native navigation (distinct
+                         from SpeechCursor review-nav, which lives
+                         under Interface > Speech Cursor). All
+                         placeholders today. -->
+                    <MenuItem Header="Next Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Previous Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="First Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Last Cell (not yet implemented)" IsEnabled="False" />
+                    <Separator />
+                    <MenuItem Header="Next Input Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Previous Input Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Next Output Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Previous Output Cell (not yet implemented)" IsEnabled="False" />
+                    <Separator />
+                    <MenuItem Header="Next Failed Command (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Previous Failed Command (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Jump to Bookmarked Cell (not yet implemented)" IsEnabled="False" />
+                </MenuItem>
+                <MenuItem Header="_Focused Cell Operations">
+                    <MenuItem x:Name="MenuItem_CopyFocusedCell"
+                              x:FieldModifier="public"
+                              Header="Copy _Focused Cell to Clipboard" />
+                    <MenuItem x:Name="MenuItem_CopyFocusedCellCommand"
+                              x:FieldModifier="public"
+                              Header="Copy Focused Cell Co_mmand" />
+                    <MenuItem x:Name="MenuItem_CopyFocusedCellOutput"
+                              x:FieldModifier="public"
+                              Header="Copy Focused Cell Out_put" />
+                    <MenuItem x:Name="MenuItem_RerunFocusedInput"
+                              x:FieldModifier="public"
+                              Header="_Rerun Focused Input" />
+                    <Separator />
+                    <MenuItem Header="Insert Focused Command at Prompt (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Copy Focused Cell as Markdown (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Save Focused Cell Output to File (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Bookmark Focused Cell (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Remove Bookmark (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Delete Focused Cell from History (not yet implemented)" IsEnabled="False" />
+                    <MenuItem Header="Expand / Collapse Focused Cell (not yet implemented)" IsEnabled="False" />
+                </MenuItem>
+                <MenuItem Header="_Output and Session">
                     <MenuItem Header="_Last Output">
                         <MenuItem x:Name="MenuItem_OpenLastOutput"
                                   x:FieldModifier="public"
@@ -179,24 +266,11 @@
                     <MenuItem x:Name="MenuItem_CopyHistoryToClipboard"
                               x:FieldModifier="public"
                               Header="_Copy Session History to Clipboard" />
-                    <MenuItem x:Name="MenuItem_CopyFocusedCell"
-                              x:FieldModifier="public"
-                              Header="Copy _Focused Cell to Clipboard" />
-                    <MenuItem x:Name="MenuItem_CopyFocusedCellCommand"
-                              x:FieldModifier="public"
-                              Header="Copy Focused Cell Co_mmand" />
-                    <MenuItem x:Name="MenuItem_CopyFocusedCellOutput"
-                              x:FieldModifier="public"
-                              Header="Copy Focused Cell Out_put" />
-                    <MenuItem x:Name="MenuItem_JumpToLastError"
-                              x:FieldModifier="public"
-                              Header="Jump to Last _Error" />
-                    <MenuItem x:Name="MenuItem_RerunFocusedInput"
-                              x:FieldModifier="public"
-                              Header="_Rerun Focused Input" />
                     <MenuItem x:Name="MenuItem_AnnounceSessionLogPath"
                               x:FieldModifier="public"
                               Header="Announce _Session Log Path" />
+                    <Separator />
+                    <MenuItem Header="Export Session History to File (not yet implemented)" IsEnabled="False" />
                 </MenuItem>
             </MenuItem>
             <!-- Cycle 48 post-PR-F (2026-05-13) — Diagnostics
@@ -346,23 +420,6 @@
                     </MenuItem>
                 </MenuItem>
                 </MenuItem><!-- /Inspect -->
-            </MenuItem>
-            <!-- Cycle 28 — Window menu. Both items are menu-only
-                 commands (no keyboard accelerator registered with
-                 HotkeyRegistry). Close Window's
-                 InputGestureText="Alt+F4" is hardcoded here so
-                 NVDA reads "Close Window, Alt plus F4, menu item"
-                 — the gesture string is purely visual since the
-                 OS-level Alt+F4 is handled by WPF Window
-                 natively, not by an entry in AppReservedHotkeys. -->
-            <MenuItem Header="_Window">
-                <MenuItem x:Name="MenuItem_CloseWindow"
-                          x:FieldModifier="public"
-                          Header="_Close Window"
-                          InputGestureText="Alt+F4" />
-                <MenuItem x:Name="MenuItem_ExitApp"
-                          x:FieldModifier="public"
-                          Header="E_xit" />
             </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem x:Name="MenuItem_CheckForUpdates"


### PR DESCRIPTION
## Summary

Maintainer-directed menu reorganization. **XAML-only** — every actionable item is wired by `x:Name` (reflection + explicit handlers in `compose()`), never by tree position, so relocating items needs no Program.fs changes. (This confirms the maintainer's "should be simple" expectation — no refactor required.)

- **New top-level `Terminal`** menu; the `Shell` menu (Cmd / PowerShell / Claude) is now a submenu of it.
- **`Window`** (Close Window / Exit) moved from a top-level menu into a submenu of `Interface`.
- **New top-level `Cell History`** menu (name matches the cell-history panel title), grouped:
  - **Navigation** — placeholders only today (cell-history-native nav, distinct from SpeechCursor review-nav).
  - **Focused Cell Operations** — the real wired ops (Copy Focused Cell / Command / Output, Rerun Focused Input) + placeholders.
  - **Output and Session** — Last Output (Open in Editor / Announce Again), Copy Session History, Announce Session Log Path + placeholder.
  - These real items moved here out of the old `Interface › Output History` submenu (which is removed).
- **SpeechCursor discipline**: `Jump to Last Error` is a SpeechCursor nav command → moved into `Interface › Speech Cursor`. `Pane` focus commands stay under `Interface › Pane` (main-UI navigation, not cell-history).
- **`(not yet implemented)` placeholders**: disabled, unwired entries sketching the ideal comprehensive op-set (cell navigation, per-cell ops, session export) — a concrete target for the later ADR 0007 D2 / Phase 6 work; an early low-cost stand-in for the Phase 6d operation-discovery menu.

Validated: `xmllint` well-formed; no duplicate `x:Name`s; top-level order Terminal · Interface · Cell History · Diagnostics · Help. No behaviour change to any existing wired command.

## Test plan

- [ ] CI green (Windows build compiles the XAML — the real check; no local .NET).
- [ ] Dogfood: `Alt` opens the menu bar; tab/arrow through Terminal › Shell, Interface (Speech Cursor incl. Jump to Last Error, Pane, Window), Cell History (Navigation / Focused Cell Operations / Output and Session). Wired items still work (copy focused cell, rerun, last output, shell switch, close/exit); `(not yet implemented)` items are announced disabled by NVDA.

Locally unverifiable (no WPF/NVDA in the sandbox) — CI is the only build check.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_