### PR TITLE
docs: ADRs 0013 + 0014 — computational notebook + config/keymap/speech/diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15881,6 +15881,24 @@ ring) follow.
   Implemented & CI-green; ARCHITECTURE / SESSION-HANDOFF /
   CLAUDE.md updated.
 
+### Cycle 54 kick-off (2026-06-12): ADRs 0013 + 0014 (launch-readiness cycle)
+
+- **Added (docs / decision records)**:
+  [ADR 0013](docs/adr/0013-computational-notebook-authored-layer.md)
+  — the computational notebook (authored layer): N1 notebook =
+  references (pinned chunks) + narrative + sections, never
+  copies; N2 two host modes, one minimal surface; N3 export =
+  markdown (publishable AND re-ingestable — narratives flow
+  into new conversations); N4 session + notebook persistence
+  as schema-v1 JSONL with validated restore + auto-save +
+  open-last-session (`--resume` carried across restarts); N5
+  rerun verb. [ADR 0014](docs/adr/0014-engine-config-keymap-speech-diagnostics.md)
+  — `engine.toml` (C1, warn-and-default discipline), the
+  declarative conflict-checked keymap with generated help
+  (C2), speech rate/voice controls on the sink seam (C3), and
+  the ear-first diagnostics path (spoken summary + dump file +
+  session event log) (C4).
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0013-computational-notebook-authored-layer.md
+++ b/docs/adr/0013-computational-notebook-authored-layer.md
@@ -1,0 +1,135 @@
+# ADR 0013 — The computational notebook: authored layer, pinning, narrative export, session persistence
+
+- **Status**: Proposed — authored 2026-06-12 under the
+  maintainer's explicit instruction to push the engine toward a
+  launch-ready, audio-only **computational notebook** (the
+  Wolfram-notebook-inspired direction named in the directive),
+  with autonomy to decide implementation questions. The
+  `P0-ENGINE-1` dogfood (extended) ratifies.
+- **Date**: 2026-06-12
+- **Deciders**: Claude (autonomous, per maintainer grant);
+  maintainer ratifies retroactively.
+- **Companion docs**:
+  [`docs/RELAUNCH-SPEC.md`](../RELAUNCH-SPEC.md) §5.3
+  (capture layer vs authored layer — this ADR builds the
+  authored layer), §6.3 (editor verbs), §3 (the Wolfram
+  notebook as the primary reference experience),
+  [ADR 0011](0011-phase0-interaction-engine-bootstrap.md),
+  [ADR 0012](0012-semantic-outline-and-spatial-event-signatures.md).
+
+## Context
+
+The spec's sharpest reference experience (§3) is the Wolfram
+notebook: a reorderable document of typed cells that serves
+both the final output **and** the act of holding contextual
+awareness mid-exploration. The spec separates the **capture
+layer** (the immutable transcript — shipped: the chunk tree)
+from the **authored layer** (the notebook the user *thinks
+in*) and warns: never collapse them (§14.5).
+
+The maintainer's directive asks for exactly this: a minimal
+interface that records an **editable final sequence** composed
+into a higher-order computational narrative — memory of complex
+workflows that can later be modified and flow into new domains.
+The capture tree already holds everything that happened; what
+is missing is the *curated* sequence built from it.
+
+The interface must remain language-agnostic (the participant
+seam supports many languages/tools); the notebook's canonical
+vocabulary is the typed chunk kinds, not any one language's
+syntax — code cells carry their language tag, nothing more.
+
+## Decisions
+
+### N1 — The notebook model: references + narrative, never copies
+
+`Notebook` (pure, `Engine.Core`) is an ordered sequence of
+cells, each one of:
+
+- **`PinnedChunk of ChunkId`** — a *reference* into the capture
+  tree (never a copy: the transcript stays the single source of
+  truth; a pinned cell renders through the live tree).
+- **`Narrative of text`** — the user's own authored words (the
+  connective tissue of the computational narrative).
+- **`SectionHeader of title`** — the higher-order structure.
+
+Operations (the §6.3 editor verbs, v1 set): `pin`,
+`addNarrative`, `addSection`, `moveUp`/`moveDown`, `removeAt`.
+All pure, all total (out-of-range indices are no-ops returning
+the notebook unchanged — editing by ear must never throw).
+Capture-vs-authored stays uncollapsed by construction: pinning
+mutates only the notebook; the tree is never written by any
+notebook operation.
+
+### N2 — Two host modes, one minimal surface
+
+The host gains a **mode**: *Transcript* (the capture tree —
+everything shipped so far) and *Notebook* (the authored
+sequence). One key toggles; the same movement keys work in
+both (`j`/`k`, `r`, `w`, edges cue identically). In transcript
+mode `p` pins the focused chunk (appended to the notebook); in
+notebook mode the editor verbs are live. Minimal by design:
+no panes, no chrome — a mode is just which sequence the cursor
+walks.
+
+### N3 — Export: the notebook IS a markdown document
+
+`Notebook.toMarkdown` renders the authored sequence to plain
+markdown: sections become `##` headings, narrative becomes
+paragraphs, pinned chunks render by kind (headings demoted
+under their section, code blocks re-fenced with their language
+tag, tool results fenced as output). The export is therefore
+immediately publishable, diffable, and — because markdown is
+the engine's own ingest format — **re-ingestable**: a narrative
+composed today can flow into a new conversation tomorrow (the
+maintainer's "flow into new domains of knowledge"). This is the
+Wolfram lesson adapted honestly: where Wolfram has one language
+for interface and data, the engine's interchange form is typed
+markdown — the one structure every participant already speaks.
+
+### N4 — Persistence: sessions and notebooks as JSONL, schema v1
+
+- **Session capture**: the chunk tree serializes to JSONL (one
+  chunk per line, capture order; a leading meta line carries
+  `schemaVersion`, the participant session id, and the cursor
+  anchors). `ChunkTree.restore` rebuilds a tree from chunk
+  records, *validating* the invariants (parents precede
+  children, capture order strict, authored index consistent) —
+  a corrupt file degrades to a typed error, never a crash.
+- **Auto-save** after every completed turn to
+  `%LOCALAPPDATA%\PtySpeak\engine-sessions\`; manual save verb;
+  an **open-last-session** verb restores both the tree and the
+  CLI `--resume` id, so the conversation continues across app
+  restarts — the "seamlessly holds the memory" requirement,
+  mechanically.
+- **Notebook** persists alongside the session (same JSONL
+  discipline) and exports to `.md` on demand.
+- Format discipline follows `docs/IOCELL-SCHEMA.md` precedent:
+  locked key order, explicit `schemaVersion`, one-way
+  migrations.
+
+### N5 — Re-issue: rerun a captured request
+
+In transcript mode, the rerun verb on a focused `UserRequest`
+chunk sends that request text again as a new turn (the §6.3
+"revisit a cell and re-issue" in its v1 form — re-issue
+verbatim; inline editing of the text is the v2 editor). On any
+other chunk kind it explains itself instead of guessing.
+
+## Consequences
+
+- The user's loop becomes: explore in the transcript → pin the
+  results worth keeping → narrate between them → reorder into
+  an argument → export a publishable markdown narrative →
+  re-ingest it tomorrow as the seed of the next exploration.
+- The notebook is unbounded by participant or language — pinned
+  cells are typed chunks, whatever produced them.
+- Deliberately deferred (v2 editor): inline text editing of
+  narrative cells, split/merge/re-segment, anchored re-issue
+  with modifications, multi-notebook management.
+
+## Status notes
+
+- 2026-06-12: authored; implementation lands in this cycle
+  (serde → auto-save/restore → notebook model → host mode →
+  export → rerun), each its own PR.

--- a/docs/adr/0014-engine-config-keymap-speech-diagnostics.md
+++ b/docs/adr/0014-engine-config-keymap-speech-diagnostics.md
@@ -1,0 +1,124 @@
+# ADR 0014 — Engine configuration, declarative keymap, speech controls, and diagnostics
+
+- **Status**: Proposed — authored 2026-06-12 in the
+  launch-readiness cycle (same autonomy grant as ADR 0013).
+  The extended `P0-ENGINE-1` dogfood ratifies.
+- **Date**: 2026-06-12
+- **Deciders**: Claude (autonomous, per maintainer grant);
+  maintainer ratifies retroactively.
+- **Companion docs**: [ADR 0011](0011-phase0-interaction-engine-bootstrap.md),
+  [ADR 0013](0013-computational-notebook-authored-layer.md),
+  [`docs/RELAUNCH-SPEC.md`](../RELAUNCH-SPEC.md) §1.1 (the
+  narration quality bar), `Terminal.Core.Config` (the TOML
+  precedent this follows).
+
+## Context
+
+Launch readiness for a keyboard-only, audio-only instrument
+means three things the Phase 0 build lacks: (1) the user must
+be able to **tune the instrument** — voice, rate, verbosity,
+cue gains, key bindings — without recompiling; (2) the key
+surface must be **one declarative table**, not a hand-matched
+switch, so help text, documentation, conflict detection, and
+user overrides all derive from a single source of truth; (3)
+when something goes wrong in the field, the maintainer needs
+**diagnostics the user can produce by ear** — a spoken summary
+plus a dump file — because the user cannot read a console.
+
+## Decisions
+
+### C1 — `engine.toml`: the engine's own config file
+
+`EngineConfig` (pure parse, `Engine.Core`; Tomlyn via the
+established non-throwing `Toml.Parse → HasErrors → ToModel`
+pattern) loads `%LOCALAPPDATA%\PtySpeak\engine.toml`:
+
+```toml
+schema_version = 1
+
+[participant]
+claude_executable = "C:\\path\\to\\claude.exe"  # else ENGINE_CLAUDE_PATH, else claude.cmd
+
+[speech]
+rate = 2          # SAPI -10..10, clamped
+voice = "Microsoft Zira Desktop"  # substring match, optional
+
+[narration]
+move_read_cap_chars = 600   # navigation read bound
+
+[cues]
+enabled = true
+gain = 1.0        # master multiplier 0.0..1.0 over per-cue gains
+
+[keys]
+# verb = "x"  — single-character overrides, validated for conflicts
+pin = "p"
+```
+
+Every malformed value degrades to its default **with a typed
+warning** the host speaks once at startup ("2 configuration
+warnings; press d for details") and records in diagnostics —
+never a crash, never silence (ADR 0008 honesty applied to
+config). Missing file = pure defaults, no warning.
+
+### C2 — The declarative keymap
+
+`KeyMap` (pure, `Engine.Core`): every verb is a case of a
+`Verb` union; the default bindings are one table of
+`{ Verb; Key; Mode; Description }`. The host's key loop is a
+table lookup, not a match ladder. Consequences, all tested:
+
+- **No conflicts by construction**: a validator rejects
+  duplicate keys per mode (defaults are asserted
+  conflict-free in CI; user overrides that collide produce a
+  warning and keep the default).
+- **Help is generated** from the table — `?` can never drift
+  from reality, and the keyboard-reference doc is checked
+  against the same table's content.
+- **User remapping** via `[keys]` in `engine.toml` (single
+  printable character per verb; arrows stay hardwired to the
+  four tree moves as the universal fallback).
+
+### C3 — Speech controls on the sink seam
+
+`ISpeechSink` gains `SetRate(int)` (clamped −10…+10) and
+construction-time voice selection (case-insensitive substring
+match against installed voices; no match = default voice + a
+spoken note). Live keys: rate up / rate down step ±1 and
+confirm ("Rate 3."). Rationale: for a power listener, rate is
+the single highest-leverage tuning knob (§1.1); it must be a
+keystroke, not a config edit.
+
+### C4 — Diagnostics: the ear-first triage path
+
+- `EngineDiagnostics` (`Engine.Core`): a thread-safe bounded
+  ring (default 500 entries) recording every bus event,
+  every turn outcome, config warnings, and host errors, with
+  per-category counts.
+- The diagnostics verb speaks a **summary** (uptime, turns,
+  chunks sealed, notes/errors count, last error if any) and
+  writes the **full dump** to a timestamped file under
+  `%LOCALAPPDATA%\PtySpeak\engine-diagnostics\`, then speaks
+  the file path — the exact bundle a bug report needs,
+  produced without sight, in two keystrokes.
+- The host also appends a **session event log** (one line per
+  bus event) next to the session files, so post-hoc triage can
+  replay what the user heard.
+
+## Consequences
+
+- Every behavioural constant a user might reasonably want to
+  change now has a config key, a default, and a documented
+  degradation path; `docs/engine/CONFIGURATION.md` is the
+  reference.
+- Adding a verb = one union case + one table row + one handler
+  — the development guide's worked example.
+- The diagnostics dump becomes the standard first ask in any
+  field issue (mirroring the WPF app's `Ctrl+Shift+D`
+  discipline, rebuilt ear-first).
+
+## Status notes
+
+- 2026-06-12: authored; implementation lands in this cycle
+  (config → diagnostics → keymap → speech controls → host
+  integration), each its own PR.


### PR DESCRIPTION
## Summary

Cycle 54 (launch-readiness) PR 1 — decision records first:

- **[ADR 0013](docs/adr/0013-computational-notebook-authored-layer.md)** — the **computational notebook** (the RELAUNCH-SPEC §5.3 authored layer, Wolfram-notebook-inspired): notebook cells are *references* into the capture tree (pinned chunks) plus narrative text and section headers — never copies; two host modes on one minimal surface; **export is markdown**, which is both publishable and re-ingestable (a narrative composed today seeds tomorrow's conversation); session + notebook persistence as schema-v1 JSONL with validated restore, auto-save, and open-last-session carrying the CLI `--resume` id across restarts; a rerun verb.
- **[ADR 0014](docs/adr/0014-engine-config-keymap-speech-diagnostics.md)** — `engine.toml` with the warn-and-default discipline; a **declarative, conflict-checked keymap** (help text and docs generated from one table; user remapping via config); speech rate/voice controls on the `ISpeechSink` seam; and the **ear-first diagnostics path** (spoken summary + dump file + session event log — a field bug report in two keystrokes, no sight required).

Docs-only — fast lane. Implementation follows PR by PR.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_