### PR TITLE
feat(engine): markdown → chunk-spec decomposition (ADR 0011 E2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15642,6 +15642,18 @@ ring) follow.
   wire contract until the Phase 0 dogfood re-verifies it on the
   maintainer's machine.
 
+### Phase 0 PR-3 (2026-06-11): markdown → chunk decomposition
+
+- **Added**: `Engine.Core/MarkdownChunker.fs` — the ADR 0011 E2
+  chunk grain realized: assistant markdown decomposed with
+  Markdig at the block boundaries the model itself marked
+  (heading / paragraph / list + items / fenced + indented code
+  / quote / thematic break), into a pure `ChunkSpec` forest
+  (nested lists nest under their item). Inline emphasis / code
+  / links flatten into narration text. Whitespace-only leaves
+  are dropped; structural kinds survive. `MarkdownChunkerTests`
+  pin the grain incl. a realistic agent-response decomposition.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -24,10 +24,18 @@
     -->
     <Compile Include="AgentEvent.fs" />
     <Compile Include="ClaudeStreamJson.fs" />
+    <!--
+      ADR 0011 E2 — markdown → chunk-spec decomposition (the
+      chunk grain). Markdig is platform-free and already in the
+      central package set (Terminal.Core uses it for the manual
+      tests HTML).
+    -->
+    <Compile Include="MarkdownChunker.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Markdig" />
   </ItemGroup>
 
 </Project>

--- a/src/Engine.Core/MarkdownChunker.fs
+++ b/src/Engine.Core/MarkdownChunker.fs
@@ -1,0 +1,166 @@
+namespace Engine.Core
+
+open Markdig
+open Markdig.Syntax
+open Markdig.Syntax.Inlines
+
+/// ADR 0011 E2 — markdown → chunk decomposition (the chunk
+/// grain). An assistant text block is decomposed at the block
+/// boundaries the model itself marked (heading, paragraph,
+/// list, list item, fenced code, quote, thematic break): the
+/// structure is already present in the source and is kept,
+/// never flattened (ADR 0008 at conversation granularity,
+/// RELAUNCH-SPEC §5.1).
+///
+/// Pure: text in, `ChunkSpec` forest out. The tree (ids,
+/// capture order) is assigned by the ingest layer appending
+/// the specs; this module never touches `ChunkTree`.
+///
+/// `Engine.Core.Chunk` is deliberately NOT opened — Markdig's
+/// `ListBlock` / `CodeBlock` syntax types share names with the
+/// `ChunkKind` cases, so the kinds are `Chunk.`-qualified
+/// throughout.
+module MarkdownChunker =
+
+    /// A chunk-to-be: kind + narration text + nested children
+    /// (list items under their list; nested lists under their
+    /// item). Ids / ordering are assigned at append.
+    type ChunkSpec =
+        { Kind: Chunk.ChunkKind
+          Text: string
+          Children: ChunkSpec list }
+
+    /// Flatten an inline (sub)tree to plain narration text.
+    /// Literals, code spans, and line breaks carry text;
+    /// containers (emphasis, links) recurse; anything else
+    /// contributes nothing.
+    let rec private inlineToText (il: Inline) : string =
+        match il with
+        | :? LiteralInline as lit -> lit.Content.ToString()
+        | :? CodeInline as code -> code.Content
+        | :? LineBreakInline -> "\n"
+        | :? ContainerInline as container ->
+            container
+            |> Seq.cast<Inline>
+            |> Seq.map inlineToText
+            |> String.concat ""
+        | _ -> ""
+
+    /// A leaf block's processed inline text ("" when the parser
+    /// attached no inline tree, e.g. HTML blocks).
+    let private inlinesOf (leaf: LeafBlock) : string =
+        match leaf.Inline with
+        | null -> ""
+        | inl -> inlineToText (inl :> Inline)
+
+    /// One Markdig block → zero or more chunk specs. Fenced
+    /// code is matched before the indented-code base class.
+    let rec private blockToSpecs (block: Block) : ChunkSpec list =
+        match block with
+        | :? HeadingBlock as h ->
+            [ { Kind = Chunk.Heading h.Level
+                Text = inlinesOf h
+                Children = [] } ]
+        | :? FencedCodeBlock as f ->
+            let language =
+                match f.Info with
+                | null -> None
+                | "" -> None
+                | s -> Some s
+            [ { Kind = Chunk.CodeBlock language
+                Text = f.Lines.ToString()
+                Children = [] } ]
+        | :? Markdig.Syntax.CodeBlock as c ->
+            [ { Kind = Chunk.CodeBlock None
+                Text = c.Lines.ToString()
+                Children = [] } ]
+        | :? Markdig.Syntax.ListBlock as list ->
+            let items =
+                list
+                |> Seq.cast<Block>
+                |> Seq.choose (fun child ->
+                    match child with
+                    | :? ListItemBlock as item ->
+                        Some (listItemSpec item)
+                    | _ -> None)
+                |> List.ofSeq
+            [ { Kind = Chunk.ListBlock list.IsOrdered
+                Text = ""
+                Children = items } ]
+        | :? QuoteBlock as q ->
+            let inner =
+                q
+                |> Seq.cast<Block>
+                |> Seq.collect blockToSpecs
+                |> List.ofSeq
+            let text =
+                inner
+                |> List.map (fun s -> s.Text)
+                |> List.filter (fun t ->
+                    not (System.String.IsNullOrWhiteSpace t))
+                |> String.concat "\n"
+            [ { Kind = Chunk.BlockQuote
+                Text = text
+                Children = [] } ]
+        | :? ThematicBreakBlock ->
+            [ { Kind = Chunk.ThematicBreak
+                Text = ""
+                Children = [] } ]
+        | :? ParagraphBlock as p ->
+            [ { Kind = Chunk.Paragraph
+                Text = inlinesOf p
+                Children = [] } ]
+        | :? LeafBlock as leaf ->
+            // HTML blocks and similar — keep whatever text the
+            // inline tree provides; empties are filtered at the
+            // top level.
+            [ { Kind = Chunk.Paragraph
+                Text = inlinesOf leaf
+                Children = [] } ]
+        | :? ContainerBlock as container ->
+            container
+            |> Seq.cast<Block>
+            |> Seq.collect blockToSpecs
+            |> List.ofSeq
+        | _ -> []
+
+    /// One list item: its paragraph text becomes the item's
+    /// narration text; nested blocks (sub-lists, code) become
+    /// children.
+    and private listItemSpec (item: ListItemBlock) : ChunkSpec =
+        let childBlocks = item |> Seq.cast<Block> |> List.ofSeq
+        let textParts =
+            childBlocks
+            |> List.choose (fun b ->
+                match b with
+                | :? ParagraphBlock as p -> Some (inlinesOf p)
+                | _ -> None)
+        let nested =
+            childBlocks
+            |> List.collect (fun b ->
+                match b with
+                | :? ParagraphBlock -> []
+                | other -> blockToSpecs other)
+        { Kind = Chunk.ListItem
+          Text = textParts |> String.concat "\n"
+          Children = nested }
+
+    /// Decompose markdown into a chunk-spec forest. Whitespace-
+    /// only leaves are dropped; structural kinds (lists, breaks)
+    /// survive with empty text. A whitespace-only input yields
+    /// the empty forest.
+    let decompose (markdown: string) : ChunkSpec list =
+        if System.String.IsNullOrWhiteSpace markdown then
+            []
+        else
+            let doc = Markdown.Parse(markdown)
+            doc
+            |> Seq.cast<Block>
+            |> Seq.collect blockToSpecs
+            |> Seq.filter (fun spec ->
+                match spec.Kind with
+                | Chunk.ListBlock _ -> not spec.Children.IsEmpty
+                | Chunk.ThematicBreak -> true
+                | _ ->
+                    not (System.String.IsNullOrWhiteSpace spec.Text))
+            |> List.ofSeq

--- a/tests/Tests.Unit/MarkdownChunkerTests.fs
+++ b/tests/Tests.Unit/MarkdownChunkerTests.fs
@@ -1,0 +1,131 @@
+module PtySpeak.Tests.Unit.MarkdownChunkerTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.MarkdownChunker
+
+// ---------------------------------------------------------------------
+// ADR 0011 E2 — markdown → chunk-spec decomposition tests.
+// ---------------------------------------------------------------------
+//
+// Pins the chunk grain: block-level boundaries the model itself
+// marked. The chunker is pure (text → spec forest); ids and
+// ordering are the tree's concern, not tested here.
+
+[<Fact>]
+let ``whitespace-only input decomposes to nothing`` () =
+    Assert.Empty(MarkdownChunker.decompose "")
+    Assert.Empty(MarkdownChunker.decompose "   \n  ")
+
+[<Fact>]
+let ``plain prose becomes one paragraph spec`` () =
+    match MarkdownChunker.decompose "Just a sentence." with
+    | [ spec ] ->
+        Assert.Equal(Chunk.Paragraph, spec.Kind)
+        Assert.Equal("Just a sentence.", spec.Text)
+        Assert.Empty(spec.Children)
+    | other -> failwithf "expected one paragraph, got %A" other
+
+[<Fact>]
+let ``heading and paragraphs split at block boundaries`` () =
+    let md = "# Title\n\nFirst para.\n\nSecond para."
+    match MarkdownChunker.decompose md with
+    | [ h; p1; p2 ] ->
+        Assert.Equal(Chunk.Heading 1, h.Kind)
+        Assert.Equal("Title", h.Text)
+        Assert.Equal(Chunk.Paragraph, p1.Kind)
+        Assert.Equal("First para.", p1.Text)
+        Assert.Equal("Second para.", p2.Text)
+    | other -> failwithf "expected three specs, got %A" other
+
+[<Fact>]
+let ``emphasis and inline code flatten into narration text`` () =
+    match MarkdownChunker.decompose "Use **the** `dotnet` tool." with
+    | [ p ] -> Assert.Equal("Use the dotnet tool.", p.Text)
+    | other -> failwithf "expected one paragraph, got %A" other
+
+[<Fact>]
+let ``fenced code block keeps language and verbatim body`` () =
+    let md = "```fsharp\nlet x = 1\nlet y = 2\n```"
+    match MarkdownChunker.decompose md with
+    | [ c ] ->
+        Assert.Equal(Chunk.CodeBlock (Some "fsharp"), c.Kind)
+        Assert.Equal("let x = 1\nlet y = 2", c.Text.TrimEnd())
+    | other -> failwithf "expected one code block, got %A" other
+
+[<Fact>]
+let ``fence without info string has no language`` () =
+    match MarkdownChunker.decompose "```\nplain\n```" with
+    | [ c ] -> Assert.Equal(Chunk.CodeBlock None, c.Kind)
+    | other -> failwithf "expected one code block, got %A" other
+
+[<Fact>]
+let ``bulleted list becomes a list block with item children`` () =
+    let md = "- alpha\n- beta\n- gamma"
+    match MarkdownChunker.decompose md with
+    | [ list ] ->
+        Assert.Equal(Chunk.ListBlock false, list.Kind)
+        Assert.Equal<string list>(
+            [ "alpha"; "beta"; "gamma" ],
+            list.Children |> List.map (fun i -> i.Text))
+        for item in list.Children do
+            Assert.Equal(Chunk.ListItem, item.Kind)
+    | other -> failwithf "expected one list, got %A" other
+
+[<Fact>]
+let ``ordered list is marked ordered`` () =
+    match MarkdownChunker.decompose "1. one\n2. two" with
+    | [ list ] -> Assert.Equal(Chunk.ListBlock true, list.Kind)
+    | other -> failwithf "expected one list, got %A" other
+
+[<Fact>]
+let ``nested list nests under its parent item`` () =
+    let md = "- outer\n  - inner one\n  - inner two"
+    match MarkdownChunker.decompose md with
+    | [ list ] ->
+        match list.Children with
+        | [ outer ] ->
+            Assert.Equal("outer", outer.Text)
+            match outer.Children with
+            | [ nested ] ->
+                Assert.Equal(Chunk.ListBlock false, nested.Kind)
+                Assert.Equal<string list>(
+                    [ "inner one"; "inner two" ],
+                    nested.Children |> List.map (fun i -> i.Text))
+            | other -> failwithf "expected one nested list, got %A" other
+        | other -> failwithf "expected one outer item, got %A" other
+    | other -> failwithf "expected one list, got %A" other
+
+[<Fact>]
+let ``block quote flattens to one quote spec`` () =
+    match MarkdownChunker.decompose "> quoted wisdom" with
+    | [ q ] ->
+        Assert.Equal(Chunk.BlockQuote, q.Kind)
+        Assert.Equal("quoted wisdom", q.Text)
+    | other -> failwithf "expected one quote, got %A" other
+
+[<Fact>]
+let ``thematic break survives with empty text`` () =
+    let md = "before\n\n---\n\nafter"
+    match MarkdownChunker.decompose md with
+    | [ p1; hr; p2 ] ->
+        Assert.Equal(Chunk.Paragraph, p1.Kind)
+        Assert.Equal(Chunk.ThematicBreak, hr.Kind)
+        Assert.Equal("after", p2.Text)
+    | other -> failwithf "expected para/break/para, got %A" other
+
+[<Fact>]
+let ``a realistic agent response decomposes block by block`` () =
+    let md =
+        "# Plan\n\nTwo steps are needed.\n\n"
+        + "1. Read the file\n2. Fix the bug\n\n"
+        + "```fsharp\nlet fix () = ()\n```\n\n"
+        + "Done."
+    let specs = MarkdownChunker.decompose md
+    Assert.Equal<Chunk.ChunkKind list>(
+        [ Chunk.Heading 1
+          Chunk.Paragraph
+          Chunk.ListBlock true
+          Chunk.CodeBlock (Some "fsharp")
+          Chunk.Paragraph ],
+        specs |> List.map (fun s -> s.Kind))

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -98,6 +98,7 @@
     -->
     <Compile Include="ChunkTreeTests.fs" />
     <Compile Include="ClaudeStreamJsonTests.fs" />
+    <Compile Include="MarkdownChunkerTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Phase 0 PR-3 (per [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)): the **chunk grain** — assistant markdown decomposed with Markdig at the block boundaries the model itself marked (RELAUNCH-SPEC §5.1 / ADR 0008: the structure is already in the source; keep it, never flatten).

- **`MarkdownChunker.fs`** — pure text → `ChunkSpec` forest: heading / paragraph / list (+ item children, nested lists nest under their item) / fenced + indented code (language kept) / quote (flattened) / thematic break. Inline emphasis, code spans, and links flatten into narration text. Whitespace-only leaves drop; structural kinds survive.
- **`MarkdownChunkerTests.fs`** — pins the grain, including a realistic multi-block agent response.

Markdig is already in the central package set (Terminal.Core uses it); it is platform-free, so the Engine.Core portability gate stays satisfied.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_