### PR TITLE
#428 follow-up: revert the tick idle-seal gate (live regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15519,6 +15519,26 @@ ring) follow.
   wire-format change). PowerShell / PSReadLine CSI-driven
   in-line editing is a distinct concern, out of scope here.
 
+### Cycle 52 #428 follow-up: revert the tick idle-seal gate (2026-05-18)
+
+- **Fixed (regression)**: the #428 (ii) sub-decision —
+  `ContentHistory.tick` skipping idle-seal for
+  `UserInputEcho` spans — regressed the **live** announce
+  path and is **reverted**. The R6a progress/watermark path
+  (`Program.fs` ~5079–5125) depends on `tick` sealing the
+  typed-command span to keep the R3d/`commandEnterSeq`
+  watermark consistent; gating that seal reintroduced the
+  "echo hi⏎hi" + prompt-path-bleed class and garbled the
+  sub-prompt / Ctrl+C (Y/N) announces (the shell handled the
+  keys; the audio feedback was broken). The replay oracle
+  could not catch it — the harness never calls `tick` (the
+  live-only fidelity gap the design note flagged). The
+  Direction-1 **BS arm is retained** (oracle-validated; C5
+  stays an active regression guard); only the `tick` gate is
+  reverted. (ii) is deferred until a live-faithful test
+  models the idle-seal + watermark interaction. Two
+  gate-specific unit tests removed; no wire-format change.
+
 ## [0.0.1-preview.18] — 2026-04-28
 ## [0.0.1-preview.18] — 2026-04-28
 

--- a/docs/428-contenthistory-backspace-design.md
+++ b/docs/428-contenthistory-backspace-design.md
@@ -1,10 +1,28 @@
 # #428 — ContentHistory backspace-erase: design note
 
-Status: **Proposed** (2026-05-17). Scope: the cmd `\x08`-erase
-defect caught by the replay oracle's C5 fact
-(`docs/boundary-capture/REPLAY-ORACLE.md`). Implements the
+Status: **Partially shipped** (2026-05-17 → 2026-05-18). Scope:
+the cmd `\x08`-erase defect caught by the replay oracle's C5
+fact (`docs/boundary-capture/REPLAY-ORACLE.md`). Implements the
 spirit of [ADR 0004](adr/0004-iocell-model-for-shell-interaction.md)
 more faithfully; **does not amend** any ADR 0004 decision.
+
+> **Update 2026-05-18 — (ii) reverted.** The Direction-1 core
+> (the BS arm on `appendFromEvent`) shipped and is oracle-
+> validated (C5 active). The companion sub-decision **(ii)**
+> — gating `tick`'s idle-seal for `UserInputEcho` spans — was
+> implemented in #431 and **reverted the same day**: it broke
+> the live announce watermark (R3d/`commandEnterSeq`, the R6a
+> path at `Program.fs` ~5079–5125), reintroducing the
+> "echo hi⏎hi" + prompt-path-bleed class and garbling the
+> sub-prompt / Ctrl+C announces. The replay oracle could not
+> catch it because the harness never calls
+> `ContentHistory.tick` — exactly the live-only fidelity gap
+> the "Open sub-decision" section below flagged. **(ii)
+> stays deferred** until there is a live-faithful test (a
+> harness `tick` model or an integration test) that exercises
+> the idle-seal + watermark interaction. The narrow
+> slow-typed-then-paused-then-backspaced residual (i) is
+> reaccepted in the meantime.
 
 ## Problem
 

--- a/docs/adr/0004-iocell-model-for-shell-interaction.md
+++ b/docs/adr/0004-iocell-model-for-shell-interaction.md
@@ -1,13 +1,17 @@
 # ADR 0004 — IOCell is the unit of shell interaction; ContentHistory is the sole substrate; OutputDispatcher is the sole non-emergency channel
 
 - **Status**: Proposed (2026-05-14)
-- **Status-note (#428, 2026-05-17)**: Decision 3 strengthened,
-  not amended — ContentHistory now applies the `\x08`
-  backspace-erase on its active span (cmd's `BS SP BS` idiom)
-  and no longer idle-seal-fragments the composing command, so
-  the sole-extraction-substrate stays faithful to in-line
-  edits without consulting the (display-only) Screen. No
-  wire-format change. Design note:
+- **Status-note (#428, 2026-05-17 → 2026-05-18)**: Decision 3
+  strengthened, not amended — ContentHistory now applies the
+  `\x08` backspace-erase on its active span (cmd's `BS SP BS`
+  idiom), so the sole-extraction-substrate stays faithful to
+  in-line edits without consulting the (display-only) Screen.
+  No wire-format change. The companion (ii) idle-seal gate
+  (`tick` skipping `UserInputEcho` spans) was **reverted**
+  2026-05-18 — it regressed the live announce watermark
+  (R3d/`commandEnterSeq`, R6a) which the replay oracle cannot
+  model (no `tick` in the harness); deferred until a
+  live-faithful test exists. Design note:
   [`docs/428-contenthistory-backspace-design.md`](../428-contenthistory-backspace-design.md).
 - **Date**: 2026-05-14
 - **Deciders**: maintainer (KyleKeane)

--- a/docs/boundary-capture/REPLAY-ORACLE.md
+++ b/docs/boundary-capture/REPLAY-ORACLE.md
@@ -110,11 +110,17 @@ defences, both shipped R-B1:
   doesn't apply `\x08`). **#428 fixed it** (maintainer-chosen
   direction 2026-05-17): ContentHistory's `appendFromEvent`
   gained a BS arm that applies the `\x08` erase on the active
-  span (cmd's `BS SP BS` idiom nets to a deletion), and the
-  composing command is no longer idle-seal-fragmented
-  (`tick` skips `UserInputEcho` spans). C5's `Skip` was
-  **removed** — it is now an **active regression guard**.
-  Tracked: [#428](https://github.com/KyleKeane/pty-speak/issues/428).
+  span (cmd's `BS SP BS` idiom nets to a deletion). C5's
+  `Skip` was **removed** — it is now an **active regression
+  guard**. The (ii) idle-seal gate (`tick` skipping
+  `UserInputEcho` spans) was **reverted** — it broke the
+  live R3d/`commandEnterSeq` watermark (R6a, `Program.fs`
+  ~5079–5125: the "echo hi⏎hi" + prompt-bleed class) and the
+  oracle could not catch it (the harness never calls
+  `ContentHistory.tick` — the documented fidelity gap). (ii)
+  is deferred until there is a **live-faithful test** that
+  models `tick`. Tracked:
+  [#428](https://github.com/KyleKeane/pty-speak/issues/428).
   **C6** long-idle mid-compose landed — real capture (`ECHO`,
   ~54s idle with no Enter, then ` DONE`); asserts the gap
   neither splits the in-flight command nor seals early

--- a/src/Terminal.Core/ContentHistory.fs
+++ b/src/Terminal.Core/ContentHistory.fs
@@ -927,26 +927,14 @@ module ContentHistory =
         lock state.Gate (fun () ->
             if state.ActiveSpanText.Length = 0 then []
             else
-                match state.ActiveSpanSource with
-                | ValueSome EntrySource.UserInputEcho ->
-                    // #428 (ii) — never idle-seal the composing
-                    // command. Its bytes are UserInputEcho
-                    // (suppressed from announces per ADR
-                    // 0003/0008), so idle-sealing serves no
-                    // purpose and would fragment the command
-                    // across sealed TextSpans beyond a later BS's
-                    // reach. Keep it in ONE active span until the
-                    // CommandStart marker seals it.
-                    []
-                | _ ->
-                    let elapsed =
-                        (now - state.LastEventAt).TotalMilliseconds
-                    if elapsed >= float state.Parameters.IdleSpanSealMs then
-                        match sealActiveSpan state now with
-                        | Some e -> [ e ]
-                        | None -> []
-                    else
-                        [])
+                let elapsed =
+                    (now - state.LastEventAt).TotalMilliseconds
+                if elapsed >= float state.Parameters.IdleSpanSealMs then
+                    match sealActiveSpan state now with
+                    | Some e -> [ e ]
+                    | None -> []
+                else
+                    [])
 
     /// Reset to empty. Called when SessionModel transitions out
     /// of a sealed tuple so the next tuple starts fresh.

--- a/tests/Tests.Unit/ContentHistoryTests.fs
+++ b/tests/Tests.Unit/ContentHistoryTests.fs
@@ -882,30 +882,3 @@ let ``BS does not reach across a seal boundary into a sealed span`` () =
     |> ignore
     Assert.Equal<string[]>([| "ab"; "c" |], textSpans state)
 
-[<Fact>]
-let ``tick does NOT idle-seal a UserInputEcho active span (#428 ii)`` () =
-    let state = freshHistory ()
-    ContentHistory.setSourceResolver state (fun () ->
-        ContentHistory.EntrySource.UserInputEcho)
-    feed state t0
-        [ printRune 'e'; printRune 'c'; printRune 'h'; printRune 'o' ]
-    |> ignore
-    // Idle well past IdleSpanSealMs (200).
-    let ticked = ContentHistory.tick state (after 5000)
-    Assert.Empty(ticked)
-    Assert.Equal(0, ContentHistory.count state)
-    // Still one unsealed span; an LF now seals the WHOLE
-    // command in one TextSpan (no idle fragmentation).
-    feed state (after 5001) [ lf ] |> ignore
-    Assert.Equal<string[]>([| "echo" |], textSpans state)
-
-[<Fact>]
-let ``tick still idle-seals a CmdOutput active span`` () =
-    let state = freshHistory ()
-    ContentHistory.setSourceResolver state (fun () ->
-        ContentHistory.EntrySource.CmdOutput)
-    feed state t0 [ printRune 'h'; printRune 'i' ] |> ignore
-    let ticked = ContentHistory.tick state (after 500)
-    Assert.Equal(1, List.length ticked)
-    Assert.Equal(1, ContentHistory.count state)
-


### PR DESCRIPTION
## Summary

**Regression fix.** The #428 (ii) sub-decision — `ContentHistory.tick` skipping idle-seal for `UserInputEcho` spans (#431) — broke the **live** announce path. Maintainer confirmed a fresh build (post-#431) reproduces it; chosen remedy: revert the `tick` gate, keep the BS arm.

**Symptoms** (one announce-side regression, all from the tick gate):
- `echo HI` + Enter speaks **"echo HI HI"**
- the latest echo test also included the **prompt path**
- the **yes/no** script and **Ctrl+C (Y/N)** "don't handle keys" — the shell *does* handle them; the **sub-prompt announce is garbled**, so there's no usable audio feedback for a screen-reader user. Other tests unaffected.

**Root cause:** the R6a progress/watermark path (`Program.fs` ~5079–5125) depends on `tick` sealing the typed-command span to keep the R3d/`commandEnterSeq` watermark consistent — the watermark that *excludes the command echo* from the announce slice. The comment at ~5121 literally names the failure mode: *"slicing from lastAnnouncedSeq alone would re-introduce the 'echo hi⏎hi' regression."* Gating that seal shifts the watermark and reintroduces exactly that class plus the prompt-path bleed and garbled sub-prompt/Ctrl+C announces. The replay oracle could not catch it: the harness never calls `ContentHistory.tick` — the live-only fidelity gap the #428 design note explicitly flagged.

**Changes:**
- `ContentHistory.tick` restored **byte-identical to pre-#431**.
- **BS arm RETAINED** — the actual #428 Direction-1 fix; oracle-validated; **C5 stays an active regression guard**.
- Two gate-specific `ContentHistoryTests` removed; the four BS-arm tests stay.
- Docs made coherent: `REPLAY-ORACLE.md`, ADR 0004 status-note, design note (Status → *Partially shipped*; (ii) reverted + deferred behind a live-faithful test), `CHANGELOG` follow-up entry.
- No wire-format change. (ii) deferred until a live-faithful test models the idle-seal + watermark interaction.

## Test plan

- [ ] CI green: C1/C2/C3/C5/C6 oracle facts all pass (C5 via the retained BS arm); four BS unit cases pass; suite builds with the two gate tests removed
- [ ] Maintainer dogfood: `echo HI` speaks "HI" (no "echo HI HI", no prompt path); yes/no script + Ctrl+C (Y/N) announce correctly again
- [x] `tick` diff is a pure revert (verified byte-identical to pre-#431); BS arm untouched

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_