### PR TITLE
boundary-capture C1: echo hi slow reference trace + analysis

### DIFF
--- a/docs/boundary-capture/README.md
+++ b/docs/boundary-capture/README.md
@@ -47,7 +47,7 @@ typed, including anything sensitive. Per
 
 | ID | Shell | Scenario | Why | Expected | Status | Trace |
 |----|-------|----------|-----|----------|--------|-------|
-| C1 | cmd | `echo hi`, slow, deliberate pauses, wait for output | clean single IOCell, generous timing — the reference "correct" trace | seals 1 cell | _pending_ | — |
+| C1 | cmd | `echo hi`, slow, deliberate pauses, wait for output | clean single IOCell, generous timing — the reference "correct" trace | seals 1 cell | **captured 2026-05-17** | [`cmd/C1-echo-hi-slow.txt`](cmd/C1-echo-hi-slow.txt) |
 | C2 | cmd | `echo hi`, typed as fast as possible | same logical cell, timing-stressed — isolates timing-sensitivity vs C1 | seals 1 cell | _pending_ | — |
 | C3 | cmd | `Diagnostics → CMD Interaction Tests → Text Input` (`set /p`) | **the defect** — this scenario seals no cell | currently seals 0 (bug) | _pending_ | — |
 | C4 | cmd | multi-line echo / `dir` interaction test (optional) | a cell that *does* seal but with output volume — brackets C3 | seals 1 cell | _pending_ | — |
@@ -63,12 +63,56 @@ non-secret fixtures — see the safety rule).
 
 ## Per-scenario analysis
 
-### C1 — `echo hi` slow (reference)
+### C1 — `echo hi` slow (reference) — captured 2026-05-17 14:02 UTC
 
-_Awaiting trace._ Will record: prompt-emit bytes, the
-`PromptStart`/`PromptEnd` boundary markers (if any), command-echo
-bytes, output bytes, the next-prompt boundary that should seal the
-cell.
+Trace: [`cmd/C1-echo-hi-slow.txt`](cmd/C1-echo-hi-slow.txt) — 17
+events, IN 8 B, OUT 101 B. Slow typing (1.4–7.5 s between chars),
+strict per-keystroke `IN <char>` → `OUT <char>` local echo, then
+on Enter `IN \r` → `OUT \r\n` → a single 92-byte OUT flush.
+
+Decoded 92-byte flush:
+
+```
+ESC[?25l  HI  ESC[5;1H  ESC[?25h  OSC 133;D ST  OSC 133;A ST  C:\Users\Kyle\git\pty-speak\src\Terminal.App>  OSC 133;B ST
+```
+
+Findings:
+
+1. **cmd OSC-133 injection (ADR 0006 R2) is live and
+   well-formed.** Correct introducer, **ST-terminated**
+   (`ESC \`, i.e. `\e\`), not BEL. Prior-command close + next
+   prompt open both present in one flush.
+2. **Marker set is A, B, D — `OSC 133;C` is absent.** There is
+   no command-start / output-start marker between Enter and the
+   `HI` output: the flush goes `[?25l` → `HI` → cursor-move →
+   `;D` → `;A` → prompt → `;B`. cmd's injected integration does
+   not emit `;C` at all (at least for `echo`).
+3. **`OSC 133;D` carries no exit code** — literal `133;D`, not
+   `133;D;0`. Per ADR 0008 / ADR 0009 this is the honest
+   `CellOutcome = Indeterminate` case: no exit status is
+   transported, so none must be invented.
+4. Recording joined mid-prompt (first event is `IN E` at an
+   already-ready prompt), so this command's *own* opening
+   `;A`/`;B` predate the trace. The `echo hi` cell is bounded by
+   `[pre-trace ;B] … [;D in the 92-byte flush]`; the next
+   prompt's `;A … ;B` immediately follow the seal.
+
+Implication for the seal bug: with no `;C`, the extractor cannot
+bound the output region by `;C → ;D`. Output-start is implicit
+(immediately after the echoed `\r\n`); the **seal is the `;D`**,
+with the next prompt's `;A` arriving in the same flush. This
+makes the C3 (`set /p`) question precise: does the interactive
+read **defer or suppress the `;D`** (the cell never sees its
+closing boundary → dropped on `None` per
+[ADR 0004](../adr/0004-iocell-model-for-shell-interaction.md)),
+or does it interleave a sub-prompt between `;B` and `;D` that the
+single-IOCell extractor mishandles? C1 is the clean A/B/(no
+C)/D shape to diff C3 against.
+
+Outstanding for the record (non-blocking): the C1 in-app result
+— did NVDA announce the sealed `echo hi` output, and the
+`Ctrl+Shift+H` Version line (confirm the dogfood ran `de74a3f`
+or later, not a stale build).
 
 ### C2 — `echo hi` fast (timing stress)
 

--- a/docs/boundary-capture/cmd/C1-echo-hi-slow.txt
+++ b/docs/boundary-capture/cmd/C1-echo-hi-slow.txt
@@ -1,0 +1,20 @@
+=== pty-speak raw shell trace — started 2026-05-17 14:02:14.992 UTC ===
+=== 17 events; IN 8 bytes; OUT 101 bytes ===
+=== format: +<elapsed_us>us <DIR> <nbytes>B | <escaped>  (\e=ESC \r \n \t \a \xHH) ===
++14302167us IN  1B | E
++14302820us OUT 1B | E
++15705164us IN  1B | C
++15705543us OUT 1B | C
++17112162us IN  1B | H
++17112344us OUT 1B | H
++19053315us IN  1B | O
++19053824us OUT 1B | O
++20449300us IN  1B |
++20449679us OUT 1B |
++21939633us IN  1B | H
++21939952us OUT 1B | H
++23419744us IN  1B | I
++23420194us OUT 1B | I
++30873769us IN  1B | \r
++30874038us OUT 2B | \r\n
++30876502us OUT 92B | \e[?25lHI\e[5;1H\e[?25h\e]133;D\e\\e]133;A\e\C:\Users\Kyle\git\pty-speak\src\Terminal.App>\e]133;B\e\


### PR DESCRIPTION
## Summary

First captured trace for the cmd cell-seal / boundary
investigation. **C1 — `echo hi` slow** is the known-good
reference baseline (generous timing, clean single IOCell).

Adds:
- `docs/boundary-capture/cmd/C1-echo-hi-slow.txt` — verbatim B1
  trace (catalogued deterministic non-secret scenario per the
  record's safety rule).
- C1 row + full analysis section in
  `docs/boundary-capture/README.md`.

Key findings (decoded 92-byte post-Enter flush):

1. **cmd OSC-133 injection (ADR 0006 R2) is live and
   well-formed** — correct introducer, **ST-terminated**
   (`ESC \`), not BEL.
2. **Marker set is A, B, D — `OSC 133;C` is absent.** No
   command-start / output-start marker between Enter and the
   `HI` output. cmd's injected integration does not emit `;C`.
3. **`OSC 133;D` carries no exit code** (`133;D`, not
   `133;D;0`) — ADR 0008 / 0009 honest-`Indeterminate` case.
4. Recording joined mid-prompt; the `echo hi` cell is bounded
   `[pre-trace ;B] … [;D in the flush]`, next prompt's `;A … ;B`
   immediately following.

Sharpens the C3 (`set /p`) question: deferred/suppressed `;D`
(cell never sees its closing boundary → drop-on-`None` per
ADR 0004) **vs.** a sub-prompt interleaved between `;B` and `;D`
that the single-IOCell extractor mishandles. C1 is the clean
A/B/(no C)/D shape to diff C3 against.

No source / spec / workflow touched — record-only.

## Test plan

- [ ] All CI green (this PR adds a `.txt` under `docs/`, so it is
  **not** fast-merge-eligible — wait for the full Windows
  build/test + lints, not just the link check)
- [ ] Markdown link check green (relative link `cmd/C1-echo-hi-slow.txt`
  + `../adr/0004…` resolve)
- [ ] No behaviour change — `git diff --stat` is the trace file +
  the README

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_