### PR TITLE
#428: apply BS erase in ContentHistory; gate idle-seal while composing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15498,6 +15498,27 @@ path. Surfaced as `Diagnostics → Toggle Raw Shell Trace`
 items + Instrument A (always-on bounded boundary-decision
 ring) follow.
 
+### Cycle 52 #428 ContentHistory backspace-erase (2026-05-17)
+
+- **Fixed**: backspaced characters in an in-line command edit
+  no longer survive into the sealed command (history /
+  announce). cmd echoes an in-line erase as the idiom
+  `BS SP BS` (`\x08 \x20 \x08`); `ContentHistory.appendFromEvent`
+  previously had no `\x08` arm, so the to-be-deleted characters
+  stayed in the reconstructed `CommandText` (e.g.
+  `ECHO HELLOXX` instead of `ECHO HELLO`). The substrate now
+  applies the erase on its active span (the idiom nets to a
+  single deletion, clamped at empty — never reaches into
+  sealed entries), and the composing command is no longer
+  idle-seal-fragmented (`tick` skips `UserInputEcho` spans),
+  so the fix holds for slow typing with pauses, not just the
+  oracle. The C5 replay-oracle fact flipped from `Skip` to an
+  active regression guard. Direction recorded in
+  [`docs/428-contenthistory-backspace-design.md`](docs/428-contenthistory-backspace-design.md)
+  (ADR 0004 Decision 3 strengthened, not amended; no
+  wire-format change). PowerShell / PSReadLine CSI-driven
+  in-line editing is a distinct concern, out of scope here.
+
 ## [0.0.1-preview.18] — 2026-04-28
 ## [0.0.1-preview.18] — 2026-04-28
 

--- a/docs/adr/0004-iocell-model-for-shell-interaction.md
+++ b/docs/adr/0004-iocell-model-for-shell-interaction.md
@@ -1,6 +1,14 @@
 # ADR 0004 — IOCell is the unit of shell interaction; ContentHistory is the sole substrate; OutputDispatcher is the sole non-emergency channel
 
 - **Status**: Proposed (2026-05-14)
+- **Status-note (#428, 2026-05-17)**: Decision 3 strengthened,
+  not amended — ContentHistory now applies the `\x08`
+  backspace-erase on its active span (cmd's `BS SP BS` idiom)
+  and no longer idle-seal-fragments the composing command, so
+  the sole-extraction-substrate stays faithful to in-line
+  edits without consulting the (display-only) Screen. No
+  wire-format change. Design note:
+  [`docs/428-contenthistory-backspace-design.md`](../428-contenthistory-backspace-design.md).
 - **Date**: 2026-05-14
 - **Deciders**: maintainer (KyleKeane)
 - **Authoring item**: Cycle 51 PR-V, in response to the

--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -107,11 +107,14 @@ defences, both shipped R-B1:
   real defect on first run** (sealed `CommandText` is
   `ECHO HELLOXX` — cmd's `\x08 \x08` erase is Screen-level but
   extraction reads linear ContentHistory per ADR 0004, which
-  doesn't apply `\x08`). The fact ships **`Skip`-with-reason**
-  (maintainer decision 2026-05-17): the trace + `.expected`
-  stay in the corpus so it flips to an active regression guard
-  once the ADR-0004-level substrate fix lands. Tracked:
-  [#428](https://github.com/KyleKeane/pty-speak/issues/428).
+  doesn't apply `\x08`). **#428 fixed it** (maintainer-chosen
+  direction 2026-05-17): ContentHistory's `appendFromEvent`
+  gained a BS arm that applies the `\x08` erase on the active
+  span (cmd's `BS SP BS` idiom nets to a deletion), and the
+  composing command is no longer idle-seal-fragmented
+  (`tick` skips `UserInputEcho` spans). C5's `Skip` was
+  **removed** — it is now an **active regression guard**.
+  Tracked: [#428](https://github.com/KyleKeane/pty-speak/issues/428).
   **C6** long-idle mid-compose landed — real capture (`ECHO`,
   ~54s idle with no Enter, then ` DONE`); asserts the gap
   neither splits the in-flight command nor seals early

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -852,6 +852,27 @@ module ContentHistory =
                     match sealedEntry with
                     | Some e -> [ e; bellEntry ]
                     | None -> [ bellEntry ]
+                | Execute b when b = 0x08uy ->
+                    // #428 — BS: destructive cursor-back on the
+                    // active span. cmd echoes an in-line erase as
+                    // the idiom `BS SP BS`; deleting the last
+                    // accumulated char on each BS composes with it
+                    // to net the deletion. Clamp at empty — never
+                    // reach back into sealed entries (append-only
+                    // invariant; ADR 0004). cmd's line editor never
+                    // echoes a BS that would erase past the prompt.
+                    if state.ActiveSpanText.Length > 0 then
+                        state.ActiveSpanText.Remove(
+                            state.ActiveSpanText.Length - 1, 1)
+                        |> ignore
+                        if state.ActiveSpanText.Length = 0 then
+                            // Span emptied — let the next Print
+                            // re-snapshot the first-byte source +
+                            // start (keeps the PR-Q first-byte
+                            // invariant honest).
+                            state.ActiveSpanStartedAt <- ValueNone
+                            state.ActiveSpanSource <- ValueNone
+                    []
                 | CsiDispatch (_, _, 'D', _) ->
                     // CUB → defer to next event.
                     state.PendingCUB <- ValueSome 1
@@ -906,14 +927,26 @@ module ContentHistory =
         lock state.Gate (fun () ->
             if state.ActiveSpanText.Length = 0 then []
             else
-                let elapsed =
-                    (now - state.LastEventAt).TotalMilliseconds
-                if elapsed >= float state.Parameters.IdleSpanSealMs then
-                    match sealActiveSpan state now with
-                    | Some e -> [ e ]
-                    | None -> []
-                else
-                    [])
+                match state.ActiveSpanSource with
+                | ValueSome EntrySource.UserInputEcho ->
+                    // #428 (ii) — never idle-seal the composing
+                    // command. Its bytes are UserInputEcho
+                    // (suppressed from announces per ADR
+                    // 0003/0008), so idle-sealing serves no
+                    // purpose and would fragment the command
+                    // across sealed TextSpans beyond a later BS's
+                    // reach. Keep it in ONE active span until the
+                    // CommandStart marker seals it.
+                    []
+                | _ ->
+                    let elapsed =
+                        (now - state.LastEventAt).TotalMilliseconds
+                    if elapsed >= float state.Parameters.IdleSpanSealMs then
+                        match sealActiveSpan state now with
+                        | Some e -> [ e ]
+                        | None -> []
+                    else
+                        [])
 
     /// Reset to empty. Called when SessionModel transitions out
     /// of a sealed tuple so the next tuple starts fresh.

--- a/tests/Tests.Unit/BoundaryReplayOracle.fs
+++ b/tests/Tests.Unit/BoundaryReplayOracle.fs
@@ -353,15 +353,12 @@ let ``replay oracle: C3 set/p — seals (was drop-on-None), no bleed`` () =
     assertScenario
         "C3-set-p-text-input.txt" "C3-set-p-text-input.expected"
 
-// SKIPPED: caught a real defect (#428). cmd echoes the in-line
-// erase as `\x08 \x08`, a Screen-level destructive edit; extraction
-// reads linear ContentHistory (ADR 0004) which doesn't apply `\x08`,
-// so backspaced chars survive in the sealed CommandText
-// ("ECHO HELLOXX" not "ECHO HELLO"). The substrate fix is an
-// ADR-0004-level follow-up (maintainer decision 2026-05-17); the
-// trace + .expected stay in the corpus so this flips to an active
-// regression guard once #428 lands. Remove the Skip then.
-[<Fact(Skip = "known defect #428: backspace not applied to ContentHistory CommandText (ADR-0004 substrate follow-up)")>]
+// #428 fixed: ContentHistory now applies the `\x08` erase on the
+// active span (cmd's `BS SP BS` idiom nets to a deletion), and the
+// composing command is no longer idle-seal-fragmented. C5 is now an
+// active regression guard — backspaced chars must not survive into
+// the sealed CommandText.
+[<Fact>]
 let ``replay oracle: C5 backspace/retype — deleted chars gone from CommandText`` () =
     assertScenario
         "C5-backspace-retype.txt" "C5-backspace-retype.expected"

--- a/tests/Tests.Unit/ContentHistoryTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTests.fs
@@ -38,6 +38,7 @@ let private execute (b: byte) : VtEvent = Execute b
 let private lf = execute 0x0Auy
 let private cr = execute 0x0Duy
 let private bel = execute 0x07uy
+let private bs = execute 0x08uy
 
 let private cub (n: int) : VtEvent =
     CsiDispatch ([| n |], [||], 'D', None)
@@ -832,4 +833,79 @@ let ``Resolver exception falls back to Unknown`` () =
         Assert.Equal(
             ContentHistory.EntrySource.Unknown,
             ContentHistory.entrySource e)
+
+// ---------------------------------------------------------------------
+// #428 — BS (0x08) destructive cursor-back on the active span
+// ---------------------------------------------------------------------
+
+let private textSpans (state: ContentHistory.T) : string[] =
+    ContentHistory.snapshot state
+    |> Array.choose (fun e ->
+        match e with
+        | ContentHistory.TextSpan d -> Some d.Text
+        | _ -> None)
+
+[<Fact>]
+let ``BS deletes the last char of the active span`` () =
+    let state = freshHistory ()
+    feed state t0 [ printRune 'a'; printRune 'b'; printRune 'c'; bs; lf ]
+    |> ignore
+    Assert.Equal<string[]>([| "ab" |], textSpans state)
+
+[<Fact>]
+let ``BS on an empty active span is a no-op`` () =
+    let state = freshHistory ()
+    let emitted = feed state t0 [ bs ]
+    Assert.Empty(emitted)
+    Assert.Equal(0, ContentHistory.count state)
+    Assert.Equal(-1L, ContentHistory.latestSeq state)
+    // Subsequent content is unaffected.
+    feed state t0 [ printRune 'x'; lf ] |> ignore
+    Assert.Equal<string[]>([| "x" |], textSpans state)
+
+[<Fact>]
+let ``cmd BS-SP-BS erase idiom nets to a single deletion`` () =
+    let state = freshHistory ()
+    // "ECHO HELLOXX" then two `BS SP BS` erase idioms → "ECHO HELLO".
+    let typed = [ for c in "ECHO HELLOXX" -> printRune c ]
+    let eraseIdiom = [ bs; printRune ' '; bs ]
+    feed state t0 (typed @ eraseIdiom @ eraseIdiom @ [ lf ]) |> ignore
+    Assert.Equal<string[]>([| "ECHO HELLO" |], textSpans state)
+
+[<Fact>]
+let ``BS does not reach across a seal boundary into a sealed span`` () =
+    let state = freshHistory ()
+    // "ab" + LF seals "ab"; BS now hits an EMPTY active span
+    // (no-op) and must not mutate the sealed "ab".
+    feed state t0
+        [ printRune 'a'; printRune 'b'; lf; bs; printRune 'c'; lf ]
+    |> ignore
+    Assert.Equal<string[]>([| "ab"; "c" |], textSpans state)
+
+[<Fact>]
+let ``tick does NOT idle-seal a UserInputEcho active span (#428 ii)`` () =
+    let state = freshHistory ()
+    ContentHistory.setSourceResolver state (fun () ->
+        ContentHistory.EntrySource.UserInputEcho)
+    feed state t0
+        [ printRune 'e'; printRune 'c'; printRune 'h'; printRune 'o' ]
+    |> ignore
+    // Idle well past IdleSpanSealMs (200).
+    let ticked = ContentHistory.tick state (after 5000)
+    Assert.Empty(ticked)
+    Assert.Equal(0, ContentHistory.count state)
+    // Still one unsealed span; an LF now seals the WHOLE
+    // command in one TextSpan (no idle fragmentation).
+    feed state (after 5001) [ lf ] |> ignore
+    Assert.Equal<string[]>([| "echo" |], textSpans state)
+
+[<Fact>]
+let ``tick still idle-seals a CmdOutput active span`` () =
+    let state = freshHistory ()
+    ContentHistory.setSourceResolver state (fun () ->
+        ContentHistory.EntrySource.CmdOutput)
+    feed state t0 [ printRune 'h'; printRune 'i' ] |> ignore
+    let ticked = ContentHistory.tick state (after 500)
+    Assert.Equal(1, List.length ticked)
+    Assert.Equal(1, ContentHistory.count state)
 


### PR DESCRIPTION
## Summary

Step 2 of #428 — implements the maintainer-ratified direction **(ii)** from the design note (#430, merged): teach `ContentHistory` the `\x08` erase **and** stop idle-seal-fragmenting the composing command.

- **BS arm** in `ContentHistory.appendFromEvent` (`Execute 0x08uy`): delete the last char of the active span; clamp at empty — never reach into sealed entries (append-only invariant, ADR 0004); reset the first-byte start/source when emptied. cmd's in-line erase idiom `BS SP BS` (`\x08 \x20 \x08`) nets to a single deletion.
- **Idle-seal gate** in `ContentHistory.tick`: skip the seal when the active span's source is `UserInputEcho`. The composing command stays in **one** active span until `CommandStart`, so a later BS always reaches it — the fix holds for slow typing with pauses, not just the oracle (which never calls `tick`). `CmdOutput`/streaming output still idle-seals as before.
- **C5 replay-oracle fact**: `Skip` removed → active regression guard (`commandNotContains=X`).
- **New `ContentHistoryTests` cases**: bare BS deletes last char; BS on empty span no-ops; `BS SP BS` idiom nets to deletion; BS doesn't cross a seal boundary; `tick` does NOT idle-seal a `UserInputEcho` span; `tick` still idle-seals a `CmdOutput` span.
- **Docs**: ADR 0004 status-note (Decision 3 *strengthened, not amended*; no wire-format change), `REPLAY-ORACLE.md` updated, `CHANGELOG.md` `[Unreleased]` entry appended.

**Diagnostic note (CLAUDE.md "new features ship with diagnostic triggers"):** no logger added to `ContentHistory` — it's a deliberately pure substrate module (ADR 0006 R4 purity); threading an `ILogger` through `create` is disproportionate to a substrate accumulation fix. The user-visible effect is already surfaced in a `Ctrl+Shift+D` bundle via the existing `SessionModel` `CmdLen` extraction Debug log + the ContentHistory tail; the deterministic triggers are the flipped C5 fact + the new unit cases (CLAUDE.md: test fixtures count as diagnostic triggers).

PowerShell / PSReadLine CSI-driven in-line editing is a distinct ContentHistory↔CSI concern, explicitly out of scope.

## Test plan

- [ ] CI green: new `ContentHistoryTests` BS/tick cases pass; **C5 now passes** (deleted `XX` absent from `CommandText`); C1/C2/C3/C6 stay green
- [ ] Markdown link check green (CHANGELOG/ADR links to the merged design-note doc resolve)
- [x] Re-read F# twice (no local compiler): BS arm offside + `if`-without-else/`[]` shape; `tick` `ValueSome EntrySource.UserInputEcho` qualified pattern

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_