### PR TITLE
test(engine): FsCheck property suite for the chunk-tree invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15761,6 +15761,17 @@ ring) follow.
   chunk no branch was made from. `compose` now reports whether
   a turn actually started and the anchor is pushed only then.
 
+### Phase 0 PR-11 (2026-06-11): chunk-tree property tests
+
+- **Added**: `ChunkTreePropertyTests` — FsCheck properties over
+  arbitrary append sequences (a byte list scripts each chunk's
+  parent choice): count = appends; capture order = insertion
+  order; every chunk sits in its parent's child list at its
+  authored index; children point back to their parent;
+  next/previous sibling are inverse where defined; descend
+  lands on the first authored child. Guards the §5 model for
+  every reachable v1 tree, not just the example fixtures.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/tests/Tests.Unit/ChunkTreePropertyTests.fs
+++ b/tests/Tests.Unit/ChunkTreePropertyTests.fs
@@ -1,0 +1,80 @@
+module PtySpeak.Tests.Unit.ChunkTreePropertyTests
+
+open FsCheck.Xunit
+open Engine.Core
+open Engine.Core.Chunk
+
+// ---------------------------------------------------------------------
+// RELAUNCH-SPEC §5 / ADR 0011 E3 — chunk-tree invariants under
+// arbitrary append sequences (FsCheck).
+// ---------------------------------------------------------------------
+//
+// `build` folds an arbitrary byte list into a tree: each byte
+// picks the next chunk's parent (0 mod (n+1) → top level, else
+// one of the existing chunks). The properties then assert the
+// model's structural invariants hold for EVERY reachable v1
+// tree, not just the example-based fixtures.
+
+let private build (choices: byte list) : ChunkTree.Tree * ChunkId list =
+    ((ChunkTree.empty, []), choices)
+    ||> List.fold (fun (tree, ids) choice ->
+        let parent =
+            match ids with
+            | [] -> None
+            | _ when int choice % (List.length ids + 1) = 0 -> None
+            | _ -> ids |> List.tryItem (int choice % List.length ids)
+        match ChunkTree.append parent Paragraph (sprintf "c%d" (int choice)) tree with
+        | Ok (chunk, tree') -> (tree', ids @ [ chunk.Id ])
+        | Error _ -> (tree, ids))
+
+[<Property>]
+let ``count equals the number of appended chunks`` (choices: byte list) =
+    let tree, ids = build choices
+    ChunkTree.count tree = List.length ids
+
+[<Property>]
+let ``capture order is exactly the insertion order`` (choices: byte list) =
+    let tree, ids = build choices
+    (ChunkTree.inCaptureOrder tree |> List.map (fun c -> c.Id)) = ids
+
+[<Property>]
+let ``every chunk sits in its parent's child list at its authored index``
+        (choices: byte list) =
+    let tree, _ = build choices
+    ChunkTree.inCaptureOrder tree
+    |> List.forall (fun c ->
+        let siblings = ChunkTree.children c.Parent tree
+        (siblings
+         |> List.tryItem c.AuthoredIndex
+         |> Option.map (fun s -> s.Id)) = Some c.Id)
+
+[<Property>]
+let ``every child listed under a parent points back to it`` (choices: byte list) =
+    let tree, ids = build choices
+    ids
+    |> List.forall (fun id ->
+        ChunkTree.children (Some id) tree
+        |> List.forall (fun child -> child.Parent = Some id))
+
+[<Property>]
+let ``next and previous sibling are inverse where defined`` (choices: byte list) =
+    let tree, _ = build choices
+    ChunkTree.inCaptureOrder tree
+    |> List.forall (fun c ->
+        match ChunkTree.nextSibling c.Id tree with
+        | None -> true
+        | Some next ->
+            match ChunkTree.prevSibling next.Id tree with
+            | Some back -> back.Id = c.Id
+            | None -> false)
+
+[<Property>]
+let ``descend lands on the first authored child`` (choices: byte list) =
+    let tree, ids = build choices
+    ids
+    |> List.forall (fun id ->
+        match ChunkTree.children (Some id) tree with
+        | [] -> (ChunkTree.firstChild id tree).IsNone
+        | first :: _ ->
+            (ChunkTree.firstChild id tree
+             |> Option.map (fun c -> c.Id)) = Some first.Id)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -97,6 +97,7 @@
       a Windows TFM referencing a plain TFM is fine.
     -->
     <Compile Include="ChunkTreeTests.fs" />
+    <Compile Include="ChunkTreePropertyTests.fs" />
     <Compile Include="ClaudeStreamJsonTests.fs" />
     <Compile Include="MarkdownChunkerTests.fs" />
     <Compile Include="EngineBusTests.fs" />


### PR DESCRIPTION
## Summary

Phase 0 PR-11 (hardening): FsCheck properties over **arbitrary** append sequences — a generated byte list scripts each chunk's parent choice (top level or any existing chunk), so every reachable v1 tree shape is exercised, not just the example fixtures.

Invariants pinned:
- `count` = number of appends; capture order = insertion order (the immutable transcript).
- Every chunk sits in its parent's child list **at its authored index**; every listed child points back to its parent.
- `nextSibling`/`prevSibling` are inverse where defined; `firstChild` lands on the first authored child (and is `None` exactly when there are none).

Tests-only; no production code change.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_