### PR TITLE
feat(engine): engine.toml config + diagnostics ring (ADR 0014 C1/C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15899,6 +15899,20 @@ ring) follow.
   the ear-first diagnostics path (spoken summary + dump file +
   session event log) (C4).
 
+### Cycle 54 PR-2 (2026-06-12): engine.toml + diagnostics ring
+
+- **Added**: `Engine.Core/EngineConfig.fs` — `engine.toml`
+  parse (ADR 0014 C1): participant executable, speech
+  rate/voice, narration cap, cue enable/gain, single-char key
+  overrides; schema_version gate; the warn-and-default
+  discipline (no input can crash or silently change
+  behaviour). `Engine.Core/EngineDiagnostics.fs` — the
+  bounded thread-safe ring (lifetime counts, last-error
+  tracking, speakable `Summary`, grep-friendly `Dump`,
+  `describeEvent` bus rendering with clipped bodies).
+  Tests pin both incl. forward-compatible unknown-key
+  silence and ring eviction-vs-lifetime-count honesty.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -65,11 +65,18 @@
       after it.
     -->
     <Compile Include="SpatialCue.fs" />
+    <!--
+      ADR 0014 C1/C4 — engine.toml (Tomlyn, the Terminal.Core
+      Config pattern) + the ear-first diagnostics ring.
+    -->
+    <Compile Include="EngineConfig.fs" />
+    <Compile Include="EngineDiagnostics.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Markdig" />
+    <PackageReference Include="Tomlyn" />
   </ItemGroup>
 
 </Project>

--- a/src/Engine.Core/EngineConfig.fs
+++ b/src/Engine.Core/EngineConfig.fs
@@ -1,0 +1,222 @@
+namespace Engine.Core
+
+open System
+open Tomlyn
+open Tomlyn.Model
+
+/// ADR 0014 C1 — the engine's own configuration file
+/// (`engine.toml`). Pure parse: TOML text in, (config,
+/// warnings) out. Follows the `Terminal.Core.Config` precedent
+/// exactly: the non-throwing `Toml.Parse → HasErrors → ToModel`
+/// entry, `TryGetValue` tuple-deconstruction (sidesteps the
+/// F# 9 `byref<obj | null>` mismatch), and the
+/// **warn-and-default discipline** — every malformed value
+/// degrades to its default with a typed warning the host
+/// speaks once and records in diagnostics; never a crash,
+/// never silence. A missing file is pure defaults, no warning.
+module EngineConfig =
+
+    /// The schema this build reads. A file declaring a NEWER
+    /// schema is rejected whole (defaults + warning) so an old
+    /// build never half-reads a future format.
+    [<Literal>]
+    let CurrentSchemaVersion = 1
+
+    type Config =
+        { /// Overrides ENGINE_CLAUDE_PATH and the "claude.cmd"
+          /// default. `[participant] claude_executable`.
+          ClaudeExecutable: string option
+          /// SAPI rate, clamped −10…+10. `[speech] rate`.
+          SpeechRate: int
+          /// Case-insensitive substring match against installed
+          /// voices. `[speech] voice`.
+          VoiceName: string option
+          /// Navigation-read bound (chars). `[narration]
+          /// move_read_cap_chars`.
+          MoveReadCapChars: int
+          /// Master switch for spatial cues. `[cues] enabled`.
+          CuesEnabled: bool
+          /// Master gain multiplier over per-cue gains,
+          /// clamped 0.0…1.0. `[cues] gain`.
+          CueGain: float
+          /// Single-character verb rebindings. `[keys]`
+          /// verb-name = "x". Applied by `KeyMap.withOverrides`
+          /// (conflicts warn and keep defaults).
+          KeyOverrides: Map<string, char> }
+
+    let defaults : Config =
+        { ClaudeExecutable = None
+          SpeechRate = 0
+          VoiceName = None
+          MoveReadCapChars = 600
+          CuesEnabled = true
+          CueGain = 1.0
+          KeyOverrides = Map.empty }
+
+    let private tryGetTable (table: TomlTable) (key: string) : TomlTable option =
+        match table.TryGetValue(key) with
+        | true, (:? TomlTable as t) -> Some t
+        | _ -> None
+
+    let private tryGetString (table: TomlTable) (key: string) : string option =
+        match table.TryGetValue(key) with
+        | true, (:? string as s) -> Some s
+        | _ -> None
+
+    let private tryGetInt (table: TomlTable) (key: string) : int64 option =
+        match table.TryGetValue(key) with
+        | true, (:? int64 as i) -> Some i
+        | _ -> None
+
+    let private tryGetBool (table: TomlTable) (key: string) : bool option =
+        match table.TryGetValue(key) with
+        | true, (:? bool as b) -> Some b
+        | _ -> None
+
+    /// TOML floats box as `float`; integers as `int64` — accept
+    /// both for a gain value (a user writing `1` means 1.0).
+    let private tryGetFloat (table: TomlTable) (key: string) : float option =
+        match table.TryGetValue(key) with
+        | true, (:? float as f) -> Some f
+        | true, (:? int64 as i) -> Some (float i)
+        | _ -> None
+
+    /// Parse TOML text. Returns the effective config plus
+    /// human-readable warnings (spoken once at startup,
+    /// recorded in diagnostics).
+    let parse (toml: string) : Config * string list =
+        let doc = Toml.Parse(toml)
+        if doc.HasErrors then
+            let detail =
+                doc.Diagnostics
+                |> Seq.map (fun d -> d.ToString())
+                |> String.concat "; "
+            defaults,
+            [ sprintf "engine.toml is malformed; using defaults. %s" detail ]
+        else
+            let model = doc.ToModel()
+            let warnings = ResizeArray<string>()
+            let warn (message: string) = warnings.Add(message)
+
+            let schemaOk =
+                match tryGetInt model "schema_version" with
+                | Some v when int v > CurrentSchemaVersion ->
+                    warn (
+                        sprintf
+                            "engine.toml schema_version %d is newer than this build supports (%d); using defaults."
+                            (int v) CurrentSchemaVersion)
+                    false
+                | _ -> true
+
+            if not schemaOk then
+                defaults, List.ofSeq warnings
+            else
+                let participant =
+                    match tryGetTable model "participant" with
+                    | Some t -> tryGetString t "claude_executable"
+                    | None -> None
+
+                let speechRate, voiceName =
+                    match tryGetTable model "speech" with
+                    | None -> defaults.SpeechRate, defaults.VoiceName
+                    | Some t ->
+                        let rate =
+                            match tryGetInt t "rate" with
+                            | None ->
+                                if t.ContainsKey("rate") then
+                                    warn "[speech] rate is not an integer; using 0."
+                                defaults.SpeechRate
+                            | Some raw ->
+                                let clamped = max -10 (min 10 (int raw))
+                                if int64 clamped <> raw then
+                                    warn (
+                                        sprintf
+                                            "[speech] rate %d out of range; clamped to %d."
+                                            (int raw) clamped)
+                                clamped
+                        rate, tryGetString t "voice"
+
+                let moveCap =
+                    match tryGetTable model "narration" with
+                    | None -> defaults.MoveReadCapChars
+                    | Some t ->
+                        match tryGetInt t "move_read_cap_chars" with
+                        | None ->
+                            if t.ContainsKey("move_read_cap_chars") then
+                                warn "[narration] move_read_cap_chars is not an integer; using 600."
+                            defaults.MoveReadCapChars
+                        | Some raw when raw < 50L ->
+                            warn "[narration] move_read_cap_chars below 50; clamped to 50."
+                            50
+                        | Some raw -> int (min raw 100_000L)
+
+                let cuesEnabled, cueGain =
+                    match tryGetTable model "cues" with
+                    | None -> defaults.CuesEnabled, defaults.CueGain
+                    | Some t ->
+                        let enabled =
+                            match tryGetBool t "enabled" with
+                            | None ->
+                                if t.ContainsKey("enabled") then
+                                    warn "[cues] enabled is not a boolean; using true."
+                                defaults.CuesEnabled
+                            | Some b -> b
+                        let gain =
+                            match tryGetFloat t "gain" with
+                            | None ->
+                                if t.ContainsKey("gain") then
+                                    warn "[cues] gain is not a number; using 1.0."
+                                defaults.CueGain
+                            | Some g ->
+                                let clamped = max 0.0 (min 1.0 g)
+                                if clamped <> g then
+                                    warn (
+                                        sprintf
+                                            "[cues] gain %g out of range; clamped to %g."
+                                            g clamped)
+                                clamped
+                        enabled, gain
+
+                let keyOverrides =
+                    match tryGetTable model "keys" with
+                    | None -> Map.empty
+                    | Some t ->
+                        (Map.empty, t.Keys |> List.ofSeq)
+                        ||> List.fold (fun acc key ->
+                            match tryGetString t key with
+                            | Some v when v.Length = 1
+                                          && not (Char.IsControl v.[0]) ->
+                                acc |> Map.add key v.[0]
+                            | Some v ->
+                                warn (
+                                    sprintf
+                                        "[keys] %s = \"%s\" is not a single printable character; keeping the default."
+                                        key v)
+                                acc
+                            | None ->
+                                warn (
+                                    sprintf
+                                        "[keys] %s is not a string; keeping the default."
+                                        key)
+                                acc)
+
+                { ClaudeExecutable = participant
+                  SpeechRate = speechRate
+                  VoiceName = voiceName
+                  MoveReadCapChars = moveCap
+                  CuesEnabled = cuesEnabled
+                  CueGain = cueGain
+                  KeyOverrides = keyOverrides },
+                List.ofSeq warnings
+
+    /// Load from a file path. Missing file = pure defaults
+    /// (no warning); unreadable file = defaults + warning.
+    let load (path: string) : Config * string list =
+        if not (IO.File.Exists path) then
+            defaults, []
+        else
+            try
+                parse (IO.File.ReadAllText path)
+            with ex ->
+                defaults,
+                [ sprintf "engine.toml could not be read; using defaults. %s" ex.Message ]

--- a/src/Engine.Core/EngineDiagnostics.fs
+++ b/src/Engine.Core/EngineDiagnostics.fs
@@ -1,0 +1,122 @@
+namespace Engine.Core
+
+open System
+
+/// ADR 0014 C4 — the ear-first diagnostics substrate: a
+/// thread-safe bounded ring recording everything a field bug
+/// report needs (bus events, turn outcomes, config warnings,
+/// host errors), with per-category counts, a speakable
+/// summary, and a full plain-text dump. Instance-scoped (one
+/// per host) like `EngineBus`.
+module EngineDiagnostics =
+
+    type Entry =
+        { AtUtc: DateTime
+          Category: string
+          Message: string }
+
+    /// Bounded ring: oldest entries fall off; counts are
+    /// lifetime (they keep growing after eviction so the
+    /// summary stays honest about volume).
+    type Ring(capacity: int) =
+        let gate: obj = obj ()
+        let entries = System.Collections.Generic.Queue<Entry>()
+        let mutable counts: Map<string, int> = Map.empty
+        let mutable lastError: Entry option = None
+        let startedUtc = DateTime.UtcNow
+
+        new() = Ring(500)
+
+        member _.StartedUtc = startedUtc
+
+        member _.Record (category: string) (message: string) : unit =
+            let entry =
+                { AtUtc = DateTime.UtcNow
+                  Category = category
+                  Message = message }
+            lock gate (fun () ->
+                entries.Enqueue(entry)
+                while entries.Count > capacity do
+                    entries.Dequeue() |> ignore
+                counts <-
+                    counts
+                    |> Map.change category (function
+                        | Some n -> Some (n + 1)
+                        | None -> Some 1)
+                if category = "error" then
+                    lastError <- Some entry)
+
+        /// Lifetime count for one category (0 if never seen).
+        member _.CountOf (category: string) : int =
+            lock gate (fun () ->
+                counts |> Map.tryFind category |> Option.defaultValue 0)
+
+        /// Snapshot of the retained entries, oldest first.
+        member _.Snapshot() : Entry list =
+            lock gate (fun () -> entries |> List.ofSeq)
+
+        /// The speakable one-breath summary (the `d` verb's
+        /// first half). Counts are lifetime; the last error is
+        /// included verbatim when one occurred.
+        member this.Summary() : string =
+            let uptime = DateTime.UtcNow - startedUtc
+            let countsText =
+                lock gate (fun () ->
+                    if counts.IsEmpty then "No events recorded."
+                    else
+                        counts
+                        |> Map.toList
+                        |> List.sortBy fst
+                        |> List.map (fun (category, n) ->
+                            sprintf "%s %d" category n)
+                        |> String.concat ", ")
+            let errorTail =
+                match lock gate (fun () -> lastError) with
+                | Some e -> sprintf " Last error: %s" e.Message
+                | None -> ""
+            sprintf
+                "Up %d minutes. %s.%s"
+                (int uptime.TotalMinutes)
+                countsText
+                errorTail
+
+        /// The full dump (the bug-report artifact): header +
+        /// every retained entry, one per line, grep-friendly.
+        member this.Dump() : string =
+            let header =
+                sprintf
+                    "engine diagnostics dump\nstarted-utc=%s\ndumped-utc=%s\n%s\n---"
+                    (startedUtc.ToString("o"))
+                    (DateTime.UtcNow.ToString("o"))
+                    (this.Summary())
+            let lines =
+                this.Snapshot()
+                |> List.map (fun e ->
+                    sprintf
+                        "%s [%s] %s"
+                        (e.AtUtc.ToString("o"))
+                        e.Category
+                        e.Message)
+            String.concat "\n" (header :: lines)
+
+    /// Render a bus event as a diagnostics line (category +
+    /// terse payload — bodies are clipped: diagnostics traces
+    /// shape, the session tree holds content).
+    let describeEvent (event: EngineEvent.EngineEvent) : string * string =
+        let clip (text: string) =
+            if text.Length > 80 then text.Substring(0, 80) + "…"
+            else text
+        match event with
+        | EngineEvent.RequestCaptured chunk ->
+            "request", clip chunk.Text
+        | EngineEvent.SessionStarted sid ->
+            "session", sid
+        | EngineEvent.ChunkSealed chunk ->
+            "seal", sprintf "%A seq=%d" chunk.Kind chunk.CaptureSeq
+        | EngineEvent.ResponseProgress count ->
+            "progress", string count
+        | EngineEvent.ResponseCompleted (isError, count) ->
+            (if isError then "error" else "completed"),
+            sprintf "chunks=%d" count
+        | EngineEvent.EngineNote text ->
+            "note", clip text

--- a/tests/Tests.Unit/EngineConfigTests.fs
+++ b/tests/Tests.Unit/EngineConfigTests.fs
@@ -1,0 +1,116 @@
+module PtySpeak.Tests.Unit.EngineConfigTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.EngineConfig
+
+// ---------------------------------------------------------------------
+// ADR 0014 C1 — engine.toml parse contract. The load-bearing
+// property is the warn-and-default discipline: NO input text
+// can crash the parse or silently change behaviour — every
+// degradation is a typed warning.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``empty text is pure defaults with no warnings`` () =
+    let config, warnings = EngineConfig.parse ""
+    Assert.Equal(EngineConfig.defaults, config)
+    Assert.Empty(warnings)
+
+[<Fact>]
+let ``a full valid file parses every section`` () =
+    let toml =
+        """
+schema_version = 1
+
+[participant]
+claude_executable = "C:\\tools\\claude.exe"
+
+[speech]
+rate = 3
+voice = "Zira"
+
+[narration]
+move_read_cap_chars = 900
+
+[cues]
+enabled = false
+gain = 0.5
+
+[keys]
+pin = "z"
+"""
+    let config, warnings = EngineConfig.parse toml
+    Assert.Empty(warnings)
+    Assert.Equal(Some "C:\\tools\\claude.exe", config.ClaudeExecutable)
+    Assert.Equal(3, config.SpeechRate)
+    Assert.Equal(Some "Zira", config.VoiceName)
+    Assert.Equal(900, config.MoveReadCapChars)
+    Assert.False(config.CuesEnabled)
+    Assert.Equal(0.5, config.CueGain)
+    Assert.Equal(Some 'z', config.KeyOverrides |> Map.tryFind "pin")
+
+[<Fact>]
+let ``malformed toml degrades to defaults with one warning`` () =
+    let config, warnings = EngineConfig.parse "[speech\nrate = "
+    Assert.Equal(EngineConfig.defaults, config)
+    match warnings with
+    | [ w ] -> Assert.Contains("malformed", w)
+    | other -> failwithf "expected one warning, got %A" other
+
+[<Fact>]
+let ``a newer schema version is rejected whole`` () =
+    let config, warnings =
+        EngineConfig.parse "schema_version = 99\n[speech]\nrate = 5"
+    Assert.Equal(EngineConfig.defaults, config)
+    Assert.True(
+        warnings |> List.exists (fun w -> w.Contains "newer"))
+
+[<Fact>]
+let ``out-of-range rate clamps with a warning`` () =
+    let config, warnings = EngineConfig.parse "[speech]\nrate = 40"
+    Assert.Equal(10, config.SpeechRate)
+    Assert.True(warnings |> List.exists (fun w -> w.Contains "clamped"))
+
+[<Fact>]
+let ``wrong-typed values warn and keep defaults`` () =
+    let toml =
+        "[speech]\nrate = \"fast\"\n[cues]\nenabled = \"yes\"\ngain = \"loud\""
+    let config, warnings = EngineConfig.parse toml
+    Assert.Equal(0, config.SpeechRate)
+    Assert.True(config.CuesEnabled)
+    Assert.Equal(1.0, config.CueGain)
+    Assert.Equal(3, List.length warnings)
+
+[<Fact>]
+let ``cue gain accepts integers and clamps range`` () =
+    let config, _ = EngineConfig.parse "[cues]\ngain = 1"
+    Assert.Equal(1.0, config.CueGain)
+    let config2, warnings2 = EngineConfig.parse "[cues]\ngain = 7.5"
+    Assert.Equal(1.0, config2.CueGain)
+    Assert.True(warnings2 |> List.exists (fun w -> w.Contains "clamped"))
+
+[<Fact>]
+let ``too-small narration cap clamps to the floor`` () =
+    let config, warnings =
+        EngineConfig.parse "[narration]\nmove_read_cap_chars = 5"
+    Assert.Equal(50, config.MoveReadCapChars)
+    Assert.True(warnings |> List.exists (fun w -> w.Contains "50"))
+
+[<Fact>]
+let ``multi-character key overrides warn and are dropped`` () =
+    let config, warnings = EngineConfig.parse "[keys]\npin = \"zz\""
+    Assert.True(config.KeyOverrides.IsEmpty)
+    Assert.True(
+        warnings
+        |> List.exists (fun w -> w.Contains "single printable"))
+
+[<Fact>]
+let ``unknown sections and keys are ignored silently`` () =
+    // Forward compatibility: an older build must not nag about
+    // keys a newer build added (the schema_version gate handles
+    // true incompatibility).
+    let config, warnings =
+        EngineConfig.parse "[future_section]\nmystery = 1"
+    Assert.Equal(EngineConfig.defaults, config)
+    Assert.Empty(warnings)

--- a/tests/Tests.Unit/EngineDiagnosticsTests.fs
+++ b/tests/Tests.Unit/EngineDiagnosticsTests.fs
@@ -1,0 +1,89 @@
+module PtySpeak.Tests.Unit.EngineDiagnosticsTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.EngineDiagnostics
+
+// ---------------------------------------------------------------------
+// ADR 0014 C4 — diagnostics ring contract: bounded retention,
+// lifetime counts, last-error tracking, speakable summary,
+// grep-friendly dump, bus-event rendering.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``recording accumulates entries and counts`` () =
+    let ring = Ring()
+    ring.Record "note" "one"
+    ring.Record "note" "two"
+    ring.Record "seal" "x"
+    Assert.Equal(2, ring.CountOf "note")
+    Assert.Equal(1, ring.CountOf "seal")
+    Assert.Equal(0, ring.CountOf "error")
+    Assert.Equal(3, ring.Snapshot() |> List.length)
+
+[<Fact>]
+let ``the ring is bounded but counts are lifetime`` () =
+    let ring = Ring(3)
+    for i in 1 .. 10 do
+        ring.Record "note" (string i)
+    let kept = ring.Snapshot()
+    Assert.Equal(3, List.length kept)
+    // Oldest evicted; the tail survives.
+    Assert.Equal<string list>(
+        [ "8"; "9"; "10" ],
+        kept |> List.map (fun e -> e.Message))
+    Assert.Equal(10, ring.CountOf "note")
+
+[<Fact>]
+let ``the summary speaks counts and the last error`` () =
+    let ring = Ring()
+    ring.Record "completed" "chunks=4"
+    ring.Record "error" "participant exited with code 1"
+    let summary = ring.Summary()
+    Assert.Contains("completed 1", summary)
+    Assert.Contains("error 1", summary)
+    Assert.Contains("participant exited with code 1", summary)
+
+[<Fact>]
+let ``the summary without events says so`` () =
+    Assert.Contains("No events recorded", Ring().Summary())
+
+[<Fact>]
+let ``the dump carries the header and every retained line`` () =
+    let ring = Ring()
+    ring.Record "note" "alpha"
+    ring.Record "seal" "beta"
+    let dump = ring.Dump()
+    Assert.Contains("engine diagnostics dump", dump)
+    Assert.Contains("[note] alpha", dump)
+    Assert.Contains("[seal] beta", dump)
+
+[<Fact>]
+let ``bus events render with stable categories`` () =
+    let chunk =
+        match ChunkTree.append None Chunk.Paragraph "hello world" ChunkTree.empty with
+        | Ok (c, _) -> c
+        | Error e -> failwith e
+    Assert.Equal(
+        "request",
+        fst (describeEvent (EngineEvent.RequestCaptured chunk)))
+    Assert.Equal(
+        "seal",
+        fst (describeEvent (EngineEvent.ChunkSealed chunk)))
+    Assert.Equal(
+        "error",
+        fst (describeEvent (EngineEvent.ResponseCompleted (true, 2))))
+    Assert.Equal(
+        "completed",
+        fst (describeEvent (EngineEvent.ResponseCompleted (false, 2))))
+
+[<Fact>]
+let ``event bodies are clipped in diagnostics`` () =
+    let long = String.replicate 30 "abcdefghij"
+    let chunk =
+        match ChunkTree.append None Chunk.UserRequest long ChunkTree.empty with
+        | Ok (c, _) -> c
+        | Error e -> failwith e
+    let _, body = describeEvent (EngineEvent.RequestCaptured chunk)
+    Assert.True(body.Length <= 82)
+    Assert.EndsWith("…", body)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -107,6 +107,8 @@
     <Compile Include="ChunkNarrationTests.fs" />
     <Compile Include="AttentionTests.fs" />
     <Compile Include="SpatialCueTests.fs" />
+    <Compile Include="EngineConfigTests.fs" />
+    <Compile Include="EngineDiagnosticsTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Cycle 54 PR-2 ([ADR 0014](docs/adr/0014-engine-config-keymap-speech-diagnostics.md) C1 + C4):

- **`EngineConfig.fs`** — `engine.toml` parsing (Tomlyn, the established non-throwing `Toml.Parse → HasErrors → ToModel` + tuple-deconstruct `TryGetValue` patterns from `Terminal.Core.Config`): participant executable, speech rate (clamped) + voice, narration cap (floored), cue enable + master gain (clamped, int-tolerant), single-character key overrides, and a `schema_version` gate that rejects newer files whole. **The warn-and-default discipline is the contract**: no input text can crash the parse or silently change behaviour — every degradation is a typed warning the host will speak; unknown sections/keys are forward-compatibly silent.
- **`EngineDiagnostics.fs`** — the ear-first triage substrate: a thread-safe bounded ring (default 500) with **lifetime** category counts (eviction never lies about volume), last-error tracking, a speakable one-breath `Summary`, a grep-friendly `Dump`, and `describeEvent` rendering every bus event with clipped bodies (diagnostics traces shape; the session tree holds content).
- 17 new tests pin both contracts.

Host wiring lands with the keymap/integration PRs.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_