### PR TITLE
docs: ratify ADR 0010 Option A — two-mode reframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15566,6 +15566,27 @@ ring) follow.
   setting *"Automatically delete head branches"* + a
   one-time maintainer/Action `is:merged` verified sweep.
 
+### Cycle 52 ADR-0010 ratification — Option A (2026-05-18)
+
+- **Changed (docs / decision record)**: [ADR 0010](docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
+  ratified by the maintainer — **Option A (two-mode reframe)**.
+  A structured command-runner becomes the *primary* surface
+  (exact command/output boundaries + a real exit code for free
+  on the non-interactive coding path — no scraping, no OSC-133
+  for the common case); the existing raw-PTY passthrough is
+  demoted to an explicit, user-selected *secondary "interactive
+  terminal" mode*. Reuses the ADR 0006 three-layer seam, ADR
+  0004 IOCell, ADR 0007 CellEventBus + navigable history, and
+  the replay-oracle unchanged — the runner is a new transport
+  adapter behind the existing `ShellAdapter` / `SessionHost`
+  seam, not a rewrite. The A1–A4 consequence list is now the
+  cycle plan (`docs/SESSION-HANDOFF.md` § Next stage). ADR 0010
+  status flipped Proposed → Accepted; the previously-paused
+  status-quo fix (Option B's specified boundary/extraction + the
+  C2 channel fix) is **reprioritised to the secondary PTY mode,
+  not deleted**; #437 / #438 become secondary-mode issues. No
+  code / behaviour change.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,20 +152,24 @@ before deviating.
    maintainer's call. Read before any cell-metadata /
    outcome / schema-version / tag-search work.
 9b. **[`docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md`](docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)**
-   — Cycle 52 **Proposed** (2026-05-18). The first-principles
-   strategy fork: does raw-shell-passthrough + semantic
-   segmentation earn its keep vs a structured command-runner,
-   given the goal is a clean Windows coding interface for
-   blind devs. Grounded in the boundary-capture data
+   — Cycle 52 **Accepted — Option A ratified 2026-05-18**.
+   The first-principles strategy fork: does raw-shell-
+   passthrough + semantic segmentation earn its keep vs a
+   structured command-runner, given the goal is a clean
+   Windows coding interface for blind devs. Grounded in the
+   boundary-capture data
    ([`docs/boundary-capture/README.md`](docs/boundary-capture/README.md)):
    the non-interactive path is bounded (one specified
    oracle-guarded fix); the interactive sub-prompt tail is
-   intrinsically unbounded. Options **A** two-mode reframe
-   (recommended) / **B** stay the course / **C** hybrid.
-   **Proposed — awaiting maintainer ratification; status-quo
-   implementation (= Option B) is PAUSED until then.** Read
-   FIRST before any boundary / extraction / runner /
-   primary-surface work — it gates the next cycle.
+   intrinsically unbounded. **Maintainer ratified Option A
+   (two-mode reframe): structured command-runner = primary
+   surface; raw-PTY passthrough demoted to a secondary
+   "interactive terminal" mode.** The A1–A4 consequence list
+   is the cycle plan (`docs/SESSION-HANDOFF.md` § Next stage);
+   A1 `StructuredRunnerAdapter` behind the existing
+   `ShellAdapter` seam is the start — no shipped work
+   discarded. Read FIRST before any boundary / extraction /
+   runner / primary-surface work — it sets the current cycle.
 10. **RFC 0001 (archived)** — Cycle 33 pivot-gate RFC, formalised
    the `LinearTextStream` substrate + streaming-emission protocol.
    The substrate it specified was replaced by `ContentHistory` +
@@ -1048,15 +1052,22 @@ points at the cycle headline.
   retained, (ii) tick-gate reverted (#431→#432). Also
   merged: #433/#435/#436. Open: #434, #437, #438 (yes/no
   `choice` — parked intermittent).
-- **Next** = **maintainer ratifies [ADR 0010](docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
-  (Proposed 2026-05-18)** — the structured-runner-vs-
-  passthrough strategy fork (A two-mode reframe recommended /
-  B stay-the-course / C hybrid). The capture/diagnosis is
-  *done*; the next move is a **decision**, not more
-  investigation. Status-quo implementation (= ADR 0010
-  Option B, the specified boundary fix) is **ready but
-  PAUSED**. On ratification the chosen option's Consequences
-  become the cycle plan. **Start-here: [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md)
+- **Next** = **[ADR 0010](docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
+  Option A — two-mode reframe (RATIFIED 2026-05-18)**. The
+  structured-runner-vs-passthrough strategy fork is decided:
+  **structured command-runner = primary surface**; raw-PTY
+  passthrough demoted to a secondary "interactive terminal"
+  mode. The capture/diagnosis is *done* (#417–#429); the
+  decision is *made*. ADR 0010's **Consequences A1–A4 are the
+  cycle plan** — a walking skeleton, each its own PR +
+  dogfood, no shipped work discarded (the runner is a new
+  transport adapter behind the existing `ShellAdapter` seam;
+  ADR 0006/0004/0007 + replay-oracle carry over). **A1
+  `StructuredRunnerAdapter` is the start.** Option B's
+  specified boundary fix is reprioritised to the secondary
+  PTY mode (A4), not deleted; #437 / #438 become
+  secondary-mode issues. **Start-here:
+  [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md)
   § Current state (2026-05-18 block) + § Next stage** +
   ADR 0010. Other backlog (independent): 45g
   `ShellPolicy` consolidation; full deferral list in ADR

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -51,18 +51,23 @@ and serves the decision-trail role this file used to overload.
 >   single-key — investigated, **PARKED as intermittent**;
 >   focus-report/timing hypothesis; ruled out: #428, the
 >   OSC-133 pivot, the input handler — see the issue).
-> - **GATE — the next direction is a maintainer decision, not
->   more diagnosis.** [ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
->   (**Proposed** 2026-05-18) puts the first-principles ROI
->   fork to the maintainer: **A** two-mode reframe (structured
->   command-runner primary + raw-PTY passthrough secondary —
->   recommended), **B** stay the course (implement the
->   specified boundary fix + C2 fix), **C** hybrid auto-detect.
->   **Status-quo implementation (= ADR 0010 Option B) is READY
->   but PAUSED** so the decision is not pre-empted. **Next
->   stage = the maintainer ratifies A/B/C in ADR 0010; the
->   chosen option's consequence list becomes the next cycle's
->   plan** (see § Next stage).
+> - **GATE RESOLVED 2026-05-18 — [ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
+>   ratified: Option A (two-mode reframe).** The maintainer
+>   chose the structured command-runner as the *primary*
+>   surface (exact boundaries + a real exit code for free on
+>   the non-interactive path, no scraping); the existing
+>   raw-PTY passthrough is demoted to an explicit secondary
+>   "interactive terminal" mode. ADR 0010 status flipped
+>   Proposed → Accepted. **Next stage = the A1–A4
+>   walking-skeleton consequence list** (each its own PR +
+>   dogfood; no shipped work discarded — the runner is a new
+>   transport adapter behind the existing `ShellAdapter` /
+>   `SessionHost` seam, reusing ADR 0006/0004/0007 + the
+>   replay-oracle). The previously-paused Option B fix
+>   (specified boundary/extraction + C2 channel fix) is
+>   **reprioritised to the secondary PTY mode (A4), not
+>   deleted**; #437 / #438 become secondary-mode issues. See
+>   § Next stage.
 >
 > *(Earlier blocks retained as the narrative trail; the block
 > above is authoritative.)*
@@ -420,39 +425,50 @@ State after the maintainer's batched dogfood of post-`cab2a0d`
 
 ## Next stage
 
-**CURRENT next stage (2026-05-18): ratify [ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
-— the interaction-strategy fork.** The boundary-diagnostic-
-capture pass that the *previous* "next stage" called for is
-**done** (#417–#429); the cell-seal defect is characterised
-from data and the fix is specified + oracle-guarded
-([`docs/boundary-capture/README.md`](boundary-capture/README.md)).
-Before implementing it, the maintainer asked the
-first-principles question: does raw-shell-passthrough +
-semantic segmentation earn its keep for the actual goal (a
-clean Windows coding interface for blind devs), versus a
-structured command-runner. ADR 0010 (**Proposed**) records
-the analysis + three options and **must be ratified before
-implementation resumes**:
+**CURRENT next stage (2026-05-18): [ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
+Option A — two-mode reframe (RATIFIED).** The maintainer
+ratified Option A: a **structured command-runner becomes the
+primary surface**, the existing raw-PTY passthrough is demoted
+to an explicit secondary "interactive terminal" mode. The
+boundary-diagnostic-capture pass the previous "next stage"
+called for is **done** (#417–#429); the strategy decision that
+gated implementation is now made. ADR 0010's **Consequences
+A1–A4 are the cycle plan** — a walking skeleton, each its own
+PR + dogfood, **no shipped work discarded** (the runner is a
+new transport adapter behind the existing `ShellAdapter` /
+`SessionHost` seam; ADR 0006 three-layer + ADR 0004 IOCell +
+ADR 0007 CellEventBus/navigable-history + the replay-oracle all
+carry over unchanged):
 
-- **A — two-mode reframe (recommended):** structured
-  command-runner as the *primary* surface (exact boundaries +
-  real exit codes *for free*, no scraping for the ~80%
-  non-interactive path) with the existing raw-PTY passthrough
-  demoted to an explicit secondary "interactive terminal"
-  mode. Reuses the three-layer/IOCell/CellEventBus/history/
-  oracle investment via the `ShellAdapter` seam.
-- **B — stay the course:** implement the already-specified
-  one boundary/extraction fix + the independent C2
-  channel-layer fix, oracle-guarded; raw terminal stays the
-  single primary surface.
-- **C — hybrid auto-detect.**
+- **A1 — `StructuredRunnerAdapter`** behind the existing
+  `ShellAdapter` / `SessionHost` seam (ADR 0006): invoke +
+  capture stdout / stderr / exit-code directly; emit one
+  sealed `IOCell` with exact `CommandStartedAt` /
+  `CommandFinishedAt` and a **real** `ExitCode` (turns ADR
+  0009's `Indeterminate`-for-cmd into a genuine
+  `Succeeded` / `Failed` on this path). No OSC-133, no
+  `HeuristicPromptDetector` on this path. **A1 is the start.**
+- **A2 — clean command-input surface as the default.** The
+  ADR 0007 IOCell history is already the right output model —
+  it simply receives *exact* cells.
+- **A3 — explicit mode switch** to the existing raw-PTY
+  passthrough, relabelled **"Interactive terminal"**; its
+  known segmentation imperfections become *documented, scoped*
+  limitations of an opt-in mode, not product-critical bugs.
+- **A4 — in-flight status-quo items reprioritised, not
+  deleted:** the specified boundary/extraction fix + the
+  independent C2 channel fix still apply to the secondary PTY
+  mode; the replay-oracle still guards it; **#437 / #438
+  become secondary-mode issues**.
 
-On ratification, the chosen option's **Consequences** list
-becomes the cycle plan and this section is rewritten to it.
-ADR 0007 Phase 4/4b/5 (segments) + 6c/6d + the real
+Each A-stage stays independently CI- + NVDA-dogfood-gated
+(matrix rows per stage in
+[`ACCESSIBILITY-TESTING.md`](ACCESSIBILITY-TESTING.md)). ADR
+0007 Phase 4/4b/5 (segments) + 6c/6d + the real
 cell-nav/per-cell-op implementations behind the enabled
 `(not yet implemented)` placeholders follow once cells
-reliably seal — under whichever mode A/B/C makes primary.
+reliably seal — they seal *exactly and for free* on the A1
+primary path.
 
 *Historical (shipped) — R4c / R5 / R6 below are DONE; kept
 as the build-order trail, not "next":*

--- a/docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md
+++ b/docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md
@@ -1,11 +1,13 @@
 # ADR 0010 — Interaction strategy: structured command-runner vs raw-terminal passthrough
 
-- **Status**: **Proposed** (2026-05-18; the maintainer requested
-  this decision record *before* any further implementation —
-  "Strategy ADR first". No code changes accompany it. The
-  maintainer ratifies one of the options below; until then the
-  status-quo path (Option B) is **paused** so the decision is
-  not pre-empted.)
+- **Status**: **Accepted — Option A (two-mode reframe) ratified
+  by the maintainer 2026-05-18.** The decision record was
+  requested *before* any further implementation ("Strategy ADR
+  first"); no code changes accompany the ADR itself. The A1–A4
+  consequence list is now the cycle plan
+  ([`docs/SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) § Next
+  stage). Implementation is a walking skeleton — each of A1–A4
+  is its own PR + dogfood; no shipped work is discarded.
 - **Date**: 2026-05-18
 - **Deciders**: maintainer (KyleKeane)
 - **Authoring item**: Cycle 52, session-closure reconciliation.
@@ -133,7 +135,13 @@ de-risking property (it keeps an unbounded predictor on the
 hot path).
 
 This ADR records the analysis; **the maintainer ratifies the
-option.** Status stays Proposed until then.
+option.**
+
+**Ratified 2026-05-18: Option A (two-mode reframe).** The
+structured command-runner becomes the primary surface; raw-PTY
+passthrough is demoted to an explicit secondary "interactive
+terminal" mode. The Consequences A1–A4 below are the cycle
+plan.
 
 ## Consequences
 
@@ -202,10 +210,13 @@ heuristic surface.
 
 ## Status / next
 
-**Proposed 2026-05-18.** No implementation. The maintainer
-selects A, B, or C; the chosen option's consequence list
-becomes the next cycle's plan and `docs/SESSION-HANDOFF.md`
-§ Next stage is set to it. Until ratified, status-quo
-implementation is **paused** — the specified boundary fix is
-*ready* but deliberately not started so this decision is not
-pre-empted.
+**Accepted 2026-05-18 — Option A (two-mode reframe), maintainer
+ratified.** The A1–A4 consequence list is the next cycle's plan
+and [`docs/SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) § Next
+stage is set to it. Implementation is a walking skeleton (A1
+`StructuredRunnerAdapter` first, each its own PR + dogfood); no
+shipped work is discarded. The status-quo Option B fix (the
+specified boundary/extraction fix + the independent C2 channel
+fix) is **reprioritised to the secondary PTY mode (A4), not
+deleted** — it still applies there, still oracle-guarded;
+#437 / #438 become secondary-mode issues.


### PR DESCRIPTION
## Summary

The maintainer ratified **ADR 0010 Option A — two-mode reframe** (2026-05-18). This PR records the decision and sets the cycle plan to Option A's Consequences. Docs-only, no code / behaviour change.

- **`docs/adr/0010-...md`** — Status flipped **Proposed → Accepted (Option A ratified)**; added a Ratified note after the Recommendation; rewrote the `## Status / next` section to the A1–A4 walking-skeleton plan with Option B's fix reprioritised to the secondary PTY mode (A4), not deleted.
- **`docs/SESSION-HANDOFF.md`** — authoritative *Current state* GATE bullet flipped to **RESOLVED**; `§ Next stage` rewritten to the ratified Option A cycle plan (A1 `StructuredRunnerAdapter` is the start; A2 input surface; A3 explicit "Interactive terminal" mode switch; A4 reprioritised status-quo items + #437/#438 → secondary-mode issues).
- **`CLAUDE.md`** — reading-order index entry 9b + `§ Current sequencing` "Next" updated to the ratified Option A plan.
- **`CHANGELOG.md`** — `[Unreleased]` bottom-append recording the ratification.

The structured command-runner becomes the **primary** surface (exact command/output boundaries + a real exit code for free on the non-interactive path — no scraping, no OSC-133 for the common case); raw-PTY passthrough is demoted to an explicit secondary "interactive terminal" mode. No shipped work is discarded — the runner is a new transport adapter behind the existing `ShellAdapter` / `SessionHost` seam; ADR 0006 / 0004 / 0007 + the replay-oracle all carry over unchanged.

## Scope check

Docs-only per the strict CLAUDE.md definition (`*.md` + `CHANGELOG.md` only — no `src/`, `tests/`, workflows, spec). Eligible for the fast-merge lane via the markdown link check. 4 files, +134 / −75.

## Test plan

- [ ] Markdown link check passes (the one signal that matters for a docs-only PR).
- [ ] No internal links broken by the ADR 0010 / SESSION-HANDOFF / CLAUDE.md edits.

https://claude.ai/code/session_01U47wp8ovBPSU46TSWGf4yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01U47wp8ovBPSU46TSWGf4yj)_