### PR TITLE
fix(engine): attention-layer audit corrections (ADR 0012 S5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15800,6 +15800,22 @@ ring) follow.
   `CYCLE-51-PLAYBOOK.md` path (rotted when the playbook moved
   to `docs/archive/cycle-closed/`).
 
+### Cycle 53 ADR-0012 S5 (2026-06-12): attention-layer audit fixes
+
+- **Fixed**: a user-initiated read (`speakNow`) now cancels
+  current speech FIRST and drops stale pending foreground
+  before queueing — a queued "Response complete…" no longer
+  delays the chunk the user just asked for (ambient survives).
+  New pure `Attention.clearForeground` / `Attention.clear`.
+- **Fixed**: the stop verb (`s`) now empties the whole queue as
+  well as cancelling — previously queued utterances resumed
+  speaking after a stop.
+- **Added**: `ChunkNarration.describeCapped` — navigation reads
+  are bounded (600 chars in the host) with an honest marker
+  ("Truncated; N more characters — press r to hear all."); `r`
+  reads the full body. The structure-first narration order
+  means the kind/label always survives the cut.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Attention.fs
+++ b/src/Engine.Core/Attention.fs
@@ -65,6 +65,18 @@ module Attention =
             | (_, text) :: rest -> Some (text, { q with Amb = rest })
             | [] -> None
 
+    /// ADR 0012 S5 — drop pending foreground (ambient kept).
+    /// A user-initiated read supersedes stale queued narrative
+    /// (a queued "Response complete…" must not delay the chunk
+    /// the user just asked for).
+    let clearForeground (q: Queue) : Queue =
+        { q with Fg = [] }
+
+    /// ADR 0012 S5 — drop everything. The stop verb means
+    /// stop: nothing queued may resume speaking afterwards.
+    let clear (_q: Queue) : Queue =
+        empty
+
     /// The routing policy: engine event → utterance (or
     /// silence). Sealed chunks are deliberately NOT auto-spoken
     /// (§5.2 — the user navigates sealed content on demand; the

--- a/src/Engine.Core/ChunkNarration.fs
+++ b/src/Engine.Core/ChunkNarration.fs
@@ -61,3 +61,24 @@ module ChunkNarration =
             sprintf "Agent error. %s" chunk.Text
         | Chunk.SystemNote ->
             chunk.Text
+
+    /// ADR 0012 S5 — `describe` bounded for navigation reads:
+    /// a long body (a big code block, a wall of tool output) is
+    /// cut at `maxChars` with an honest marker telling the
+    /// listener how much remains and how to hear it all. The
+    /// structure prefix always survives — the cut applies to
+    /// the rendered string, and kinds put structure first.
+    let describeCapped
+            (maxChars: int)
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : string =
+        let full = describe tree chunk
+        if full.Length <= maxChars then
+            full
+        else
+            let remaining = full.Length - maxChars
+            sprintf
+                "%s… Truncated; %d more characters — press r to hear all."
+                (full.Substring(0, maxChars))
+                remaining

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -96,13 +96,17 @@ let main _argv =
             state.Queue <- Attention.enqueue utterance state.Queue)
         speakNext ()
 
-    /// A user-initiated read preempts whatever is being spoken:
-    /// cancel, then queue foreground. (Ambient still never
-    /// preempts — this is the user's own interrupt.)
+    /// A user-initiated read preempts whatever is being spoken
+    /// AND whatever narrative was queued (ADR 0012 S5): cancel
+    /// first, drop stale pending foreground, then queue this.
+    /// Ambient survives — awareness is not the user's target.
     let speakNow (text: string) =
-        lock gate (fun () ->
-            state.Queue <- Attention.enqueue (Attention.Foreground text) state.Queue)
         speech.CancelAll ()
+        lock gate (fun () ->
+            state.Queue <-
+                Attention.enqueue
+                    (Attention.Foreground text)
+                    (Attention.clearForeground state.Queue))
         speakNext ()
 
     // --- bus → attention --------------------------------------------
@@ -159,12 +163,19 @@ let main _argv =
         thread.Start()
 
     // --- navigation --------------------------------------------------
+    // Navigation reads are bounded (ADR 0012 S5); `r` reads
+    // the full body.
+    let moveReadCapChars = 600
+
     let narrateMove (move: Navigator.Move) =
         match move with
         | Navigator.Moved chunk ->
             let text =
                 lock gate (fun () ->
-                    ChunkNarration.describe state.Session.Tree chunk)
+                    ChunkNarration.describeCapped
+                        moveReadCapChars
+                        state.Session.Tree
+                        chunk)
             speakNow text
         | Navigator.Edge description ->
             speakNow description
@@ -241,7 +252,13 @@ let main _argv =
             match chunk with
             | Some text -> speakNow text
             | None -> speakNow "Nothing is focused."
-        | ConsoleKey.S -> speech.CancelAll ()
+        | ConsoleKey.S ->
+            // Stop means stop (ADR 0012 S5): silence the
+            // current utterance AND everything queued behind
+            // it — nothing may resume speaking after a stop.
+            lock gate (fun () ->
+                state.Queue <- Attention.clear state.Queue)
+            speech.CancelAll ()
         | _ when key.KeyChar = '?' -> speakNow helpText
         | _ -> ()
 

--- a/tests/Tests.Unit/AttentionTests.fs
+++ b/tests/Tests.Unit/AttentionTests.fs
@@ -107,3 +107,24 @@ let ``notes are ambient`` () =
     match route (EngineNote "Unrecognized stream event type: x") with
     | Some (Ambient ("note", _)) -> ()
     | other -> failwithf "expected ambient note, got %A" other
+
+// --- ADR 0012 S5 audit fixes ----------------------------------------
+
+[<Fact>]
+let ``clearForeground drops pending narrative but keeps ambient`` () =
+    let q =
+        empty
+        |> enqueue (Foreground "stale completion")
+        |> enqueue (Ambient ("progress", "3 chunks so far."))
+        |> enqueue (Foreground "another stale")
+    Assert.Equal<string list>(
+        [ "3 chunks so far." ],
+        drain (clearForeground q))
+
+[<Fact>]
+let ``clear drops everything`` () =
+    let q =
+        empty
+        |> enqueue (Foreground "a")
+        |> enqueue (Ambient ("k", "b"))
+    Assert.True(isEmpty (clear q))

--- a/tests/Tests.Unit/ChunkNarrationTests.fs
+++ b/tests/Tests.Unit/ChunkNarrationTests.fs
@@ -77,3 +77,30 @@ let ``user request is labelled`` () =
 [<Fact>]
 let ``separator has a fixed word`` () =
     Assert.Equal("Separator.", describeSolo ThematicBreak "")
+
+// --- ADR 0012 S5 — capped narration ---------------------------------
+
+let private describeCappedSolo maxChars (kind: ChunkKind) (text: string) =
+    let chunk, tree = ok (ChunkTree.append None kind text ChunkTree.empty)
+    ChunkNarration.describeCapped maxChars tree chunk
+
+[<Fact>]
+let ``short bodies are not truncated`` () =
+    Assert.Equal(
+        "Plain words.",
+        describeCappedSolo 600 Paragraph "Plain words.")
+
+[<Fact>]
+let ``long bodies cut with an honest marker and remaining count`` () =
+    let longText = String.replicate 100 "abcdefghij" // 1000 chars
+    let rendered = describeCappedSolo 100 Paragraph longText
+    Assert.StartsWith(longText.Substring(0, 100), rendered)
+    Assert.Contains("Truncated; 900 more characters", rendered)
+    Assert.Contains("press r to hear all", rendered)
+
+[<Fact>]
+let ``the structure prefix survives the cut`` () =
+    let longCode = String.replicate 200 "let x = 1\n"
+    let rendered =
+        describeCappedSolo 80 (CodeBlock (Some "fsharp")) longCode
+    Assert.StartsWith("Code block, fsharp, ", rendered)


### PR DESCRIPTION
## Summary

Audit fixes from the deep review pass ([ADR 0012](docs/adr/0012-semantic-outline-and-spatial-event-signatures.md) S5):

- **User reads supersede stale narrative**: `speakNow` now cancels current speech *first* (better ordering against the completion-handler race) and drops pending foreground before queueing its text — a queued "Response complete…" no longer delays the chunk the user just asked for. Ambient awareness survives. New pure `Attention.clearForeground`.
- **Stop means stop**: `s` previously only cancelled the current utterance; everything queued then resumed speaking. It now also empties the queue (`Attention.clear`).
- **Bounded navigation reads**: `ChunkNarration.describeCapped` cuts long bodies (600 chars in the host) with an honest marker — "Truncated; N more characters — press r to hear all." — and the structure-first narration order guarantees the kind/label prefix survives the cut. `r` (re-narrate) still reads the full body.

Tests extend the existing Attention and ChunkNarration suites.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_