### PR TITLE
ui(menu): Diagnostics accelerator D; Test Scripts S + to top; Toggle Trace to bottom

### DIFF
--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -28,7 +28,7 @@
              Compose's reflection-driven wiring auto-picks it up.
 
              Top-level order + mnemonics: _Interface, _Terminal,
-             _Cell History, Dia_gnostics, _About (all unique;
+             _Cell History, _Diagnostics, _About (all unique;
              non-conflicting with AppReservedHotkeys's
              Ctrl+Shift+letter gestures since different modifier
              sets are different gestures).

--- a/src/Views/MainWindow.xaml
+++ b/src/Views/MainWindow.xaml
@@ -248,56 +248,15 @@
                  Top-level had ~10 items; grouping by "what it
                  does" reduces scan depth. Logging Level stays
                  at top because it's a frequent toggle. -->
-            <MenuItem Header="Dia_gnostics">
-                <MenuItem x:Name="MenuItem_LoggingLevel"
-                          x:FieldModifier="public"
-                          Header="Logging _Level">
-                    <MenuItem x:Name="MenuItem_LoggingLevel_information"
-                              x:FieldModifier="public"
-                              Header="_Information" />
-                    <MenuItem x:Name="MenuItem_LoggingLevel_debug"
-                              x:FieldModifier="public"
-                              Header="_Debug" />
-                </MenuItem>
-                <!-- Open Data Folder moved here from Interface
-                     (maintainer 2026-05-17): it is a
-                     troubleshooting affordance — the parent of
-                     \logs, \sessions, config.toml. -->
-                <MenuItem x:Name="MenuItem_OpenDataFolder"
-                          x:FieldModifier="public"
-                          Header="Open _Data Folder" />
-                <!-- Cycle 52 boundary-diagnostic-capture
-                     (Instrument B). Same RoutedCommand as
-                     Ctrl+Shift+T; toggles raw PTY byte
-                     recording. (Open / Copy most-recent trace
-                     items land in a follow-up.) -->
-                <MenuItem x:Name="MenuItem_ToggleRawTrace"
-                          x:FieldModifier="public"
-                          Header="Toggle Raw Shell _Trace" />
-                <!-- Probe — quick "fire an action and watch what
-                     happens" probes: health check, incident
-                     marker, the diagnostic battery. The
-                     longer-running Process Cleanup Test moves
-                     to Test Scripts below (per maintainer
-                     preview.118 feedback) so the accelerators
-                     within Probe stay short + unique. -->
-                <MenuItem Header="_Probe">
-                    <MenuItem x:Name="MenuItem_HealthCheck"
-                              x:FieldModifier="public"
-                              Header="_Health Check" />
-                    <MenuItem x:Name="MenuItem_IncidentMarker"
-                              x:FieldModifier="public"
-                              Header="_Incident Marker" />
-                    <MenuItem x:Name="MenuItem_RunDiagnostic"
-                              x:FieldModifier="public"
-                              Header="Run Diagnostic _Battery" />
-                </MenuItem>
+            <MenuItem Header="_Diagnostics">
                 <!-- Test Scripts — runnable scripts that exercise
                      specific subsystems. The CMD Interaction
                      Tests submenu, the manual-test browser,
                      and the process-cleanup test all live here
-                     per maintainer preview.118 feedback. -->
-                <MenuItem Header="_Test Scripts">
+                     per maintainer preview.118 feedback. Moved
+                     to the top of Diagnostics + accelerator S
+                     (maintainer 2026-05-18). -->
+                <MenuItem Header="Test _Scripts">
                     <MenuItem x:Name="MenuItem_OpenManualTests"
                               x:FieldModifier="public"
                               Header="Open _Manual Tests" />
@@ -333,6 +292,41 @@
                                   x:FieldModifier="public"
                                   Header="_Multi-Interrupt (R3c)" />
                     </MenuItem>
+                </MenuItem>
+                <MenuItem x:Name="MenuItem_LoggingLevel"
+                          x:FieldModifier="public"
+                          Header="Logging _Level">
+                    <MenuItem x:Name="MenuItem_LoggingLevel_information"
+                              x:FieldModifier="public"
+                              Header="_Information" />
+                    <MenuItem x:Name="MenuItem_LoggingLevel_debug"
+                              x:FieldModifier="public"
+                              Header="_Debug" />
+                </MenuItem>
+                <!-- Open Data Folder moved here from Interface
+                     (maintainer 2026-05-17): it is a
+                     troubleshooting affordance — the parent of
+                     \logs, \sessions, config.toml. -->
+                <MenuItem x:Name="MenuItem_OpenDataFolder"
+                          x:FieldModifier="public"
+                          Header="Open _Data Folder" />
+                <!-- Probe — quick "fire an action and watch what
+                     happens" probes: health check, incident
+                     marker, the diagnostic battery. The
+                     longer-running Process Cleanup Test lives
+                     in Test Scripts (per maintainer
+                     preview.118 feedback) so the accelerators
+                     within Probe stay short + unique. -->
+                <MenuItem Header="_Probe">
+                    <MenuItem x:Name="MenuItem_HealthCheck"
+                              x:FieldModifier="public"
+                              Header="_Health Check" />
+                    <MenuItem x:Name="MenuItem_IncidentMarker"
+                              x:FieldModifier="public"
+                              Header="_Incident Marker" />
+                    <MenuItem x:Name="MenuItem_RunDiagnostic"
+                              x:FieldModifier="public"
+                              Header="Run Diagnostic _Battery" />
                 </MenuItem>
                 <!-- Inspect — "look at what already happened"
                      tools: bundle copy, grep, extract submenu. -->
@@ -404,6 +398,14 @@
                     </MenuItem>
                 </MenuItem>
                 </MenuItem><!-- /Inspect -->
+                <!-- Cycle 52 boundary-diagnostic-capture
+                     (Instrument B). Same RoutedCommand as
+                     Ctrl+Shift+T; toggles raw PTY byte
+                     recording. Moved to the bottom of
+                     Diagnostics (maintainer 2026-05-18). -->
+                <MenuItem x:Name="MenuItem_ToggleRawTrace"
+                          x:FieldModifier="public"
+                          Header="Toggle Raw Shell _Trace" />
             </MenuItem>
             <!-- Cycle 52 Phase 6b round 2 — "Help" renamed
                  "About" (maintainer 2026-05-17). Acknowledgment


### PR DESCRIPTION
## Summary

Keyboard-accessibility menu changes requested by the maintainer (2026-05-18):

- **Top-level Diagnostics accelerator G → D** (`Dia_gnostics` → `_Diagnostics`). `D` is free among the top-level set (Interface I / Terminal T / Cell History C / Diagnostics D / About A).
- **Test Scripts: accelerator T → S** (`_Test Scripts` → `Test _Scripts`) and **moved to the top** of the Diagnostics menu (it's the most-used item during dogfood capture).
- **Toggle Raw Shell Trace moved to the bottom** of the Diagnostics menu.
- **CMD Interaction Tests** is already `_CMD` (C) — unchanged; satisfies "C inside that submenu for CMD scripts".

New Diagnostics child order: **Test Scripts → Logging Level → Open Data Folder → Probe → Inspect → Toggle Raw Shell Trace**. Within-submenu accelerators stay unique (S/L/D/P/I/T at the Diagnostics level; M/P/C inside Test Scripts).

Pure reorder + two `Header` attribute changes + comment updates. No `MenuItem` added or removed (113 unchanged); `MainWindow.xaml` parses well-formed (verified with an XML parse). Comment text updated where it referenced the old position ("moves to Test Scripts below" → "lives in Test Scripts").

## Test plan

- [ ] CI green (XAML compiles; no code logic changed)
- [ ] Maintainer keyboard check: `Alt` → `D` opens Diagnostics; `S` → Test Scripts (now first); `C` → CMD Interaction Tests; Toggle Raw Shell Trace is last in the menu
- [x] XAML well-formedness verified locally; MenuItem count unchanged (113)

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAW2kD)_