### PR TITLE
feat(engine): spatial signatures for every bus event (ADR 0012 S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15844,6 +15844,25 @@ ring) follow.
   surface at chunk scale, computed from the tree so it cannot
   drift. Help text + key map updated.
 
+### Cycle 53 ADR-0012 S3 (2026-06-12): spatial signatures for every bus event
+
+- **Added**: `Engine.Core/SpatialCue.fs` — every universal-
+  event-bus event maps to a deterministic stereo-stage cue
+  (`Pan` / `Pitch` / `DurationMs` / `Gain`). The stage layout
+  encodes the §7.3 attention contract by position: narrative
+  center (request 660 Hz, completion 880, failure 220 low+long);
+  content trickle near-right with a **unique pitch per
+  `ChunkKind`** (the ear hears WHAT kind of content sealed);
+  progress right with count-rising pitch (capped); lifecycle
+  far-left; notes left. Navigation cues are direction-coded
+  (next/previous pan toward the movement; descend low / ascend
+  high; an edge rings dull on the side of the refused move).
+  `SpatialCueTests` pin **uniqueness as a property** (pairwise
+  distinct family signatures; pairwise distinct kind pitches)
+  plus the stage layout, the rising progress series, the
+  low-and-long failure, and under-speech gains. Pure model
+  only — the renderer lands next.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -58,6 +58,13 @@
     -->
     <Compile Include="Attention.fs" />
     <Compile Include="SpeechSink.fs" />
+    <!--
+      ADR 0012 S3 — deterministic spatial-audio signatures for
+      the universal event bus (pure cue model; renderers live
+      in Engine.Audio). Depends on EngineEvent, so it sits
+      after it.
+    -->
+    <Compile Include="SpatialCue.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/SpatialCue.fs
+++ b/src/Engine.Core/SpatialCue.fs
@@ -1,0 +1,128 @@
+namespace Engine.Core
+
+open Engine.Core.EngineEvent
+
+/// ADR 0012 S3 — deterministic spatial-audio signatures for the
+/// universal event bus (RELAUNCH-SPEC §7.1 device 2 + §7.3).
+/// Every engine event maps to a stereo-stage cue; the stage
+/// layout encodes the attention contract by position:
+///
+///   far left −0.8        lifecycle (session)
+///   left     −0.5        diagnostics (notes)
+///   center    0.0        the narrative thread (request,
+///                        completion) — foreground lives where
+///                        the voice lives
+///   near right +0.35     content trickle (chunk seals;
+///                        pitch identifies the ChunkKind)
+///   right    +0.6        turn progress (pitch rises with the
+///                        count — progression is audible)
+///
+/// Navigation cues are direction-coded: next/previous pan
+/// toward the movement, descend is pitched low, ascend high;
+/// an edge is a dull low tone on the side of the attempt.
+///
+/// Pure data + total functions. Renderers (Engine.Audio's
+/// stereo panner today; an HRTF renderer later) consume `Cue`
+/// — the model carries stage position, never implementation.
+module SpatialCue =
+
+    /// One spatial-audio signature. `Pan` is −1.0 (hard left)
+    /// … 0.0 (center) … +1.0 (hard right); `Pitch` in Hz;
+    /// `Gain` 0.0–1.0 (cues sit under speech, so most are
+    /// well below 1).
+    type Cue =
+        { Pan: float
+          Pitch: float
+          DurationMs: int
+          Gain: float }
+
+    /// Unique pitch identity per chunk kind (ADR 0012 S3 —
+    /// the ear can tell WHAT kind of content just sealed).
+    /// Frequencies are distinct musical pitches spread across
+    /// the 300–1000 Hz earcon-friendly band.
+    let pitchForKind (kind: Chunk.ChunkKind) : float =
+        match kind with
+        | Chunk.Heading _ -> 988.0 // B5 — sections ring highest
+        | Chunk.Paragraph -> 523.0 // C5
+        | Chunk.ListBlock _ -> 587.0 // D5
+        | Chunk.ListItem -> 659.0 // E5
+        | Chunk.CodeBlock _ -> 698.0 // F5
+        | Chunk.BlockQuote -> 494.0 // B4
+        | Chunk.ThematicBreak -> 350.0
+        | Chunk.UserRequest -> 660.0
+        | Chunk.ToolUse _ -> 784.0 // G5
+        | Chunk.ToolResult false -> 740.0 // F#5
+        | Chunk.ToolResult true -> 311.0 // D#4 — errors ring low
+        | Chunk.AgentError -> 233.0 // A#3
+        | Chunk.SystemNote -> 415.0 // G#4
+
+    /// The cue for one engine event; `None` = deliberately
+    /// silent (no event is silent today, but the policy seam
+    /// is total and explicit).
+    let forEvent (event: EngineEvent.EngineEvent) : Cue option =
+        match event with
+        | RequestCaptured _ ->
+            // Center stage, bright: your words entered the tree.
+            Some { Pan = 0.0; Pitch = 660.0; DurationMs = 70; Gain = 0.35 }
+        | SessionStarted _ ->
+            Some { Pan = -0.8; Pitch = 392.0; DurationMs = 120; Gain = 0.3 }
+        | ChunkSealed chunk ->
+            // The content trickle: a soft per-kind tick near
+            // right — ambient awareness of WHAT is landing
+            // without a single spoken word (§5.2).
+            Some { Pan = 0.35
+                   Pitch = pitchForKind chunk.Kind
+                   DurationMs = 35
+                   Gain = 0.18 }
+        | ResponseProgress count ->
+            // Rising series on the right: each ambient progress
+            // step is audibly "further along".
+            let capped = min count 12
+            Some { Pan = 0.6
+                   Pitch = 440.0 + 20.0 * float capped
+                   DurationMs = 45
+                   Gain = 0.2 }
+        | ResponseCompleted (false, _) ->
+            Some { Pan = 0.0; Pitch = 880.0; DurationMs = 140; Gain = 0.4 }
+        | ResponseCompleted (true, _) ->
+            Some { Pan = 0.0; Pitch = 220.0; DurationMs = 260; Gain = 0.45 }
+        | EngineNote _ ->
+            Some { Pan = -0.5; Pitch = 330.0; DurationMs = 80; Gain = 0.25 }
+
+    /// Navigation verbs, for direction-coded cues.
+    type NavDirection =
+        | Next
+        | Previous
+        | Descend
+        | Ascend
+        | Jump
+        | ReturnToAnchor
+
+    let private sideOf (direction: NavDirection) : float =
+        match direction with
+        | Next -> 0.3
+        | Previous -> -0.3
+        | Jump -> 0.5
+        | ReturnToAnchor -> -0.5
+        | Descend | Ascend -> 0.0
+
+    /// The cue for a navigation outcome: a crisp tick panned
+    /// toward the movement (descend low / ascend high); a dull
+    /// low tone on the side of a refused move (the §6.4 edge —
+    /// you hear WHERE you bumped before the voice says why).
+    let forNav (direction: NavDirection) (moved: bool) : Cue =
+        if moved then
+            let pitch =
+                match direction with
+                | Descend -> 392.0 // down in space, down in pitch
+                | Ascend -> 587.0
+                | _ -> 466.0
+            { Pan = sideOf direction
+              Pitch = pitch
+              DurationMs = 30
+              Gain = 0.22 }
+        else
+            { Pan = sideOf direction
+              Pitch = 196.0
+              DurationMs = 90
+              Gain = 0.3 }

--- a/tests/Tests.Unit/SpatialCueTests.fs
+++ b/tests/Tests.Unit/SpatialCueTests.fs
@@ -1,0 +1,101 @@
+module PtySpeak.Tests.Unit.SpatialCueTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.EngineEvent
+open Engine.Core.SpatialCue
+
+// ---------------------------------------------------------------------
+// ADR 0012 S3 — spatial-signature tests. Uniqueness is the
+// load-bearing property: the ear must be able to identify the
+// event class (and the sealed chunk's kind) without speech.
+// ---------------------------------------------------------------------
+
+let private mkChunk (kind: Chunk.ChunkKind) : Chunk.Chunk =
+    let parentless =
+        ChunkTree.append None kind "x" ChunkTree.empty
+    match parentless with
+    | Ok (c, _) -> c
+    | Error e -> failwith e
+
+let private cueOf (ev: EngineEvent) : Cue =
+    match forEvent ev with
+    | Some c -> c
+    | None -> failwithf "expected a cue for %A" ev
+
+/// One representative event per family.
+let private familyEvents : (string * EngineEvent) list =
+    [ "request", RequestCaptured (mkChunk Chunk.UserRequest)
+      "session", SessionStarted "s"
+      "seal", ChunkSealed (mkChunk Chunk.Paragraph)
+      "progress", ResponseProgress 3
+      "completed", ResponseCompleted (false, 5)
+      "failed", ResponseCompleted (true, 5)
+      "note", EngineNote "n" ]
+
+[<Fact>]
+let ``every event family has a cue`` () =
+    for _, ev in familyEvents do
+        Assert.True((forEvent ev).IsSome)
+
+[<Fact>]
+let ``every event family has a unique pan-pitch signature`` () =
+    let signatures =
+        familyEvents
+        |> List.map (fun (name, ev) ->
+            let cue = cueOf ev
+            name, (cue.Pan, cue.Pitch))
+    let distinct =
+        signatures |> List.map snd |> List.distinct
+    Assert.Equal(List.length signatures, List.length distinct)
+
+[<Fact>]
+let ``every chunk kind seals with a distinct pitch`` () =
+    let kinds : Chunk.ChunkKind list =
+        [ Chunk.Heading 1; Chunk.Paragraph; Chunk.ListBlock true
+          Chunk.ListItem; Chunk.CodeBlock None; Chunk.BlockQuote
+          Chunk.ThematicBreak; Chunk.UserRequest
+          Chunk.ToolUse "Bash"; Chunk.ToolResult false
+          Chunk.ToolResult true; Chunk.AgentError; Chunk.SystemNote ]
+    let pitches = kinds |> List.map pitchForKind
+    Assert.Equal(List.length pitches, List.length (List.distinct pitches))
+
+[<Fact>]
+let ``the stage layout encodes the attention contract`` () =
+    // Narrative thread = center; ambient = off to the sides.
+    Assert.Equal(0.0, (cueOf (RequestCaptured (mkChunk Chunk.UserRequest))).Pan)
+    Assert.Equal(0.0, (cueOf (ResponseCompleted (false, 1))).Pan)
+    Assert.True((cueOf (ResponseProgress 1)).Pan > 0.0)
+    Assert.True((cueOf (ChunkSealed (mkChunk Chunk.Paragraph))).Pan > 0.0)
+    Assert.True((cueOf (SessionStarted "s")).Pan < 0.0)
+    Assert.True((cueOf (EngineNote "n")).Pan < 0.0)
+
+[<Fact>]
+let ``progress pitch rises with the count and caps`` () =
+    let pitchAt n = (cueOf (ResponseProgress n)).Pitch
+    Assert.True(pitchAt 2 > pitchAt 1)
+    Assert.True(pitchAt 12 > pitchAt 6)
+    Assert.Equal(pitchAt 12, pitchAt 50)
+
+[<Fact>]
+let ``failure rings low and long relative to success`` () =
+    let okCue = cueOf (ResponseCompleted (false, 1))
+    let errCue = cueOf (ResponseCompleted (true, 1))
+    Assert.True(errCue.Pitch < okCue.Pitch)
+    Assert.True(errCue.DurationMs > okCue.DurationMs)
+
+[<Fact>]
+let ``nav cues pan toward the movement and edges ring dull`` () =
+    Assert.True((forNav Next true).Pan > 0.0)
+    Assert.True((forNav Previous true).Pan < 0.0)
+    Assert.Equal(0.0, (forNav Descend true).Pan)
+    Assert.True((forNav Descend true).Pitch < (forNav Ascend true).Pitch)
+    let edge = forNav Next false
+    Assert.True(edge.Pitch < (forNav Next true).Pitch)
+    Assert.True(edge.Pan > 0.0)
+
+[<Fact>]
+let ``cue gains sit under speech`` () =
+    for _, ev in familyEvents do
+        Assert.True((cueOf ev).Gain <= 0.5)
+    Assert.True((forNav Next true).Gain <= 0.5)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -106,6 +106,7 @@
     <Compile Include="NavigatorTests.fs" />
     <Compile Include="ChunkNarrationTests.fs" />
     <Compile Include="AttentionTests.fs" />
+    <Compile Include="SpatialCueTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

[ADR 0012](docs/adr/0012-semantic-outline-and-spatial-event-signatures.md) S3 — **unique spatial-audio signatures for every universal-event-bus event** (pure model; the renderer lands in the next PR):

- **`SpatialCue.fs`** — a deterministic mapping from `EngineEvent` to a stereo-stage cue (`Pan` −1…+1, `Pitch` Hz, `DurationMs`, `Gain`). The **stage layout encodes the §7.3 attention contract by position**: the narrative thread lives center (request 660 Hz / completion 880 / failure 220 low-and-long); the content trickle sits near-right with a **unique pitch per `ChunkKind`** — headings ring B5, paragraphs C5, code F5, tool errors low D#4 — so the ear identifies *what kind* of content just sealed without a word; turn progress sits right with a count-rising pitch series (capped); lifecycle far-left; diagnostics left.
- **Direction-coded navigation cues** (`forNav`): next/previous pan toward the movement, descend pitched low / ascend high, and a refused move (the §6.4 edge) rings dull *on the side of the attempt* — you hear where you bumped before the voice says why.
- **`SpatialCueTests`** pin uniqueness as a property: pairwise-distinct (pan, pitch) per event family, pairwise-distinct pitches across all 13 chunk kinds, the rising-then-capped progress series, the low/long failure contrast, direction coding, and under-speech gains.

The cue model deliberately carries *stage position*, never implementation — the stereo panner (next PR) and any future HRTF renderer consume the same data.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_