### PR TITLE
boundary-diagnostic-capture B1: raw PTY byte recorder + Ctrl+Shift+T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15475,6 +15475,30 @@ cell-seal / boundary computational-accuracy work (the
 input-test seals no command cell — ADR 0004 drop-on-None /
 boundary detection); see SESSION-HANDOFF § Next stage.
 
+### Cycle 52 boundary-diagnostic-capture B1 (2026-05-17): raw PTY byte recorder
+
+First instrument of the cell-seal / boundary track. New
+`Ctrl+Shift+T` **toggles** a raw PTY byte recorder
+(`Terminal.Core/RawShellRecorder.fs`) — explicitly start/stop,
+**not** always-on, so a long session never accumulates an
+unbounded buffer. Records every byte in (keystrokes) and out
+(shell output) with a microsecond elapsed timestamp +
+direction, into an in-RAM buffer that exists only for the
+capture window. Start announces a warning that all keystrokes
+(including secrets) are recorded. Stop: formats a
+one-event-per-line escaped trace (`\e`/`\r`/`\n`/`\t`/`\xHH`,
+so OSC-133 reads as `\e]133;A\e\\`), **always** writes
+`%LOCALAPPDATA%\PtySpeak\extracts\rawtrace-<ts>.txt`, copies
+to the clipboard capped at 60 KB, and announces the path +
+whether the clipboard copy was truncated. Two additive PTY
+taps (the `Stdout` reader consumer and the single
+`host.WriteBytes` funnel) — no behaviour change to the seal
+path. Surfaced as `Diagnostics → Toggle Raw Shell Trace`
+(same `RoutedCommand`). The Open / Copy most-recent menu
+items + Instrument A (always-on bounded boundary-decision
+ring) follow.
+
+## [0.0.1-preview.18] — 2026-04-28
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Terminal.App/Program.fs
+++ b/src/Terminal.App/Program.fs
@@ -129,6 +129,12 @@ module Program =
                     while not ct.IsCancellationRequested do
                         let! chunk = host.Stdout.ReadAsync(ct).AsTask()
                         if chunk.Length > 0 then
+                            // Cycle 52 boundary-diagnostic-capture
+                            // (Instrument B) — additive raw OUT tap
+                            // (shell → app). No-op unless a
+                            // Ctrl+Shift+T capture is active.
+                            RawShellRecorder.record
+                                RawShellRecorder.Output chunk
                             // Stage 7-followup PR-F — record the
                             // moment of last live PTY activity. The
                             // heartbeat timer + Ctrl+Shift+H health
@@ -3755,6 +3761,130 @@ module Program =
                         sprintf "Could not save output: %s" safe,
                         ActivityIds.error)
 
+        // Cycle 52 boundary-diagnostic-capture (Instrument B) —
+        // Ctrl+Shift+T toggles the raw PTY byte recorder. ON:
+        // announce the keystroke-recording warning + begin
+        // capturing every byte in/out. OFF: format the trace,
+        // ALWAYS write a one-off `extracts\rawtrace-<ts>.txt`
+        // (user-intentional, not always-on disk growth), copy
+        // to the clipboard capped at 60 KB, and announce the
+        // path + a truncation warning if the clipboard copy was
+        // capped. File-write + STA-clipboard shapes mirror
+        // `runOpenLastOutput` / `runCopyHistoryToClipboard`.
+        let runToggleRawTrace () : unit =
+            let log =
+                Logger.get "Terminal.App.Program.runToggleRawTrace"
+            if RawShellRecorder.isRecording () then
+                match RawShellRecorder.stop () with
+                | None ->
+                    window.TerminalSurface.Announce(
+                        "Raw shell trace was not recording.",
+                        ActivityIds.diagnostic)
+                | Some (text, inB, outB) ->
+                    let timestamp =
+                        DateTime.UtcNow.ToString(
+                            "yyyy-MM-dd-HH-mm-ss-fff")
+                    let extractsDir =
+                        System.IO.Path.Combine(
+                            Environment.GetFolderPath(
+                                Environment.SpecialFolder.LocalApplicationData),
+                            "PtySpeak",
+                            "extracts")
+                    let filePath =
+                        System.IO.Path.Combine(
+                            extractsDir,
+                            sprintf "rawtrace-%s.txt" timestamp)
+                    let mutable wrote = false
+                    try
+                        System.IO.Directory.CreateDirectory(extractsDir)
+                        |> ignore
+                        System.IO.File.WriteAllText(
+                            filePath, text, System.Text.Encoding.UTF8)
+                        RawShellRecorder.setLastTracePath filePath
+                        wrote <- true
+                        log.LogInformation(
+                            "Raw shell trace written. Path={Path} InBytes={In} OutBytes={Out} TextLen={Len}",
+                            filePath,
+                            inB,
+                            outB,
+                            text.Length)
+                    with ex ->
+                        let safe = AnnounceSanitiser.sanitise ex.Message
+                        log.LogError(
+                            ex,
+                            "Could not write raw trace file at {Path}.",
+                            filePath)
+                        window.TerminalSurface.Announce(
+                            sprintf "Could not save the raw trace: %s" safe,
+                            ActivityIds.error)
+                    if wrote then
+                        let cap = 60 * 1024
+                        let truncated = text.Length > cap
+                        let clip =
+                            if truncated then
+                                text.Substring(0, cap)
+                                + "\n\n... [clipboard truncated; full trace in the file] ..."
+                            else
+                                text
+                        let _ =
+                            task {
+                                try
+                                    let setOk = TaskCompletionSource<bool>()
+                                    let staBody =
+                                        ThreadStart(fun () ->
+                                            try
+                                                System.Windows.Clipboard.SetText(clip)
+                                                setOk.TrySetResult(true)
+                                                |> ignore
+                                            with ex ->
+                                                log.LogWarning(
+                                                    ex,
+                                                    "Clipboard.SetText threw: {Message}",
+                                                    ex.Message)
+                                                setOk.TrySetResult(false)
+                                                |> ignore)
+                                    let staThread = new Thread(staBody)
+                                    staThread.SetApartmentState(
+                                        ApartmentState.STA)
+                                    staThread.IsBackground <- true
+                                    staThread.Start()
+                                    let! winner =
+                                        Task.WhenAny(
+                                            setOk.Task :> Task,
+                                            Task.Delay(3000))
+                                    let copied =
+                                        obj.ReferenceEquals(
+                                            winner, setOk.Task)
+                                        && setOk.Task.Result
+                                    let msg =
+                                        if not copied then
+                                            sprintf
+                                                "Raw shell trace stopped. %d bytes in, %d out. Saved to %s. Clipboard copy failed; open the file."
+                                                inB outB filePath
+                                        elif truncated then
+                                            sprintf
+                                                "Raw shell trace stopped. %d bytes in, %d out. Saved to %s. Clipboard copy was truncated; open the file for the full trace."
+                                                inB outB filePath
+                                        else
+                                            sprintf
+                                                "Raw shell trace stopped. %d bytes in, %d out. Saved to %s and copied to the clipboard."
+                                                inB outB filePath
+                                    window.TerminalSurface.Announce(
+                                        msg, ActivityIds.diagnostic)
+                                with ex ->
+                                    log.LogWarning(
+                                        ex,
+                                        "Raw trace clipboard task threw.")
+                            }
+                        ()
+            else
+                RawShellRecorder.start () |> ignore
+                log.LogInformation(
+                    "Raw shell trace recording started.")
+                window.TerminalSurface.Announce(
+                    "Raw shell trace recording started. Warning: every keystroke you type, including any passwords or secrets, and all shell output is being recorded until you press Control Shift T again.",
+                    ActivityIds.diagnostic)
+
         // Cycle 46 post-audit (2026-05-13) — re-narrate the
         // latest finalised tuple's `OutputText`, capped at the
         // same `OutputAnnounceCapChars` the auto-narrate uses.
@@ -4312,6 +4442,7 @@ module Program =
         bind HotkeyRegistry.CopyHistoryToClipboard runCopyHistoryToClipboard
         bind HotkeyRegistry.AnnounceSessionLogPath runAnnounceSessionLogPath
         bind HotkeyRegistry.OpenLastOutput runOpenLastOutput
+        bind HotkeyRegistry.ToggleRawTrace runToggleRawTrace
         bind HotkeyRegistry.AnnounceLastOutput runAnnounceLastOutput
         bind HotkeyRegistry.CopyFocusedCell runCopyFocusedCell
         bind HotkeyRegistry.CopyFocusedCellCommand runCopyFocusedCellCommand
@@ -5408,6 +5539,12 @@ module Program =
                        && (bytes.[1] = 0x5Buy || bytes.[1] = 0x4Fuy)
                        && (bytes.[2] = 0x41uy || bytes.[2] = 0x42uy) then
                         triggerHistoryRecallDebounce ()
+                    // Cycle 52 boundary-diagnostic-capture
+                    // (Instrument B) — additive raw IN tap
+                    // (app → shell keystrokes). No-op unless a
+                    // Ctrl+Shift+T capture is active.
+                    RawShellRecorder.record
+                        RawShellRecorder.Input bytes
                     host.WriteBytes(bytes)),
                 Action<int, int>(fun cols rows ->
                     // Resize is best-effort: a transient failure

--- a/src/Terminal.Core/HotkeyRegistry.fs
+++ b/src/Terminal.Core/HotkeyRegistry.fs
@@ -101,6 +101,9 @@ module HotkeyRegistry =
         | OpenGitHubRepo
         | OpenFeatureRequest
         | OpenSubmitIssue
+        // Cycle 52 boundary-diagnostic-capture (Instrument B) —
+        // Ctrl+Shift+T toggles the raw PTY byte recorder.
+        | ToggleRawTrace
         // Stage 7-followup PR-F + PR-J liveness probe — health check.
         | HealthCheck
         // Stage 7-followup PR-F — incident marker.
@@ -268,6 +271,7 @@ module HotkeyRegistry =
         | OpenGitHubRepo -> "OpenGitHubRepo"
         | OpenFeatureRequest -> "OpenFeatureRequest"
         | OpenSubmitIssue -> "OpenSubmitIssue"
+        | ToggleRawTrace -> "ToggleRawTrace"
         | HealthCheck -> "HealthCheck"
         | IncidentMarker -> "IncidentMarker"
         | SwitchToCmd -> "SwitchToCmd"
@@ -382,6 +386,10 @@ module HotkeyRegistry =
             Key = None
             Modifiers = None
             Description = "Open the GitHub new-issue page in the default browser (menu-only; About menu)" }
+          { Command = ToggleRawTrace
+            Key = Some (Letter 'T')
+            Modifiers = Some ctrlShift
+            Description = "Toggle the raw PTY byte trace recorder (Cycle 52 boundary-diagnostic-capture; on = announce + record every byte in/out, off = write file + copy to clipboard)" }
           { Command = HealthCheck
             Key = Some (Letter 'H')
             Modifiers = Some ctrlShift
@@ -711,6 +719,7 @@ module HotkeyRegistry =
           OpenGitHubRepo
           OpenFeatureRequest
           OpenSubmitIssue
+          ToggleRawTrace
           HealthCheck
           IncidentMarker
           SwitchToCmd

--- a/src/Terminal.Core/RawShellRecorder.fs
+++ b/src/Terminal.Core/RawShellRecorder.fs
@@ -1,0 +1,169 @@
+namespace Terminal.Core
+
+open System
+open System.Text
+open System.Collections.Generic
+
+/// Cycle 52 boundary-diagnostic-capture — **Instrument B**:
+/// the explicitly-toggled raw PTY byte recorder.
+///
+/// NOT always-on (that is Instrument A, the bounded
+/// boundary-decision ring). `start`/`stop` gate an in-RAM
+/// event buffer that exists only for the capture window, so a
+/// long session never accumulates an unbounded object. Records
+/// every byte **in** (app → shell: the user's keystrokes) and
+/// **out** (shell → app: everything the shell produced) with a
+/// high-resolution elapsed timestamp + direction, so the
+/// input / output / sub-prompt boundary can be reconstructed
+/// from ground truth (the whole point of the cell-seal track).
+///
+/// WPF-free `Terminal.Core` module. Fed from two threads — the
+/// reader loop (`Output`) and the dispatcher thread (`Input`)
+/// — so all state is behind one lock. The mutable-module +
+/// lock shape mirrors `EarconChannel`; `clearForTests` mirrors
+/// its test-isolation hook.
+module RawShellRecorder =
+
+    type Direction =
+        /// app → shell — bytes the user typed (keystrokes).
+        | Input
+        /// shell → app — bytes the shell produced.
+        | Output
+
+    [<Struct>]
+    type private Event =
+        { ElapsedUs: int64
+          Dir: Direction
+          Bytes: byte[] }
+
+    let private gate: obj = obj ()
+    let mutable private recording: bool = false
+    let mutable private startedUtc: DateTime = DateTime.MinValue
+    let private sw = System.Diagnostics.Stopwatch()
+    let private events = List<Event>()
+    let mutable private lastTrace: string option = None
+    let mutable private lastTracePath: string option = None
+
+    /// True while a capture is in progress.
+    let isRecording () : bool =
+        lock gate (fun () -> recording)
+
+    /// Begin a capture (clearing any prior in-progress buffer).
+    /// Returns false if already recording.
+    let start () : bool =
+        lock gate (fun () ->
+            if recording then false
+            else
+                events.Clear()
+                startedUtc <- DateTime.UtcNow
+                sw.Restart()
+                recording <- true
+                true)
+
+    /// Record a chunk. Cheap early-out when not recording — the
+    /// PTY taps call this unconditionally and additively. A
+    /// defensive copy is taken so a later mutation of the
+    /// caller's buffer cannot corrupt the trace.
+    let record (dir: Direction) (bytes: byte[]) : unit =
+        if bytes.Length > 0 then
+            lock gate (fun () ->
+                if recording then
+                    events.Add(
+                        { ElapsedUs = sw.Elapsed.Ticks / 10L
+                          Dir = dir
+                          Bytes = Array.copy bytes }))
+
+    // byte → readable, unambiguous token. Screen-reader-safe
+    // and one-event-per-line (no embedded real newline) so the
+    // trace stays grep-/paste-analysable; OSC-133 reads as
+    // `\e]133;A\e\\`.
+    let private esc (b: byte) : string =
+        match b with
+        | 0x1Buy -> "\\e"
+        | 0x0Duy -> "\\r"
+        | 0x0Auy -> "\\n"
+        | 0x09uy -> "\\t"
+        | 0x07uy -> "\\a"
+        | _ when b >= 0x20uy && b < 0x7Fuy -> string (char b)
+        | _ -> sprintf "\\x%02X" (int b)
+
+    let private renderBytes (bytes: byte[]) : string =
+        let sb = StringBuilder(bytes.Length * 2)
+        for b in bytes do
+            sb.Append(esc b) |> ignore
+        sb.ToString()
+
+    /// Stop the capture and format the trace. Returns
+    /// `(formattedText, inBytes, outBytes)` or `None` when not
+    /// recording. The formatted text is retained in RAM
+    /// (`getLastTrace`) for the "copy most recent" command and
+    /// the Ctrl+Shift+D fold-in; the on-disk path is recorded
+    /// by the caller via `setLastTracePath`.
+    let stop () : (string * int * int) option =
+        lock gate (fun () ->
+            if not recording then None
+            else
+                recording <- false
+                let inB =
+                    events
+                    |> Seq.filter (fun e -> e.Dir = Input)
+                    |> Seq.sumBy (fun e -> e.Bytes.Length)
+                let outB =
+                    events
+                    |> Seq.filter (fun e -> e.Dir = Output)
+                    |> Seq.sumBy (fun e -> e.Bytes.Length)
+                let sb = StringBuilder()
+                sb.AppendLine(
+                    sprintf
+                        "=== pty-speak raw shell trace — started %s UTC ==="
+                        (startedUtc.ToString(
+                            "yyyy-MM-dd HH:mm:ss.fff")))
+                |> ignore
+                sb.AppendLine(
+                    sprintf
+                        "=== %d events; IN %d bytes; OUT %d bytes ==="
+                        events.Count
+                        inB
+                        outB)
+                |> ignore
+                sb.AppendLine(
+                    "=== format: +<elapsed_us>us <DIR> <nbytes>B | <escaped>  (\\e=ESC \\r \\n \\t \\a \\xHH) ===")
+                |> ignore
+                for e in events do
+                    let dir =
+                        match e.Dir with
+                        | Input -> "IN "
+                        | Output -> "OUT"
+                    sb.AppendLine(
+                        sprintf
+                            "+%dus %s %dB | %s"
+                            e.ElapsedUs
+                            dir
+                            e.Bytes.Length
+                            (renderBytes e.Bytes))
+                    |> ignore
+                let text = sb.ToString()
+                lastTrace <- Some text
+                events.Clear()
+                Some(text, inB, outB))
+
+    /// The most recent finished trace's formatted text (RAM
+    /// only; survives until the next `start` or `clearForTests`).
+    let getLastTrace () : string option =
+        lock gate (fun () -> lastTrace)
+
+    let setLastTracePath (path: string) : unit =
+        lock gate (fun () -> lastTracePath <- Some path)
+
+    /// The on-disk path the most recent trace was written to.
+    let getLastTracePath () : string option =
+        lock gate (fun () -> lastTracePath)
+
+    /// Test isolation — drop all state.
+    let clearForTests () : unit =
+        lock gate (fun () ->
+            recording <- false
+            startedUtc <- DateTime.MinValue
+            events.Clear()
+            lastTrace <- None
+            lastTracePath <- None)

--- a/src/Terminal.Core/Terminal.Core.fsproj
+++ b/src/Terminal.Core/Terminal.Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="UpdateMessages.fs" />
     <Compile Include="FileLogger.fs" />
     <Compile Include="Coalescer.fs" />
+    <Compile Include="RawShellRecorder.fs" />
     <!--
       Cycle 45 — ContentHistory is the aural substrate. Depends
       only on `Types.fs` (VtEvent). Cycle 45c PR-3a moved it

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -266,6 +266,14 @@
                 <MenuItem x:Name="MenuItem_OpenDataFolder"
                           x:FieldModifier="public"
                           Header="Open _Data Folder" />
+                <!-- Cycle 52 boundary-diagnostic-capture
+                     (Instrument B). Same RoutedCommand as
+                     Ctrl+Shift+T; toggles raw PTY byte
+                     recording. (Open / Copy most-recent trace
+                     items land in a follow-up.) -->
+                <MenuItem x:Name="MenuItem_ToggleRawTrace"
+                          x:FieldModifier="public"
+                          Header="Toggle Raw Shell _Trace" />
                 <!-- Probe — quick "fire an action and watch what
                      happens" probes: health check, incident
                      marker, the diagnostic battery. The

--- a/src/Views/TerminalView.cs
+++ b/src/Views/TerminalView.cs
@@ -722,6 +722,9 @@ public class TerminalView : FrameworkElement
             // Ctrl+Shift+arrow is free.
             (Key.Left, ModifierKeys.Control | ModifierKeys.Shift, "Focus terminal pane (left)"),
             (Key.Right, ModifierKeys.Control | ModifierKeys.Shift, "Focus cell-history pane (right)"),
+            // Cycle 52 boundary-diagnostic-capture — raw PTY
+            // byte trace recorder toggle.
+            (Key.T, ModifierKeys.Control | ModifierKeys.Shift, "Toggle raw PTY byte trace recorder"),
 
             // Future entries (NOT yet bound; commented for
             // forward-planning):

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -329,14 +329,15 @@ let ``OpenConfig is bound to Ctrl+Shift+E (Cycle 25a)`` () =
         hk.Modifiers)
 
 [<Fact>]
-let ``Ctrl+Shift+T is unbound (Cycle 25b removed RunTestMatrix placeholder)`` () =
-    // Cycle 25b — the RunTestMatrix placeholder shipped in 25a is
-    // removed. The diagnostic suite folds into Ctrl+Shift+D rather
-    // than splitting across two hotkeys; the interactive cleanup
-    // test (which required user input) moves to a future app menu.
+let ``Ctrl+Shift+T is bound to ToggleRawTrace (Cycle 52 boundary-diagnostic-capture)`` () =
+    // Cycle 25b vacated Ctrl+Shift+T (RunTestMatrix placeholder
+    // removed) and this test pinned it free. Cycle 52
+    // intentionally claims the slot for the raw PTY byte trace
+    // toggle (boundary-diagnostic-capture Instrument B), so the
+    // pin flips from "unbound" to a positive binding assertion.
     let modifiers = Set.ofList [ HotkeyRegistry.Ctrl; HotkeyRegistry.Shift ]
     let result = HotkeyRegistry.tryFind (HotkeyRegistry.Letter 'T') modifiers
-    Assert.Equal(None, result)
+    Assert.Equal(Some HotkeyRegistry.ToggleRawTrace, result)
 
 [<Fact>]
 let ``Ctrl+Shift+; is unbound (Cycle 25a vacated)`` () =

--- a/tests/Tests.Unit/HotkeyRegistryTests.fs
+++ b/tests/Tests.Unit/HotkeyRegistryTests.fs
@@ -69,6 +69,9 @@ let ``allCommands contains exactly the documented commands (PR-O)`` () =
               HotkeyRegistry.OpenGitHubRepo
               HotkeyRegistry.OpenFeatureRequest
               HotkeyRegistry.OpenSubmitIssue
+              // Cycle 52 boundary-diagnostic-capture — raw PTY
+              // byte trace toggle (Ctrl+Shift+T).
+              HotkeyRegistry.ToggleRawTrace
               // Cycle 25b-1a — CopyLatestLog removed (D's bundle
               // subsumes it).
               // Cycle 27 — `ToggleDebugLog` and `MuteEarcons`


### PR DESCRIPTION
## Summary

First instrument of the cell-seal / boundary computational-accuracy track (#2). Per the ratified design: **explicitly-toggled raw PTY byte recorder, not always-on** — so a long session never accumulates an unbounded buffer (your ballooning concern). This is the ground-truth "what actually crossed the wire" capture we'll use to see *why* the input-test's `set /p` sub-prompt desyncs the input/output/sub-prompt boundary.

- **`src/Terminal.Core/RawShellRecorder.fs`** (new, WPF-free, lock-guarded): `start`/`stop`/`record`/`isRecording`; an in-RAM event buffer that exists **only for the capture window**; microsecond elapsed timestamps + direction; a one-event-per-line escaped formatter (`\e \r \n \t \a \xHH`, so OSC-133 reads legibly as `\e]133;A\e\\`); `getLastTrace`/`getLastTracePath` + `clearForTests`. Added to `Terminal.Core.fsproj`.
- **Two additive PTY taps** (`Program.fs`): the `Stdout` reader consumer (OUT = shell→app) and the single `host.WriteBytes` funnel (IN = app→shell keystrokes). Cheap no-op unless a capture is active — **no behaviour change to the seal path**.
- **`Ctrl+Shift+T` toggle** (`ToggleRawTrace` HotkeyRegistry command — DU/nameOf/builtIns/allCommands + the `allCommands` expected-set test + the `TerminalView.AppReservedHotkeys` row so the F#↔C# mirror test stays green).
- **`runToggleRawTrace`**: ON announces the keystroke-recording warning ("…including any passwords or secrets…"); OFF **always** writes `%LOCALAPPDATA%\PtySpeak\extracts\rawtrace-<ts>.txt`, copies to clipboard capped at 60 KB, and announces the path + whether the clipboard copy was truncated. File-write / STA-clipboard shapes mirror the proven `runOpenLastOutput` / `runCopyHistoryToClipboard`.
- **`Diagnostics → Toggle Raw Shell Trace`** menu item (same `RoutedCommand`).

**B2** (the *Open most-recent* / *Copy most-recent* Diagnostics menu items + a `RawShellRecorder` formatter unit test) and **Instrument A** (the always-on bounded boundary-decision ring, folded into `Ctrl+Shift+D`) follow as separate PRs.

## Test plan

- [ ] CI green (Windows build compiles the new F# module + the taps + HotkeyRegistry; the `allCommands` / mirror tests now include `ToggleRawTrace`).
- [ ] Dogfood: `Ctrl+Shift+T` → hear the recording warning; run `Diagnostics → CMD Interaction Tests → Text Input` and complete it; `Ctrl+Shift+T` again → hear "saved to …rawtrace-….txt … copied to the clipboard"; open the file and confirm a readable per-event in/out timeline with OSC-133 markers and the `set /p` interaction visible. Also confirm normal typing/output is unaffected when **not** recording (no-op tap).

Locally unverifiable (no WPF/NVDA/.NET in the sandbox) — CI is the only build check; this is the instrument that will let us capture the real data to design the seal/boundary fix from.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_