### PR TITLE
feat(engine): the notebook model — authored layer over the capture tree (ADR 0013 N1/N3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15913,6 +15913,20 @@ ring) follow.
   Tests pin both incl. forward-compatible unknown-key
   silence and ring eviction-vs-lifetime-count honesty.
 
+### Cycle 54 PR-3 (2026-06-12): the notebook model (authored layer)
+
+- **Added**: `Engine.Core/Notebook.fs` — ADR 0013 N1/N3: cells
+  are pinned chunk REFERENCES (render through the live tree —
+  a pinned heading announces its live child count), authored
+  narrative, and section headers; pin / addNarrative /
+  addSection / moveUp / moveDown / removeAt, all pure and
+  total (out-of-range = honest no-op report — editing by ear
+  never throws); `describeCell` narration; `toMarkdown` export
+  (sections → `##`, code re-fenced with language, lists
+  re-rendered from the live tree, requests/tool calls
+  labelled) — **provably re-ingestable** by the engine's own
+  chunker (tested). `NotebookTests` pin all of it.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -71,6 +71,11 @@
     -->
     <Compile Include="EngineConfig.fs" />
     <Compile Include="EngineDiagnostics.fs" />
+    <!--
+      ADR 0013 N1/N3 — the authored layer (notebook over the
+      capture tree). Depends on ChunkNarration, so it sits last.
+    -->
+    <Compile Include="Notebook.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/Notebook.fs
+++ b/src/Engine.Core/Notebook.fs
@@ -1,0 +1,162 @@
+namespace Engine.Core
+
+open System
+
+/// ADR 0013 N1/N3 — the authored layer (RELAUNCH-SPEC §5.3):
+/// the notebook the user *thinks in*, built over the immutable
+/// capture tree. Cells are **references** (pinned chunks) plus
+/// the user's own narrative and section structure — never
+/// copies, so the transcript stays the single source of truth
+/// and the two layers cannot collapse (§14.5) by construction.
+///
+/// Every operation is pure and **total**: out-of-range indices
+/// are no-ops (editing by ear must never throw), and move
+/// operations report whether they moved so the host can cue
+/// edge-vs-moved exactly like tree navigation.
+module Notebook =
+
+    type CellContent =
+        /// A reference into the capture tree; renders through
+        /// the live tree at narration/export time.
+        | PinnedChunk of Chunk.ChunkId
+        /// The user's authored words — the connective tissue of
+        /// the computational narrative.
+        | Narrative of text: string
+        /// Higher-order structure (exports as a markdown
+        /// heading).
+        | SectionHeader of title: string
+
+    type Cell =
+        { Id: string
+          Content: CellContent }
+
+    type Notebook =
+        { Cells: Cell list }
+
+    let empty : Notebook =
+        { Cells = [] }
+
+    let count (notebook: Notebook) : int =
+        List.length notebook.Cells
+
+    let private newCell (content: CellContent) : Cell =
+        { Id = Guid.NewGuid().ToString("N")
+          Content = content }
+
+    /// Append a pinned reference to a capture chunk.
+    let pin (chunkId: Chunk.ChunkId) (notebook: Notebook) : Notebook =
+        { Cells = notebook.Cells @ [ newCell (PinnedChunk chunkId) ] }
+
+    /// Append an authored narrative cell.
+    let addNarrative (text: string) (notebook: Notebook) : Notebook =
+        { Cells = notebook.Cells @ [ newCell (Narrative text) ] }
+
+    /// Append a section header.
+    let addSection (title: string) (notebook: Notebook) : Notebook =
+        { Cells = notebook.Cells @ [ newCell (SectionHeader title) ] }
+
+    let tryItem (index: int) (notebook: Notebook) : Cell option =
+        List.tryItem index notebook.Cells
+
+    /// Remove the cell at `index`; out of range = unchanged.
+    /// Reports whether a cell was removed.
+    let removeAt (index: int) (notebook: Notebook) : Notebook * bool =
+        if index < 0 || index >= count notebook then
+            notebook, false
+        else
+            { Cells =
+                notebook.Cells
+                |> List.mapi (fun i cell -> i, cell)
+                |> List.filter (fun (i, _) -> i <> index)
+                |> List.map snd },
+            true
+
+    let private swap (i: int) (j: int) (cells: Cell list) : Cell list =
+        let arr = List.toArray cells
+        let tmp = arr.[i]
+        arr.[i] <- arr.[j]
+        arr.[j] <- tmp
+        List.ofArray arr
+
+    /// Move the cell at `index` one position earlier; at the
+    /// top or out of range = unchanged (reported).
+    let moveUp (index: int) (notebook: Notebook) : Notebook * bool =
+        if index <= 0 || index >= count notebook then
+            notebook, false
+        else
+            { Cells = swap (index - 1) index notebook.Cells }, true
+
+    /// Move the cell at `index` one position later; at the end
+    /// or out of range = unchanged (reported).
+    let moveDown (index: int) (notebook: Notebook) : Notebook * bool =
+        if index < 0 || index >= count notebook - 1 then
+            notebook, false
+        else
+            { Cells = swap index (index + 1) notebook.Cells }, true
+
+    /// Narrate one cell. Pinned chunks render through the live
+    /// tree (full canonical narration); a dangling reference —
+    /// structurally impossible today (the tree is append-only)
+    /// but possible across file edits — degrades honestly.
+    let describeCell
+            (tree: ChunkTree.Tree)
+            (cell: Cell)
+            : string =
+        match cell.Content with
+        | PinnedChunk chunkId ->
+            match ChunkTree.tryFind chunkId tree with
+            | Some chunk ->
+                sprintf "Pinned: %s" (ChunkNarration.describe tree chunk)
+            | None -> "Pinned chunk is no longer in this session."
+        | Narrative text -> text
+        | SectionHeader title -> sprintf "Section: %s" title
+
+    /// ADR 0013 N3 — render the authored sequence as plain
+    /// markdown: publishable, diffable, and — because markdown
+    /// is the engine's own ingest grain — re-ingestable, so a
+    /// narrative composed today can seed tomorrow's
+    /// conversation.
+    let toMarkdown
+            (tree: ChunkTree.Tree)
+            (notebook: Notebook)
+            : string =
+        let renderChunk (chunk: Chunk.Chunk) : string =
+            match chunk.Kind with
+            | Chunk.Heading _ -> sprintf "### %s" chunk.Text
+            | Chunk.Paragraph -> chunk.Text
+            | Chunk.CodeBlock language ->
+                let fence =
+                    match language with
+                    | Some lang -> "```" + lang
+                    | None -> "```"
+                sprintf "%s\n%s\n```" fence (chunk.Text.TrimEnd('\n'))
+            | Chunk.ListBlock _ ->
+                ChunkTree.children (Some chunk.Id) tree
+                |> List.map (fun item -> sprintf "- %s" item.Text)
+                |> String.concat "\n"
+            | Chunk.ListItem -> sprintf "- %s" chunk.Text
+            | Chunk.BlockQuote -> sprintf "> %s" chunk.Text
+            | Chunk.ThematicBreak -> "---"
+            | Chunk.UserRequest -> sprintf "**Request:** %s" chunk.Text
+            | Chunk.ToolUse name ->
+                sprintf
+                    "**Tool call (%s):**\n```json\n%s\n```"
+                    name (chunk.Text.TrimEnd('\n'))
+            | Chunk.ToolResult isError ->
+                let label = if isError then "Tool error" else "Tool result"
+                sprintf
+                    "**%s:**\n```\n%s\n```"
+                    label (chunk.Text.TrimEnd('\n'))
+            | Chunk.AgentError -> sprintf "**Agent error:** %s" chunk.Text
+            | Chunk.SystemNote -> chunk.Text
+        let renderCell (cell: Cell) : string =
+            match cell.Content with
+            | SectionHeader title -> sprintf "## %s" title
+            | Narrative text -> text
+            | PinnedChunk chunkId ->
+                match ChunkTree.tryFind chunkId tree with
+                | Some chunk -> renderChunk chunk
+                | None -> "<!-- pinned chunk missing -->"
+        notebook.Cells
+        |> List.map renderCell
+        |> String.concat "\n\n"

--- a/tests/Tests.Unit/NotebookTests.fs
+++ b/tests/Tests.Unit/NotebookTests.fs
@@ -1,0 +1,128 @@
+module PtySpeak.Tests.Unit.NotebookTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.Notebook
+
+// ---------------------------------------------------------------------
+// ADR 0013 N1/N3 — notebook contract: reference-not-copy
+// pinning, total editing operations (no input throws), honest
+// move/remove reporting, narration through the live tree, and
+// the markdown export shape.
+// ---------------------------------------------------------------------
+
+let private ok r =
+    match r with
+    | Ok v -> v
+    | Error e -> failwithf "fixture: %s" e
+
+let private contentTexts (tree: ChunkTree.Tree) (nb: Notebook) =
+    nb.Cells |> List.map (describeCell tree)
+
+[<Fact>]
+let ``pin narrative and section append in order`` () =
+    let chunk, tree =
+        ok (ChunkTree.append None Chunk.Paragraph "finding" ChunkTree.empty)
+    let nb =
+        empty
+        |> addSection "Results"
+        |> pin chunk.Id
+        |> addNarrative "This matters because..."
+    Assert.Equal(3, count nb)
+    Assert.Equal<string list>(
+        [ "Section: Results"
+          "Pinned: finding"
+          "This matters because..." ],
+        contentTexts tree nb)
+
+[<Fact>]
+let ``pinning is a reference not a copy`` () =
+    // The narration renders THROUGH the tree: a pinned heading
+    // announces its live child count, proving no snapshot was
+    // taken at pin time.
+    let h, tree =
+        ok (ChunkTree.append None (Chunk.Heading 1) "Plan" ChunkTree.empty)
+    let nb = empty |> pin h.Id
+    let _, tree =
+        ok (ChunkTree.append (Some h.Id) Chunk.Paragraph "later child" tree)
+    Assert.Equal<string list>(
+        [ "Pinned: Heading level 1: Plan. 1 items inside." ],
+        contentTexts tree nb)
+
+[<Fact>]
+let ``removeAt is total and reports honestly`` () =
+    let nb = empty |> addNarrative "a" |> addNarrative "b"
+    let nb1, removed1 = removeAt 0 nb
+    Assert.True(removed1)
+    Assert.Equal(1, count nb1)
+    let nb2, removed2 = removeAt 5 nb1
+    Assert.False(removed2)
+    Assert.Equal(1, count nb2)
+    let nb3, removed3 = removeAt -1 nb2
+    Assert.False(removed3)
+    Assert.Equal(1, count nb3)
+
+[<Fact>]
+let ``moveUp and moveDown swap neighbours and stop at edges`` () =
+    let tree = ChunkTree.empty
+    let nb =
+        empty |> addNarrative "1" |> addNarrative "2" |> addNarrative "3"
+    let nb1, moved1 = moveUp 1 nb
+    Assert.True(moved1)
+    Assert.Equal<string list>([ "2"; "1"; "3" ], contentTexts tree nb1)
+    let nb2, moved2 = moveUp 0 nb1
+    Assert.False(moved2)
+    Assert.Equal<string list>([ "2"; "1"; "3" ], contentTexts tree nb2)
+    let nb3, moved3 = moveDown 2 nb2
+    Assert.False(moved3)
+    let nb4, moved4 = moveDown 0 nb3
+    Assert.True(moved4)
+    Assert.Equal<string list>([ "1"; "2"; "3" ], contentTexts tree nb4)
+
+[<Fact>]
+let ``markdown export renders sections narrative and pinned kinds`` () =
+    let req, tree =
+        ok (ChunkTree.append None Chunk.UserRequest "find primes" ChunkTree.empty)
+    let code, tree =
+        ok (ChunkTree.append
+                (Some req.Id)
+                (Chunk.CodeBlock (Some "python"))
+                "print(2)"
+                tree)
+    let nb =
+        empty
+        |> addSection "Prime hunt"
+        |> addNarrative "We started with the obvious."
+        |> pin req.Id
+        |> pin code.Id
+    let md = toMarkdown tree nb
+    Assert.Contains("## Prime hunt", md)
+    Assert.Contains("We started with the obvious.", md)
+    Assert.Contains("**Request:** find primes", md)
+    Assert.Contains("```python\nprint(2)\n```", md)
+
+[<Fact>]
+let ``markdown export re-renders a pinned list from the live tree`` () =
+    let list, tree =
+        ok (ChunkTree.append None (Chunk.ListBlock false) "" ChunkTree.empty)
+    let _, tree = ok (ChunkTree.append (Some list.Id) Chunk.ListItem "alpha" tree)
+    let _, tree = ok (ChunkTree.append (Some list.Id) Chunk.ListItem "beta" tree)
+    let md = toMarkdown tree (empty |> pin list.Id)
+    Assert.Equal("- alpha\n- beta", md)
+
+[<Fact>]
+let ``markdown export is re-ingestable by the engine's own chunker`` () =
+    // ADR 0013 N3's closing of the loop: export → decompose →
+    // the structure survives.
+    let h, tree =
+        ok (ChunkTree.append None (Chunk.Heading 2) "Findings" ChunkTree.empty)
+    let nb =
+        empty
+        |> addSection "Narrative"
+        |> addNarrative "Plain prose survives."
+        |> pin h.Id
+    let md = toMarkdown tree nb
+    let specs = MarkdownChunker.decompose md
+    Assert.Equal<Chunk.ChunkKind list>(
+        [ Chunk.Heading 2; Chunk.Paragraph; Chunk.Heading 3 ],
+        specs |> List.map (fun s -> s.Kind))

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -109,6 +109,7 @@
     <Compile Include="SpatialCueTests.fs" />
     <Compile Include="EngineConfigTests.fs" />
     <Compile Include="EngineDiagnosticsTests.fs" />
+    <Compile Include="NotebookTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Cycle 54 PR-3 ([ADR 0013](docs/adr/0013-computational-notebook-authored-layer.md) N1 + N3) — **the notebook model**, the authored layer of the computational notebook:

- Cells are **references, never copies**: a pinned chunk renders through the live capture tree (tested: a pinned heading announces its *live* child count), so capture and authored layers cannot collapse by construction (spec §14.5).
- Editor operations — `pin`, `addNarrative`, `addSection`, `moveUp`/`moveDown`, `removeAt` — are pure and **total**: out-of-range indices are honest no-op reports; editing by ear never throws; moves report moved-vs-edge so the host cues them exactly like tree navigation.
- **`toMarkdown`**: sections → `##`, narrative → prose, pinned chunks render by kind (code re-fenced with its language tag, lists re-rendered from the live tree, requests and tool calls labelled). The export is publishable **and provably re-ingestable** — a test feeds the export back through the engine's own chunker and the structure survives, closing the narrative loop ("flows into new domains").

`NotebookTests` (7 tests) pin the contract.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_