### PR TITLE
replay-oracle R-A: deterministic trace-replay harness + C3 scenario

### DIFF
--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -1,0 +1,61 @@
+# Boundary replay oracle
+
+Deterministic regression suite that replaces manual dogfood for
+the cmd cell-seal / boundary track. Replays a committed
+`RawShellRecorder` trace (`cmd/*.txt`) through the **real
+Terminal.Core pipeline** and asserts the resulting
+`SessionModel.IOCell` history.
+
+## Why
+
+The 40 hand-built `SessionModelTests` cases never caught
+C1/C2/C3 because they construct ContentHistory directly and so
+do **not** reproduce the production ordering that actually
+breaks: the reader thread appends a whole PTY chunk's text
+(command output **and** the next prompt's path) to ContentHistory
+*before* any boundary is handled, and a boundary's own
+ContentHistory marker is appended *after* `extractIOCell` runs.
+The oracle drives that exact ordering headlessly, so a boundary
+regression is caught in CI, deterministically, instead of by
+non-deterministic manual NVDA dogfood.
+
+## Design (decisions locked, R-A)
+
+- **Replay, don't simulate.** Parser → ContentHistory → Screen
+  (OSC-133 `PromptBoundary`) → SessionModel — the production
+  seam. No WPF / P-Invoke / real `cmd.exe` / PTY.
+- **Chunk-granular, recorded order.** Per recorded chunk: the
+  whole chunk's events are appended to ContentHistory first, then
+  `Screen.Apply` fires that chunk's boundaries, then each
+  boundary is handled (the SessionModel subset of
+  `Program.fs handlePromptBoundary`). This is the load-bearing
+  fidelity — the C1/C2 lesson.
+- **Virtual clock.** A clock derived from the trace's µs
+  timestamps reproduces idle gaps (incl. a user idling while
+  thinking) with zero real waiting → fast, non-flaky CI.
+- **Seed prompt.** The C1–C3 traces were captured with
+  `Ctrl+Shift+T` toggled *after* the prompt was shown, so the
+  cell's opening `;A`/`;B` predate the trace. The harness seeds a
+  synthetic "joined at a ready prompt P" (P = the stable cmd
+  prompt the trace exhibits) so the captured closing `;D` seals
+  the cell — faithful to the mid-session production state.
+  **Future captures should toggle `Ctrl+Shift+T` *before* the
+  prompt** for a full lifecycle (then the seed is unnecessary).
+- **IOCell-only oracle.** Asserts cell count + per cell
+  `{CommandText, OutputText, Phase, ExitCode}`. SpeechCursor is
+  explicitly out of scope (deprecating).
+
+## Status
+
+- **R-A (this):** harness + the **C3** (`set /p`) scenario
+  asserted inline — deterministically retro-validates P2′
+  (#423) on the real defect bytes. `tests/Tests.Unit/BoundaryReplayOracle.fs`.
+- **R-B:** externalise per-trace `*.expected` files; add C1/C2
+  + new capture dimensions — **backspace/retype** (deleted chars
+  must not reappear in `CommandText`) and **long idle**
+  mid-compose; the CMD-test scripts; a dedicated
+  "Boundary replay oracle" CI job.
+- **R-C onward:** P3 (inline sub-prompt) and all further
+  boundary work gated by this oracle, never manual dogfood.
+
+Generalises ADR 0007 D6 (on-send test-oracle).

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -1,0 +1,266 @@
+module PtySpeak.Tests.Unit.BoundaryReplayOracle
+
+open System
+open System.IO
+open Xunit
+open Terminal.Core
+
+// =====================================================================
+// Cycle 52 — Boundary replay oracle (R-A).
+//
+// Replays a committed RawShellRecorder trace
+// (`docs/boundary-capture/cmd/*.txt`) through the REAL
+// Terminal.Core pipeline — parser → ContentHistory → Screen
+// (OSC-133 PromptBoundary) → SessionModel — reproducing the
+// production reader-loop ordering (whole-chunk text appended
+// BEFORE that chunk's boundaries are handled; this boundary's
+// ContentHistory marker appended AFTER extractIOCell runs) that
+// the hand-built SessionModelTests structurally cannot model and
+// that produced the C1/C2/C3 defects.
+//
+// Deterministic: a virtual clock derived from the trace's µs
+// timestamps reproduces idle gaps with no real waiting; no WPF,
+// no P/Invoke, no real cmd.exe / PTY.
+//
+// Seed convention: the C1–C3 traces were captured with
+// Ctrl+Shift+T toggled AFTER the prompt was already shown, so
+// the cell's opening `;A`/`;B` predate the trace. The harness
+// seeds a synthetic "joined at a ready prompt P" (P = the stable
+// cmd prompt the trace exhibits) so the trace's closing `;D`
+// seals the cell — faithful to the mid-session production state.
+//
+// R-A asserts the C3 (`set /p`) scenario inline (the defect that
+// drove the fix). R-B externalises per-trace expectation files,
+// adds C1/C2 + backspace/long-idle corpus + the dedicated CI job.
+// =====================================================================
+
+// ---- trace parsing --------------------------------------------------
+
+type private Dir =
+    | In
+    | Out
+
+type private TraceEvent =
+    { ElapsedUs: int64
+      Dir: Dir
+      Bytes: byte[] }
+
+/// Unescape the RawShellRecorder rendering. The recorder writes
+/// ESC/CR/LF/TAB/BEL as `\e \r \n \t \a`, non-ASCII as `\xHH`,
+/// and every printable 0x20–0x7E (INCLUDING `\` 0x5C) verbatim.
+/// So a `\` followed by a non-escape char is a LITERAL backslash
+/// and the next char is reprocessed — this is what makes both
+/// `C:\Users\Kyle` and ST-chains like `\e\\e]` decode correctly.
+let private unescape (s: string) : byte[] =
+    let out = ResizeArray<byte>(s.Length)
+    let mutable i = 0
+    while i < s.Length do
+        let c = s.[i]
+        if c = '\\' && i + 1 < s.Length then
+            match s.[i + 1] with
+            | 'e' -> out.Add 0x1Buy; i <- i + 2
+            | 'r' -> out.Add 0x0Duy; i <- i + 2
+            | 'n' -> out.Add 0x0Auy; i <- i + 2
+            | 't' -> out.Add 0x09uy; i <- i + 2
+            | 'a' -> out.Add 0x07uy; i <- i + 2
+            | 'x' when i + 3 < s.Length ->
+                let hex = s.Substring(i + 2, 2)
+                out.Add(Convert.ToByte(hex, 16))
+                i <- i + 4
+            | _ ->
+                // Literal backslash; reprocess the next char.
+                out.Add 0x5Cuy
+                i <- i + 1
+        else
+            out.Add(byte c)
+            i <- i + 1
+    out.ToArray()
+
+let private parseTrace (path: string) : TraceEvent list =
+    File.ReadAllLines path
+    |> Array.choose (fun line ->
+        if line.StartsWith "===" || line.Trim().Length = 0 then None
+        else
+            // +{us}us {DIR} {n}B | {escaped}
+            let bar = line.IndexOf " | "
+            let head =
+                if bar >= 0 then line.Substring(0, bar) else line
+            let payload =
+                if bar >= 0 then line.Substring(bar + 3) else ""
+            let parts =
+                head.Split([| ' ' |], StringSplitOptions.RemoveEmptyEntries)
+            if parts.Length < 3 then None
+            else
+                let us =
+                    parts.[0].TrimStart('+').TrimEnd([| 'u'; 's' |])
+                let dir =
+                    match parts.[1] with
+                    | "IN" -> In
+                    | _ -> Out
+                match Int64.TryParse us with
+                | true, v ->
+                    Some { ElapsedUs = v
+                           Dir = dir
+                           Bytes = unescape payload }
+                | _ -> None)
+    |> Array.toList
+
+// ---- synthetic boundary (mirrors SessionModelTests' helper) ---------
+
+let private mkBoundary
+        (kind: BoundaryKind)
+        (at: DateTime)
+        (matched: string option)
+        : PromptBoundaryData
+        =
+    { Kind = kind
+      Source = BoundarySource.Osc133
+      DetectedAt = at
+      CommandId = None
+      ExtraParams = Map.empty
+      MatchedRowText = matched
+      MatchedRowIndex = None }
+
+let private markerOf (k: BoundaryKind) : ContentHistory.MarkerKind =
+    match k with
+    | BoundaryKind.PromptStart -> ContentHistory.MarkerKind.PromptStart
+    | BoundaryKind.CommandStart -> ContentHistory.MarkerKind.CommandStart
+    | BoundaryKind.OutputStart -> ContentHistory.MarkerKind.OutputStart
+    | BoundaryKind.CommandFinished _ ->
+        ContentHistory.MarkerKind.CommandFinished
+
+// ---- replay engine --------------------------------------------------
+
+/// Replay a trace and return (sealed cells, final state). Seeds a
+/// synthetic ready-prompt `seedPrompt` so a mid-prompt-join trace
+/// can still seal its cell at the captured `;D`.
+let private replay
+        (trace: TraceEvent list)
+        (seedPrompt: string)
+        : SessionModel.IOCell list
+        =
+    let virtualBase =
+        DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+    let clockAt (us: int64) = virtualBase.AddTicks(us * 10L)
+
+    let history = ContentHistory.create ContentHistory.defaultParameters
+    let screen = Screen(40, 120)
+    let parser = Terminal.Parser.Parser.create ()
+    let mutable state = SessionModel.create "cmd" 100
+    let mutable commandEnterSeq = -1L
+    let sealedCells = ResizeArray<SessionModel.IOCell>()
+
+    // Screen buffers OSC-133 boundaries and fires them after each
+    // Apply; collect per chunk, drain after the chunk's appends.
+    let pending = ResizeArray<PromptBoundaryData>()
+    screen.PromptBoundary.Add(fun b -> pending.Add b)
+
+    // Faithful per-boundary handling (the SessionModel subset of
+    // Program.fs handlePromptBoundary; cmd OSC sessions don't hit
+    // the heuristic synthetic-CF branch).
+    let handleBoundary (b: PromptBoundaryData) (now: DateTime) =
+        let aug =
+            match b.MatchedRowText, b.Kind with
+            | None, (BoundaryKind.PromptStart | BoundaryKind.CommandFinished _) ->
+                let _, (cr, _), snap =
+                    screen.SnapshotRows(0, screen.Rows)
+                { b with
+                    MatchedRowText = Some(CanonicalState.renderRow snap cr)
+                    MatchedRowIndex = Some cr }
+            | _ -> b
+        let _, _, snap = screen.SnapshotRows(0, screen.Rows)
+        let nextState, finalised =
+            SessionModel.applyAndCaptureWithContentHistory
+                state aug snap history true commandEnterSeq
+        state <- nextState
+        match finalised with
+        | Some c -> sealedCells.Add c
+        | None -> ()
+        ContentHistory.appendMarker history (markerOf aug.Kind) now None
+        |> ignore
+
+    // --- seed: joined at a ready prompt ---
+    let t0 = clockAt 0L
+    ContentHistory.appendMarker
+        history ContentHistory.MarkerKind.PromptStart t0 None
+    |> ignore
+    for ev in Terminal.Parser.Parser.feedArray
+                  parser
+                  (Text.Encoding.ASCII.GetBytes seedPrompt) do
+        ContentHistory.appendFromEvent history t0 ev |> ignore
+    ContentHistory.appendMarker
+        history ContentHistory.MarkerKind.CommandStart t0 None
+    |> ignore
+    state <-
+        (SessionModel.applyWithContentHistory
+            state
+            (mkBoundary BoundaryKind.PromptStart t0 (Some seedPrompt))
+            [||] history true -1L)
+    state <-
+        (SessionModel.applyWithContentHistory
+            state
+            (mkBoundary BoundaryKind.CommandStart t0 None)
+            [||] history true -1L)
+
+    // --- replay the recorded chunks ---
+    for ev in trace do
+        let now = clockAt ev.ElapsedUs
+        match ev.Dir with
+        | In ->
+            // The only IN effect SessionModel observes is the
+            // command-Enter watermark (Program.fs:5514). P2′'s cmd
+            // split is timing-independent, so this is fidelity, not
+            // load-bearing for cmd; still captured for the record.
+            for b in ev.Bytes do
+                if b = 0x0Duy then
+                    commandEnterSeq <- ContentHistory.latestSeq history
+        | Out ->
+            let events = Terminal.Parser.Parser.feedArray parser ev.Bytes
+            // Whole chunk's text/markers FIRST (reader thread).
+            for e in events do
+                ContentHistory.appendFromEvent history now e |> ignore
+            // Then Screen.Apply (fires the chunk's boundaries).
+            pending.Clear()
+            for e in events do
+                screen.Apply e
+            // Then drain boundaries (consumer thread).
+            for b in List.ofSeq pending do
+                handleBoundary b now
+
+    List.ofSeq sealedCells
+
+// ---- C3 oracle ------------------------------------------------------
+
+let private repoFile (rel: string) : string =
+    // Walk up from the test bin dir to the repo root.
+    let mutable d = DirectoryInfo(AppContext.BaseDirectory)
+    let mutable found = ""
+    while not (isNull d) && found = "" do
+        let candidate = Path.Combine(d.FullName, rel)
+        if File.Exists candidate then found <- candidate
+        else d <- d.Parent
+    found
+
+[<Fact>]
+let ``R-A oracle: C3 set/p trace seals a cell with no prompt-path bleed`` () =
+    let path =
+        repoFile (Path.Combine("docs", "boundary-capture", "cmd",
+                               "C3-set-p-text-input.txt"))
+    Assert.True(
+        File.Exists path,
+        sprintf "C3 trace not found from %s" AppContext.BaseDirectory)
+    let trace = parseTrace path
+    Assert.NotEmpty trace
+    // The stable cmd prompt the C3 trace exhibits (its trailing
+    // next-prompt path) — the seed for the mid-prompt join.
+    let seed =
+        "C:\\Users\\Kyle\\git\\pty-speak\\src\\Terminal.App>"
+    let cells = replay trace seed
+    // The C3 DEFECT was: this sealed NO cell (drop-on-None).
+    // P2′ must seal exactly one, with the set/p result as output
+    // and the next-prompt path fenced out (no bleed).
+    Assert.Equal(1, List.length cells)
+    let c = List.head cells
+    Assert.Equal(SessionModel.IOCellPhase.Sealed, c.Phase)
+    Assert.Contains("Hello, NAME!", c.OutputText)
+    Assert.DoesNotContain(seed, c.OutputText)

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -232,14 +232,18 @@ let private replay
 // ---- C3 oracle ------------------------------------------------------
 
 let private repoFile (rel: string) : string =
-    // Walk up from the test bin dir to the repo root.
-    let mutable d = DirectoryInfo(AppContext.BaseDirectory)
-    let mutable found = ""
-    while not (isNull d) && found = "" do
-        let candidate = Path.Combine(d.FullName, rel)
-        if File.Exists candidate then found <- candidate
-        else d <- d.Parent
-    found
+    // `DirectoryInfo.Parent` is `DirectoryInfo | null` (F# 9
+    // nullness). Walk via an explicit nullable-pattern recursion
+    // (CLAUDE.md FS3261 guidance) — no `isNull` on a
+    // non-nullable, no nullable→non-nullable assignment.
+    let rec walk (dir: DirectoryInfo | null) : string =
+        match dir with
+        | null -> ""
+        | d ->
+            let candidate = Path.Combine(d.FullName, rel)
+            if File.Exists candidate then candidate
+            else walk d.Parent
+    walk (DirectoryInfo(AppContext.BaseDirectory))
 
 [<Fact>]
 let ``R-A oracle: C3 set/p trace seals a cell with no prompt-path bleed`` () =

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="AnnounceSanitiserTests.fs" />
     <Compile Include="CanonicalStateTests.fs" />
     <Compile Include="SessionModelTests.fs" />
+    <Compile Include="BoundaryReplayOracle.fs" />
     <Compile Include="SessionPersistenceTests.fs" />
     <Compile Include="SessionSanitiserTests.fs" />
     <Compile Include="SessionModelJsonlTests.fs" />


### PR DESCRIPTION
## Summary

**R-A** of the replay-oracle track — the deterministic
regression suite that **replaces manual dogfood** for the cmd
cell-seal / boundary work (your call: abstract this away from
manual NVDA testing).

A headless harness (`tests/Tests.Unit/BoundaryReplayOracle.fs`)
replays a committed `RawShellRecorder` trace through the **real
Terminal.Core pipeline** (parser → ContentHistory → Screen
OSC-133 → SessionModel), reproducing the **production ordering**
the 40 hand-built `SessionModelTests` structurally cannot model
(whole chunk's text appended before its boundaries are handled;
the boundary's ContentHistory marker appended after
`extractIOCell`) — the exact ordering that produced C1/C2/C3.

Locked design decisions (per your delegation; QA best-practice):
- **Replay, don't simulate** — no WPF / P-Invoke / real
  `cmd.exe` / PTY.
- **Chunk-granular, recorded order** — the load-bearing fidelity.
- **Virtual clock** from the µs timestamps — idle gaps (incl. a
  user idling while thinking) reproduced with zero real waiting.
- **Seed-prompt** convention for the mid-prompt-join captures
  (documented; future captures should toggle `Ctrl+Shift+T`
  *before* the prompt).
- **IOCell-only** (SpeechCursor explicitly out of scope —
  deprecating).

R-A asserts the **C3 (`set /p`) scenario inline** —
deterministically **retro-validates P2′ (#423)** on the real
defect bytes: exactly one cell seals, output carries the `set /p`
result, the next-prompt path is fenced out (no bleed).

`docs/boundary-capture/REPLAY-ORACLE.md` is the track section.

**R-B (next):** externalise per-trace `*.expected` files; C1/C2
+ **backspace/retype** (deleted chars must not reappear in
`CommandText`) + **long-idle** corpus + the CMD-test scripts +
the dedicated CI job. R-C onward: P3 and all boundary work
gated by this oracle, never manual dogfood.

## Test plan

- [ ] Full CI green (the Windows build compiles the harness —
  the real first check of this much new F#; fixups expected if
  any seam signature differs)
- [ ] `R-A oracle: C3 …` fact passes → P2′ validated on real
  bytes. If it **fails**, that is a precise deterministic
  signal that P2′ is still wrong on the real C3 trace → P2′′
  (far better than manual dogfood ping-pong).
- [ ] No behaviour change to shipped code — test infra + docs
  only.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_