### PR TITLE
replay-oracle R-B1-followup: drop the dedicated CI job (oracle runs in the standard suite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,49 +97,6 @@ jobs:
           path: releases/
           retention-days: 7
 
-  replay-oracle:
-    name: Boundary replay oracle
-    runs-on: windows-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup .NET 9
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 9.0.x
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.fsproj', '**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build Tests.Unit
-        run: dotnet build tests/Tests.Unit/Tests.Unit.fsproj --configuration Release --no-restore
-
-      # Runs ONLY the boundary replay-oracle facts so a boundary
-      # regression (cmd cell-seal / prompt-path bleed) is a
-      # distinct red signal, separate from generic unit failures.
-      # Replays the committed docs/boundary-capture/cmd traces
-      # through the real Terminal.Core pipeline.
-      - name: Run boundary replay oracle
-        run: dotnet test tests/Tests.Unit/Tests.Unit.fsproj --configuration Release --no-build --filter "FullyQualifiedName~BoundaryReplayOracle" --logger "trx;LogFileName=oracle-results.trx"
-
-      - name: Upload oracle results
-        if: always() && hashFiles('**/oracle-results.trx') != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: boundary-oracle-results
-          path: '**/oracle-results.trx'
-
   portability-lint:
     name: Portability lint (substrate / channel boundary)
     runs-on: ubuntu-latest

--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -92,11 +92,13 @@ defences, both shipped R-B1:
 - **R-A:** harness + the **C3** (`set /p`) scenario —
   deterministically retro-validated P2′ (#423) on the real
   defect bytes. `tests/Tests.Unit/BoundaryReplayOracle.fs`.
-- **R-B1 (this):** externalised per-trace `*.expected` files;
+- **R-B1:** externalised per-trace `*.expected` files;
   **C1/C2** scenarios added (locks the prompt-path-bleed fix +
-  the slow/fast determinism on the real echo traces); a
-  dedicated **"Boundary replay oracle" CI job** (a boundary
-  regression is now a distinct red signal).
+  the slow/fast determinism on the real echo traces). Runs as
+  part of the standard **Build and test** job — the oracle
+  facts are plain `Tests.Unit` xUnit cases (~2 s); a separate
+  CI job would only duplicate the .NET runner/restore/build
+  infra for no coverage gain (R-B1-followup removed it).
 - **R-B2 (awaiting maintainer captures):** **C5**
   backspace/retype (deleted chars must not reappear in
   `CommandText`) and **C6** long-idle mid-compose; the


### PR DESCRIPTION
## Summary

Removes the dedicated **"Boundary replay oracle"** CI job added
in R-B1. The oracle facts are plain `Tests.Unit` xUnit cases
(~2 s) that already run inside the standard **Build and test**
job's `dotnet test`. The separate job duplicated a full .NET
runner + NuGet restore + build (minutes of infra) just to
re-run that ~2 s test for a separate red signal — not worth the
duplicated infrastructure.

- **Zero coverage lost** — the C1/C2/C3 oracle facts still run
  on every push/PR via the standard suite.
- Only the separate-signal granularity is dropped (maintainer
  decision).
- `docs/boundary-capture/REPLAY-ORACLE.md` updated to match.

## Test plan

- [ ] CI green: 4 checks now (Build and test, both lints, link
  check) — no separate oracle job
- [ ] Build and test still exercises the BoundaryReplayOracle
  C1/C2/C3 facts (they're in Tests.Unit)
- [ ] actionlint green on the trimmed workflow

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_