### PR TITLE
feat(engine): AgentEvent vocabulary + Claude CLI stream-json parser (ADR 0011 E4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15625,6 +15625,23 @@ ring) follow.
   opens, no P/Invoke, no `Terminal.*` project references
   (ADR 0011 E1/E10).
 
+### Phase 0 PR-2 (2026-06-11): Claude CLI stream-json parser
+
+- **Added**: `Engine.Core/AgentEvent.fs` — the typed vocabulary
+  a participant's structured stream normalizes into
+  (`SessionInit` / `AssistantMessage` with typed content blocks
+  / `ToolResults` / `TurnResult` / typed `Unknown` +
+  `ParseError`), and `Engine.Core/ClaudeStreamJson.fs` — the
+  pure one-line-in / one-typed-event-out parser for the Claude
+  Code CLI's `-p --output-format stream-json --verbose` wire
+  format (ADR 0011 E4). Tolerance rules are load-bearing:
+  unknown top-level types and unknown content-block types are
+  surfaced typed (ADR 0008 — never silently dropped, never
+  relayed ambiguous); malformed lines become `ParseError`;
+  nothing throws. `ClaudeStreamJsonTests` fixture corpus is the
+  wire contract until the Phase 0 dogfood re-verifies it on the
+  maintainer's machine.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/AgentEvent.fs
+++ b/src/Engine.Core/AgentEvent.fs
@@ -1,0 +1,57 @@
+namespace Engine.Core
+
+/// RELAUNCH-SPEC §4.3 / ADR 0011 E4 — the typed vocabulary a
+/// participant's structured stream is normalized into (the
+/// §0.2 event handler's output for the agent-result input
+/// class). The Claude Code CLI's stream-json interface is the
+/// first producer (`ClaudeStreamJson.fs`); further participants
+/// (Aider, Wolfram, …) normalize into the same vocabulary.
+///
+/// ADR 0008 discipline: recover exactly the structure the
+/// stream unambiguously provides; anything outside the known
+/// vocabulary is surfaced as a typed `Unknown` / `ParseError`
+/// carrying its provenance — never silently dropped, never
+/// relayed as ambiguous text.
+module AgentEvent =
+
+    /// One content block of an assistant message, as typed by
+    /// the stream itself.
+    type ContentBlock =
+        /// Prose (markdown) — decomposed into chunks on ingest.
+        | Text of text: string
+        /// A tool invocation; `inputJson` is the raw JSON of
+        /// the tool input (kept verbatim — the §6.2 "semantic
+        /// info about run code" verb renders it on demand).
+        | ToolUse of id: string * name: string * inputJson: string
+        /// A block type outside the known vocabulary; the type
+        /// tag is preserved for diagnostics.
+        | UnknownBlock of blockType: string
+
+    /// A tool's result, echoed back through the stream.
+    type ToolResult =
+        { ToolUseId: string
+          /// Flattened text of the result content (string or
+          /// text-block-array in the wire format).
+          Content: string
+          IsError: bool }
+
+    /// One typed event per stream-json line.
+    type AgentEvent =
+        /// `system/init` — the session began; carries the CLI
+        /// session id used for `--resume` continuity (E4).
+        | SessionInit of sessionId: string * model: string option
+        /// A complete assistant message (the E5 seal boundary).
+        | AssistantMessage of blocks: ContentBlock list
+        /// Tool results re-entering the conversation.
+        | ToolResults of results: ToolResult list
+        /// The turn finished; `resultText` is the CLI's final
+        /// result field when present.
+        | TurnResult of
+            isError: bool *
+            resultText: string option *
+            sessionId: string option
+        /// A line whose `type` is outside the known vocabulary
+        /// — surfaced, not dropped (ADR 0008).
+        | Unknown of eventType: string * rawJson: string
+        /// A line that was not valid JSON (or had no `type`).
+        | ParseError of message: string * rawLine: string

--- a/src/Engine.Core/ClaudeStreamJson.fs
+++ b/src/Engine.Core/ClaudeStreamJson.fs
@@ -1,0 +1,190 @@
+namespace Engine.Core
+
+open System
+open System.Text.Json
+open Engine.Core.AgentEvent
+
+/// ADR 0011 E4 — the Claude Code CLI stream-json line parser.
+/// Pure: one JSON line in, one typed `AgentEvent` out. No
+/// process handling here (that is `Engine.Participants`); no
+/// chunking here (that is `MarkdownChunker.fs` on ingest).
+///
+/// Wire format (verified against the CLI's `-p --output-format
+/// stream-json --verbose` mode; the fixture corpus in
+/// `ClaudeStreamJsonTests.fs` is the contract, and the Phase 0
+/// dogfood re-verifies on the maintainer's machine per ADR 0011
+/// E4): one JSON object per line —
+///
+///   {"type":"system","subtype":"init","session_id":…,"model":…}
+///   {"type":"assistant","message":{"content":[{"type":"text",…}
+///        | {"type":"tool_use","id":…,"name":…,"input":{…}}]}}
+///   {"type":"user","message":{"content":[{"type":"tool_result",
+///        "tool_use_id":…,"content":…,"is_error":…}]}}
+///   {"type":"result","subtype":…,"is_error":…,"result":…}
+///
+/// Tolerance rules: unknown top-level types → `Unknown`;
+/// unknown block types → `UnknownBlock`; malformed JSON →
+/// `ParseError`. Nothing throws; nothing is silently dropped.
+module ClaudeStreamJson =
+
+    /// A property's string value, when present and a string.
+    /// (`JsonElement.GetString()` is nullable-annotated; the
+    /// null arm is folded into `None`.)
+    let private tryStringProp
+            (el: JsonElement)
+            (name: string)
+            : string option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.String then
+            match v.GetString() with
+            | null -> None
+            | s -> Some s
+        else
+            None
+
+    let private tryBoolProp
+            (el: JsonElement)
+            (name: string)
+            : bool option =
+        let found, v = el.TryGetProperty(name)
+        if not found then None
+        elif v.ValueKind = JsonValueKind.True then Some true
+        elif v.ValueKind = JsonValueKind.False then Some false
+        else None
+
+    let private tryObjectProp
+            (el: JsonElement)
+            (name: string)
+            : JsonElement option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.Object then Some v
+        else None
+
+    let private tryArrayProp
+            (el: JsonElement)
+            (name: string)
+            : JsonElement option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.Array then Some v
+        else None
+
+    /// Flatten a `tool_result` content value: the wire carries
+    /// either a plain string or an array of `{type:"text"}`
+    /// blocks. Anything else flattens to "".
+    let private flattenResultContent (el: JsonElement) : string =
+        match el.ValueKind with
+        | JsonValueKind.String ->
+            match el.GetString() with
+            | null -> ""
+            | s -> s
+        | JsonValueKind.Array ->
+            el.EnumerateArray()
+            |> Seq.choose (fun item ->
+                if item.ValueKind = JsonValueKind.Object then
+                    match tryStringProp item "type" with
+                    | Some "text" -> tryStringProp item "text"
+                    | _ -> None
+                else None)
+            |> String.concat "\n"
+        | _ -> ""
+
+    /// One assistant-message content block → typed block.
+    let private parseContentBlock (el: JsonElement) : ContentBlock =
+        match tryStringProp el "type" with
+        | Some "text" ->
+            Text (tryStringProp el "text" |> Option.defaultValue "")
+        | Some "tool_use" ->
+            let inputJson =
+                let found, v = el.TryGetProperty("input")
+                if found then v.GetRawText() else "{}"
+            ToolUse (
+                tryStringProp el "id" |> Option.defaultValue "",
+                tryStringProp el "name" |> Option.defaultValue "",
+                inputJson)
+        | Some other -> UnknownBlock other
+        | None -> UnknownBlock "<untyped>"
+
+    /// The `message.content` array of an envelope, as blocks.
+    let private messageBlocks (root: JsonElement) : ContentBlock list =
+        match tryObjectProp root "message" with
+        | None -> []
+        | Some message ->
+            match tryArrayProp message "content" with
+            | None -> []
+            | Some content ->
+                content.EnumerateArray()
+                |> Seq.map parseContentBlock
+                |> List.ofSeq
+
+    /// A `user` envelope's tool results (only `tool_result`
+    /// blocks are typed; the CLI's user envelopes carry tool
+    /// results, not human input).
+    let private toolResults (root: JsonElement) : ToolResult list =
+        match tryObjectProp root "message" with
+        | None -> []
+        | Some message ->
+            match tryArrayProp message "content" with
+            | None -> []
+            | Some content ->
+                content.EnumerateArray()
+                |> Seq.choose (fun block ->
+                    if block.ValueKind <> JsonValueKind.Object then
+                        None
+                    else
+                        match tryStringProp block "type" with
+                        | Some "tool_result" ->
+                            let payload : ToolResult =
+                                { ToolUseId =
+                                    tryStringProp block "tool_use_id"
+                                    |> Option.defaultValue ""
+                                  Content =
+                                    let found, v =
+                                        block.TryGetProperty("content")
+                                    if found then flattenResultContent v
+                                    else ""
+                                  IsError =
+                                    tryBoolProp block "is_error"
+                                    |> Option.defaultValue false }
+                            Some payload
+                        | _ -> None)
+                |> List.ofSeq
+
+    /// Parse one stream line. `None` for blank lines (the line
+    /// pump may deliver trailing empties); every non-blank line
+    /// yields exactly one typed event.
+    let parseLine (line: string) : AgentEvent.AgentEvent option =
+        if String.IsNullOrWhiteSpace line then
+            None
+        else
+            try
+                use doc = JsonDocument.Parse(line)
+                let root = doc.RootElement
+                if root.ValueKind <> JsonValueKind.Object then
+                    Some (ParseError ("not a JSON object", line))
+                else
+                    match tryStringProp root "type" with
+                    | Some "system" ->
+                        match tryStringProp root "subtype" with
+                        | Some "init" ->
+                            Some (SessionInit (
+                                tryStringProp root "session_id"
+                                |> Option.defaultValue "",
+                                tryStringProp root "model"))
+                        | _ ->
+                            Some (Unknown ("system", root.GetRawText()))
+                    | Some "assistant" ->
+                        Some (AssistantMessage (messageBlocks root))
+                    | Some "user" ->
+                        Some (ToolResults (toolResults root))
+                    | Some "result" ->
+                        Some (TurnResult (
+                            tryBoolProp root "is_error"
+                            |> Option.defaultValue false,
+                            tryStringProp root "result",
+                            tryStringProp root "session_id"))
+                    | Some other ->
+                        Some (Unknown (other, root.GetRawText()))
+                    | None ->
+                        Some (ParseError ("missing type", line))
+            with :? JsonException as ex ->
+                Some (ParseError (ex.Message, line))

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -17,6 +17,13 @@
   <ItemGroup>
     <Compile Include="Chunk.fs" />
     <Compile Include="ChunkTree.fs" />
+    <!--
+      ADR 0011 E4 — the participant-stream vocabulary + the
+      Claude CLI stream-json parser (pure; System.Text.Json is
+      inbox on net9.0, no package needed).
+    -->
+    <Compile Include="AgentEvent.fs" />
+    <Compile Include="ClaudeStreamJson.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Unit/ClaudeStreamJsonTests.fs
+++ b/tests/Tests.Unit/ClaudeStreamJsonTests.fs
@@ -1,0 +1,151 @@
+module PtySpeak.Tests.Unit.ClaudeStreamJsonTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.AgentEvent
+
+// ---------------------------------------------------------------------
+// ADR 0011 E4 — Claude CLI stream-json parser contract tests.
+// ---------------------------------------------------------------------
+//
+// The fixture lines mirror the CLI's `-p --output-format
+// stream-json --verbose` output shape; this corpus is the
+// parser's contract until the Phase 0 dogfood re-verifies the
+// wire format on the maintainer's machine (ADR 0011 E4). The
+// tolerance rules are the load-bearing part: unknown types are
+// surfaced typed, malformed lines become ParseError, and no
+// input shape throws.
+
+let private parsed (line: string) : AgentEvent.AgentEvent =
+    match ClaudeStreamJson.parseLine line with
+    | Some ev -> ev
+    | None -> failwith "expected an event for a non-blank line"
+
+[<Fact>]
+let ``blank and whitespace lines produce no event`` () =
+    Assert.True((ClaudeStreamJson.parseLine "").IsNone)
+    Assert.True((ClaudeStreamJson.parseLine "   ").IsNone)
+
+[<Fact>]
+let ``system init yields SessionInit with session id and model`` () =
+    let line =
+        """{"type":"system","subtype":"init","cwd":"C:\\work","session_id":"abc-123","tools":["Bash"],"model":"claude-sonnet-4-6"}"""
+    match parsed line with
+    | SessionInit (sid, model) ->
+        Assert.Equal("abc-123", sid)
+        Assert.Equal(Some "claude-sonnet-4-6", model)
+    | other -> failwithf "expected SessionInit, got %A" other
+
+[<Fact>]
+let ``assistant text message yields typed Text blocks`` () =
+    let line =
+        """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"# Hi\n\nHello there."}]},"session_id":"abc-123"}"""
+    match parsed line with
+    | AssistantMessage [ Text t ] ->
+        Assert.Equal("# Hi\n\nHello there.", t)
+    | other -> failwithf "expected one Text block, got %A" other
+
+[<Fact>]
+let ``assistant tool_use block carries id name and raw input json`` () =
+    let line =
+        """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"dir"}}]}}"""
+    match parsed line with
+    | AssistantMessage [ ToolUse (id, name, inputJson) ] ->
+        Assert.Equal("toolu_01", id)
+        Assert.Equal("Bash", name)
+        Assert.Contains("\"command\"", inputJson)
+    | other -> failwithf "expected one ToolUse block, got %A" other
+
+[<Fact>]
+let ``mixed content keeps block order and types unknown blocks`` () =
+    let line =
+        """{"type":"assistant","message":{"content":[{"type":"text","text":"before"},{"type":"thinking","thinking":"..."},{"type":"text","text":"after"}]}}"""
+    match parsed line with
+    | AssistantMessage [ Text "before"; UnknownBlock "thinking"; Text "after" ] -> ()
+    | other -> failwithf "expected text/unknown/text, got %A" other
+
+[<Fact>]
+let ``user tool_result with string content yields ToolResults`` () =
+    let line =
+        """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"file1.txt\nfile2.txt","is_error":false}]}}"""
+    match parsed line with
+    | ToolResults [ r ] ->
+        Assert.Equal("toolu_01", r.ToolUseId)
+        Assert.Equal("file1.txt\nfile2.txt", r.Content)
+        Assert.False(r.IsError)
+    | other -> failwithf "expected one ToolResult, got %A" other
+
+[<Fact>]
+let ``user tool_result with text-block-array content is flattened`` () =
+    let line =
+        """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_02","content":[{"type":"text","text":"line A"},{"type":"text","text":"line B"}],"is_error":true}]}}"""
+    match parsed line with
+    | ToolResults [ r ] ->
+        Assert.Equal("line A\nline B", r.Content)
+        Assert.True(r.IsError)
+    | other -> failwithf "expected one ToolResult, got %A" other
+
+[<Fact>]
+let ``result line yields TurnResult with text and session`` () =
+    let line =
+        """{"type":"result","subtype":"success","is_error":false,"duration_ms":4200,"num_turns":3,"result":"Done.","session_id":"abc-123","total_cost_usd":0.012}"""
+    match parsed line with
+    | TurnResult (isError, text, sid) ->
+        Assert.False(isError)
+        Assert.Equal(Some "Done.", text)
+        Assert.Equal(Some "abc-123", sid)
+    | other -> failwithf "expected TurnResult, got %A" other
+
+[<Fact>]
+let ``error result keeps the error flag`` () =
+    let line =
+        """{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"abc-123"}"""
+    match parsed line with
+    | TurnResult (true, None, Some "abc-123") -> ()
+    | other -> failwithf "expected error TurnResult, got %A" other
+
+[<Fact>]
+let ``unknown top-level type is surfaced typed not dropped`` () =
+    let line = """{"type":"stream_event","event":{"foo":1}}"""
+    match parsed line with
+    | Unknown ("stream_event", raw) -> Assert.Contains("foo", raw)
+    | other -> failwithf "expected Unknown, got %A" other
+
+[<Fact>]
+let ``malformed json becomes ParseError carrying the line`` () =
+    let line = """{"type":"assistant","message":"""
+    match parsed line with
+    | ParseError (_, raw) -> Assert.Equal(line, raw)
+    | other -> failwithf "expected ParseError, got %A" other
+
+[<Fact>]
+let ``json without a type field becomes ParseError`` () =
+    match parsed """{"foo":"bar"}""" with
+    | ParseError (msg, _) -> Assert.Contains("type", msg)
+    | other -> failwithf "expected ParseError, got %A" other
+
+[<Fact>]
+let ``non-object json becomes ParseError`` () =
+    match parsed "[1,2,3]" with
+    | ParseError _ -> ()
+    | other -> failwithf "expected ParseError, got %A" other
+
+[<Fact>]
+let ``a multi-line transcript parses to the expected event sequence`` () =
+    // A miniature end-to-end turn: init → assistant(tool_use) →
+    // tool_result → assistant(text) → result.
+    let transcript =
+        [ """{"type":"system","subtype":"init","session_id":"s1","model":"m"}"""
+          """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"x.fs"}}]}}"""
+          """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"let x = 1"}]}}"""
+          """{"type":"assistant","message":{"content":[{"type":"text","text":"The file defines x."}]}}"""
+          """{"type":"result","subtype":"success","is_error":false,"result":"The file defines x.","session_id":"s1"}""" ]
+    let events = transcript |> List.choose ClaudeStreamJson.parseLine
+    Assert.Equal(5, List.length events)
+    match events with
+    | [ SessionInit ("s1", Some "m");
+        AssistantMessage [ ToolUse ("t1", "Read", _) ];
+        ToolResults [ _ ];
+        AssistantMessage [ Text "The file defines x." ];
+        TurnResult (false, Some _, Some "s1") ] -> ()
+    | other -> failwithf "unexpected event sequence: %A" other

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -97,6 +97,7 @@
       a Windows TFM referencing a plain TFM is fine.
     -->
     <Compile Include="ChunkTreeTests.fs" />
+    <Compile Include="ClaudeStreamJsonTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Phase 0 PR-2 (per [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)):

- **`AgentEvent.fs`** — the typed vocabulary a participant's structured stream normalizes into: `SessionInit` / `AssistantMessage` (typed content blocks: `Text`, `ToolUse` with verbatim input JSON, `UnknownBlock`) / `ToolResults` / `TurnResult` / typed `Unknown` + `ParseError`.
- **`ClaudeStreamJson.fs`** — pure one-line-in / one-typed-event-out parser for the Claude Code CLI's `-p --output-format stream-json --verbose` format. Tolerance rules are the load-bearing part (ADR 0008): unknown types surface typed, never silently dropped, never relayed ambiguous; malformed lines → `ParseError`; nothing throws. `System.Text.Json` is inbox on net9.0 — no new package.
- **`ClaudeStreamJsonTests.fs`** — fixture corpus covering init / text / tool_use / tool_result (string + block-array content) / success + error results / unknown types / malformed lines / a full miniature turn. This corpus is the wire contract until the Phase 0 dogfood re-verifies the format on the maintainer's machine (E4).

Engine.Core stays platform-free (the new portability-lint gate from #444 covers these files).

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_