### PR TITLE
docs: correct #439 CHANGELOG — branch prune was not performed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15555,9 +15555,16 @@ ring) follow.
   ADR 0006 three-layer split + `CellEventBus` +
   `PowerShellAdapter`; removed the accidental ~1 MB
   `diagnostics/1.txt` and added a `diagnostics/` gitignore
-  rule; pruned stale squash-merged `claude/*` branches. No
-  code / behaviour change. Issues #437 (corpus battery) /
-  #438 (yes/no `choice`, parked intermittent) recorded.
+  rule. No code / behaviour change. Issues #437 (corpus
+  battery) / #438 (yes/no `choice`, parked intermittent)
+  recorded. **Branch prune NOT performed**: the stale
+  `claude/*` set is ~220 (not the audited 44) and the
+  sandbox git proxy + GitHub MCP both refuse remote
+  branch-deletes (same constraint class as the tag-push
+  limitation), so it cannot be done from a Claude session
+  at all. Durable fix is GitHub-side: enable the repo
+  setting *"Automatically delete head branches"* + a
+  one-time maintainer/Action `is:merged` verified sweep.
 
 ## [0.0.1-preview.18] — 2026-04-28
 


### PR DESCRIPTION
## Summary

#439's CHANGELOG entry claimed "pruned stale squash-merged `claude/*` branches" — that did **not** happen, and leaving the false claim would be exactly the doc-vs-reality drift the reconciliation exists to remove.

Reality (now recorded accurately):
- The stale `claude/*` set is **~220**, not the audited 44.
- Remote branch-deletes are **impossible from a Claude session here**: the sandbox git proxy turns `git push --delete` into a no-op ("Everything up-to-date"), and there is no GitHub MCP branch/ref-delete tool — same constraint class as the documented tag-push limitation.
- Durable fix is GitHub-side: enable the repo setting *"Automatically delete head branches"* + a one-time maintainer/Action `is:merged` verified sweep.

CHANGELOG-only; strict docs-only fast-merge lane (link-check is the only signal that matters).

## Test plan

- [ ] Markdown link check green.

https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSF6STzQhY4NoLQiAME2kD)_