### PR TITLE
feat(engine): v1 navigation verbs + canonical narration (RELAUNCH-SPEC §6.2/§4.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15672,6 +15672,19 @@ ring) follow.
   text; latest-response-start tracked for the §6.2 jump verb).
   `EngineBusTests` + `IngestTests` pin both.
 
+### Phase 0 PR-5 (2026-06-11): navigation verbs + canonical narration
+
+- **Added**: `Engine.Core/Navigator.fs` — the RELAUNCH-SPEC
+  §6.2 v1 verbs as pure transitions (focus / jump-to-latest /
+  next / previous / descend / ascend / re-narrate /
+  push-anchor + return-to-anchor as a nesting stack). The §6.4
+  non-ejection invariant holds by construction: an `Edge`
+  outcome never moves focus and no verb can focus outside the
+  tree. `Engine.Core/ChunkNarration.fs` — canonical self-voicing
+  rendering (§4.6/§14.11): structure announced before content,
+  container child counts, §6.2 "what was run" for tool calls.
+  `NavigatorTests` + `ChunkNarrationTests` pin both.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/ChunkNarration.fs
+++ b/src/Engine.Core/ChunkNarration.fs
@@ -1,0 +1,63 @@
+namespace Engine.Core
+
+/// RELAUNCH-SPEC §4.6 / §14.11 — canonical narration rendering:
+/// the chunk's typed structure rendered to speakable text by
+/// the system itself (self-voicing — meaning is never re-derived
+/// by an external layer). Pure; the voice channel speaks the
+/// returned string verbatim.
+module ChunkNarration =
+
+    /// Render one chunk for narration. Structure is announced
+    /// before content (kind, then text) so a listener can skip
+    /// early; container kinds announce their child count from
+    /// the tree.
+    let describe
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : string =
+        let childCount =
+            ChunkTree.children (Some chunk.Id) tree |> List.length
+        match chunk.Kind with
+        | Chunk.Heading level ->
+            sprintf "Heading level %d. %s" level chunk.Text
+        | Chunk.Paragraph ->
+            chunk.Text
+        | Chunk.ListBlock ordered ->
+            let label = if ordered then "Numbered" else "Bulleted"
+            sprintf "%s list, %d items." label childCount
+        | Chunk.ListItem ->
+            if childCount > 0 then
+                sprintf "%s. Has nested content." chunk.Text
+            else
+                chunk.Text
+        | Chunk.CodeBlock language ->
+            let lineCount =
+                if chunk.Text = "" then 0
+                else (chunk.Text.Split('\n') |> Array.length)
+            match language with
+            | Some lang ->
+                sprintf
+                    "Code block, %s, %d lines. %s"
+                    lang lineCount chunk.Text
+            | None ->
+                sprintf "Code block, %d lines. %s" lineCount chunk.Text
+        | Chunk.BlockQuote ->
+            sprintf "Quote. %s" chunk.Text
+        | Chunk.ThematicBreak ->
+            "Separator."
+        | Chunk.UserRequest ->
+            sprintf "Your request: %s" chunk.Text
+        | Chunk.ToolUse name ->
+            // §6.2 "semantic info about run code": what was run,
+            // as structure. The raw input JSON is the chunk
+            // text; spoken on demand, after the tool name.
+            sprintf "Tool call, %s. Input: %s" name chunk.Text
+        | Chunk.ToolResult isError ->
+            if isError then
+                sprintf "Tool result, error. %s" chunk.Text
+            else
+                sprintf "Tool result. %s" chunk.Text
+        | Chunk.AgentError ->
+            sprintf "Agent error. %s" chunk.Text
+        | Chunk.SystemNote ->
+            chunk.Text

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -39,6 +39,13 @@
     -->
     <Compile Include="EngineEvent.fs" />
     <Compile Include="Ingest.fs" />
+    <!--
+      RELAUNCH-SPEC §6.2/§6.4 + §4.6 — the v1 navigation verbs
+      (pure transitions; non-ejection by construction) and the
+      canonical self-voicing narration rendering.
+    -->
+    <Compile Include="Navigator.fs" />
+    <Compile Include="ChunkNarration.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/Navigator.fs
+++ b/src/Engine.Core/Navigator.fs
@@ -1,0 +1,106 @@
+namespace Engine.Core
+
+/// RELAUNCH-SPEC §6.2 — the v1 navigation verbs, as pure
+/// transitions over the chunk tree. The non-ejection invariant
+/// (§6.4) holds by construction: every verb either moves focus
+/// to an existing chunk or reports an edge while leaving focus
+/// unchanged — focus can never land outside the content model.
+module Navigator =
+
+    /// Navigation state: the focused chunk plus the anchor
+    /// stack (§5.1 anchor + return; a stack so branches nest).
+    type State =
+        { Current: Chunk.ChunkId option
+          AnchorStack: Chunk.ChunkId list }
+
+    let initial : State =
+        { Current = None
+          AnchorStack = [] }
+
+    /// A verb's outcome. `Edge` carries a short canonical
+    /// description ("no next chunk") the voice channel renders;
+    /// focus is unchanged on `Edge` / `NothingFocused`.
+    type Move =
+        | Moved of Chunk.Chunk
+        | Edge of description: string
+        | NothingFocused
+
+    /// Focus a specific chunk (host-driven, e.g. after a seal
+    /// or a return-to-anchor).
+    let focus
+            (id: Chunk.ChunkId)
+            (state: State)
+            (tree: ChunkTree.Tree)
+            : State * Move =
+        match ChunkTree.tryFind id tree with
+        | Some chunk -> { state with Current = Some chunk.Id }, Moved chunk
+        | None -> state, Edge "that chunk is gone"
+
+    /// §6.2 "jump to the start of the latest agent response".
+    /// `latestStart` comes from `Ingest.Session`.
+    let jumpToLatestResponse
+            (latestStart: Chunk.ChunkId option)
+            (state: State)
+            (tree: ChunkTree.Tree)
+            : State * Move =
+        match latestStart with
+        | None -> state, Edge "no response yet"
+        | Some id -> focus id state tree
+
+    let private moveVia
+            (step: Chunk.ChunkId -> ChunkTree.Tree -> Chunk.Chunk option)
+            (edgeDescription: string)
+            (state: State)
+            (tree: ChunkTree.Tree)
+            : State * Move =
+        match state.Current with
+        | None -> state, NothingFocused
+        | Some id ->
+            match step id tree with
+            | Some chunk ->
+                { state with Current = Some chunk.Id }, Moved chunk
+            | None -> state, Edge edgeDescription
+
+    /// Next sibling chunk (authored order).
+    let next (state: State) (tree: ChunkTree.Tree) : State * Move =
+        moveVia ChunkTree.nextSibling "no next chunk" state tree
+
+    /// Previous sibling chunk.
+    let previous (state: State) (tree: ChunkTree.Tree) : State * Move =
+        moveVia ChunkTree.prevSibling "no previous chunk" state tree
+
+    /// Descend into the focused chunk's children.
+    let descend (state: State) (tree: ChunkTree.Tree) : State * Move =
+        moveVia ChunkTree.firstChild "no content inside" state tree
+
+    /// Ascend to the focused chunk's parent.
+    let ascend (state: State) (tree: ChunkTree.Tree) : State * Move =
+        moveVia
+            (fun id t -> ChunkTree.parent id t)
+            "already at the top level"
+            state
+            tree
+
+    /// The focused chunk, for re-narration (§6.2).
+    let current (state: State) (tree: ChunkTree.Tree) : Chunk.Chunk option =
+        state.Current
+        |> Option.bind (fun id -> ChunkTree.tryFind id tree)
+
+    /// Remember the focused chunk as a branch anchor (§5.1) —
+    /// called when the host starts a side branch from here.
+    let pushAnchor (state: State) : State =
+        match state.Current with
+        | None -> state
+        | Some id -> { state with AnchorStack = id :: state.AnchorStack }
+
+    /// §6.2 "return to anchor" — back to the exact chunk the
+    /// branch was spun from.
+    let returnToAnchor
+            (state: State)
+            (tree: ChunkTree.Tree)
+            : State * Move =
+        match state.AnchorStack with
+        | [] -> state, Edge "no anchor to return to"
+        | anchor :: rest ->
+            let popped = { state with AnchorStack = rest }
+            focus anchor popped tree

--- a/tests/Tests.Unit/ChunkNarrationTests.fs
+++ b/tests/Tests.Unit/ChunkNarrationTests.fs
@@ -1,0 +1,79 @@
+module PtySpeak.Tests.Unit.ChunkNarrationTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.Chunk
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §4.6 / §14.11 — canonical narration rendering.
+// ---------------------------------------------------------------------
+//
+// Structure announced before content; container kinds announce
+// child counts; tool calls render the §6.2 "what was run" info.
+
+let private ok r =
+    match r with
+    | Ok v -> v
+    | Error e -> failwithf "fixture build failed: %s" e
+
+let private describeSolo (kind: ChunkKind) (text: string) : string =
+    let chunk, tree = ok (ChunkTree.append None kind text ChunkTree.empty)
+    ChunkNarration.describe tree chunk
+
+[<Fact>]
+let ``paragraph narrates its text verbatim`` () =
+    Assert.Equal("Plain words.", describeSolo Paragraph "Plain words.")
+
+[<Fact>]
+let ``heading announces its level first`` () =
+    Assert.Equal(
+        "Heading level 2. Setup",
+        describeSolo (Heading 2) "Setup")
+
+[<Fact>]
+let ``list announces order and item count`` () =
+    let list, tree =
+        ok (ChunkTree.append None (ListBlock true) "" ChunkTree.empty)
+    let _, tree = ok (ChunkTree.append (Some list.Id) ListItem "one" tree)
+    let _, tree = ok (ChunkTree.append (Some list.Id) ListItem "two" tree)
+    Assert.Equal(
+        "Numbered list, 2 items.",
+        ChunkNarration.describe tree list)
+
+[<Fact>]
+let ``list item with nested content says so`` () =
+    let item, tree =
+        ok (ChunkTree.append None ListItem "outer" ChunkTree.empty)
+    let _, tree =
+        ok (ChunkTree.append (Some item.Id) (ListBlock false) "" tree)
+    Assert.Equal(
+        "outer. Has nested content.",
+        ChunkNarration.describe tree item)
+
+[<Fact>]
+let ``code block announces language and line count before the body`` () =
+    Assert.Equal(
+        "Code block, fsharp, 2 lines. let x = 1\nlet y = 2",
+        describeSolo (CodeBlock (Some "fsharp")) "let x = 1\nlet y = 2")
+
+[<Fact>]
+let ``tool call renders name then input`` () =
+    Assert.Equal(
+        """Tool call, Bash. Input: {"command":"dir"}""",
+        describeSolo (ToolUse "Bash") """{"command":"dir"}""")
+
+[<Fact>]
+let ``tool error result is announced as an error`` () =
+    Assert.Equal(
+        "Tool result, error. boom",
+        describeSolo (ToolResult true) "boom")
+
+[<Fact>]
+let ``user request is labelled`` () =
+    Assert.Equal(
+        "Your request: fix the bug",
+        describeSolo UserRequest "fix the bug")
+
+[<Fact>]
+let ``separator has a fixed word`` () =
+    Assert.Equal("Separator.", describeSolo ThematicBreak "")

--- a/tests/Tests.Unit/NavigatorTests.fs
+++ b/tests/Tests.Unit/NavigatorTests.fs
@@ -1,0 +1,151 @@
+module PtySpeak.Tests.Unit.NavigatorTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.Chunk
+open Engine.Core.Navigator
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §6.2 / §6.4 — navigation-verb contract tests.
+// ---------------------------------------------------------------------
+//
+// Pins the v1 verbs over a fixed small tree and the
+// non-ejection invariant: an Edge outcome never moves focus,
+// and no verb can focus a chunk outside the tree.
+
+/// Fixture: req ── [p1; list ── [item1; item2]; p2]
+type private Fixture =
+    { Tree: ChunkTree.Tree
+      Req: Chunk.Chunk
+      P1: Chunk.Chunk
+      List: Chunk.Chunk
+      Item1: Chunk.Chunk
+      Item2: Chunk.Chunk
+      P2: Chunk.Chunk }
+
+let private ok r =
+    match r with
+    | Ok v -> v
+    | Error e -> failwithf "fixture build failed: %s" e
+
+let private fixture () : Fixture =
+    let req, t = ok (ChunkTree.append None UserRequest "req" ChunkTree.empty)
+    let p1, t = ok (ChunkTree.append (Some req.Id) Paragraph "first" t)
+    let list, t = ok (ChunkTree.append (Some req.Id) (ListBlock false) "" t)
+    let item1, t = ok (ChunkTree.append (Some list.Id) ListItem "alpha" t)
+    let item2, t = ok (ChunkTree.append (Some list.Id) ListItem "beta" t)
+    let p2, t = ok (ChunkTree.append (Some req.Id) Paragraph "last" t)
+    { Tree = t; Req = req; P1 = p1; List = list
+      Item1 = item1; Item2 = item2; P2 = p2 }
+
+let private movedTo (expected: ChunkId) (move: Move) =
+    match move with
+    | Moved c -> Assert.Equal<ChunkId>(expected, c.Id)
+    | other -> failwithf "expected Moved, got %A" other
+
+[<Fact>]
+let ``verbs report NothingFocused before any focus`` () =
+    let f = fixture ()
+    let _, move = Navigator.next Navigator.initial f.Tree
+    match move with
+    | NothingFocused -> ()
+    | other -> failwithf "expected NothingFocused, got %A" other
+
+[<Fact>]
+let ``jump to latest response focuses its first chunk`` () =
+    let f = fixture ()
+    let state, move =
+        Navigator.jumpToLatestResponse (Some f.P1.Id) Navigator.initial f.Tree
+    movedTo f.P1.Id move
+    Assert.Equal(Some f.P1.Id, state.Current)
+
+[<Fact>]
+let ``jump with no response yet is an Edge and keeps focus`` () =
+    let f = fixture ()
+    let state, move =
+        Navigator.jumpToLatestResponse None Navigator.initial f.Tree
+    match move with
+    | Edge _ -> Assert.Equal(None, state.Current)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``next and previous walk siblings and stop at edges without moving`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree
+    let s1, m1 = Navigator.next s0 f.Tree
+    movedTo f.List.Id m1
+    let s2, m2 = Navigator.next s1 f.Tree
+    movedTo f.P2.Id m2
+    // Edge: no next — focus must not move (§6.4).
+    let s3, m3 = Navigator.next s2 f.Tree
+    match m3 with
+    | Edge _ -> Assert.Equal(Some f.P2.Id, s3.Current)
+    | other -> failwithf "expected Edge, got %A" other
+    let s4, m4 = Navigator.previous s3 f.Tree
+    movedTo f.List.Id m4
+    Assert.Equal(Some f.List.Id, s4.Current)
+
+[<Fact>]
+let ``descend enters children and ascend returns to the parent`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.List.Id Navigator.initial f.Tree
+    let s1, m1 = Navigator.descend s0 f.Tree
+    movedTo f.Item1.Id m1
+    let s2, m2 = Navigator.ascend s1 f.Tree
+    movedTo f.List.Id m2
+    // A leaf has nothing inside: Edge, focus unchanged.
+    let s3, _ = Navigator.focus f.Item2.Id s2 f.Tree
+    let s4, m4 = Navigator.descend s3 f.Tree
+    match m4 with
+    | Edge _ -> Assert.Equal(Some f.Item2.Id, s4.Current)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``ascend from the top level is an Edge`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.Req.Id Navigator.initial f.Tree
+    let s1, move = Navigator.ascend s0 f.Tree
+    match move with
+    | Edge _ -> Assert.Equal(Some f.Req.Id, s1.Current)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``current re-narrates the focused chunk`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.Item1.Id Navigator.initial f.Tree
+    match Navigator.current s0 f.Tree with
+    | Some c -> Assert.Equal("alpha", c.Text)
+    | None -> failwith "expected a focused chunk"
+
+[<Fact>]
+let ``anchor push and return restore the exact branch origin`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree
+    let s1 = Navigator.pushAnchor s0
+    // Wander away (a side branch would move focus further).
+    let s2, _ = Navigator.focus f.Item2.Id s1 f.Tree
+    let s3, move = Navigator.returnToAnchor s2 f.Tree
+    movedTo f.P1.Id move
+    Assert.Empty(s3.AnchorStack)
+
+[<Fact>]
+let ``return with no anchor is an Edge`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree
+    let s1, move = Navigator.returnToAnchor s0 f.Tree
+    match move with
+    | Edge _ -> Assert.Equal(Some f.P1.Id, s1.Current)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``anchors nest as a stack`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree
+    let s1 = Navigator.pushAnchor s0
+    let s2, _ = Navigator.focus f.List.Id s1 f.Tree
+    let s3 = Navigator.pushAnchor s2
+    let s4, _ = Navigator.focus f.Item2.Id s3 f.Tree
+    let s5, m1 = Navigator.returnToAnchor s4 f.Tree
+    movedTo f.List.Id m1
+    let _s6, m2 = Navigator.returnToAnchor s5 f.Tree
+    movedTo f.P1.Id m2

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -101,6 +101,8 @@
     <Compile Include="MarkdownChunkerTests.fs" />
     <Compile Include="EngineBusTests.fs" />
     <Compile Include="IngestTests.fs" />
+    <Compile Include="NavigatorTests.fs" />
+    <Compile Include="ChunkNarrationTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Phase 0 PR-5 (per [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)):

- **`Navigator.fs`** — the §6.2 v1 verbs as pure transitions over the chunk tree: `focus`, `jumpToLatestResponse`, `next`/`previous` (siblings), `descend`/`ascend`, `current` (re-narrate), `pushAnchor` + `returnToAnchor` (a nesting stack, §5.1 anchor + return). The **§6.4 non-ejection invariant holds by construction**: an `Edge` outcome never moves focus, and no verb can focus a chunk outside the tree.
- **`ChunkNarration.fs`** — canonical self-voicing rendering (§4.6/§14.11): typed structure announced before content ("Heading level 2. …", "Numbered list, 3 items.", "Code block, fsharp, 2 lines. …"), container child counts from the tree, and the §6.2 "semantic info about run code" rendering for tool calls.
- **`NavigatorTests.fs` + `ChunkNarrationTests.fs`** — pin every verb (edges included), the anchor stack, and the narration formats.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_