### PR TITLE
ci: union-merge CHANGELOG.md to stop concurrent-PR collisions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Concurrent PRs both append a new dated `### Cycle N …` block at
+# the bottom of CHANGELOG.md's [Unreleased] section. Git's 3-way
+# merge flags those adjacent insertions as a conflict even though
+# they are semantically independent (the per-entry headers carry
+# the ordering, not file position). The built-in `union` merge
+# driver concatenates both sides instead of conflicting — exactly
+# right for append-only standalone blocks.
+#
+# Safe ONLY because CHANGELOG entries are append-only: never
+# rewrite an earlier entry in place (union would duplicate, not
+# replace). See CONTRIBUTING.md / CLAUDE.md changelog rules and
+# the tracked follow-up to generate the changelog from
+# Conventional Commits.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Summary

Changelog-maintenance **Option 1** (the cheap, immediate mitigation we discussed): add a `.gitattributes` `merge=union` driver for `CHANGELOG.md`.

**Why:** concurrent PRs both append a dated `### Cycle N …` block at the bottom of the `[Unreleased]` section. Git's 3-way merge flags those adjacent insertions as a conflict even though they're semantically independent (the per-entry headers carry the ordering, not file position). The built-in `union` driver concatenates both sides instead of conflicting — exactly right for append-only standalone blocks. Net effect: parallel PRs no longer need to be serialised just to dodge a trivial CHANGELOG collision.

**Safe only because** entries are append-only: union blindly keeps both sides, so an in-place rewrite of an earlier entry would be duplicated rather than replaced. The existing "append at the bottom, never edit earlier entries" rule already guarantees this; the file comment + commit message call it out.

The structural endgame (generate the changelog from Conventional Commits so PRs don't touch the file at all — **Option 3**) is filed as a separate tracked follow-up issue.

## Test plan

- [ ] CI green (no code change — single `.gitattributes` file; full CI runs since it's not `.md`-only)
- [x] `union` is a git built-in driver — no `.git/config` / global git-config change required (works on fresh clone)

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_