### PR TITLE
ADR 0007 Phase 6b: About-menu GitHub links + version display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15434,6 +15434,30 @@ per the maintainer's own conclusion. A follow-up adds an
 change — needs a wired command + HotkeyRegistry/test
 updates).
 
+### Cycle 52 ADR 0007 Phase 6b: About-menu GitHub links + version (2026-05-17)
+
+The About menu gains three browser-link commands and a
+version display:
+
+- **Open GitHub Repo** → `https://github.com/KyleKeane/pty-speak`
+- **Submit a Feature Request** → the repo's new-issue chooser
+  (`/issues/new/choose`, surfacing any feature-request
+  template)
+- **Submit an Issue** → the repo's blank new-issue page
+  (`/issues/new`)
+- **Version** submenu — a single informational item whose
+  header is set at startup to the build version + git short
+  SHA (`resolveInformationalVersion ()`, the same string the
+  `Ctrl+Shift+H` health check speaks); a screen reader reads
+  it on focus. No command (display only).
+
+The three links are menu-only `HotkeyRegistry` commands
+(Key=None) bound to one shared `runOpenUrlInBrowser` helper
+(announce-before-launch + STA-safe dispatch, mirroring
+`runOpenDataFolder`). HotkeyRegistry DU / nameOf / builtIns /
+allCommands + the `allCommands` expected-set test updated
+accordingly.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -561,6 +561,44 @@ module Program =
             }
         ()
 
+    /// Cycle 52 Phase 6b round 2 — open a URL in the default
+    /// browser. Menu-only (About menu): GitHub repo / feature
+    /// request form / new issue page. Mirrors
+    /// `runOpenDataFolder`'s announce-before-launch + STA-safe
+    /// dispatch shape; opens a URL instead of a folder. `what`
+    /// is the screen-reader-friendly noun phrase for announces.
+    let private runOpenUrlInBrowser
+            (window: MainWindow)
+            (url: string)
+            (what: string)
+            : unit =
+        let log = Logger.get "Terminal.App.Program.runOpenUrlInBrowser"
+        log.LogInformation(
+            "Open-URL menu item — launching {What} {Url}.",
+            what,
+            url)
+        window.TerminalSurface.Announce(
+            sprintf "Opening %s in your browser." what,
+            ActivityIds.openDataFolder)
+        let _ =
+            task {
+                do! Task.Delay(700)
+                let action () =
+                    try
+                        let psi = System.Diagnostics.ProcessStartInfo()
+                        psi.FileName <- url
+                        psi.UseShellExecute <- true
+                        System.Diagnostics.Process.Start(psi) |> ignore
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        window.TerminalSurface.Announce(
+                            sprintf "Could not open %s: %s" what safe,
+                            ActivityIds.error)
+                do! window.Dispatcher.InvokeAsync(Action(action)).Task
+                ()
+            }
+        ()
+
     /// Cycle 25a — auto-create `config.toml` with sensible
     /// defaults if no file exists, then open in the default app
     /// (Notepad on a stock Windows install). Triggered by
@@ -1278,6 +1316,27 @@ module Program =
         bind HotkeyRegistry.DraftNewRelease (fun () -> runOpenNewRelease window)
         bind HotkeyRegistry.OpenDataFolder (fun () -> runOpenDataFolder window)
         bind HotkeyRegistry.OpenConfig (fun () -> runOpenConfig window)
+        bind HotkeyRegistry.OpenGitHubRepo (fun () ->
+            runOpenUrlInBrowser
+                window
+                "https://github.com/KyleKeane/pty-speak"
+                "the pty-speak GitHub repository")
+        bind HotkeyRegistry.OpenFeatureRequest (fun () ->
+            runOpenUrlInBrowser
+                window
+                "https://github.com/KyleKeane/pty-speak/issues/new/choose"
+                "the feature request form")
+        bind HotkeyRegistry.OpenSubmitIssue (fun () ->
+            runOpenUrlInBrowser
+                window
+                "https://github.com/KyleKeane/pty-speak/issues/new"
+                "the new issue page")
+        // ADR 0007 Phase 6b round 2 — surface the build version
+        // + git short SHA as a readable About > Version item
+        // (the only thing distinguishing local builds; same
+        // string the Ctrl+Shift+H health check speaks).
+        window.MenuItem_VersionValue.Header <-
+            box (resolveInformationalVersion ())
         // Cycle 27 — `ToggleDebugLog` and `MuteEarcons` migrated
         // to `MultiStateCommand` as `LoggingLevel` and
         // `EarconsMode`. Their wiring lives in the

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -96,6 +96,11 @@ module HotkeyRegistry =
         // Cycle 25a — auto-create config.toml with defaults if
         // missing, then open in default app.
         | OpenConfig
+        // Cycle 52 Phase 6b round 2 — About-menu links opened in
+        // the default browser (all menu-only).
+        | OpenGitHubRepo
+        | OpenFeatureRequest
+        | OpenSubmitIssue
         // Stage 7-followup PR-F + PR-J liveness probe — health check.
         | HealthCheck
         // Stage 7-followup PR-F — incident marker.
@@ -260,6 +265,9 @@ module HotkeyRegistry =
         | DraftNewRelease -> "DraftNewRelease"
         | OpenDataFolder -> "OpenDataFolder"
         | OpenConfig -> "OpenConfig"
+        | OpenGitHubRepo -> "OpenGitHubRepo"
+        | OpenFeatureRequest -> "OpenFeatureRequest"
+        | OpenSubmitIssue -> "OpenSubmitIssue"
         | HealthCheck -> "HealthCheck"
         | IncidentMarker -> "IncidentMarker"
         | SwitchToCmd -> "SwitchToCmd"
@@ -362,6 +370,18 @@ module HotkeyRegistry =
             Key = Some (Letter 'E')
             Modifiers = Some ctrlShift
             Description = "Edit config.toml (Cycle 25a; auto-creates with defaults if missing)" }
+          { Command = OpenGitHubRepo
+            Key = None
+            Modifiers = None
+            Description = "Open the pty-speak GitHub repository in the default browser (menu-only; About menu)" }
+          { Command = OpenFeatureRequest
+            Key = None
+            Modifiers = None
+            Description = "Open the GitHub feature request form in the default browser (menu-only; About menu)" }
+          { Command = OpenSubmitIssue
+            Key = None
+            Modifiers = None
+            Description = "Open the GitHub new-issue page in the default browser (menu-only; About menu)" }
           { Command = HealthCheck
             Key = Some (Letter 'H')
             Modifiers = Some ctrlShift
@@ -688,6 +708,9 @@ module HotkeyRegistry =
           DraftNewRelease
           OpenDataFolder
           OpenConfig
+          OpenGitHubRepo
+          OpenFeatureRequest
+          OpenSubmitIssue
           HealthCheck
           IncidentMarker
           SwitchToCmd

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -410,6 +410,25 @@
                 <MenuItem x:Name="MenuItem_DraftNewRelease"
                           x:FieldModifier="public"
                           Header="Draft New _Release" />
+                <MenuItem x:Name="MenuItem_OpenGitHubRepo"
+                          x:FieldModifier="public"
+                          Header="Open _GitHub Repo" />
+                <MenuItem x:Name="MenuItem_OpenFeatureRequest"
+                          x:FieldModifier="public"
+                          Header="Submit a _Feature Request" />
+                <MenuItem x:Name="MenuItem_OpenSubmitIssue"
+                          x:FieldModifier="public"
+                          Header="Submit an _Issue" />
+                <!-- Version value is set at runtime in compose()
+                     from resolveInformationalVersion() (version
+                     + git short SHA). The child item is
+                     informational (no command); a screen reader
+                     reads the version when it receives focus. -->
+                <MenuItem Header="_Version">
+                    <MenuItem x:Name="MenuItem_VersionValue"
+                              x:FieldModifier="public"
+                              Header="(version unavailable)" />
+                </MenuItem>
                 <MenuItem Header="_Acknowledgment">
                     <MenuItem Header="Made by Dr. Kyle Keane, University of Bristol" />
                     <MenuItem Header="Use is governed by the license and terms of use on the GitHub repository" />

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -64,6 +64,11 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               // and OpenConfig take its slot.
               HotkeyRegistry.OpenDataFolder
               HotkeyRegistry.OpenConfig
+              // Cycle 52 Phase 6b round 2 — About-menu browser
+              // links (all menu-only).
+              HotkeyRegistry.OpenGitHubRepo
+              HotkeyRegistry.OpenFeatureRequest
+              HotkeyRegistry.OpenSubmitIssue
               // Cycle 25b-1a — CopyLatestLog removed (D's bundle
               // subsumes it).
               // Cycle 27 — `ToggleDebugLog` and `MuteEarcons`


### PR DESCRIPTION
## Summary

The About menu's actionable build-out (your "Open GitHub Repo" item plus the three follow-ups you sent: Version, Feature Request, Submit Issue). Folded into one PR since they're the same concern (About-menu GitHub/version commands).

- **Open GitHub Repo** → `https://github.com/KyleKeane/pty-speak`
- **Submit a Feature Request** → `https://github.com/KyleKeane/pty-speak/issues/new/choose` (the new-issue chooser — surfaces a feature-request template if the repo defines one; the closest stable "feature request form" entry point without guessing a template slug)
- **Submit an Issue** → `https://github.com/KyleKeane/pty-speak/issues/new` (blank new issue)
- **Version** submenu → one informational item whose header is set at startup from `resolveInformationalVersion ()` — the build version **+ git short SHA**, the same string `Ctrl+Shift+H` speaks (the only thing that distinguishes local builds). A screen reader reads it on focus; no command (display only).

The three links are menu-only `HotkeyRegistry` commands (Key=None) bound to **one shared `runOpenUrlInBrowser` helper** (announce-before-launch + STA-safe dispatch, mirroring the proven `runOpenDataFolder` shape — no per-link duplication). HotkeyRegistry DU / `nameOf` / `builtIns` / `allCommands` and the `allCommands` expected-set test updated for all three.

Validated: `xmllint` well-formed; no duplicate `x:Name`; each new command present exactly once across registry + tests; version-header assignment wired in `compose()`.

## Test plan

- [ ] CI green (Windows build compiles F# + XAML; HotkeyRegistry unit tests — the expected-set test now includes the three new commands).
- [ ] Dogfood: About menu shows Check for Updates · Draft New Release · Open GitHub Repo · Submit a Feature Request · Submit an Issue · Version (› the version+SHA string, read by NVDA) · Acknowledgment. Each of the three links opens the right page in the default browser; Version reads the same string as `Ctrl+Shift+H`.

Locally unverifiable (no WPF/NVDA/.NET in the sandbox) — CI is the only build check.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_