### PR TITLE
feat(engine): attention contract + ISpeechSink seam (RELAUNCH-SPEC §7.3, ADR 0011 E6/E7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15685,6 +15685,21 @@ ring) follow.
   container child counts, §6.2 "what was run" for tool calls.
   `NavigatorTests` + `ChunkNarrationTests` pin both.
 
+### Phase 0 PR-6 (2026-06-11): attention contract + speech-sink seam
+
+- **Added**: `Engine.Core/Attention.fs` — the RELAUNCH-SPEC
+  §7.3 attention contract, output-side enforcement (ADR 0011
+  E6): a pure queue (foreground strict non-preemptible FIFO;
+  ambient coalesced latest-wins per key, surfaced only when no
+  foreground waits) + the routing policy (requests confirmed
+  foreground — the §6.1 narrate-and-confirm echo; progress and
+  notes ambient; completion foreground and error-aware; sealed
+  chunks deliberately silent per §5.2).
+  `Engine.Core/SpeechSink.fs` — the platform-free `ISpeechSink`
+  contract the self-voicing channel implements (speak / cancel
+  / utterance-completed drain trigger). `AttentionTests` pin
+  the discipline.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Attention.fs
+++ b/src/Engine.Core/Attention.fs
@@ -1,0 +1,91 @@
+namespace Engine.Core
+
+open Engine.Core.EngineEvent
+
+/// RELAUNCH-SPEC §7.3 / ADR 0011 E6 — the attention contract,
+/// output-side enforcement. Two routing classes, always
+/// distinguished:
+///
+///   * **Foreground** — the narrative thread (request
+///     confirmations, completion announcements, navigation
+///     reads). A single ordered, non-preemptible FIFO.
+///   * **Ambient** — peripheral awareness (progress, lifecycle,
+///     notes). Coalesced latest-wins per key; surfaced only
+///     when no foreground utterance is waiting — ambient can
+///     never interrupt the thread (§14.6).
+///
+/// Pure: the queue is data, the policy is a function. The host
+/// drains the queue into an `ISpeechSink` as utterances finish.
+module Attention =
+
+    /// One thing to say, with its attention class.
+    type Utterance =
+        | Foreground of text: string
+        /// `key` identifies the ambient stream (e.g.
+        /// "progress") — a newer utterance with the same key
+        /// replaces the queued older one.
+        | Ambient of key: string * text: string
+
+    /// The pending-speech queue. Ambient entries keep first-
+    /// arrival key order but latest-wins content.
+    type Queue =
+        private
+            { Fg: string list
+              Amb: (string * string) list }
+
+    let empty : Queue =
+        { Fg = []; Amb = [] }
+
+    let isEmpty (q: Queue) : bool =
+        q.Fg.IsEmpty && q.Amb.IsEmpty
+
+    /// Add an utterance per its class.
+    let enqueue (utterance: Utterance) (q: Queue) : Queue =
+        match utterance with
+        | Foreground text ->
+            { q with Fg = q.Fg @ [ text ] }
+        | Ambient (key, text) ->
+            let replaced, found =
+                ((([], false)), q.Amb)
+                ||> List.fold (fun (acc, found) (k, t) ->
+                    if k = key then (acc @ [ (k, text) ], true)
+                    else (acc @ [ (k, t) ], found))
+            { q with
+                Amb =
+                    if found then replaced
+                    else q.Amb @ [ (key, text) ] }
+
+    /// The next utterance to speak: foreground strictly first;
+    /// ambient only when no foreground waits.
+    let tryDequeue (q: Queue) : (string * Queue) option =
+        match q.Fg with
+        | text :: rest -> Some (text, { q with Fg = rest })
+        | [] ->
+            match q.Amb with
+            | (_, text) :: rest -> Some (text, { q with Amb = rest })
+            | [] -> None
+
+    /// The routing policy: engine event → utterance (or
+    /// silence). Sealed chunks are deliberately NOT auto-spoken
+    /// (§5.2 — the user navigates sealed content on demand; the
+    /// ambient progress count carries in-flight awareness).
+    let route (event: EngineEvent.EngineEvent) : Utterance option =
+        match event with
+        | RequestCaptured chunk ->
+            // The §6.1 narrate-and-confirm echo.
+            Some (Foreground (sprintf "Sent: %s" chunk.Text))
+        | SessionStarted _ ->
+            Some (Ambient ("session", "Session started."))
+        | ChunkSealed _ ->
+            None
+        | ResponseProgress count ->
+            Some (Ambient ("progress",
+                           sprintf "%d chunks so far." count))
+        | ResponseCompleted (false, count) ->
+            Some (Foreground (
+                    sprintf "Response complete, %d chunks." count))
+        | ResponseCompleted (true, count) ->
+            Some (Foreground (
+                    sprintf "Response failed after %d chunks." count))
+        | EngineNote text ->
+            Some (Ambient ("note", text))

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -46,6 +46,13 @@
     -->
     <Compile Include="Navigator.fs" />
     <Compile Include="ChunkNarration.fs" />
+    <!--
+      RELAUNCH-SPEC §7.3 / §4.6 — the attention contract
+      (output-side enforcement: pure queue + routing policy)
+      and the platform-free self-voicing sink seam.
+    -->
+    <Compile Include="Attention.fs" />
+    <Compile Include="SpeechSink.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/SpeechSink.fs
+++ b/src/Engine.Core/SpeechSink.fs
@@ -1,0 +1,21 @@
+namespace Engine.Core
+
+open System
+
+/// RELAUNCH-SPEC §4.6 / §14.11 / ADR 0011 E7 — the self-voicing
+/// channel's sink contract. The engine owns the audio path
+/// end-to-end; a sink renders canonical text to audio and
+/// reports utterance completion so the host can drain the
+/// attention queue. Implementations are universal-event-bus
+/// consumers' back-ends (Phase 0: `Engine.Voice.SapiSink` over
+/// Windows SAPI); the contract itself is platform-free.
+type ISpeechSink =
+    inherit IDisposable
+    /// Queue one utterance after anything already speaking.
+    abstract member SpeakAsync: text: string -> unit
+    /// Stop all current and queued speech immediately (the
+    /// user's interrupt verb — §7.1 "interruptible").
+    abstract member CancelAll: unit -> unit
+    /// Fires when an utterance finishes (spoken to the end or
+    /// cancelled); the host's drain trigger.
+    abstract member UtteranceCompleted: IEvent<unit>

--- a/tests/Tests.Unit/AttentionTests.fs
+++ b/tests/Tests.Unit/AttentionTests.fs
@@ -1,0 +1,109 @@
+module PtySpeak.Tests.Unit.AttentionTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.Attention
+open Engine.Core.EngineEvent
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §7.3 / ADR 0011 E6 — attention contract tests.
+// ---------------------------------------------------------------------
+//
+// Pins the two-class output discipline: foreground FIFO is
+// strict and non-preemptible; ambient coalesces latest-wins per
+// key and never outranks foreground; the routing policy keeps
+// sealed chunks silent (§5.2) and confirms requests foreground.
+
+let private drain (q: Queue) : string list =
+    let rec go acc q =
+        match tryDequeue q with
+        | Some (text, rest) -> go (acc @ [ text ]) rest
+        | None -> acc
+    go [] q
+
+[<Fact>]
+let ``empty queue dequeues nothing`` () =
+    Assert.True(isEmpty empty)
+    Assert.True((tryDequeue empty).IsNone)
+
+[<Fact>]
+let ``foreground is strict FIFO`` () =
+    let q =
+        empty
+        |> enqueue (Foreground "one")
+        |> enqueue (Foreground "two")
+        |> enqueue (Foreground "three")
+    Assert.Equal<string list>([ "one"; "two"; "three" ], drain q)
+
+[<Fact>]
+let ``ambient never outranks queued foreground`` () =
+    let q =
+        empty
+        |> enqueue (Ambient ("progress", "2 chunks so far."))
+        |> enqueue (Foreground "Sent: hello")
+        |> enqueue (Ambient ("note", "fyi"))
+        |> enqueue (Foreground "Response complete, 3 chunks.")
+    Assert.Equal<string list>(
+        [ "Sent: hello"
+          "Response complete, 3 chunks."
+          "2 chunks so far."
+          "fyi" ],
+        drain q)
+
+[<Fact>]
+let ``ambient coalesces latest-wins per key`` () =
+    let q =
+        empty
+        |> enqueue (Ambient ("progress", "1 chunks so far."))
+        |> enqueue (Ambient ("note", "first note"))
+        |> enqueue (Ambient ("progress", "5 chunks so far."))
+    Assert.Equal<string list>(
+        [ "5 chunks so far."; "first note" ],
+        drain q)
+
+[<Fact>]
+let ``distinct ambient keys are all preserved`` () =
+    let q =
+        empty
+        |> enqueue (Ambient ("a", "alpha"))
+        |> enqueue (Ambient ("b", "beta"))
+    Assert.Equal<string list>([ "alpha"; "beta" ], drain q)
+
+// --- routing policy -------------------------------------------------
+
+let private mkChunk (text: string) : Chunk.Chunk =
+    match ChunkTree.append None Chunk.UserRequest text ChunkTree.empty with
+    | Ok (c, _) -> c
+    | Error e -> failwith e
+
+[<Fact>]
+let ``a captured request is confirmed foreground`` () =
+    match route (RequestCaptured (mkChunk "fix the bug")) with
+    | Some (Foreground text) -> Assert.Equal("Sent: fix the bug", text)
+    | other -> failwithf "expected foreground confirm, got %A" other
+
+[<Fact>]
+let ``sealed chunks are silent by policy`` () =
+    Assert.True((route (ChunkSealed (mkChunk "x"))).IsNone)
+
+[<Fact>]
+let ``progress is ambient on the progress key`` () =
+    match route (ResponseProgress 4) with
+    | Some (Ambient ("progress", text)) ->
+        Assert.Equal("4 chunks so far.", text)
+    | other -> failwithf "expected ambient progress, got %A" other
+
+[<Fact>]
+let ``completion is foreground and error-aware`` () =
+    match route (ResponseCompleted (false, 7)) with
+    | Some (Foreground "Response complete, 7 chunks.") -> ()
+    | other -> failwithf "unexpected %A" other
+    match route (ResponseCompleted (true, 2)) with
+    | Some (Foreground "Response failed after 2 chunks.") -> ()
+    | other -> failwithf "unexpected %A" other
+
+[<Fact>]
+let ``notes are ambient`` () =
+    match route (EngineNote "Unrecognized stream event type: x") with
+    | Some (Ambient ("note", _)) -> ()
+    | other -> failwithf "expected ambient note, got %A" other

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -103,6 +103,7 @@
     <Compile Include="IngestTests.fs" />
     <Compile Include="NavigatorTests.fs" />
     <Compile Include="ChunkNarrationTests.fs" />
+    <Compile Include="AttentionTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Phase 0 PR-6 (per [ADR 0011](docs/adr/0011-phase0-interaction-engine-bootstrap.md)):

- **`Attention.fs`** — the §7.3 attention contract, output-side enforcement (E6), pure: foreground is a strict non-preemptible FIFO; ambient coalesces latest-wins per key and is surfaced only when no foreground utterance waits (§14.6 "foreground is never interrupted by ambient"). The routing policy maps engine events: request → foreground confirm (the §6.1 narrate-and-confirm echo); progress/notes → ambient; completion → foreground, error-aware; **sealed chunks deliberately silent** (§5.2 — navigated on demand).
- **`SpeechSink.fs`** — the platform-free `ISpeechSink` contract (speak / cancel-all / utterance-completed drain trigger) the self-voicing channel implements; the SAPI back-end lands next (E7).
- **`AttentionTests.fs`** — pins FIFO order, ambient subordination, per-key coalescing, and the full routing policy.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_