### PR TITLE
docs: ADR 0011 Phase 0 engine bootstrap + RELAUNCH-SPEC cross-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15587,6 +15587,28 @@ ring) follow.
   not deleted**; #437 / #438 become secondary-mode issues. No
   code / behaviour change.
 
+### Re-launch Phase 0 kick-off — ADR 0011 + cross-links (2026-06-11)
+
+- **Added (docs / decision record)**: [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)
+  — Phase 0 interaction-engine bootstrap (Proposed; authored
+  during a maintainer-authorized autonomous session). Records
+  decisions E1–E10: additive `Engine.*` assembly layout (pure
+  `net9.0` `Engine.Core`; `Engine.Participants` Claude CLI
+  runner; `Engine.Voice` SAPI self-voicing sink; `Engine.Host`
+  console host), Markdig block-level chunk grain, GUID chunk
+  ids + capture/authored order, per-turn `claude -p
+  --output-format stream-json` transport with tolerant typed
+  parsing, seal-at-message-boundary streaming rule, output-side
+  attention router, keyboard-first Phase 0 host, nothing
+  deleted, CI + local-dogfood validation split.
+- **Changed (docs)**: the deliberate follow-up
+  [`docs/RELAUNCH-SPEC.md`](docs/RELAUNCH-SPEC.md) §15/§17
+  named is done — ADR 0010 carries a "framing superseded by
+  the re-launch spec" status note; `docs/SESSION-HANDOFF.md`
+  § Current state / § Next stage and `CLAUDE.md` (reading
+  order 9c + Current sequencing) now point at RELAUNCH-SPEC
+  Phase 0 as the active work. No code / behaviour change.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,21 @@ before deviating.
    `ShellAdapter` seam is the start — no shipped work
    discarded. Read FIRST before any boundary / extraction /
    runner / primary-surface work — it sets the current cycle.
+9c. **[`docs/RELAUNCH-SPEC.md`](docs/RELAUNCH-SPEC.md)** —
+   **the current strategic target (2026-05-19; core canon
+   §0.1/§0.2 maintainer-ratified). Read FIRST for any new
+   work** — it supersedes ADR 0010's framing. An audio-first
+   multi-agent computational workspace: the **interaction
+   engine** + **universal event bus** as fixed canon;
+   self-voicing output ownership; GUI / UIA / NVDA ignored
+   from day zero on the new path; chunk-tree data model
+   (locked); §13 phased plan with **Phase 0 (local
+   Claude-Code-CLI bootstrap) as the committed start**.
+   Implementation decisions for Phase 0 are in
+   [`docs/adr/0011-phase0-interaction-engine-bootstrap.md`](docs/adr/0011-phase0-interaction-engine-bootstrap.md)
+   (Proposed, 2026-06-11 — new additive `Engine.*`
+   assemblies; nothing existing deleted; the §4.2 freeze on
+   terminal-scraping heuristics stands).
 10. **RFC 0001 (archived)** — Cycle 33 pivot-gate RFC, formalised
    the `LinearTextStream` substrate + streaming-emission protocol.
    The substrate it specified was replaced by `ContentHistory` +
@@ -1052,24 +1067,23 @@ points at the cycle headline.
   retained, (ii) tick-gate reverted (#431→#432). Also
   merged: #433/#435/#436. Open: #434, #437, #438 (yes/no
   `choice` — parked intermittent).
-- **Next** = **[ADR 0010](docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
-  Option A — two-mode reframe (RATIFIED 2026-05-18)**. The
-  structured-runner-vs-passthrough strategy fork is decided:
-  **structured command-runner = primary surface**; raw-PTY
-  passthrough demoted to a secondary "interactive terminal"
-  mode. The capture/diagnosis is *done* (#417–#429); the
-  decision is *made*. ADR 0010's **Consequences A1–A4 are the
-  cycle plan** — a walking skeleton, each its own PR +
-  dogfood, no shipped work discarded (the runner is a new
-  transport adapter behind the existing `ShellAdapter` seam;
-  ADR 0006/0004/0007 + replay-oracle carry over). **A1
-  `StructuredRunnerAdapter` is the start.** Option B's
-  specified boundary fix is reprioritised to the secondary
-  PTY mode (A4), not deleted; #437 / #438 become
-  secondary-mode issues. **Start-here:
+- **Next** = **[`docs/RELAUNCH-SPEC.md`](docs/RELAUNCH-SPEC.md)
+  Phase 0 — the local bootstrap (IN IMPLEMENTATION,
+  2026-06-11)** per
+  [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md):
+  additive `Engine.*` assemblies (pure chunk-tree core +
+  Claude CLI stream-json parser + Markdig chunker + ingest /
+  engine event bus + navigation verbs + attention router +
+  CLI participant runner + SAPI self-voicing sink + console
+  host). The spec supersedes ADR 0010's framing (status note
+  in the ADR); A1–A4 are subsumed; the raw-PTY path is the
+  secondary mode (§4.2 freeze stands); ADR 0007 Phase 4+ is
+  deferred behind the spec's plan. Phase 0 acceptance = the
+  maintainer's local dogfood on the self-voicing channel.
+  **Start-here:
   [`docs/SESSION-HANDOFF.md`](docs/SESSION-HANDOFF.md)
-  § Current state (2026-05-18 block) + § Next stage** +
-  ADR 0010. Other backlog (independent): 45g
+  § Current state (2026-06-11 block) + § Next stage** +
+  RELAUNCH-SPEC + ADR 0011. Other backlog (independent): 45g
   `ShellPolicy` consolidation; full deferral list in ADR
   0006 §"Deferred to R6+".
 

--- a/docs/RELAUNCH-SPEC.md
+++ b/docs/RELAUNCH-SPEC.md
@@ -1172,7 +1172,7 @@ green-field restart:
 | Diagnostics, hotkey contract, accessibility + dogfood *discipline* | **Keep** — triage + the "accessibility outcome is the acceptance criterion" rule; validation mechanism becomes the self-voicing channel (§14.1). |
 | WPF / UIA shell, NVDA integration | **Defer (not day zero)** — per core canon (§0.1) GUI / UIA / NVDA are ignored from day zero; a GUI, if ever essential, re-enters only as one universal-event-bus consumer among many (§4.6, §14.12), never the host. |
 | `HeuristicPromptDetector`, OSC-133 precedence, sub-prompt accumulators, boundary-capture fix, #437 / #438 | **Freeze** — opt-in secondary PTY mode (§4.2); not invested in. |
-| ADR 0010 Option A framing | **Superseded by this document** — directionally right, under-scoped. (Cross-link / status update is a follow-up, not done here.) |
+| ADR 0010 Option A framing | **Superseded by this document** — directionally right, under-scoped. (Cross-link / status update recorded in ADR 0010 + `SESSION-HANDOFF` + `CLAUDE.md`, 2026-06-11.) |
 | `SESSION-HANDOFF` / ADR / `CLAUDE.md` orientation apparatus | **Keep, then automate** — it is the §10 orientation-surface spec. |
 
 ## 16. Open decisions (decide these)
@@ -1248,10 +1248,12 @@ Stated so they are correctable rather than silent:
 - "Re-launch" means a new transport adapter + the chunk-tree
   model + the local loop on the kept skeleton — **not** a
   rewrite.
-- This document supersedes ADR 0010's *framing* but does not
-  itself edit ADR 0010 / `SESSION-HANDOFF` / `CLAUDE.md`; those
-  cross-links are a deliberate follow-up so this draft can be
-  reviewed in isolation first.
+- This document supersedes ADR 0010's *framing*. The
+  cross-links into ADR 0010 / `SESSION-HANDOFF` / `CLAUDE.md`
+  were a deliberate follow-up so this draft could be reviewed
+  in isolation first; they landed 2026-06-11 alongside
+  [ADR 0011](adr/0011-phase0-interaction-engine-bootstrap.md)
+  (the Phase 0 implementation-decision record).
 
 ## 18. Glossary
 

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -11,10 +11,40 @@ previous (multi-thousand-line) handoff is at
 [`docs/archive/pre-cycle-45/SESSION-HANDOFF-pre-cycle-45c-historical.md`](archive/pre-cycle-45/SESSION-HANDOFF-pre-cycle-45c-historical.md)
 and serves the decision-trail role this file used to overload.
 
-## Current state (2026-05-18)
+## Current state (2026-06-11)
 
-> **⇒ 2026-05-18 — SESSION-CLOSURE RECONCILIATION (read THIS
-> first; it supersedes every earlier block in this section).**
+> **⇒ 2026-06-11 — RE-LAUNCH UNDERWAY (read THIS first; it
+> supersedes every earlier block in this section).** The
+> strategic target is now
+> [`docs/RELAUNCH-SPEC.md`](RELAUNCH-SPEC.md) (2026-05-19,
+> core canon §0.1/§0.2 maintainer-ratified): an audio-first
+> multi-agent computational workspace — the **interaction
+> engine** + **universal event bus**, self-voicing, GUI / UIA /
+> NVDA ignored from day zero on the new path. It supersedes
+> ADR 0010 Option A's *framing* (the runner reframe was
+> directionally right, under-scoped — status note now in the
+> ADR itself).
+> **Phase 0 (spec §13) is in implementation** under
+> [ADR 0011](adr/0011-phase0-interaction-engine-bootstrap.md)
+> (Proposed — authored during the maintainer-authorized
+> autonomous session of 2026-06-11; decisions E1–E10 are
+> implemented-pending-ratification): new additive `Engine.*`
+> assemblies (pure `Engine.Core` chunk-tree model + Claude CLI
+> stream-json parser + Markdig block chunker + ingest/bus +
+> navigation verbs + attention router; `Engine.Participants`
+> Claude CLI runner; `Engine.Voice` SAPI self-voicing sink;
+> `Engine.Host` console host). Nothing existing is deleted or
+> modified — the WPF app keeps shipping; the §4.2 freeze on
+> terminal-scraping heuristics stands. The Phase 0 acceptance
+> gate is the maintainer's **local** dogfood on the
+> self-voicing channel (spec §14.1) — CI validates everything
+> except narration.
+>
+> *(The 2026-05-18 block below is retained as the narrative
+> trail; the block above is authoritative.)*
+
+> **⇒ 2026-05-18 — SESSION-CLOSURE RECONCILIATION (superseded
+> by the 2026-06-11 block above; kept as trail).**
 > The boundary-diagnostic-capture track is **COMPLETE and on
 > main** (#417–#429), *not* "next" (the earlier blocks below
 > wrongly imply it is pending — that stale framing was the
@@ -425,7 +455,25 @@ State after the maintainer's batched dogfood of post-`cab2a0d`
 
 ## Next stage
 
-**CURRENT next stage (2026-05-18): [ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
+**CURRENT next stage (2026-06-11):
+[`RELAUNCH-SPEC.md`](RELAUNCH-SPEC.md) Phase 0 — the local
+bootstrap — per [ADR 0011](adr/0011-phase0-interaction-engine-bootstrap.md).**
+PR sequence (walking skeleton, one concern per PR, all
+additive): chunk-tree model → Claude CLI stream-json parser →
+markdown chunker → ingest + engine event bus → navigation
+verbs → attention router → Claude CLI participant runner →
+self-voicing sink + console host → closure audit. After the
+code lands CI-green, the remaining Phase 0 work is **on the
+maintainer's machine**: install the .NET 9 SDK + Claude Code
+CLI locally, run `Engine.Host`, and validate the §13
+acceptance loop on the self-voicing channel. ADR 0007 Phase
+4/4b/5 etc. and the ADR 0010 A1–A4 list are subsumed /
+deferred per the spec (§4.2 freeze stands; PTY mode =
+secondary).
+
+*Historical (superseded by the spec) — the 2026-05-18 plan:*
+
+**[ADR 0010](adr/0010-interaction-strategy-structured-runner-vs-passthrough.md)
 Option A — two-mode reframe (RATIFIED).** The maintainer
 ratified Option A: a **structured command-runner becomes the
 primary surface**, the existing raw-PTY passthrough is demoted

--- a/docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md
+++ b/docs/adr/0010-interaction-strategy-structured-runner-vs-passthrough.md
@@ -8,6 +8,19 @@
   ([`docs/SESSION-HANDOFF.md`](../SESSION-HANDOFF.md) § Next
   stage). Implementation is a walking skeleton — each of A1–A4
   is its own PR + dogfood; no shipped work is discarded.
+  **Framing superseded 2026-05-19 by
+  [`docs/RELAUNCH-SPEC.md`](../RELAUNCH-SPEC.md)** (cross-link
+  recorded 2026-06-11): Option A was directionally right —
+  stop depending on raw-terminal scraping for the primary
+  surface — but under-scoped. The primary surface is a
+  *structured AI-agent session* fed by the agent's native typed
+  stream (spec §4.3), not a generic command runner; the A1–A4
+  list is subsumed by the spec's §13 phased plan (Phase 0
+  first; implementation decisions in
+  [ADR 0011](0011-phase0-interaction-engine-bootstrap.md)).
+  A4's demotion of the raw-PTY path to a secondary
+  "interactive terminal" mode carries over unchanged (spec
+  §4.2).
 - **Date**: 2026-05-18
 - **Deciders**: maintainer (KyleKeane)
 - **Authoring item**: Cycle 52, session-closure reconciliation.

--- a/docs/adr/0011-phase0-interaction-engine-bootstrap.md
+++ b/docs/adr/0011-phase0-interaction-engine-bootstrap.md
@@ -1,0 +1,209 @@
+# ADR 0011 — Phase 0 interaction-engine bootstrap (engine assemblies, chunk tree, Claude CLI participant, self-voicing channel)
+
+- **Status**: Proposed — authored 2026-06-11 during an
+  explicitly-authorized autonomous session (the maintainer
+  instructed Claude to work unattended toward the
+  [`docs/RELAUNCH-SPEC.md`](../RELAUNCH-SPEC.md) goal and to
+  decide open implementation questions on best recommendation).
+  Every decision below is therefore **implemented but awaiting
+  maintainer ratification**; each is reversible behind a seam,
+  and none touches the shipped WPF app. The Phase 0 local
+  dogfood (spec §13 acceptance, on the self-voicing channel per
+  §14.1) is the ratification gate.
+- **Date**: 2026-06-11
+- **Deciders**: Claude (autonomous, per maintainer grant);
+  maintainer ratifies retroactively.
+- **Companion docs**:
+  [`docs/RELAUNCH-SPEC.md`](../RELAUNCH-SPEC.md) (the target;
+  §13 Phase 0 is what this ADR builds),
+  [ADR 0006](0006-three-layer-refoundation.md) (the
+  transport / core / channel seam the engine reuses),
+  [ADR 0008](0008-maximal-semantic-surfacing.md) (the spine
+  principle), [ADR 0010](0010-interaction-strategy-structured-runner-vs-passthrough.md)
+  (superseded in framing by the spec; this ADR is the spec's
+  first implementation step).
+
+## Context
+
+The re-launch specification (2026-05-19, maintainer-ratified
+core canon §0.1/§0.2) commits to **Phase 0**: the smallest
+honest version of the primary loop — compose a request, send it
+to a **local Claude Code CLI over its structured stream**,
+ingest the response as a sealed **chunk tree**, navigate it with
+the v1 verbs, and hear everything through a **self-voicing audio
+channel** the system owns end-to-end. No WPF, no UIA, no NVDA on
+this path (day-zero canon).
+
+The spec deliberately left implementation-shaping questions open
+(§16) or to be decided at build time. This ADR records the
+choices made so they are visible, reviewable, and individually
+reversible. The repo conventions (one concern per PR, CI-gated,
+walking skeleton) carry over unchanged.
+
+## Decisions
+
+### E1 — Assembly layout: new `Engine.*` projects, additive
+
+Four new projects; nothing existing is modified or deleted:
+
+| Project | TFM | Role |
+|---|---|---|
+| `src/Engine.Core` | `net9.0` | The interaction engine's pure core: chunk-tree model, agent-event vocabulary, Claude stream-json parser, markdown chunker, ingest, navigation, attention routing, the engine event bus. **No platform types** — enforced structurally by the plain (non-Windows) TFM plus the portability lint. |
+| `src/Engine.Participants` | `net9.0` | The participant seam's first instance: the Claude Code CLI process runner (spawn, line pump, lifecycle). Transport-layer only; translation logic stays pure in `Engine.Core`. |
+| `src/Engine.Voice` | `net9.0-windows` | The self-voicing channel: `ISpeechSink` realized over Windows SAPI (`System.Speech`). A universal-event-bus consumer, never a foundation (§0.1). |
+| `src/Engine.Host` | `net9.0-windows` | The Phase 0 console host executable wiring participant → ingest → tree → navigation → voice. The dogfoodable artifact. |
+
+Named `Engine.*`, not `Terminal.*`: the spec's core canon says
+the thing being built is the *interaction engine* and explicitly
+not a terminal. `Terminal.*` assemblies continue to exist and
+build (the §4.2 freeze list is quarantined, not deleted).
+
+The dependency direction is `Engine.Host → {Engine.Participants,
+Engine.Voice} → Engine.Core`, mirroring ADR 0006's
+transport / core / channel discipline. `Engine.Core` references
+only `FSharp.Core`, `Microsoft.Extensions.Logging.Abstractions`,
+and `Markdig` (all already in the central package set) — no
+`Terminal.*` project references, so the engine core cannot
+silently inherit terminal-scraping types.
+
+### E2 — Chunk grain: Markdig block-level decomposition
+
+Spec §16 open decision 1 (chunk grain), default chosen:
+**model-marked block boundaries** — the Markdown block elements
+the agent already emits (heading, paragraph, list, list item,
+fenced code block, block quote), decomposed with Markdig (a
+dependency the repo already carries). Rationale: ADR 0008 says
+recover the structure the source unambiguously provides — the
+agent's markdown *is* model-marked structure; block-level is
+the Wolfram-cell-like grain the spec's reference experience
+names. Finer grains (sentence-level) and coarser
+(heading-section-level) remain a navigator-layer choice later;
+the stored grain is the source's own block structure.
+
+### E3 — Identity: GUID chunk ids + capture sequence + authored index
+
+Spec §16 open decision 7, v1 scheme: every chunk gets an opaque
+`ChunkId` (GUID, "N" format) at ingest; every chunk carries a
+per-session monotonic `CaptureSeq` (the immutable temporal
+position) and a separate `AuthoredIndex` (the §5.1 authored
+order, present in the model from the first commit even though
+v1 only appends). Ids are never positional, so reorder /
+branch / re-issue cannot invalidate an address. Cross-document
+addressing is deferred (it needs the structured-memory-repo
+design, not Phase 0).
+
+### E4 — Participant transport: per-turn `claude -p` with `--resume`
+
+The Claude Code CLI is invoked **per turn** as
+`claude -p <prompt> --output-format stream-json --verbose`,
+with `--resume <sessionId>` carrying conversation continuity
+(the session id is taken from the stream's `system/init`
+event). A long-lived `--input-format stream-json` bidirectional
+process is a later optimization, not Phase 0 — per-turn
+invocation is simpler to supervise, loses nothing semantically,
+and the CLI owns its own session persistence.
+
+The parser is **tolerant by construction**: every line is
+decoded into a typed `AgentEvent`; anything outside the known
+vocabulary becomes a typed `Unknown` event carrying its raw
+type tag — surfaced honestly, never silently dropped and never
+relayed as ambiguous text (ADR 0008). The spec's §17 working
+assumption ("the CLI exposes a usable structured interface")
+is treated as **format-verified at the maintainer's machine
+during the Phase 0 dogfood**; the parser's fixture corpus is
+the contract in the meantime, and a format drift surfaces as
+`Unknown` events plus a diagnostic log line, not a crash.
+
+### E5 — The streaming rule realized: seal at message boundary
+
+Spec §5.2: chunks are navigable only once sealed. Phase 0 seals
+at the **assistant-message boundary** — when the CLI emits a
+complete assistant message, its content blocks are decomposed
+(E2) and sealed as a batch; while a turn is in flight the engine
+emits ambient `ResponseProgress` events (chunk count so far)
+and a `ResponseCompleted` event at the result line. Partial-
+message streaming (`--include-partial-messages`) is deliberately
+not consumed in Phase 0: it reintroduces the moving-target
+problem the streaming rule exists to prevent, for no Phase 0
+benefit.
+
+### E6 — Attention contract enforced output-side in `AttentionRouter`
+
+Spec §0.2 names two enforcement points for foreground/ambient;
+Phase 0 builds the **output-side** one as a pure `Engine.Core`
+fold: foreground utterances (confirmation echoes, navigation
+narration, sealed-chunk reads the user asked for) form a single
+ordered non-preemptible queue; ambient events (progress,
+lifecycle) are **coalesced** (latest-wins per ambient key) and
+only surface between foreground utterances. The input-side
+scheduler is deferred until there is more than one input source
+(Phase 0 input is a single console stream, already serialized).
+
+### E7 — Self-voicing sink: Windows SAPI behind `ISpeechSink`
+
+Phase 0's only output channel (spec §13). The seam is
+`ISpeechSink` (speak / interrupt / sink-level state), defined
+next to the router; `Engine.Voice` implements it over
+`System.Speech.Synthesis.SpeechSynthesizer` (SAPI — in-box
+voices, no install step, decades-stable). SAPI's voice quality
+and latency are accepted for Phase 0 as the *bootstrap* sink;
+the §1.1 "fast, reliable narration" bar is ultimately met by
+swapping better TTS behind the same seam (the sink is a bus
+consumer, so this is a configuration change by construction).
+The dogfood explicitly measures: time-to-first-phoneme on
+confirmation, interrupt latency, and drop-free sustained reads.
+
+### E8 — Phase 0 input: keyboard-first console host
+
+Spec §6.1 allows "speaking (or typing)" for composition. The
+Phase 0 host is a console executable reading line-oriented
+composition input plus single-key navigation chords. Speech
+input arrives via OS-level dictation into the same console line
+(no engine work needed), with a first-class speech-input
+pipeline as a later event-handler instance (§0.2). This keeps
+Phase 0's risk concentrated on the loop that matters (structured
+ingest + navigation + self-voicing), not on audio capture.
+
+### E9 — Nothing discarded
+
+The WPF app, the PTY path, and every shipped `Terminal.*`
+assembly keep building and shipping exactly as today. The
+engine is additive. The §4.2 freeze stands: no further
+investment in terminal-scraping heuristics. The existing
+`CellEventBus`/`OutputDispatcher` are untouched; the engine
+event bus is the *engine's* instance of the same pattern
+(instance-scoped rather than global, so tests and multiple
+engines compose).
+
+### E10 — Validation: CI tests now, maintainer dogfood as the gate
+
+Every pure module lands with xUnit coverage in `Tests.Unit`
+(which already targets Windows and references multiple
+projects). The portability lint gains `Engine.Core` enforcement
+(no WPF/Win32 opens, no P/Invoke, no `Terminal.Shell` and no
+`Terminal.Core` dependency). The Phase 0 **acceptance** is the
+spec §13 criterion, validated by the maintainer locally on the
+self-voicing channel (§14.1) — a matrix row lands with the
+closure PR. CI cannot validate narration; it validates
+everything else.
+
+## Consequences
+
+- The repo gains a second, parallel product surface (the
+  engine) with zero coupling to the first (the WPF terminal
+  app). The two share conventions and the central package set,
+  nothing else.
+- The maintainer can ratify or reverse each E-decision
+  independently: grain (E2) is one function, the transport
+  shape (E4) is one runner, the sink (E7) is one
+  implementation of one interface.
+- The Phase 0 dogfood happens on the maintainer's machine with
+  a local `claude` install; the cloud session can only deliver
+  CI-green code plus the run instructions (`docs/` updates land
+  with the closure PR).
+
+## Status notes
+
+- 2026-06-11: ADR authored; implementation PR sequence begins
+  (model → parser → chunker → ingest/bus → navigation →
+  router → participant runner → voice/host → closure audit).


### PR DESCRIPTION
## Summary

First PR of the RELAUNCH-SPEC Phase 0 implementation sequence, authored during the maintainer-authorized autonomous session (2026-06-11).

- **New [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)** (Proposed): records the Phase 0 implementation decisions E1–E10 — additive `Engine.*` assembly layout (pure `net9.0` `Engine.Core`, `Engine.Participants` Claude CLI runner, `Engine.Voice` SAPI self-voicing sink, `Engine.Host` console host), Markdig block-level chunk grain, GUID ids + capture/authored order, per-turn `claude -p --output-format stream-json` transport with tolerant typed parsing, seal-at-message-boundary streaming rule, output-side attention router, keyboard-first host, nothing deleted, CI + local-dogfood validation split.
- **The deliberate follow-up the spec named (§15/§17)**: ADR 0010 status note (framing superseded by RELAUNCH-SPEC), SESSION-HANDOFF § Current state / § Next stage, CLAUDE.md reading order 9c + Current sequencing, spec §15/§17 follow-up bullets closed.
- CHANGELOG `[Unreleased]` entry (bottom-append).

**Docs-only** — eligible for the fast-merge lane (markdown link check only). No code / behaviour change.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_