### PR TITLE
replay-oracle R-B2: C6 long-idle mid-compose scenario (completes the R-B corpus)

### DIFF
--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -112,7 +112,12 @@ defences, both shipped R-B1:
   stay in the corpus so it flips to an active regression guard
   once the ADR-0004-level substrate fix lands. Tracked:
   [#428](https://github.com/KyleKeane/pty-speak/issues/428).
-  **C6** long-idle mid-compose still awaiting capture.
+  **C6** long-idle mid-compose landed — real capture (`ECHO`,
+  ~54s idle with no Enter, then ` DONE`); asserts the gap
+  neither splits the in-flight command nor seals early
+  (exactly one cell, `commandContains=ECHO DONE` spanning the
+  gap, output `DONE`, no next-prompt bleed). The R-B corpus
+  (C1/C2/C3/C5/C6) is now complete.
 - **R-C onward:** P3 (inline sub-prompt) and all further
   boundary work gated by this oracle, never manual dogfood.
 

--- a/docs/boundary-capture/cmd/C6-long-idle-midcompose.expected
+++ b/docs/boundary-capture/cmd/C6-long-idle-midcompose.expected
@@ -1,0 +1,23 @@
+# Boundary replay oracle expectation — schema v1 (R-B2).
+# C6: typed `ECHO`, idled ~54s MID-COMPOSE (no Enter yet),
+# then typed ` DONE` and ran it. THE C6 invariant: the long
+# idle gap inside the prompt must NOT split the in-flight
+# command or seal early — exactly ONE cell seals, and its
+# CommandText spans the gap intact (`ECHO DONE`, not a
+# truncated `ECHO` nor a post-idle-only ` DONE`). The idle is
+# reproduced as a 54s virtual-clock jump between the `O` and
+# the space echo; no flush timer runs in the harness, so this
+# pins that nothing in the parser → ContentHistory → Screen
+# (OSC-133) → SessionModel path keys off the wall-clock gap.
+# Plus the standing invariants: result in OutputText, no
+# next-prompt-path bleed. Joined mid-prompt → seedPrompt is
+# the stable cmd prompt the trace exhibits (same as C1–C5).
+# Substring assertions on purpose (exact boundary text is
+# slice-semantics-sensitive — P3's concern).
+schemaVersion=1
+seedPrompt=C:\Users\Kyle\git\pty-speak\src\Terminal.App>
+cellCount=1
+cell0.phase=Sealed
+cell0.commandContains=ECHO DONE
+cell0.outputContains=DONE
+cell0.outputNotContains=C:\Users\Kyle\git\pty-speak\src\Terminal.App>

--- a/docs/boundary-capture/cmd/C6-long-idle-midcompose.txt
+++ b/docs/boundary-capture/cmd/C6-long-idle-midcompose.txt
@@ -1,0 +1,24 @@
+=== pty-speak raw shell trace — started 2026-05-17 20:37:52.266 UTC ===
+=== 21 events; IN 10 bytes; OUT 106 bytes ===
+=== format: +<elapsed_us>us <DIR> <nbytes>B | <escaped>  (\e=ESC \r \n \t \a \xHH) ===
++4396565us IN  1B | E
++4396793us OUT 1B | E
++5525931us IN  1B | C
++5527668us OUT 1B | C
++7100203us IN  1B | H
++7100402us OUT 1B | H
++8389161us IN  1B | O
++8390046us OUT 1B | O
++62604354us IN  1B | \x20
++62604675us OUT 1B | \x20
++65001873us IN  1B | D
++65002468us OUT 1B | D
++68491393us IN  1B | O
++68492039us OUT 1B | O
++69866181us IN  1B | N
++69866713us OUT 1B | N
++73057009us IN  1B | E
++73057203us OUT 1B | E
++77096946us IN  1B | \r
++77097224us OUT 2B | \r\n
++77099297us OUT 95B | \e[?25lDONE\e[21;1H\e[?25h\e]133;D\e\\e]133;A\e\C:\Users\Kyle\git\pty-speak\src\Terminal.App>\e]133;B\e\

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -365,3 +365,8 @@ let ``replay oracle: C3 set/p — seals (was drop-on-None), no bleed`` () =
 let ``replay oracle: C5 backspace/retype — deleted chars gone from CommandText`` () =
     assertScenario
         "C5-backspace-retype.txt" "C5-backspace-retype.expected"
+
+[<Fact>]
+let ``replay oracle: C6 long-idle mid-compose — one cell, command spans the gap`` () =
+    assertScenario
+        "C6-long-idle-midcompose.txt" "C6-long-idle-midcompose.expected"


### PR DESCRIPTION
## Summary

**R-B2** — adds the **C6 long-idle mid-compose** scenario from a real `Ctrl+Shift+T` capture. Completes the R-B corpus (C1/C2/C3/C5/C6).

- Trace: typed `ECHO`, idled **~54s mid-compose** (no Enter), then typed ` DONE` and ran it → output `DONE`, OSC-133 framed.
- **C6 invariant:** a long idle *inside* the prompt must neither split the in-flight command nor seal early. Asserts exactly one sealed cell, `commandContains=ECHO DONE` (spans the gap — catches both an `ECHO` truncation and a post-idle-only ` DONE`), output `DONE`, and no next-prompt-path bleed.
- The idle is reproduced as a 54s **virtual-clock jump** between the `O` and the space echo. No flush timer runs in the harness, so this locks that nothing in parser → ContentHistory → Screen (OSC-133) → SessionModel keys off the wall-clock gap.
- Lone-0x20 payloads normalised to `\x20` per the R-B1 fixture-hygiene rule (the `parseTrace` whitespace-strip guard). Same mid-prompt-join seed as C1–C5.
- `REPLAY-ORACLE.md` R-B2 bullet updated; C6 marked landed, R-B corpus complete.

If C6 **fails** on CI it's a genuine finding (the idle gap leaking into boundary detection), not a flake — I'll confirm from the log and report before any fix, per the established R-B protocol.

## Test plan

- [ ] CI green; the new C6 fact passes (one sealed cell, command `ECHO DONE` intact across the idle, output `DONE`, no prompt-path bleed)
- [ ] C1/C2/C3 still green; C5 still skipped (#428) — no behaviour change to them
- [x] No shipped-code change — test infra + fixtures + docs only

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_