### PR TITLE
feat(engine): positional orientation + where-verb (ADR 0012 S2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15832,6 +15832,18 @@ ring) follow.
   `SemanticOutlineTests` pin the nesting law incl. skipped
   levels, scope-closing, and an end-to-end markdown outline.
 
+### Cycle 53 ADR-0012 S2 (2026-06-12): positional orientation + where-verb
+
+- **Added**: `ChunkNarration.positionOf` / `describeAt` — every
+  navigation move now ends with its sibling position ("…, 3 of
+  5", the screen-reader positional convention); `r` stays pure
+  content. `ChunkNarration.locate` — the new **where-verb**
+  (`w` in the host): the focused chunk's kind + position, the
+  ancestor trail innermost-first ("inside section Setup, inside
+  your request: …"), and the depth — the spec §10 orientation
+  surface at chunk scale, computed from the tree so it cannot
+  drift. Help text + key map updated.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/ChunkNarration.fs
+++ b/src/Engine.Core/ChunkNarration.fs
@@ -69,6 +69,95 @@ module ChunkNarration =
         | Chunk.SystemNote ->
             chunk.Text
 
+    /// ADR 0012 S2 — "N of M" among the chunk's siblings
+    /// (1-based; the screen-reader positional convention).
+    let positionOf
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : int * int =
+        let siblings = ChunkTree.children chunk.Parent tree
+        let index =
+            siblings
+            |> List.tryFindIndex (fun c -> c.Id = chunk.Id)
+            |> Option.defaultValue 0
+        (index + 1, List.length siblings)
+
+    /// A short label for a chunk used in breadcrumb trails;
+    /// long texts are clipped — the trail is orientation, not
+    /// content.
+    let private trailLabel (chunk: Chunk.Chunk) : string =
+        let clip (text: string) =
+            if text.Length > 40 then text.Substring(0, 40) + "…"
+            else text
+        match chunk.Kind with
+        | Chunk.Heading _ -> sprintf "section %s" (clip chunk.Text)
+        | Chunk.UserRequest ->
+            sprintf "your request: %s" (clip chunk.Text)
+        | Chunk.ListBlock true -> "a numbered list"
+        | Chunk.ListBlock false -> "a bulleted list"
+        | Chunk.ListItem -> sprintf "list item %s" (clip chunk.Text)
+        | Chunk.ToolUse name -> sprintf "tool call %s" name
+        | Chunk.BlockQuote -> "a quote"
+        | Chunk.Paragraph -> "a paragraph"
+        | Chunk.CodeBlock _ -> "a code block"
+        | Chunk.ThematicBreak -> "a separator"
+        | Chunk.ToolResult _ -> "a tool result"
+        | Chunk.AgentError -> "an agent error"
+        | Chunk.SystemNote -> "a note"
+
+    /// The focused chunk's own short label (kind-first, no
+    /// body) for the where-verb.
+    let private selfLabel (chunk: Chunk.Chunk) : string =
+        let clip (text: string) =
+            if text.Length > 40 then text.Substring(0, 40) + "…"
+            else text
+        match chunk.Kind with
+        | Chunk.Heading level ->
+            sprintf "Heading level %d: %s" level (clip chunk.Text)
+        | Chunk.Paragraph -> "Paragraph"
+        | Chunk.ListBlock true -> "Numbered list"
+        | Chunk.ListBlock false -> "Bulleted list"
+        | Chunk.ListItem -> "List item"
+        | Chunk.CodeBlock (Some lang) -> sprintf "Code block, %s" lang
+        | Chunk.CodeBlock None -> "Code block"
+        | Chunk.BlockQuote -> "Quote"
+        | Chunk.ThematicBreak -> "Separator"
+        | Chunk.UserRequest -> "Your request"
+        | Chunk.ToolUse name -> sprintf "Tool call %s" name
+        | Chunk.ToolResult true -> "Tool error result"
+        | Chunk.ToolResult false -> "Tool result"
+        | Chunk.AgentError -> "Agent error"
+        | Chunk.SystemNote -> "Note"
+
+    /// ADR 0012 S2 — the where-verb: the focused chunk's kind
+    /// and position, then the ancestor trail innermost-first,
+    /// then the depth. The §10 orientation surface at chunk
+    /// scale — computed from the tree, so it can never drift.
+    let locate
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : string =
+        let position, total = positionOf tree chunk
+        let rec trail (current: Chunk.Chunk) (acc: string list) =
+            match current.Parent with
+            | None -> acc
+            | Some parentId ->
+                match ChunkTree.tryFind parentId tree with
+                | None -> acc
+                | Some parent ->
+                    trail parent (acc @ [ trailLabel parent ])
+        let ancestors = trail chunk []
+        let inside =
+            if List.isEmpty ancestors then ""
+            else ", inside " + String.concat ", inside " ancestors
+        sprintf
+            "%s, %d of %d%s. Depth %d."
+            (selfLabel chunk)
+            position
+            total
+            inside
+            (List.length ancestors + 1)
+
     /// ADR 0012 S5 — `describe` bounded for navigation reads:
     /// a long body (a big code block, a wall of tool output) is
     /// cut at `maxChars` with an honest marker telling the
@@ -89,3 +178,18 @@ module ChunkNarration =
                 "%s… Truncated; %d more characters — press r to hear all."
                 (full.Substring(0, maxChars))
                 remaining
+
+    /// ADR 0012 S2 — the navigation read: bounded content plus
+    /// the positional suffix ("…, 3 of 5"). The re-narrate verb
+    /// uses plain `describe` (pure content, no position).
+    let describeAt
+            (maxChars: int)
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : string =
+        let position, total = positionOf tree chunk
+        sprintf
+            "%s — %d of %d."
+            (describeCapped maxChars tree chunk)
+            position
+            total

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -14,7 +14,8 @@ module Engine.Host.Program
 //   g       jump to the start of the latest response
 //   j / ↓   next chunk        k / ↑   previous chunk
 //   l / →   descend into chunk  h / ←  ascend to parent
-//   r       re-narrate the focused chunk
+//   r       re-narrate the focused chunk (full body)
+//   w       where am I — breadcrumb + position + depth
 //   s       stop speech
 //   ?       speak the key list
 //   q       quit
@@ -43,7 +44,7 @@ type private HostState =
 let private helpText =
     "Keys: c compose. b branch at focus. a return to anchor. "
     + "g latest response. j next. k previous. l descend. "
-    + "h ascend. r repeat. s stop speech. q quit."
+    + "h ascend. r repeat. w where am I. s stop speech. q quit."
 
 [<EntryPoint>]
 let main _argv =
@@ -170,9 +171,10 @@ let main _argv =
     let narrateMove (move: Navigator.Move) =
         match move with
         | Navigator.Moved chunk ->
+            // ADR 0012 S2 — moves carry their position.
             let text =
                 lock gate (fun () ->
-                    ChunkNarration.describeCapped
+                    ChunkNarration.describeAt
                         moveReadCapChars
                         state.Session.Tree
                         chunk)
@@ -250,6 +252,17 @@ let main _argv =
                     |> Option.map (fun c ->
                         ChunkNarration.describe state.Session.Tree c))
             match chunk with
+            | Some text -> speakNow text
+            | None -> speakNow "Nothing is focused."
+        | ConsoleKey.W ->
+            // ADR 0012 S2 — the where-verb: breadcrumb +
+            // position + depth, from the tree (never drifts).
+            let located =
+                lock gate (fun () ->
+                    Navigator.current state.Nav state.Session.Tree
+                    |> Option.map (fun c ->
+                        ChunkNarration.locate state.Session.Tree c))
+            match located with
             | Some text -> speakNow text
             | None -> speakNow "Nothing is focused."
         | ConsoleKey.S ->

--- a/tests/Tests.Unit/ChunkNarrationTests.fs
+++ b/tests/Tests.Unit/ChunkNarrationTests.fs
@@ -113,3 +113,53 @@ let ``the structure prefix survives the cut`` () =
     let rendered =
         describeCappedSolo 80 (CodeBlock (Some "fsharp")) longCode
     Assert.StartsWith("Code block, fsharp, ", rendered)
+
+// --- ADR 0012 S2 — positional orientation ---------------------------
+
+/// req ── [p1; heading ── [inner]; p2]
+let private orientationFixture () =
+    let req, tree = ok (ChunkTree.append None UserRequest "explain the plan" ChunkTree.empty)
+    let p1, tree = ok (ChunkTree.append (Some req.Id) Paragraph "first" tree)
+    let h, tree = ok (ChunkTree.append (Some req.Id) (Heading 2) "Setup" tree)
+    let inner, tree = ok (ChunkTree.append (Some h.Id) Paragraph "inside text" tree)
+    let p2, tree = ok (ChunkTree.append (Some req.Id) Paragraph "last" tree)
+    tree, req, p1, h, inner, p2
+
+[<Fact>]
+let ``positionOf is one-based among siblings`` () =
+    let tree, _, p1, h, inner, p2 = orientationFixture ()
+    Assert.Equal((1, 3), ChunkNarration.positionOf tree p1)
+    Assert.Equal((2, 3), ChunkNarration.positionOf tree h)
+    Assert.Equal((3, 3), ChunkNarration.positionOf tree p2)
+    Assert.Equal((1, 1), ChunkNarration.positionOf tree inner)
+
+[<Fact>]
+let ``describeAt appends the position to the bounded read`` () =
+    let tree, _, p1, _, _, _ = orientationFixture ()
+    Assert.Equal(
+        "first — 1 of 3.",
+        ChunkNarration.describeAt 600 tree p1)
+
+[<Fact>]
+let ``locate speaks kind position trail and depth`` () =
+    let tree, _, _, _, inner, _ = orientationFixture ()
+    Assert.Equal(
+        "Paragraph, 1 of 1, inside section Setup, "
+        + "inside your request: explain the plan. Depth 3.",
+        ChunkNarration.locate tree inner)
+
+[<Fact>]
+let ``locate at top level has no trail and depth 1`` () =
+    let req, tree =
+        ok (ChunkTree.append None UserRequest "solo" ChunkTree.empty)
+    Assert.Equal(
+        "Your request, 1 of 1. Depth 1.",
+        ChunkNarration.locate tree req)
+
+[<Fact>]
+let ``locate clips long ancestor labels`` () =
+    let longReq = String.replicate 30 "abc" // 90 chars
+    let req, tree = ok (ChunkTree.append None UserRequest longReq ChunkTree.empty)
+    let kid, tree = ok (ChunkTree.append (Some req.Id) Paragraph "x" tree)
+    let located = ChunkNarration.locate tree kid
+    Assert.Contains("your request: " + longReq.Substring(0, 40) + "…", located)


### PR DESCRIPTION
## Summary

[ADR 0012](docs/adr/0012-semantic-outline-and-spatial-event-signatures.md) S2 — **positional orientation**, the second leg of the audio-workflow push:

- **"N of M" on every move** (`ChunkNarration.positionOf` + `describeAt`): each navigation read ends with its sibling position — the audio equivalent of a scrollbar. `r` (re-narrate) stays pure content.
- **The where-verb** (`w` in the host, `ChunkNarration.locate`): speaks the focused chunk's kind + position, then the ancestor trail innermost-first ("Paragraph, 1 of 1, inside section Setup, inside your request: explain the plan. Depth 3.") — the spec §10 orientation surface at chunk scale, computed live from the tree so it can never drift the way a hand-maintained orientation does. Long ancestor labels clip at 40 chars (the trail is orientation, not content).
- Help text + the host key map updated; tests pin positions, the `describeAt` suffix, trail composition, top-level depth, and label clipping.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_