### PR TITLE
replay-oracle R-B2: C5 backspace/retype scenario (caught real defect #428, shipped Skip-with-reason)

### DIFF
--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -99,11 +99,12 @@ defences, both shipped R-B1:
   facts are plain `Tests.Unit` xUnit cases (~2 s); a separate
   CI job would only duplicate the .NET runner/restore/build
   infra for no coverage gain (R-B1-followup removed it).
-- **R-B2 (awaiting maintainer captures):** **C5**
-  backspace/retype (deleted chars must not reappear in
-  `CommandText`) and **C6** long-idle mid-compose; the
-  CMD-test scripts. Capture with `Ctrl+Shift+T` toggled
-  *before* the prompt for a full lifecycle (no seed needed).
+- **R-B2 (in progress):** **C5** backspace/retype landed —
+  real capture (`ECHO HELLOXX` → 2×Backspace → `ECHO HELLO`);
+  asserts the deleted `XX` never reaches `CommandText`
+  (`commandNotContains=X` — only the two deleted bytes contain
+  X). Added the `commandNotContains` schema key. **C6**
+  long-idle mid-compose still awaiting capture.
 - **R-C onward:** P3 (inline sub-prompt) and all further
   boundary work gated by this oracle, never manual dogfood.
 

--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -103,8 +103,16 @@ defences, both shipped R-B1:
   real capture (`ECHO HELLOXX` → 2×Backspace → `ECHO HELLO`);
   asserts the deleted `XX` never reaches `CommandText`
   (`commandNotContains=X` — only the two deleted bytes contain
-  X). Added the `commandNotContains` schema key. **C6**
-  long-idle mid-compose still awaiting capture.
+  X). Added the `commandNotContains` schema key. **C5 caught a
+  real defect on first run** (sealed `CommandText` is
+  `ECHO HELLOXX` — cmd's `\x08 \x08` erase is Screen-level but
+  extraction reads linear ContentHistory per ADR 0004, which
+  doesn't apply `\x08`). The fact ships **`Skip`-with-reason**
+  (maintainer decision 2026-05-17): the trace + `.expected`
+  stay in the corpus so it flips to an active regression guard
+  once the ADR-0004-level substrate fix lands. Tracked:
+  [#428](https://github.com/KyleKeane/pty-speak/issues/428).
+  **C6** long-idle mid-compose still awaiting capture.
 - **R-C onward:** P3 (inline sub-prompt) and all further
   boundary work gated by this oracle, never manual dogfood.
 

--- a/docs/boundary-capture/cmd/C5-backspace-retype.expected
+++ b/docs/boundary-capture/cmd/C5-backspace-retype.expected
@@ -1,0 +1,21 @@
+# Boundary replay oracle expectation — schema v1 (R-B2).
+# C5: typed `ECHO HELLOXX`, two Backspaces (each \x7F →
+# `\x08 \x08` erase), ran `ECHO HELLO`. THE C5 invariant: the
+# deleted `XX` must NOT survive into CommandText. The only `X`
+# bytes in the whole interaction are the two deleted ones, so
+# `commandNotContains=X` is the tightest correctness assertion
+# (a single stray X from an off-by-one in backspace handling
+# fails it too). Plus the standing invariants: exactly one
+# sealed cell, the result in OutputText, no next-prompt-path
+# bleed. Joined mid-prompt → seedPrompt is the stable cmd
+# prompt the trace exhibits (same as C1–C3).
+# NB: parseExpected is a Map (last dup key wins) — one
+# *NotContains per field; the prompt-path bleed guard is the
+# load-bearing output assertion, kept over a redundant no-X.
+schemaVersion=1
+seedPrompt=C:\Users\Kyle\git\pty-speak\src\Terminal.App>
+cellCount=1
+cell0.phase=Sealed
+cell0.commandNotContains=X
+cell0.outputContains=HELLO
+cell0.outputNotContains=C:\Users\Kyle\git\pty-speak\src\Terminal.App>

--- a/docs/boundary-capture/cmd/C5-backspace-retype.txt
+++ b/docs/boundary-capture/cmd/C5-backspace-retype.txt
@@ -1,0 +1,34 @@
+=== pty-speak raw shell trace — started 2026-05-17 20:36:32.619 UTC ===
+=== 31 events; IN 15 bytes; OUT 116 bytes ===
+=== format: +<elapsed_us>us <DIR> <nbytes>B | <escaped>  (\e=ESC \r \n \t \a \xHH) ===
++2519847us IN  1B | E
++2520078us OUT 1B | E
++3560334us IN  1B | C
++3560682us OUT 1B | C
++4509907us IN  1B | H
++4510290us OUT 1B | H
++5232949us IN  1B | O
++5233453us OUT 1B | O
++6119285us IN  1B | \x20
++6120260us OUT 1B | \x20
++7298348us IN  1B | H
++7299024us OUT 1B | H
++8529131us IN  1B | E
++8530325us OUT 1B | E
++9240898us IN  1B | L
++9241145us OUT 1B | L
++9777767us IN  1B | L
++9778178us OUT 1B | L
++10529183us IN  1B | O
++10529432us OUT 1B | O
++13457143us IN  1B | X
++13457399us OUT 1B | X
++14074875us IN  1B | X
++14075129us OUT 1B | X
++16280244us IN  1B | \x7F
++16280531us OUT 3B | \x08 \x08
++17034356us IN  1B | \x7F
++17034875us OUT 3B | \x08 \x08
++18732897us IN  1B | \r
++18733270us OUT 2B | \r\n
++18734819us OUT 96B | \e[?25lHELLO\e[18;1H\e[?25h\e]133;D\e\\e]133;A\e\C:\Users\Kyle\git\pty-speak\src\Terminal.App>\e]133;B\e\

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -353,7 +353,15 @@ let ``replay oracle: C3 set/p — seals (was drop-on-None), no bleed`` () =
     assertScenario
         "C3-set-p-text-input.txt" "C3-set-p-text-input.expected"
 
-[<Fact>]
+// SKIPPED: caught a real defect (#428). cmd echoes the in-line
+// erase as `\x08 \x08`, a Screen-level destructive edit; extraction
+// reads linear ContentHistory (ADR 0004) which doesn't apply `\x08`,
+// so backspaced chars survive in the sealed CommandText
+// ("ECHO HELLOXX" not "ECHO HELLO"). The substrate fix is an
+// ADR-0004-level follow-up (maintainer decision 2026-05-17); the
+// trace + .expected stay in the corpus so this flips to an active
+// regression guard once #428 lands. Remove the Skip then.
+[<Fact(Skip = "known defect #428: backspace not applied to ContentHistory CommandText (ADR-0004 substrate follow-up)")>]
 let ``replay oracle: C5 backspace/retype — deleted chars gone from CommandText`` () =
     assertScenario
         "C5-backspace-retype.txt" "C5-backspace-retype.expected"

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -326,6 +326,9 @@ let private assertScenario (traceName: string) (expectedName: string) =
         match g "commandContains" with
         | Some s -> Assert.Contains(s, c.CommandText)
         | None -> ()
+        match g "commandNotContains" with
+        | Some s -> Assert.DoesNotContain(s, c.CommandText)
+        | None -> ()
         match g "outputContains" with
         | Some s -> Assert.Contains(s, c.OutputText)
         | None -> ()
@@ -349,3 +352,8 @@ let ``replay oracle: C2 echo fast — byte-identical, same invariants`` () =
 let ``replay oracle: C3 set/p — seals (was drop-on-None), no bleed`` () =
     assertScenario
         "C3-set-p-text-input.txt" "C3-set-p-text-input.expected"
+
+[<Fact>]
+let ``replay oracle: C5 backspace/retype — deleted chars gone from CommandText`` () =
+    assertScenario
+        "C5-backspace-retype.txt" "C5-backspace-retype.expected"


### PR DESCRIPTION
## Summary

**R-B2** — adds the **C5 backspace/retype** scenario from a real `Ctrl+Shift+T` capture, plus the `commandNotContains` schema key.

- Trace: typed `ECHO HELLOXX`, two Backspaces (each `\x7F` → `\x08 \x08` erase), ran `ECHO HELLO` → output `HELLO`.
- Asserts the invariant flagged earlier: **deleted chars must not survive into `CommandText`** (`commandNotContains=X` — the only `X` bytes in the whole interaction are the two deleted ones, so a single stray X fails it).
- Adds the `commandNotContains` key to the `.expected` schema + the matching assertion in `assertScenario`.
- Lone-0x20 payloads normalised to `\x20` per the R-B1 fixture-hygiene rule.

## Outcome — C5 caught a real defect (true positive)

C5 fired on its first CI run. Sealed `CommandText` is **`ECHO HELLOXX`**, not `ECHO HELLO`:

```
Assert.DoesNotContain() Failure: Sub-string found
String: "ECHO HELLOXX"   Found: "X"
```

Root cause: cmd echoes the in-line erase as `\x08 \x08` (a **Screen-level** destructive edit). Extraction reads the **linear `ContentHistory`** substrate per [ADR 0004](docs/adr/0004-iocell-model-for-shell-interaction.md), which does **not** apply `\x08`, so the backspaced chars survive into the sealed command. This is the ContentHistory-vs-Screen tension — an **ADR-0004-level substrate follow-up**, not a localised slice bug.

### Decisions (maintainer, 2026-05-17)

1. **Land #427 via Skip-with-reason.** The C5 fact ships `[<Fact(Skip = ...)>]`. The deterministic trace + `.expected` corpus stay in the repo so it flips to an active regression guard when the substrate fix lands. R-B oracle track / C6 proceed unblocked.
2. **Substrate fix tracked as a follow-up:** **#428** (its own ADR-0004-touching investigation/PR later). Not in scope here.

`REPLAY-ORACLE.md` R-B2 bullet records the finding + Skip + tracker for doc coherence.

## Test plan

- [x] C5 fact `Skip`-ped with reason referencing #428; trace + `.expected` preserved
- [ ] CI green: C1/C2/C3 still pass (schema-key addition is additive), C5 skipped (1 skipped, 0 failed)
- [x] No shipped-code change — test infra + fixtures + docs only

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_