### PR TITLE
feat(engine): declarative conflict-checked keymap with generated help (ADR 0014 C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15927,6 +15927,18 @@ ring) follow.
   labelled) — **provably re-ingestable** by the engine's own
   chunker (tested). `NotebookTests` pin all of it.
 
+### Cycle 54 PR-4 (2026-06-12): the declarative keymap
+
+- **Added**: `Engine.Core/KeyMap.fs` (ADR 0014 C2) — every
+  verb a union case; ONE bindings table (verb, key, modes,
+  description); dispatch, per-mode conflict validation,
+  generated help, and `[keys]` overrides all derive from it.
+  Conflicting or unknown overrides warn and keep the default;
+  cross-mode-disjoint reuse is legitimately allowed. The
+  defaults are CI-asserted conflict-free; help is asserted to
+  cover every binding. `KeyMapTests` pin all rules. Host
+  switchover lands with the integration PR.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -76,6 +76,11 @@
       capture tree). Depends on ChunkNarration, so it sits last.
     -->
     <Compile Include="Notebook.fs" />
+    <!--
+      ADR 0014 C2 — the declarative keymap: one table, derived
+      dispatch / conflict checks / generated help / overrides.
+    -->
+    <Compile Include="KeyMap.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/KeyMap.fs
+++ b/src/Engine.Core/KeyMap.fs
@@ -1,0 +1,222 @@
+namespace Engine.Core
+
+/// ADR 0014 C2 — the declarative keymap: every verb is a union
+/// case, the bindings are ONE table, and everything else —
+/// dispatch, conflict checking, generated help, user overrides
+/// — derives from it. The host's key loop is a lookup, never a
+/// hand-matched ladder, so help and documentation cannot drift
+/// from behaviour.
+module KeyMap =
+
+    /// The two host modes (ADR 0013 N2).
+    type Mode =
+        | Transcript
+        | NotebookMode
+
+    /// Every keyboard verb the engine understands. Adding one
+    /// is the development guide's worked example: one case
+    /// here, one row in `defaults`, one handler in the host.
+    type Verb =
+        | Compose
+        | Branch
+        | ReturnAnchor
+        | JumpLatest
+        | Next
+        | Previous
+        | Descend
+        | Ascend
+        | FirstSibling
+        | LastSibling
+        | Repeat
+        | Where
+        | Pin
+        | Rerun
+        | ToggleNotebook
+        | NotebookMoveUp
+        | NotebookMoveDown
+        | NotebookRemove
+        | NotebookNarrative
+        | NotebookSection
+        | ExportNotebook
+        | SaveSession
+        | OpenLastSession
+        | Diagnostics
+        | RateUp
+        | RateDown
+        | Stop
+        | Help
+        | Quit
+
+    /// The `[keys]` override name for a verb (stable, lowercase,
+    /// documented in CONFIGURATION.md).
+    let verbName (verb: Verb) : string =
+        match verb with
+        | Compose -> "compose"
+        | Branch -> "branch"
+        | ReturnAnchor -> "return_anchor"
+        | JumpLatest -> "jump_latest"
+        | Next -> "next"
+        | Previous -> "previous"
+        | Descend -> "descend"
+        | Ascend -> "ascend"
+        | FirstSibling -> "first_sibling"
+        | LastSibling -> "last_sibling"
+        | Repeat -> "repeat"
+        | Where -> "where"
+        | Pin -> "pin"
+        | Rerun -> "rerun"
+        | ToggleNotebook -> "toggle_notebook"
+        | NotebookMoveUp -> "notebook_move_up"
+        | NotebookMoveDown -> "notebook_move_down"
+        | NotebookRemove -> "notebook_remove"
+        | NotebookNarrative -> "notebook_narrative"
+        | NotebookSection -> "notebook_section"
+        | ExportNotebook -> "export_notebook"
+        | SaveSession -> "save_session"
+        | OpenLastSession -> "open_last_session"
+        | Diagnostics -> "diagnostics"
+        | RateUp -> "rate_up"
+        | RateDown -> "rate_down"
+        | Stop -> "stop"
+        | Help -> "help"
+        | Quit -> "quit"
+
+    type Binding =
+        { Verb: Verb
+          Key: char
+          Modes: Mode list
+          Description: string }
+
+    let private both = [ Transcript; NotebookMode ]
+
+    /// The single source of truth. Arrow keys are additionally
+    /// hardwired in the host to the four tree moves (the
+    /// universal fallback that survives any remapping).
+    let defaults : Binding list =
+        [ { Verb = Compose; Key = 'c'; Modes = [ Transcript ]
+            Description = "compose a request" }
+          { Verb = Branch; Key = 'b'; Modes = [ Transcript ]
+            Description = "branch at the focused chunk" }
+          { Verb = ReturnAnchor; Key = 'a'; Modes = [ Transcript ]
+            Description = "return to the branch anchor" }
+          { Verb = JumpLatest; Key = 'g'; Modes = [ Transcript ]
+            Description = "jump to the latest response" }
+          { Verb = Next; Key = 'j'; Modes = both
+            Description = "next" }
+          { Verb = Previous; Key = 'k'; Modes = both
+            Description = "previous" }
+          { Verb = Descend; Key = 'l'; Modes = [ Transcript ]
+            Description = "descend into the chunk" }
+          { Verb = Ascend; Key = 'h'; Modes = [ Transcript ]
+            Description = "ascend to the parent" }
+          { Verb = FirstSibling; Key = 't'; Modes = both
+            Description = "first item at this level" }
+          { Verb = LastSibling; Key = 'e'; Modes = both
+            Description = "last item at this level" }
+          { Verb = Repeat; Key = 'r'; Modes = both
+            Description = "repeat in full" }
+          { Verb = Where; Key = 'w'; Modes = both
+            Description = "where am I" }
+          { Verb = Pin; Key = 'p'; Modes = [ Transcript ]
+            Description = "pin the focused chunk to the notebook" }
+          { Verb = Rerun; Key = 'y'; Modes = [ Transcript ]
+            Description = "rerun the focused request" }
+          { Verb = ToggleNotebook; Key = 'n'; Modes = both
+            Description = "switch between transcript and notebook" }
+          { Verb = NotebookMoveUp; Key = '['; Modes = [ NotebookMode ]
+            Description = "move this cell up" }
+          { Verb = NotebookMoveDown; Key = ']'; Modes = [ NotebookMode ]
+            Description = "move this cell down" }
+          { Verb = NotebookRemove; Key = 'x'; Modes = [ NotebookMode ]
+            Description = "remove this cell" }
+          { Verb = NotebookNarrative; Key = 'i'; Modes = [ NotebookMode ]
+            Description = "insert a narrative cell" }
+          { Verb = NotebookSection; Key = 'u'; Modes = [ NotebookMode ]
+            Description = "insert a section header" }
+          { Verb = ExportNotebook; Key = 'm'; Modes = [ NotebookMode ]
+            Description = "export the notebook as markdown" }
+          { Verb = SaveSession; Key = 'v'; Modes = both
+            Description = "save the session" }
+          { Verb = OpenLastSession; Key = 'o'; Modes = [ Transcript ]
+            Description = "open the last saved session" }
+          { Verb = Diagnostics; Key = 'd'; Modes = both
+            Description = "speak diagnostics and write the dump file" }
+          { Verb = RateUp; Key = '+'; Modes = both
+            Description = "speech rate up" }
+          { Verb = RateDown; Key = '-'; Modes = both
+            Description = "speech rate down" }
+          { Verb = Stop; Key = 's'; Modes = both
+            Description = "stop speech" }
+          { Verb = Help; Key = '?'; Modes = both
+            Description = "speak this key list" }
+          { Verb = Quit; Key = 'q'; Modes = both
+            Description = "quit" } ]
+
+    /// Per-mode duplicate-key detection. Empty list = valid.
+    let validate (bindings: Binding list) : string list =
+        [ Transcript; NotebookMode ]
+        |> List.collect (fun mode ->
+            bindings
+            |> List.filter (fun b -> b.Modes |> List.contains mode)
+            |> List.groupBy (fun b -> b.Key)
+            |> List.choose (fun (key, group) ->
+                if List.length group > 1 then
+                    Some (
+                        sprintf
+                            "key '%c' is bound to multiple verbs in %A mode: %s"
+                            key
+                            mode
+                            (group
+                             |> List.map (fun b -> verbName b.Verb)
+                             |> String.concat ", "))
+                else None))
+
+    /// Apply `[keys]` overrides one at a time; an override that
+    /// would create a conflict (or names no verb) is skipped
+    /// with a warning and the default stands (ADR 0014 C2).
+    let withOverrides
+            (overrides: Map<string, char>)
+            (bindings: Binding list)
+            : Binding list * string list =
+        ((bindings, []), overrides |> Map.toList)
+        ||> List.fold (fun (current, warnings) (name, key) ->
+            match current |> List.tryFind (fun b -> verbName b.Verb = name) with
+            | None ->
+                current,
+                warnings
+                @ [ sprintf "[keys] %s does not name a verb; ignored." name ]
+            | Some target ->
+                let candidate =
+                    current
+                    |> List.map (fun b ->
+                        if b.Verb = target.Verb then { b with Key = key }
+                        else b)
+                match validate candidate with
+                | [] -> candidate, warnings
+                | conflicts ->
+                    current,
+                    warnings
+                    @ [ sprintf
+                            "[keys] %s = '%c' conflicts; keeping the default. %s"
+                            name key (String.concat "; " conflicts) ])
+
+    /// Dispatch: the key pressed in the current mode.
+    let tryFind
+            (mode: Mode)
+            (key: char)
+            (bindings: Binding list)
+            : Verb option =
+        bindings
+        |> List.tryFind (fun b ->
+            b.Key = key && (b.Modes |> List.contains mode))
+        |> Option.map (fun b -> b.Verb)
+
+    /// Generated help for one mode — `?` can never drift from
+    /// the table.
+    let helpFor (mode: Mode) (bindings: Binding list) : string =
+        let entries =
+            bindings
+            |> List.filter (fun b -> b.Modes |> List.contains mode)
+            |> List.map (fun b -> sprintf "%c %s" b.Key b.Description)
+            |> String.concat ". "
+        sprintf "Keys: %s." entries

--- a/tests/Tests.Unit/KeyMapTests.fs
+++ b/tests/Tests.Unit/KeyMapTests.fs
@@ -1,0 +1,83 @@
+module PtySpeak.Tests.Unit.KeyMapTests
+
+open Xunit
+open Engine.Core.KeyMap
+
+// ---------------------------------------------------------------------
+// ADR 0014 C2 — keymap contract: conflict-free defaults (CI is
+// the guard), table-driven dispatch, generated help, override
+// rules (apply / unknown-verb / conflict-keeps-default).
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``the default bindings are conflict-free`` () =
+    Assert.Empty(validate defaults)
+
+[<Fact>]
+let ``every verb name is unique`` () =
+    let names = defaults |> List.map (fun b -> verbName b.Verb)
+    Assert.Equal(List.length names, names |> List.distinct |> List.length)
+
+[<Fact>]
+let ``dispatch resolves per mode`` () =
+    Assert.Equal(Some Compose, tryFind Transcript 'c' defaults)
+    // 'c' is transcript-only.
+    Assert.Equal(None, tryFind NotebookMode 'c' defaults)
+    // 'x' removes only in notebook mode.
+    Assert.Equal(Some NotebookRemove, tryFind NotebookMode 'x' defaults)
+    Assert.Equal(None, tryFind Transcript 'x' defaults)
+    // Shared keys resolve in both.
+    Assert.Equal(Some Quit, tryFind Transcript 'q' defaults)
+    Assert.Equal(Some Quit, tryFind NotebookMode 'q' defaults)
+
+[<Fact>]
+let ``unbound keys resolve to nothing`` () =
+    Assert.Equal(None, tryFind Transcript 'Z' defaults)
+
+[<Fact>]
+let ``help is generated from the table and covers every binding`` () =
+    for mode in [ Transcript; NotebookMode ] do
+        let help = helpFor mode defaults
+        for binding in defaults do
+            if binding.Modes |> List.contains mode then
+                Assert.Contains(binding.Description, help)
+                Assert.Contains(string binding.Key, help)
+
+[<Fact>]
+let ``an override moves a verb to a new key`` () =
+    let bindings, warnings =
+        withOverrides (Map.ofList [ "pin", 'z' ]) defaults
+    Assert.Empty(warnings)
+    Assert.Equal(Some Pin, tryFind Transcript 'z' bindings)
+    Assert.Equal(None, tryFind Transcript 'p' bindings)
+
+[<Fact>]
+let ``an unknown verb name warns and is ignored`` () =
+    let bindings, warnings =
+        withOverrides (Map.ofList [ "frobnicate", 'z' ]) defaults
+    Assert.Equal<Binding list>(defaults, bindings)
+    match warnings with
+    | [ w ] -> Assert.Contains("does not name a verb", w)
+    | other -> failwithf "expected one warning, got %A" other
+
+[<Fact>]
+let ``a conflicting override warns and keeps the default`` () =
+    // 'q' is quit in both modes; rebinding pin onto it must be
+    // refused.
+    let bindings, warnings =
+        withOverrides (Map.ofList [ "pin", 'q' ]) defaults
+    Assert.Equal(Some Pin, tryFind Transcript 'p' bindings)
+    Assert.True(
+        warnings |> List.exists (fun w -> w.Contains "conflicts"))
+
+[<Fact>]
+let ``cross-mode-disjoint keys may legitimately repeat`` () =
+    // 'e' (last sibling, both modes) vs a hypothetical
+    // notebook-only rebinding: moving notebook_remove onto a
+    // transcript-only key is fine because the modes never
+    // overlap. 'y' (rerun) is transcript-only.
+    let bindings, warnings =
+        withOverrides (Map.ofList [ "notebook_remove", 'y' ]) defaults
+    Assert.Empty(warnings)
+    Assert.Equal(Some NotebookRemove, tryFind NotebookMode 'y' bindings)
+    Assert.Equal(Some Rerun, tryFind Transcript 'y' bindings)

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -110,6 +110,7 @@
     <Compile Include="EngineConfigTests.fs" />
     <Compile Include="EngineDiagnosticsTests.fs" />
     <Compile Include="NotebookTests.fs" />
+    <Compile Include="KeyMapTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Cycle 54 PR-4 ([ADR 0014](docs/adr/0014-engine-config-keymap-speech-diagnostics.md) C2) — **the declarative keymap**:

- Every keyboard verb is a union case; the bindings are **one table** (`verb · key · modes · description`). Dispatch (`tryFind`), per-mode conflict validation, **generated help** (`?` can never drift from behaviour), and user `[keys]` overrides all derive from that single source of truth.
- Override rules, all tested: an override moves the verb; an unknown verb name warns and is ignored; an override that would collide in any shared mode warns and **keeps the default** (the keymap stays conflict-free by construction); cross-mode-disjoint key reuse is legitimately allowed.
- The default table covers the full Cycle 54 verb surface: composition (`c`/`b`/`a`/`y`), navigation (`g j k l h t e` + arrows), orientation (`r w`), notebook (`p n [ ] x i u m`), sessions (`v o`), diagnostics (`d`), speech (`+ - s`), help/quit — designed so query verbs sit on the left hand while the right rests on movement.
- CI now asserts the defaults are conflict-free and that help covers every binding (`KeyMapTests`, 9 tests).

Host switchover from the hand-matched ladder to table dispatch lands with the integration PR.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_