### PR TITLE
feat(engine): instance-scoped engine event bus + ingest fold (ADR 0011 E5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15654,6 +15654,24 @@ ring) follow.
   are dropped; structural kinds survive. `MarkdownChunkerTests`
   pin the grain incl. a realistic agent-response decomposition.
 
+### Phase 0 PR-4 (2026-06-11): engine event bus + ingest fold
+
+- **Added**: `Engine.Core/EngineEvent.fs` — the universal event
+  bus, engine instance (RELAUNCH-SPEC §0.1): typed
+  `EngineEvent` vocabulary (`RequestCaptured` / `SessionStarted`
+  / `ChunkSealed` / `ResponseProgress` / `ResponseCompleted` /
+  `EngineNote`) on an **instance-scoped** `EngineBus`
+  (token-keyed subscribe, snapshot-then-fire, throwing-sink
+  guard — the CellEventBus shape without the global state).
+- **Added**: `Engine.Core/Ingest.fs` — the §5.2 streaming rule
+  as a pure fold: `captureRequest` (typed-act capture, branch
+  anchoring) + `applyAgentEvent` (assistant messages decompose
+  + seal at message boundaries; tool use / results seal typed
+  chunks; unknown shapes surface as ambient notes, never in the
+  tree; turn results complete without re-appending duplicate
+  text; latest-response-start tracked for the §6.2 jump verb).
+  `EngineBusTests` + `IngestTests` pin both.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -31,6 +31,14 @@
       tests HTML).
     -->
     <Compile Include="MarkdownChunker.fs" />
+    <!--
+      RELAUNCH-SPEC §0.1 / ADR 0011 E5 — the engine's universal
+      event bus (instance-scoped) + the ingest fold (the §5.2
+      streaming rule). Ingest depends on the chunker + the bus
+      event vocabulary, so both sit after MarkdownChunker.
+    -->
+    <Compile Include="EngineEvent.fs" />
+    <Compile Include="Ingest.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/EngineEvent.fs
+++ b/src/Engine.Core/EngineEvent.fs
@@ -1,0 +1,80 @@
+namespace Engine.Core
+
+open System
+
+/// RELAUNCH-SPEC §0.1 — the universal event bus, the engine's
+/// instance. One typed semantic stream; every output mechanism
+/// (the Phase 0 self-voicing channel first; spatial audio,
+/// braille, haptics later) is merely a subscriber — never a
+/// foundation, never privileged.
+///
+/// Unlike the WPF app's `Terminal.Core.CellEventBus` (global,
+/// module-scoped — kept untouched per ADR 0011 E9), the engine
+/// bus is **instance-scoped**: a host owns one bus per engine,
+/// so tests and multiple engines compose without shared state.
+/// The subscriber registry mirrors the battle-tested
+/// token-keyed-map-under-a-lock shape.
+module EngineEvent =
+
+    /// The typed engine event vocabulary. Cases are added by
+    /// the phase that wires them (the established discipline) —
+    /// Phase 0 declares only what Phase 0 publishes.
+    type EngineEvent =
+        /// The user's composed request was captured into the
+        /// tree (the §6.1 narrate-and-confirm subject).
+        | RequestCaptured of Chunk.Chunk
+        /// The participant session began (carries the CLI
+        /// session id used for continuity).
+        | SessionStarted of sessionId: string
+        /// A chunk was sealed into the tree (§5.2 — only sealed
+        /// chunks are ever published; navigation never observes
+        /// a moving target).
+        | ChunkSealed of Chunk.Chunk
+        /// Ambient in-flight progress: chunks sealed so far in
+        /// the current turn (§5.2's peripheral signal).
+        | ResponseProgress of chunkCount: int
+        /// The turn finished; `isError` is the stream's own
+        /// flag. Carries the total sealed-chunk count so a
+        /// completion announcement needs no tree query.
+        | ResponseCompleted of isError: bool * chunkCount: int
+        /// An engine-side diagnostic / lifecycle note (ambient;
+        /// e.g. an unknown stream event surfaced per ADR 0008).
+        | EngineNote of text: string
+
+    /// The instance-scoped bus. Snapshot-then-fire under a
+    /// lock; a throwing subscriber neither aborts the others
+    /// nor propagates into the publisher (it must never break
+    /// ingest). Subscriber exceptions are intentionally
+    /// swallowed here — the Phase 0 host wires a logging
+    /// subscriber for diagnostics rather than the bus taking a
+    /// logger dependency.
+    type EngineBus() =
+        let gate: obj = obj ()
+        let mutable nextToken = 0
+        let mutable subscribers: Map<int, EngineEvent -> unit> =
+            Map.empty
+
+        /// Subscribe until the returned IDisposable is
+        /// disposed. Token-keyed so disposing one subscription
+        /// cannot remove another with an identical lambda.
+        member _.Subscribe(handler: EngineEvent -> unit) : IDisposable =
+            let token =
+                lock gate (fun () ->
+                    let t = nextToken
+                    nextToken <- t + 1
+                    subscribers <- subscribers |> Map.add t handler
+                    t)
+            { new IDisposable with
+                member _.Dispose() =
+                    lock gate (fun () ->
+                        subscribers <- subscribers |> Map.remove token) }
+
+        /// Publish one event to every current subscriber.
+        member _.Publish(event: EngineEvent) : unit =
+            let snapshot = lock gate (fun () -> subscribers)
+            snapshot
+            |> Map.iter (fun _ handler ->
+                try
+                    handler event
+                with _ ->
+                    ())

--- a/src/Engine.Core/Ingest.fs
+++ b/src/Engine.Core/Ingest.fs
@@ -1,0 +1,184 @@
+namespace Engine.Core
+
+open Engine.Core.AgentEvent
+open Engine.Core.EngineEvent
+
+/// RELAUNCH-SPEC §5.2 / ADR 0011 E5 — the ingest fold. Typed
+/// participant events in, (new session state, engine events to
+/// publish) out. Pure: no bus, no I/O — the host publishes the
+/// returned events, which keeps every sealing rule unit-testable.
+///
+/// The streaming rule, realized: chunks enter the tree (and are
+/// announced as `ChunkSealed`) only at assistant-message /
+/// tool-result boundaries — never mid-stream. In-flight turns
+/// surface only ambient `ResponseProgress` counts.
+module Ingest =
+
+    /// Engine session state (the capture layer's live cursor —
+    /// the tree itself is the §5.3 capture layer).
+    type Session =
+        { Tree: ChunkTree.Tree
+          /// The participant's session id (for `--resume`).
+          SessionId: string option
+          /// The `UserRequest` chunk the in-flight turn answers;
+          /// sealed response chunks nest under it.
+          CurrentRequest: Chunk.ChunkId option
+          /// First chunk of the latest response — the §6.2
+          /// "jump to start of latest agent response" target.
+          LatestResponseStart: Chunk.ChunkId option
+          /// Chunks sealed so far in the in-flight turn.
+          InFlightCount: int }
+
+    let empty : Session =
+        { Tree = ChunkTree.empty
+          SessionId = None
+          CurrentRequest = None
+          LatestResponseStart = None
+          InFlightCount = 0 }
+
+    /// Append one chunk under `parent`, tolerating the
+    /// (structurally unreachable) missing-parent error by
+    /// appending at top level instead — ingest must never lose
+    /// content.
+    let private appendSafe
+            (parent: Chunk.ChunkId option)
+            (kind: Chunk.ChunkKind)
+            (text: string)
+            (tree: ChunkTree.Tree)
+            : Chunk.Chunk * ChunkTree.Tree =
+        match ChunkTree.append parent kind text tree with
+        | Ok (chunk, tree') -> chunk, tree'
+        | Error _ ->
+            match ChunkTree.append None kind text tree with
+            | Ok (chunk, tree') -> chunk, tree'
+            | Error msg ->
+                // Top-level append cannot fail by construction.
+                failwith msg
+
+    /// Append a chunk-spec forest (depth-first, authored order)
+    /// under `parent`. Returns appended chunks in seal order.
+    let rec private appendSpecs
+            (parent: Chunk.ChunkId option)
+            (specs: MarkdownChunker.ChunkSpec list)
+            (tree: ChunkTree.Tree)
+            : Chunk.Chunk list * ChunkTree.Tree =
+        ((([], tree)), specs)
+        ||> List.fold (fun (acc, t) spec ->
+            let chunk, t1 = appendSafe parent spec.Kind spec.Text t
+            let childChunks, t2 =
+                appendSpecs (Some chunk.Id) spec.Children t1
+            (acc @ (chunk :: childChunks), t2))
+
+    /// Capture the user's composed request as a typed act into
+    /// the tree (the §0.2 interaction-manager move). `anchor`
+    /// is `None` for the main thread; `Some chunkId` forks a
+    /// clarification branch under that chunk (§5.1). A new turn
+    /// begins: the in-flight counters reset.
+    let captureRequest
+            (text: string)
+            (anchor: Chunk.ChunkId option)
+            (session: Session)
+            : Session * EngineEvent list =
+        let chunk, tree =
+            appendSafe anchor Chunk.UserRequest text session.Tree
+        let session' =
+            { session with
+                Tree = tree
+                CurrentRequest = Some chunk.Id
+                InFlightCount = 0 }
+        session', [ RequestCaptured chunk ]
+
+    /// Seal a batch of chunks: emits one `ChunkSealed` per
+    /// chunk plus one trailing ambient progress count, and
+    /// records the latest-response start on the first batch of
+    /// a turn.
+    let private sealBatch
+            (chunks: Chunk.Chunk list)
+            (tree: ChunkTree.Tree)
+            (session: Session)
+            : Session * EngineEvent list =
+        match chunks with
+        | [] -> { session with Tree = tree }, []
+        | first :: _ ->
+            let latestStart =
+                if session.InFlightCount = 0 then Some first.Id
+                else session.LatestResponseStart
+            let count = session.InFlightCount + List.length chunks
+            let session' =
+                { session with
+                    Tree = tree
+                    LatestResponseStart = latestStart
+                    InFlightCount = count }
+            let events =
+                (chunks |> List.map ChunkSealed)
+                @ [ ResponseProgress count ]
+            session', events
+
+    /// Fold one typed participant event into the session.
+    let applyAgentEvent
+            (event: AgentEvent.AgentEvent)
+            (session: Session)
+            : Session * EngineEvent list =
+        match event with
+        | SessionInit (sid, _model) ->
+            { session with SessionId = Some sid },
+            [ SessionStarted sid ]
+        | AssistantMessage blocks ->
+            let parent = session.CurrentRequest
+            let chunks, tree, notes =
+                ((([], session.Tree, []): Chunk.Chunk list * ChunkTree.Tree * EngineEvent list),
+                 blocks)
+                ||> List.fold (fun (acc, t, ns) block ->
+                    match block with
+                    | Text text ->
+                        let specs = MarkdownChunker.decompose text
+                        let sealed_, t' = appendSpecs parent specs t
+                        (acc @ sealed_, t', ns)
+                    | ToolUse (_id, name, inputJson) ->
+                        let chunk, t' =
+                            appendSafe
+                                parent
+                                (Chunk.ToolUse name)
+                                inputJson
+                                t
+                        (acc @ [ chunk ], t', ns)
+                    | UnknownBlock blockType ->
+                        // Surfaced ambient, not entombed in the
+                        // tree (ADR 0008: typed and visible).
+                        let note =
+                            EngineNote (
+                                sprintf
+                                    "Unrecognized content block type: %s"
+                                    blockType)
+                        (acc, t, ns @ [ note ]))
+            let session', sealEvents = sealBatch chunks tree session
+            session', sealEvents @ notes
+        | ToolResults results ->
+            let parent = session.CurrentRequest
+            let chunks, tree =
+                ((([], session.Tree)), results)
+                ||> List.fold (fun (acc, t) r ->
+                    let chunk, t' =
+                        appendSafe
+                            parent
+                            (Chunk.ToolResult r.IsError)
+                            r.Content
+                            t
+                    (acc @ [ chunk ], t'))
+            sealBatch chunks tree session
+        | TurnResult (isError, _resultText, sid) ->
+            // The result text duplicates the final assistant
+            // message — not re-appended (no double content).
+            let session' =
+                match sid with
+                | Some s -> { session with SessionId = Some s }
+                | None -> session
+            session',
+            [ ResponseCompleted (isError, session'.InFlightCount) ]
+        | Unknown (eventType, _raw) ->
+            session,
+            [ EngineNote (
+                sprintf "Unrecognized stream event type: %s" eventType) ]
+        | ParseError (message, _line) ->
+            session,
+            [ EngineNote (sprintf "Stream parse error: %s" message) ]

--- a/tests/Tests.Unit/EngineBusTests.fs
+++ b/tests/Tests.Unit/EngineBusTests.fs
@@ -1,0 +1,63 @@
+module PtySpeak.Tests.Unit.EngineBusTests
+
+open Xunit
+open Engine.Core.EngineEvent
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §0.1 — universal event bus (engine instance).
+// ---------------------------------------------------------------------
+//
+// Mirrors the CellEventBus contract suite, instance-scoped:
+// delivery, unsubscribe, multi-subscriber fan-out, instance
+// isolation, and the throwing-subscriber guard.
+
+[<Fact>]
+let ``a subscriber receives published events in order`` () =
+    let bus = EngineBus()
+    let received = ResizeArray<EngineEvent>()
+    use _sub = bus.Subscribe(fun ev -> received.Add ev)
+    bus.Publish(SessionStarted "s1")
+    bus.Publish(ResponseProgress 1)
+    Assert.Equal(2, received.Count)
+    match received.[0], received.[1] with
+    | SessionStarted "s1", ResponseProgress 1 -> ()
+    | a, b -> failwithf "unexpected %A %A" a b
+
+[<Fact>]
+let ``disposing the subscription stops delivery`` () =
+    let bus = EngineBus()
+    let mutable count = 0
+    let sub = bus.Subscribe(fun _ -> count <- count + 1)
+    bus.Publish(ResponseProgress 1)
+    sub.Dispose()
+    bus.Publish(ResponseProgress 2)
+    Assert.Equal(1, count)
+
+[<Fact>]
+let ``every subscriber receives every event`` () =
+    let bus = EngineBus()
+    let mutable a = 0
+    let mutable b = 0
+    use _s1 = bus.Subscribe(fun _ -> a <- a + 1)
+    use _s2 = bus.Subscribe(fun _ -> b <- b + 1)
+    bus.Publish(EngineNote "x")
+    Assert.Equal(1, a)
+    Assert.Equal(1, b)
+
+[<Fact>]
+let ``buses are instance-isolated`` () =
+    let bus1 = EngineBus()
+    let bus2 = EngineBus()
+    let mutable count = 0
+    use _sub = bus1.Subscribe(fun _ -> count <- count + 1)
+    bus2.Publish(EngineNote "elsewhere")
+    Assert.Equal(0, count)
+
+[<Fact>]
+let ``a throwing subscriber neither aborts others nor the publisher`` () =
+    let bus = EngineBus()
+    let mutable healthy = 0
+    use _bad = bus.Subscribe(fun _ -> failwith "sink crash")
+    use _good = bus.Subscribe(fun _ -> healthy <- healthy + 1)
+    bus.Publish(EngineNote "still works")
+    Assert.Equal(1, healthy)

--- a/tests/Tests.Unit/IngestTests.fs
+++ b/tests/Tests.Unit/IngestTests.fs
@@ -1,0 +1,181 @@
+module PtySpeak.Tests.Unit.IngestTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.AgentEvent
+open Engine.Core.EngineEvent
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §5.2 / ADR 0011 E5 — ingest-fold contract tests.
+// ---------------------------------------------------------------------
+//
+// Pins the streaming rule: chunks seal (and are announced) only
+// at message boundaries; in-flight turns surface ambient
+// progress counts; unknown stream shapes surface as typed notes
+// without polluting the tree; the latest-response-start tracking
+// feeds the §6.2 jump verb.
+
+let private sealedChunks (events: EngineEvent.EngineEvent list) =
+    events
+    |> List.choose (function
+        | ChunkSealed c -> Some c
+        | _ -> None)
+
+[<Fact>]
+let ``captureRequest appends a UserRequest and emits RequestCaptured`` () =
+    let session, events = Ingest.captureRequest "do the thing" None Ingest.empty
+    match events with
+    | [ RequestCaptured chunk ] ->
+        Assert.Equal(Chunk.UserRequest, chunk.Kind)
+        Assert.Equal("do the thing", chunk.Text)
+        Assert.Equal(Some chunk.Id, session.CurrentRequest)
+        Assert.Equal(1, ChunkTree.count session.Tree)
+    | other -> failwithf "expected RequestCaptured, got %A" other
+
+[<Fact>]
+let ``captureRequest with an anchor forks the branch under it`` () =
+    let s1, ev1 = Ingest.captureRequest "main" None Ingest.empty
+    let mainReq =
+        match ev1 with
+        | [ RequestCaptured c ] -> c
+        | other -> failwithf "unexpected %A" other
+    let s2, ev2 = Ingest.captureRequest "clarify?" (Some mainReq.Id) s1
+    match ev2 with
+    | [ RequestCaptured branch ] ->
+        Assert.Equal(Some mainReq.Id, branch.Parent)
+        Assert.Equal(Some branch.Id, s2.CurrentRequest)
+    | other -> failwithf "unexpected %A" other
+
+[<Fact>]
+let ``assistant text seals decomposed chunks under the request`` () =
+    let s1, ev1 = Ingest.captureRequest "explain" None Ingest.empty
+    let req =
+        match ev1 with
+        | [ RequestCaptured c ] -> c
+        | other -> failwithf "unexpected %A" other
+    let message =
+        AssistantMessage [ Text "# Plan\n\nStep one is easy." ]
+    let s2, events = Ingest.applyAgentEvent message s1
+    let chunks = sealedChunks events
+    Assert.Equal(2, List.length chunks)
+    Assert.Equal(Chunk.Heading 1, chunks.[0].Kind)
+    Assert.Equal(Chunk.Paragraph, chunks.[1].Kind)
+    for c in chunks do
+        Assert.Equal(Some req.Id, c.Parent)
+    // Trailing ambient progress carries the running count.
+    match List.last events with
+    | ResponseProgress 2 -> ()
+    | other -> failwithf "expected ResponseProgress 2, got %A" other
+    Assert.Equal(Some chunks.[0].Id, s2.LatestResponseStart)
+    Assert.Equal(2, s2.InFlightCount)
+
+[<Fact>]
+let ``a second message in the same turn accumulates without moving the start`` () =
+    let s1, _ = Ingest.captureRequest "go" None Ingest.empty
+    let s2, ev2 =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "First." ]) s1
+    let firstId = (sealedChunks ev2).Head.Id
+    let s3, ev3 =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "Second." ]) s2
+    Assert.Equal(Some firstId, s3.LatestResponseStart)
+    Assert.Equal(2, s3.InFlightCount)
+    match List.last ev3 with
+    | ResponseProgress 2 -> ()
+    | other -> failwithf "expected ResponseProgress 2, got %A" other
+
+[<Fact>]
+let ``a new turn resets the latest-response start`` () =
+    let s1, _ = Ingest.captureRequest "one" None Ingest.empty
+    let s2, _ =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "Answer one." ]) s1
+    let s3, _ = Ingest.captureRequest "two" None s2
+    Assert.Equal(0, s3.InFlightCount)
+    let s4, ev4 =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "Answer two." ]) s3
+    let newFirst = (sealedChunks ev4).Head.Id
+    Assert.Equal(Some newFirst, s4.LatestResponseStart)
+    Assert.NotEqual(s2.LatestResponseStart, s4.LatestResponseStart)
+
+[<Fact>]
+let ``tool use seals a ToolUse chunk carrying the input json`` () =
+    let s1, _ = Ingest.captureRequest "run it" None Ingest.empty
+    let message =
+        AssistantMessage [ ToolUse ("t1", "Bash", """{"command":"dir"}""") ]
+    let _s2, events = Ingest.applyAgentEvent message s1
+    match sealedChunks events with
+    | [ c ] ->
+        Assert.Equal(Chunk.ToolUse "Bash", c.Kind)
+        Assert.Contains("command", c.Text)
+    | other -> failwithf "expected one ToolUse chunk, got %A" other
+
+[<Fact>]
+let ``tool results seal ToolResult chunks`` () =
+    let s1, _ = Ingest.captureRequest "run it" None Ingest.empty
+    let results : AgentEvent.ToolResult list =
+        [ { ToolUseId = "t1"; Content = "out"; IsError = false }
+          { ToolUseId = "t2"; Content = "boom"; IsError = true } ]
+    let _s2, events = Ingest.applyAgentEvent (ToolResults results) s1
+    match sealedChunks events with
+    | [ ok_; err ] ->
+        Assert.Equal(Chunk.ToolResult false, ok_.Kind)
+        Assert.Equal("out", ok_.Text)
+        Assert.Equal(Chunk.ToolResult true, err.Kind)
+    | other -> failwithf "expected two ToolResult chunks, got %A" other
+
+[<Fact>]
+let ``turn result completes with the sealed count and error flag`` () =
+    let s1, _ = Ingest.captureRequest "go" None Ingest.empty
+    let s2, _ =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "Done deal." ]) s1
+    let _s3, events =
+        Ingest.applyAgentEvent (TurnResult (false, Some "Done deal.", Some "sid-1")) s2
+    match events with
+    | [ ResponseCompleted (false, 1) ] -> ()
+    | other -> failwithf "expected ResponseCompleted (false, 1), got %A" other
+
+[<Fact>]
+let ``turn result text is not re-appended to the tree`` () =
+    let s1, _ = Ingest.captureRequest "go" None Ingest.empty
+    let s2, _ =
+        Ingest.applyAgentEvent (AssistantMessage [ Text "Answer." ]) s1
+    let before = ChunkTree.count s2.Tree
+    let s3, _ =
+        Ingest.applyAgentEvent (TurnResult (false, Some "Answer.", None)) s2
+    Assert.Equal(before, ChunkTree.count s3.Tree)
+
+[<Fact>]
+let ``session init records the id and announces the session`` () =
+    let session, events =
+        Ingest.applyAgentEvent (SessionInit ("sid-9", Some "model")) Ingest.empty
+    Assert.Equal(Some "sid-9", session.SessionId)
+    match events with
+    | [ SessionStarted "sid-9" ] -> ()
+    | other -> failwithf "expected SessionStarted, got %A" other
+
+[<Fact>]
+let ``unknown events and parse errors become notes not chunks`` () =
+    let s1, ev1 =
+        Ingest.applyAgentEvent (Unknown ("stream_event", "{}")) Ingest.empty
+    let s2, ev2 =
+        Ingest.applyAgentEvent (ParseError ("bad json", "{oops")) s1
+    Assert.Equal(0, ChunkTree.count s2.Tree)
+    match ev1, ev2 with
+    | [ EngineNote n1 ], [ EngineNote n2 ] ->
+        Assert.Contains("stream_event", n1)
+        Assert.Contains("bad json", n2)
+    | other -> failwithf "expected notes, got %A" other
+
+[<Fact>]
+let ``unknown content blocks surface ambient and stay out of the tree`` () =
+    let s1, _ = Ingest.captureRequest "go" None Ingest.empty
+    let message =
+        AssistantMessage [ UnknownBlock "thinking"; Text "Visible." ]
+    let s2, events = Ingest.applyAgentEvent message s1
+    // One sealed chunk (the text), one ambient note (the block).
+    Assert.Equal(1, sealedChunks events |> List.length)
+    Assert.True(
+        events
+        |> List.exists (function
+            | EngineNote n -> n.Contains "thinking"
+            | _ -> false))
+    Assert.Equal(2, ChunkTree.count s2.Tree)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -99,6 +99,8 @@
     <Compile Include="ChunkTreeTests.fs" />
     <Compile Include="ClaudeStreamJsonTests.fs" />
     <Compile Include="MarkdownChunkerTests.fs" />
+    <Compile Include="EngineBusTests.fs" />
+    <Compile Include="IngestTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Phase 0 PR-4 (per [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)):

- **`EngineEvent.fs`** — the universal event bus, engine instance (RELAUNCH-SPEC §0.1): typed `EngineEvent` vocabulary (`RequestCaptured` / `SessionStarted` / `ChunkSealed` / `ResponseProgress` / `ResponseCompleted` / `EngineNote`) on an **instance-scoped** `EngineBus` — the battle-tested CellEventBus shape (token-keyed subscribe, snapshot-then-fire, throwing-sink guard) without the global mutable state, so tests and multiple engines compose.
- **`Ingest.fs`** — the §5.2 streaming rule as a pure fold (no bus, no I/O — the host publishes the returned events): `captureRequest` captures the user's intent as a typed act (with branch anchoring under any chunk); `applyAgentEvent` seals assistant content at message boundaries via the chunker, seals tool use/results as typed chunks, surfaces unknown stream shapes as ambient notes (never in the tree — ADR 0008), completes turns without re-appending duplicate result text, and tracks the latest-response start for the §6.2 jump verb.
- **`EngineBusTests.fs` + `IngestTests.fs`** pin delivery/unsubscribe/fan-out/guard and the full sealing discipline.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_