### PR TITLE
ci: stop the markdown link check spinning on github.com 429 backoff

### DIFF
--- a/.github/mlc-config.json
+++ b/.github/mlc-config.json
@@ -5,11 +5,12 @@
     { "pattern": "^https://github.com/KyleKeane/pty-speak/discussions" },
     { "pattern": "^https://github.com/KyleKeane/pty-speak/issues/new" },
     { "pattern": "^https://github.com/KyleKeane/pty-speak/security/dependabot" },
+    { "pattern": "^https://github.com/KyleKeane/pty-speak/(issues|pull)/" },
     { "pattern": "^https://signpath.org" },
     { "pattern": "^https://addons.nvda-project.org" }
   ],
   "timeout": "20s",
-  "retryOn429": true,
+  "retryOn429": false,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
   "aliveStatusCodes": [200, 206, 301, 302, 308, 403, 429]


### PR DESCRIPTION
## Summary

Fixes the "Markdown link check" job spinning for many minutes (you flagged this 2026-05-18).

**Context:** the job is *informational / non-blocking* (`ci.yml:206`, `continue-on-error: true`) — it never blocks a merge — but it was crawling toward its 10-minute cap.

**Root cause** (`.github/mlc-config.json`): `retryOn429: true` with `retryCount: 3` + `fallbackRetryDelay: 30s` means every github.com link that gets rate-limited (`429`) costs up to ~90 s of serial retry/backoff. But `429` is **already** in `aliveStatusCodes`, so the link is accepted as alive regardless — the retry is pure wasted time that never changes the verdict. The link-dense `CHANGELOG.md` plus the recently-added `…/issues/N` and `…/pull/N` references pushed the runtime way up.

**Changes:**
- `retryOn429: true → false` — a 429 is accepted immediately via `aliveStatusCodes`; no 30 s×3 wait.
- Ignore stable self-repo refs `^https://github.com/KyleKeane/pty-speak/(issues|pull)/` — they exist by construction once created and are the dominant 429 source; no value re-validating them on every docs PR (consistent with the existing `issues/new`, `discussions`, `dependabot` ignores).

**No verdict change** (a 429 was already treated as "alive"); this is a pure speedup. The job stays informational/non-blocking.

## Test plan

- [ ] CI green; the Markdown link check job completes in well under a minute (vs. multi-minute before)
- [x] `.github/mlc-config.json` validated as JSON locally

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_