### PR TITLE
fix(engine-host): push the branch anchor only when the branch is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15752,6 +15752,15 @@ ring) follow.
   module rows), `docs/DOC-MAP.md` (RELAUNCH-SPEC +
   ENGINE-PHASE0 routing rows). No code / behaviour change.
 
+### Phase 0 PR-10 (2026-06-11): branch anchor only on a sent branch
+
+- **Fixed**: `Engine.Host` — pressing `b` (branch) pushed the
+  return anchor before the compose line was read, so an
+  aborted branch (empty line, or a turn still in flight) left
+  a stale anchor on the stack and a later `a` returned to a
+  chunk no branch was made from. `compose` now reports whether
+  a turn actually started and the anchor is pushed only then.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -180,19 +180,26 @@ let main _argv =
                 move)
         narrateMove move
 
-    let compose (anchor: Chunk.ChunkId option) =
+    /// Returns true when a turn was actually started — the
+    /// branch path pushes its anchor only on success, so an
+    /// aborted compose (busy / empty line) leaves no stale
+    /// anchor on the stack.
+    let compose (anchor: Chunk.ChunkId option) : bool =
         let busy = lock gate (fun () -> state.TurnInFlight)
         if busy then
             speakNow "A response is still in progress. Wait for it to complete."
+            false
         else
             speech.CancelAll ()
             Console.Write("> ")
             match Console.ReadLine() with
-            | null -> ()
+            | null -> false
             | line when String.IsNullOrWhiteSpace line ->
                 speakNow "Nothing sent."
+                false
             | line ->
                 startTurn line anchor
+                true
 
     // --- main key loop -----------------------------------------------
     enqueue (Attention.Foreground (
@@ -203,19 +210,18 @@ let main _argv =
         let key = Console.ReadKey(true)
         match key.Key with
         | ConsoleKey.Q -> running <- false
-        | ConsoleKey.C -> compose None
+        | ConsoleKey.C -> compose None |> ignore
         | ConsoleKey.B ->
             // Branch: anchor at the focused chunk (§5.1); the
-            // anchor stack remembers where to return.
-            let anchor =
-                lock gate (fun () ->
-                    match state.Nav.Current with
-                    | Some id ->
-                        state.Nav <- Navigator.pushAnchor state.Nav
-                        Some id
-                    | None -> None)
+            // anchor stack remembers where to return. Pushed
+            // only when the branch request is actually sent —
+            // an aborted compose must not leave a stale anchor.
+            let anchor = lock gate (fun () -> state.Nav.Current)
             match anchor with
-            | Some id -> compose (Some id)
+            | Some id ->
+                if compose (Some id) then
+                    lock gate (fun () ->
+                        state.Nav <- Navigator.pushAnchor state.Nav)
             | None ->
                 speakNow "Focus a chunk first, then press b to branch from it."
         | ConsoleKey.A -> navigate Navigator.returnToAnchor


### PR DESCRIPTION
## Summary

Phase 0 PR-10 — a defect found in post-merge self-review of the host wiring:

Pressing `b` (branch) pushed the return anchor onto the navigator's stack **before** the compose line was read. An aborted branch — empty line, or a turn still in flight — therefore left a stale anchor, and a later `a` (return to anchor) jumped to a chunk no branch was ever made from, violating the §5.1 anchor-return contract.

`compose` now returns whether a turn actually started, and the `b` arm pushes the anchor only on success (focus is unchanged by compose, so the pushed anchor is still the branch origin).

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_