### PR TITLE
boundary-capture C3: set/p defect trace + corrected cross-scenario synthesis

### DIFF
--- a/docs/boundary-capture/README.md
+++ b/docs/boundary-capture/README.md
@@ -1,13 +1,20 @@
 # Boundary diagnostic capture — Cycle 52 cell-seal track
 
 Ground-truth raw-byte traces for the **cmd cell-seal / boundary
-computational-accuracy** investigation. The active defect: the cmd
-`set /p` input-test seals **no command cell** (extraction drops the
-cell per [ADR 0004](../adr/0004-iocell-model-for-shell-interaction.md)
+computational-accuracy** investigation. **Post-capture finding
+(2026-05-17): the defect is general, not `set /p`-specific.** It
+*degrades with interaction complexity* — even synchronous
+`echo hi` (C1/C2) bleeds the trailing next-prompt path into the
+sealed cell's announced output; the `set /p` input-test (C3)
+escalates that to sealing **no command cell** at all (extraction
+drops it per
+[ADR 0004](../adr/0004-iocell-model-for-shell-interaction.md)
 drop-on-`None`; boundary detection lives in the transport
-`ShellAdapter` per [ADR 0006](../adr/0006-three-layer-refoundation.md)).
-This pass captures real byte timelines *before* any fix, so the
-seal/boundary correction is driven by data, not inference.
+`ShellAdapter` per
+[ADR 0006](../adr/0006-three-layer-refoundation.md)). This pass
+captures real byte timelines *before* any fix, so the
+seal/boundary correction is driven by data, not inference. See
+**Cross-scenario synthesis** at the foot of this file.
 
 Instrument: **B1** — `RawShellRecorder`
 ([`src/Terminal.Core/RawShellRecorder.fs`](../../src/Terminal.Core/RawShellRecorder.fs)),
@@ -47,9 +54,9 @@ typed, including anything sensitive. Per
 
 | ID | Shell | Scenario | Why | Expected | Status | Trace |
 |----|-------|----------|-----|----------|--------|-------|
-| C1 | cmd | `echo hi`, slow, deliberate pauses, wait for output | clean single IOCell, generous timing — the reference "correct" trace | seals 1 cell | **captured 2026-05-17** | [`cmd/C1-echo-hi-slow.txt`](cmd/C1-echo-hi-slow.txt) |
-| C2 | cmd | `echo hi`, typed as fast as possible | same logical cell, timing-stressed — isolates timing-sensitivity vs C1 | seals 1 cell; user heard repeated speech at start | **captured 2026-05-17** | [`cmd/C2-echo-hi-fast.txt`](cmd/C2-echo-hi-fast.txt) |
-| C3 | cmd | `Diagnostics → CMD Interaction Tests → Text Input` (`set /p`) | **the defect** — this scenario seals no cell | currently seals 0 (bug) | _pending_ | — |
+| C1 | cmd | `echo hi`, slow, deliberate pauses, wait for output | intended-clean control (turned out **not** clean — see analysis) | in-app: spoke `HI` **+ next-prompt path** — boundary bleed | **captured 2026-05-17** | [`cmd/C1-echo-hi-slow.txt`](cmd/C1-echo-hi-slow.txt) |
+| C2 | cmd | `echo hi`, typed as fast as possible | same logical cell, timing-stressed — isolates timing-sensitivity vs C1 | C1's prompt-path bleed **+ repeated speech at start** | **captured 2026-05-17** | [`cmd/C2-echo-hi-fast.txt`](cmd/C2-echo-hi-fast.txt) |
+| C3 | cmd | `Diagnostics → CMD Interaction Tests → Text Input` (`set /p`) | **the defect** — this scenario seals no cell | **no cell sealed** (drop-on-`None`) | **captured 2026-05-17** | [`cmd/C3-set-p-text-input.txt`](cmd/C3-set-p-text-input.txt) |
 | C4 | cmd | multi-line echo / `dir` interaction test (optional) | a cell that *does* seal but with output volume — brackets C3 | seals 1 cell | _pending_ | — |
 
 PowerShell capture (P-series) is **deferred** until the cmd
@@ -64,6 +71,15 @@ non-secret fixtures — see the safety rule).
 ## Per-scenario analysis
 
 ### C1 — `echo hi` slow (reference) — captured 2026-05-17 14:02 UTC
+
+> **Correction (2026-05-17, post in-app result).** This section
+> originally framed C1 as the *clean* reference. The maintainer
+> confirmed the in-app behaviour: NVDA spoke **`HI` *and* the
+> next-prompt path** (`C:\…\Terminal.App>`). So C1 does **not**
+> seal a clean cell — it announces the output *plus* the trailing
+> `;A <prompt> ;B`. The byte-level findings below stand; the
+> "seal is the `;D` / C1 is the clean shape" conclusion does
+> not — superseded by **Cross-scenario synthesis** at the foot.
 
 Trace: [`cmd/C1-echo-hi-slow.txt`](cmd/C1-echo-hi-slow.txt) — 17
 events, IN 8 B, OUT 101 B. Slow typing (1.4–7.5 s between chars),
@@ -97,28 +113,34 @@ Findings:
    `[pre-trace ;B] … [;D in the 92-byte flush]`; the next
    prompt's `;A … ;B` immediately follow the seal.
 
-Implication for the seal bug: with no `;C`, the extractor cannot
-bound the output region by `;C → ;D`. Output-start is implicit
-(immediately after the echoed `\r\n`); the **seal is the `;D`**,
-with the next prompt's `;A` arriving in the same flush. This
-makes the C3 (`set /p`) question precise: does the interactive
-read **defer or suppress the `;D`** (the cell never sees its
-closing boundary → dropped on `None` per
-[ADR 0004](../adr/0004-iocell-model-for-shell-interaction.md)),
-or does it interleave a sub-prompt between `;B` and `;D` that the
-single-IOCell extractor mishandles? C1 is the clean A/B/(no
-C)/D shape to diff C3 against.
+Implication for the seal bug (revised): with no `;C`, the
+extractor cannot bound the output region by `;C → ;D`.
+Output-start is implicit (immediately after the echoed `\r\n`).
+The byte stream *does* carry a clean `;D` followed by the next
+prompt's `;A <prompt> ;B` in one flush — so the markers needed
+to fence the cell are **present**. But the in-app result shows
+the announce **includes the post-`;D` `;A <prompt> ;B`** (the
+spoken "HI + prompt path"). Therefore the extractor is **not
+using `;D` as a hard output terminator** and is **not fencing
+the trailing next-prompt `;A…;B` out** of the just-sealed
+cell's body. The defect is present even in this simplest
+synchronous case; it is not introduced by `set /p`. See
+**Cross-scenario synthesis**.
 
-Outstanding for the record (non-blocking): the C1 in-app result
-— did NVDA announce the sealed `echo hi` output, and the
-`Ctrl+Shift+H` Version line (confirm the dogfood ran `de74a3f`
-or later, not a stale build).
+In-app result (maintainer-confirmed 2026-05-17): NVDA spoke
+`HI` followed by the prompt path — output announced but the
+trailing prompt bled in. (`Ctrl+Shift+H` Version line still
+wanted for the record to pin the dogfood build ≥ `de74a3f`.)
 
 ### C2 — `echo hi` fast (timing stress) — captured 2026-05-17 14:05 UTC
 
 Trace: [`cmd/C2-echo-hi-fast.txt`](cmd/C2-echo-hi-fast.txt).
 Maintainer-observed symptom: **repeated speech at the beginning**
-when typing fast.
+when typing fast. (Note: C1 itself was later confirmed to bleed
+the trailing prompt path — see the C1 correction — so C2's
+in-app behaviour is *that same bleed* **plus** the fast-typing
+repeated speech. "C1 baseline" below means the byte-stream
+baseline, not a clean-announce baseline.)
 
 **C2 is byte-identical to the C1 baseline.** Same 17 events,
 same IN 8 B / OUT 101 B, same strict per-keystroke 1:1 local
@@ -161,14 +183,110 @@ utterance heard — which words, how many repeats — to localise
 the announce site (prompt re-read vs per-char echo re-read), and
 the `Ctrl+Shift+H` Version line.
 
-### C3 — `set /p` input-test (the defect)
+### C3 — `set /p` input-test (the defect) — captured 2026-05-17 14:13 UTC
 
-_Awaiting trace._ The key question: where in the byte timeline
-does the boundary that *should* seal the cell go missing — is the
-`PromptStart` marker absent, emitted in a position the detector
-doesn't recognise, or present-but-dropped downstream?
+Trace: [`cmd/C3-set-p-text-input.txt`](cmd/C3-set-p-text-input.txt)
+— 14 events, IN 6 B, OUT 481 B. In-app result: **no command
+cell sealed** (the open defect from SESSION-HANDOFF § Next).
+
+Decoded timeline:
+
+1. `IN \r` → `OUT \r\n` — launches `test-02-text-input.cmd`.
+   **No `OSC 133;C`** (consistent with C1/C2 — cmd's injection
+   never emits command-start).
+2. `OUT 254B` — `=== PTYSPEAK-TEST-START… ===\r\n` ·
+   `This test prompts…\r\n` · **`Enter your name:`** ·
+   `ESC]0;…cmd.exe - "…test-02…cmd"… BEL`
+   (an **OSC 0 window-title**, **BEL-terminated** `\a`).
+3. ~12 s blocking wait, then `IN N`/`A`/`M`/`E` each with a
+   1-byte `OUT` echo, then `IN \r` → `OUT \r\n`.
+4. `OUT 219B` — `ESC[?25l` · `Hello, NAME! …` ·
+   `=== PTYSPEAK-TEST-END… ===` · `ESC[18;1H` ·
+   `ESC]0;…cmd.exe BEL` (title reset) · `ESC[?25h` ·
+   **`OSC 133;D ST`** · `OSC 133;A ST` · prompt ·
+   `OSC 133;B ST`.
+
+Findings:
+
+1. **The `set /p` sub-prompt carries zero OSC-133 markers.**
+   `Enter your name:` has no `;A`/`;B` around it and no
+   `;C`/`;D`. cmd's shell-integration only wraps the top-level
+   command loop; an in-script `set /p` is invisible to it.
+   Across the whole test-02 interaction the *only* OSC-133
+   markers are a single `;D` at the very end (closing the whole
+   `.cmd`) plus the next top-level prompt's `;A`/`;B`.
+2. **Mixed OSC terminators.** OSC 0 titles are **BEL**-terminated
+   (`\a`); OSC 133 is **ST**-terminated (`ESC \`). They
+   interleave in the same write — the parser must tolerate both.
+3. **Why no cell seals.** test-02's own opening `;A`/`;B`
+   predate the recording (joined mid-prompt, like C1).
+   Mid-`Executing`, a burst of `IN`+echo arrives (the `set /p`
+   read). ADR 0004 intends sub-prompts to be *inline state
+   inside the parent IOCell*, but the boundary/state machine
+   (ADR 0003 `Composing`/`Executing`) mis-segments: the echoed
+   `NAME` mid-command reads as fresh prompt composition, a new
+   cell is opened that has **no `PromptStart`/`;A`**, ADR 0004
+   drop-on-`None` discards it, and test-02's real close (`;D`)
+   lands on the wrong/dropped cell. Net: **no cell sealed.**
+4. Same root mechanism as the C1/C2 bleed, escalated: the
+   extractor neither treats `;D` as a hard output terminator
+   nor fences the trailing `;A…;B`; once an unmarked sub-prompt
+   + mid-command input is added, "bleed" becomes "total
+   non-seal".
+
+Fix territory (separate PR, after the capture pass — *not* in
+this record): the seal must (a) anchor the cell close on the
+top-level `;D`, (b) fence the post-`;D` `;A <prompt> ;B` out as
+the **next** cell's prompt (not appended body), and (c) hold the
+current cell open across an unmarked sub-prompt — treating any
+`IN`+echo between command-launch and `;D` as ADR 0004 inline
+sub-prompt state, never a new `Composing` cell that then
+drops-on-`None`. Parser must accept BEL- and ST-terminated OSC
+interleaved.
+
+Outstanding for the record (non-blocking): the exact NVDA
+utterance during C3 (silence? partial? the sub-prompt text?)
+and the `Ctrl+Shift+H` Version line.
 
 ### C4 — multi-line / `dir` (volume bracket, optional)
 
 _Awaiting trace._ Confirms volume alone doesn't break sealing,
 isolating C3's failure to the `set /p` sub-prompt shape.
+
+## Cross-scenario synthesis (2026-05-17)
+
+After C1–C3 + the maintainer-confirmed in-app results, the
+picture is **one boundary defect that degrades with interaction
+complexity**, not three separate bugs (with one channel-layer
+rider):
+
+| | byte stream | in-app result | boundary verdict |
+|---|---|---|---|
+| **C1** slow | clean `… ;D ;A <prompt> ;B` tail | spoke `HI` **+ prompt path** | seals, but **bleeds trailing prompt** |
+| **C2** fast | **byte-identical to C1** | C1's bleed **+ repeated speech at start** | same bleed + channel timing artifact |
+| **C3** `set /p` | unmarked sub-prompt + mid-cmd `IN`/echo; one terminal `;D` | **no cell at all** | total failure |
+
+Conclusions:
+
+1. **The OSC-133 markers needed to fence a cell are present in
+   the byte stream** (C1 proves a well-formed `;D` then
+   `;A <prompt> ;B`). The bug is downstream of transport: the
+   extractor does not use `;D` as a hard output-end nor fence
+   the following `;A…;B` out of the sealed cell.
+2. **C1 = C2 at the byte level** (timing only). C2's *extra*
+   "repeated speech at the start" is a **separate
+   channel-layer** timing artifact (fast `UserInputEcho`
+   re-driving the SpeechCursor before `Composing→Executing`
+   settles; ADR 0003 / 0008). It is **not** the boundary bug
+   and must be fixed in the accessibility channel, not the
+   boundary layer.
+3. **C3 is the same boundary defect escalated** by an unmarked
+   `set /p` sub-prompt + mid-`Executing` input: "bleed"
+   becomes "drop-on-`None`, no cell".
+4. The fix is therefore **one boundary/extraction change**
+   (seal on top-level `;D`; fence the trailing next-prompt;
+   hold the cell open across unmarked sub-prompts as ADR 0004
+   inline state; tolerate mixed OSC terminators) **plus one
+   independent channel-layer change** for C2's repeated-speech
+   timing artifact. Two PRs, two layers — tracked separately,
+   *after* this capture pass, per the data-first discipline.

--- a/docs/boundary-capture/cmd/C3-set-p-text-input.txt
+++ b/docs/boundary-capture/cmd/C3-set-p-text-input.txt
@@ -1,0 +1,17 @@
+=== pty-speak raw shell trace — started 2026-05-17 14:13:06.857 UTC ===
+=== 14 events; IN 6 bytes; OUT 481 bytes ===
+=== format: +<elapsed_us>us <DIR> <nbytes>B | <escaped>  (\e=ESC \r \n \t \a \xHH) ===
++3715105us IN  1B | \r
++3715310us OUT 2B | \r\n
++3734234us OUT 254B | === PTYSPEAK-TEST-START: test-02-text-input ===\r\nThis test prompts for a text string and echoes it back.\r\nEnter your name:\e]0;C:\WINDOWS\SYSTEM32\cmd.exe - "C:\Users\Kyle\git\pty-speak\src\Terminal.App\publish\scripts\cmd-tests\test-02-text-input.cmd"  \a
++15749828us IN  1B | N
++15750186us OUT 1B | N
++16259982us IN  1B | A
++16260256us OUT 1B | A
++16678243us IN  1B | M
++16679073us OUT 1B | M
++17491122us IN  1B | E
++17491401us OUT 1B | E
++19562364us IN  1B | \r
++19562798us OUT 2B | \r\n
++19565694us OUT 219B | \e[?25lHello, NAME! Your name has N as its first letter.\r\n=== PTYSPEAK-TEST-END: test-02-text-input ===\e[18;1H\e]0;C:\WINDOWS\SYSTEM32\cmd.exe\a\e[?25h\e]133;D\e\\e]133;A\e\C:\Users\Kyle\git\pty-speak\src\Terminal.App>\e]133;B\e\


### PR DESCRIPTION
## Summary

**C3 — `set /p` Text Input**, the cell-seal defect, plus a
record correction now that the C1/C2 in-app behaviour is known.

Adds `docs/boundary-capture/cmd/C3-set-p-text-input.txt`
(verbatim B1 trace) and substantially revises the record README.

### C3 findings (the defect)

- The `set /p` sub-prompt `Enter your name:` carries **zero
  OSC-133 markers** — cmd's integration wraps only the top-level
  command loop; an in-script `set /p` is invisible to it. The
  whole interaction has just one terminal `;D` + the next
  prompt's `;A`/`;B`.
- **Mixed OSC terminators**: OSC 0 titles are BEL-terminated,
  OSC 133 is ST-terminated, interleaved in one write.
- Mid-`Executing` `IN`+echo (the read) mis-segments into a new
  cell with no `PromptStart` → ADR 0004 drop-on-`None` → **no
  cell sealed**.

### Record correction

The maintainer confirmed C1's in-app result: NVDA spoke `HI`
**and the next-prompt path**. So C1 is **not** the clean
reference the #419 record framed it as — it bleeds the trailing
`;A <prompt> ;B`. This PR adds a prominent C1 correction
callout, fixes the C1/C2 scenario-table rows and the top
defect framing, and adds a **Cross-scenario synthesis**:

> One boundary defect that **degrades with interaction
> complexity** — C1/C2 bleed the trailing prompt (markers are
> present; the extractor just doesn't fence on `;D`), C3
> escalates to total non-seal. Plus one *independent*
> channel-layer artifact (C2 fast-typing repeated speech).
> Fix = two PRs in two layers, **after** the capture pass.

Record-only — no source / spec / workflow touched. The fix
itself is explicitly out of scope here (data-first discipline).

## Test plan

- [ ] Full CI green (adds a `.txt` under `docs/` → **not**
  fast-merge-eligible; wait for the Windows build + lints)
- [ ] Markdown link check green (relative links resolve)
- [ ] No behaviour change — diff is the C3 trace + README

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_