### PR TITLE
feat(engine): heading-scoped semantic outline at ingest (ADR 0012 S1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15816,6 +15816,22 @@ ring) follow.
   reads the full body. The structure-first narration order
   means the kind/label always survives the cut.
 
+### Cycle 53 ADR-0012 S1 (2026-06-12): heading-scoped semantic outline
+
+- **Added**: `Engine.Core/SemanticOutline.fs` — `nest`
+  recovers the section structure the model already marks: a
+  heading absorbs every following block (including deeper
+  headings) as children until a heading of equal or shallower
+  level; pre-heading content stays top-level; list children
+  untouched. Ingest applies it between decomposition and
+  append, so the chunk tree carries the document's real
+  outline — `next`/`previous` at the top level is
+  section-to-section, `descend` enters a section (the §6.2
+  verbs get real hierarchy). Heading narration announces the
+  section size ("Heading level 2: Setup. 4 items inside.").
+  `SemanticOutlineTests` pin the nesting law incl. skipped
+  levels, scope-closing, and an end-to-end markdown outline.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/ChunkNarration.fs
+++ b/src/Engine.Core/ChunkNarration.fs
@@ -19,7 +19,14 @@ module ChunkNarration =
             ChunkTree.children (Some chunk.Id) tree |> List.length
         match chunk.Kind with
         | Chunk.Heading level ->
-            sprintf "Heading level %d. %s" level chunk.Text
+            // ADR 0012 S1 — a heading is a section now; say
+            // how much it holds so descend is an informed move.
+            if childCount > 0 then
+                sprintf
+                    "Heading level %d: %s. %d items inside."
+                    level chunk.Text childCount
+            else
+                sprintf "Heading level %d: %s" level chunk.Text
         | Chunk.Paragraph ->
             chunk.Text
         | Chunk.ListBlock ordered ->

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -32,6 +32,11 @@
     -->
     <Compile Include="MarkdownChunker.fs" />
     <!--
+      ADR 0012 S1 — heading-scoped semantic outline (pure
+      transform between decomposition and append).
+    -->
+    <Compile Include="SemanticOutline.fs" />
+    <!--
       RELAUNCH-SPEC §0.1 / ADR 0011 E5 — the engine's universal
       event bus (instance-scoped) + the ingest fold (the §5.2
       streaming rule). Ingest depends on the chunker + the bus

--- a/src/Engine.Core/Ingest.fs
+++ b/src/Engine.Core/Ingest.fs
@@ -131,7 +131,12 @@ module Ingest =
                 ||> List.fold (fun (acc, t, ns) block ->
                     match block with
                     | Text text ->
-                        let specs = MarkdownChunker.decompose text
+                        // ADR 0012 S1 — recover the section
+                        // structure before append: the tree
+                        // carries the document's real outline.
+                        let specs =
+                            MarkdownChunker.decompose text
+                            |> SemanticOutline.nest
                         let sealed_, t' = appendSpecs parent specs t
                         (acc @ sealed_, t', ns)
                     | ToolUse (_id, name, inputJson) ->

--- a/src/Engine.Core/SemanticOutline.fs
+++ b/src/Engine.Core/SemanticOutline.fs
@@ -1,0 +1,58 @@
+namespace Engine.Core
+
+open Engine.Core.MarkdownChunker
+
+/// ADR 0012 S1 — the heading-scoped semantic outline. The
+/// chunker yields the model's block structure as a flat list
+/// (headings are siblings of the prose they head); this module
+/// recovers the *section* structure that flat shape throws
+/// away: a heading absorbs every following spec — including
+/// deeper headings — as children, until the next heading of
+/// equal or shallower level closes its scope.
+///
+/// ADR 0008 discipline: this is recovery of structure the
+/// source unambiguously provides (the author chose the heading
+/// levels), not inference. Content before the first heading
+/// stays top-level — the source put it there.
+///
+/// Pure: spec forest in, spec forest out. Ingest applies it
+/// between decomposition and append, so the chunk tree carries
+/// the outline and the §6.2 verbs get real hierarchy: `next`
+/// at the top level is section-to-section; `descend` enters a
+/// section.
+module SemanticOutline =
+
+    /// Collect specs into `bound`-scoped children: stop (without
+    /// consuming) at any heading of level <= bound. Returns the
+    /// collected siblings + the unconsumed rest.
+    let rec private collect
+            (bound: int)
+            (specs: ChunkSpec list)
+            : ChunkSpec list * ChunkSpec list =
+        match specs with
+        | [] -> [], []
+        | spec :: rest ->
+            match spec.Kind with
+            | Chunk.Heading level when level <= bound ->
+                // This heading closes the current scope; the
+                // caller owns it.
+                [], specs
+            | Chunk.Heading level ->
+                // A deeper heading: it opens a nested section
+                // absorbing its own scope first.
+                let inner, afterInner = collect level rest
+                let section =
+                    { spec with Children = spec.Children @ inner }
+                let siblings, afterSiblings = collect bound afterInner
+                (section :: siblings), afterSiblings
+            | _ ->
+                // Ordinary block: a sibling at this scope. Its
+                // own children (list items etc.) are untouched.
+                let siblings, after = collect bound rest
+                (spec :: siblings), after
+
+    /// Nest a flat block forest into its heading-scoped outline.
+    /// Bound 0 means no enclosing heading: every real heading
+    /// (level >= 1) opens a section.
+    let nest (specs: ChunkSpec list) : ChunkSpec list =
+        collect 0 specs |> fst

--- a/tests/Tests.Unit/ChunkNarrationTests.fs
+++ b/tests/Tests.Unit/ChunkNarrationTests.fs
@@ -27,8 +27,17 @@ let ``paragraph narrates its text verbatim`` () =
 [<Fact>]
 let ``heading announces its level first`` () =
     Assert.Equal(
-        "Heading level 2. Setup",
+        "Heading level 2: Setup",
         describeSolo (Heading 2) "Setup")
+
+[<Fact>]
+let ``a heading with children announces its section size`` () =
+    let h, tree = ok (ChunkTree.append None (Heading 1) "Plan" ChunkTree.empty)
+    let _, tree = ok (ChunkTree.append (Some h.Id) Paragraph "a" tree)
+    let _, tree = ok (ChunkTree.append (Some h.Id) Paragraph "b" tree)
+    Assert.Equal(
+        "Heading level 1: Plan. 2 items inside.",
+        ChunkNarration.describe tree h)
 
 [<Fact>]
 let ``list announces order and item count`` () =

--- a/tests/Tests.Unit/IngestTests.fs
+++ b/tests/Tests.Unit/IngestTests.fs
@@ -60,8 +60,10 @@ let ``assistant text seals decomposed chunks under the request`` () =
     Assert.Equal(2, List.length chunks)
     Assert.Equal(Chunk.Heading 1, chunks.[0].Kind)
     Assert.Equal(Chunk.Paragraph, chunks.[1].Kind)
-    for c in chunks do
-        Assert.Equal(Some req.Id, c.Parent)
+    // ADR 0012 S1 — the outline nests: the section heads the
+    // response under the request; its prose nests inside it.
+    Assert.Equal(Some req.Id, chunks.[0].Parent)
+    Assert.Equal(Some chunks.[0].Id, chunks.[1].Parent)
     // Trailing ambient progress carries the running count.
     match List.last events with
     | ResponseProgress 2 -> ()

--- a/tests/Tests.Unit/SemanticOutlineTests.fs
+++ b/tests/Tests.Unit/SemanticOutlineTests.fs
@@ -1,0 +1,161 @@
+module PtySpeak.Tests.Unit.SemanticOutlineTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.MarkdownChunker
+
+// ---------------------------------------------------------------------
+// ADR 0012 S1 — heading-scoped outline tests.
+// ---------------------------------------------------------------------
+//
+// Pins the nesting law: a heading absorbs following specs
+// (including deeper headings) until a heading of equal or
+// shallower level; pre-heading content stays top-level; list
+// children survive untouched.
+
+let private spec kind text : ChunkSpec =
+    { Kind = kind; Text = text; Children = [] }
+
+let private kindsOf (specs: ChunkSpec list) =
+    specs |> List.map (fun s -> s.Kind)
+
+[<Fact>]
+let ``no headings means no change`` () =
+    let flat =
+        [ spec Chunk.Paragraph "a"
+          spec (Chunk.ListBlock false) "l"
+          spec Chunk.Paragraph "b" ]
+    Assert.Equal<ChunkSpec list>(flat, SemanticOutline.nest flat)
+
+[<Fact>]
+let ``a heading absorbs following blocks until the next equal heading`` () =
+    let flat =
+        [ spec (Chunk.Heading 1) "One"
+          spec Chunk.Paragraph "p1"
+          spec Chunk.Paragraph "p2"
+          spec (Chunk.Heading 1) "Two"
+          spec Chunk.Paragraph "p3" ]
+    match SemanticOutline.nest flat with
+    | [ one; two ] ->
+        Assert.Equal(Chunk.Heading 1, one.Kind)
+        Assert.Equal<Chunk.ChunkKind list>(
+            [ Chunk.Paragraph; Chunk.Paragraph ],
+            kindsOf one.Children)
+        Assert.Equal("Two", two.Text)
+        Assert.Equal<Chunk.ChunkKind list>(
+            [ Chunk.Paragraph ],
+            kindsOf two.Children)
+    | other -> failwithf "expected two sections, got %A" other
+
+[<Fact>]
+let ``deeper headings nest inside their parent section`` () =
+    let flat =
+        [ spec (Chunk.Heading 1) "Top"
+          spec Chunk.Paragraph "intro"
+          spec (Chunk.Heading 2) "Sub A"
+          spec Chunk.Paragraph "a-body"
+          spec (Chunk.Heading 2) "Sub B"
+          spec Chunk.Paragraph "b-body" ]
+    match SemanticOutline.nest flat with
+    | [ top ] ->
+        Assert.Equal("Top", top.Text)
+        match top.Children with
+        | [ intro; subA; subB ] ->
+            Assert.Equal(Chunk.Paragraph, intro.Kind)
+            Assert.Equal("Sub A", subA.Text)
+            Assert.Equal<string list>(
+                [ "a-body" ],
+                subA.Children |> List.map (fun s -> s.Text))
+            Assert.Equal("Sub B", subB.Text)
+        | other -> failwithf "expected intro + two subsections, got %A" other
+    | other -> failwithf "expected one top section, got %A" other
+
+[<Fact>]
+let ``a shallower heading closes the deeper scope`` () =
+    let flat =
+        [ spec (Chunk.Heading 2) "Deep first"
+          spec Chunk.Paragraph "deep-body"
+          spec (Chunk.Heading 1) "Then shallow"
+          spec Chunk.Paragraph "shallow-body" ]
+    match SemanticOutline.nest flat with
+    | [ deep; shallow ] ->
+        Assert.Equal("Deep first", deep.Text)
+        Assert.Equal(1, List.length deep.Children)
+        Assert.Equal("Then shallow", shallow.Text)
+        Assert.Equal(1, List.length shallow.Children)
+    | other -> failwithf "expected two top sections, got %A" other
+
+[<Fact>]
+let ``content before the first heading stays top-level`` () =
+    let flat =
+        [ spec Chunk.Paragraph "preamble"
+          spec (Chunk.Heading 1) "Body"
+          spec Chunk.Paragraph "inside" ]
+    match SemanticOutline.nest flat with
+    | [ pre; body ] ->
+        Assert.Equal("preamble", pre.Text)
+        Assert.Empty(pre.Children)
+        Assert.Equal<string list>(
+            [ "inside" ],
+            body.Children |> List.map (fun s -> s.Text))
+    | other -> failwithf "expected preamble + section, got %A" other
+
+[<Fact>]
+let ``list children survive nesting untouched`` () =
+    let listSpec =
+        { Kind = Chunk.ListBlock true
+          Text = ""
+          Children =
+            [ spec Chunk.ListItem "one"; spec Chunk.ListItem "two" ] }
+    let flat = [ spec (Chunk.Heading 1) "H"; listSpec ]
+    match SemanticOutline.nest flat with
+    | [ h ] ->
+        match h.Children with
+        | [ l ] ->
+            Assert.Equal<string list>(
+                [ "one"; "two" ],
+                l.Children |> List.map (fun s -> s.Text))
+        | other -> failwithf "expected the list, got %A" other
+    | other -> failwithf "expected one section, got %A" other
+
+[<Fact>]
+let ``skipped levels still nest by relative depth`` () =
+    // H1 then H3 (no H2): the H3 is deeper, so it nests.
+    let flat =
+        [ spec (Chunk.Heading 1) "Top"
+          spec (Chunk.Heading 3) "Jumped"
+          spec Chunk.Paragraph "body"
+          spec (Chunk.Heading 1) "Next" ]
+    match SemanticOutline.nest flat with
+    | [ top; next ] ->
+        Assert.Equal("Next", next.Text)
+        match top.Children with
+        | [ jumped ] ->
+            Assert.Equal("Jumped", jumped.Text)
+            Assert.Equal(1, List.length jumped.Children)
+        | other -> failwithf "expected nested H3, got %A" other
+    | other -> failwithf "expected two top sections, got %A" other
+
+[<Fact>]
+let ``end-to-end: a realistic response becomes a navigable outline`` () =
+    let md =
+        "Intro before any section.\n\n"
+        + "# Plan\n\nFirst step below.\n\n"
+        + "## Details\n\n- alpha\n- beta\n\n"
+        + "# Result\n\nAll good."
+    let outline = MarkdownChunker.decompose md |> SemanticOutline.nest
+    match outline with
+    | [ intro; plan; result ] ->
+        Assert.Equal(Chunk.Paragraph, intro.Kind)
+        Assert.Equal(Chunk.Heading 1, plan.Kind)
+        // Plan: paragraph + the Details subsection.
+        match plan.Children with
+        | [ p; details ] ->
+            Assert.Equal(Chunk.Paragraph, p.Kind)
+            Assert.Equal(Chunk.Heading 2, details.Kind)
+            match details.Children with
+            | [ list ] -> Assert.Equal(Chunk.ListBlock false, list.Kind)
+            | other -> failwithf "expected one list, got %A" other
+        | other -> failwithf "expected paragraph + subsection, got %A" other
+        Assert.Equal("Result", result.Text)
+    | other -> failwithf "expected intro + 2 sections, got %A" other

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -100,6 +100,7 @@
     <Compile Include="ChunkTreePropertyTests.fs" />
     <Compile Include="ClaudeStreamJsonTests.fs" />
     <Compile Include="MarkdownChunkerTests.fs" />
+    <Compile Include="SemanticOutlineTests.fs" />
     <Compile Include="EngineBusTests.fs" />
     <Compile Include="IngestTests.fs" />
     <Compile Include="NavigatorTests.fs" />


### PR DESCRIPTION
## Summary

The centerpiece of [ADR 0012](docs/adr/0012-semantic-outline-and-spatial-event-signatures.md) — **S1, the heading-scoped semantic outline**:

- **`SemanticOutline.nest`** (pure, tested): a heading absorbs every following block — including deeper headings — as children, until the next heading of equal or shallower level closes its scope. Pre-heading content stays top-level; list children pass through untouched. This recovers the *section* structure the model already marks (ADR 0008 at section level — no inference, no heuristics).
- **Ingest applies it** between decomposition and append, so the chunk tree carries the document's real outline: `next`/`previous` at the top level is now **section-to-section** movement, `descend` **enters a section** — the §6.2 verbs get real hierarchy for long responses.
- **Heading narration announces the section size** ("Heading level 2: Setup. 4 items inside.") so descend is an informed move.
- `SemanticOutlineTests` pin the nesting law (equal-level close, shallower-level close, skipped levels, pre-heading content, list passthrough, and an end-to-end markdown → outline case); `IngestTests`/`ChunkNarrationTests` expectations updated to the nested shape.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_