### PR TITLE
feat(engine): session JSONL serde + validated ChunkTree.restore (ADR 0013 N4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15939,6 +15939,22 @@ ring) follow.
   cover every binding. `KeyMapTests` pin all rules. Host
   switchover lands with the integration PR.
 
+### Cycle 54 PR-5 (2026-06-12): session persistence (serde + validated restore)
+
+- **Added**: `Engine.Core/ChunkSerde.fs` (ADR 0013 N4) — the
+  session as schema-v1 JSONL: one meta line (schemaVersion,
+  participant session id, cursor anchors) + one chunk per line
+  in capture order, locked key order, hand-written
+  `Utf8JsonWriter` emit; tolerant reader (malformed lines,
+  missing fields, unknown kinds, newer schema → typed
+  `Error`). `ChunkTree.restore` rebuilds a tree from chunk
+  records while RE-VALIDATING the structural invariants
+  (parents precede children, strict capture order, unique
+  ids, authored-index consistency) — a corrupt file can never
+  produce a silently wrong tree. Round-trip pinned
+  example-based AND property-based over arbitrary trees with
+  all 14 chunk kinds; special characters covered.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/ChunkSerde.fs
+++ b/src/Engine.Core/ChunkSerde.fs
@@ -1,0 +1,216 @@
+namespace Engine.Core
+
+open System
+open System.Text.Json
+open Engine.Core.Chunk
+
+/// ADR 0013 N4 — session persistence: the capture tree as
+/// JSONL, schema v1. One meta line (schema version, the
+/// participant session id for `--resume`, the cursor anchors)
+/// followed by one chunk per line in capture order. Follows the
+/// `docs/IOCELL-SCHEMA.md` discipline: locked key order,
+/// explicit `schemaVersion`, tolerant reader (a corrupt file is
+/// a typed `Error`, never a crash), one-way migrations.
+module ChunkSerde =
+
+    [<Literal>]
+    let SchemaVersion = 1
+
+    /// Everything a restored session needs (the tree itself is
+    /// rebuilt via `ChunkTree.restore`, which re-validates the
+    /// structural invariants).
+    type SessionFile =
+        { SessionId: string option
+          LatestResponseStart: ChunkId option
+          CurrentRequest: ChunkId option
+          Chunks: Chunk.Chunk list }
+
+    // --- writing -----------------------------------------------------
+
+    let private writeJson (write: Utf8JsonWriter -> unit) : string =
+        use stream = new IO.MemoryStream()
+        let options = JsonWriterOptions(Indented = false)
+        use writer = new Utf8JsonWriter(stream, options)
+        write writer
+        writer.Flush()
+        Text.Encoding.UTF8.GetString(stream.ToArray())
+
+    let private kindFields
+            (writer: Utf8JsonWriter)
+            (kind: ChunkKind)
+            : unit =
+        match kind with
+        | Heading level ->
+            writer.WriteString("kind", "heading")
+            writer.WriteNumber("level", level)
+        | Paragraph -> writer.WriteString("kind", "paragraph")
+        | ListBlock ordered ->
+            writer.WriteString("kind", "list")
+            writer.WriteBoolean("ordered", ordered)
+        | ListItem -> writer.WriteString("kind", "listItem")
+        | CodeBlock language ->
+            writer.WriteString("kind", "code")
+            match language with
+            | Some lang -> writer.WriteString("language", lang)
+            | None -> writer.WriteNull("language")
+        | BlockQuote -> writer.WriteString("kind", "quote")
+        | ThematicBreak -> writer.WriteString("kind", "break")
+        | UserRequest -> writer.WriteString("kind", "request")
+        | ToolUse name ->
+            writer.WriteString("kind", "toolUse")
+            writer.WriteString("name", name)
+        | ToolResult isError ->
+            writer.WriteString("kind", "toolResult")
+            writer.WriteBoolean("isError", isError)
+        | AgentError -> writer.WriteString("kind", "agentError")
+        | SystemNote -> writer.WriteString("kind", "note")
+
+    /// One chunk → one JSONL line (locked key order).
+    let chunkToJson (chunk: Chunk.Chunk) : string =
+        writeJson (fun writer ->
+            writer.WriteStartObject()
+            let (ChunkId id) = chunk.Id
+            writer.WriteString("id", id)
+            kindFields writer chunk.Kind
+            writer.WriteString("text", chunk.Text)
+            writer.WriteNumber("captureSeq", chunk.CaptureSeq)
+            writer.WriteNumber("authoredIndex", chunk.AuthoredIndex)
+            match chunk.Parent with
+            | Some (ChunkId pid) -> writer.WriteString("parent", pid)
+            | None -> writer.WriteNull("parent")
+            writer.WriteEndObject())
+
+    /// The whole session → JSONL text (meta line + chunks in
+    /// capture order, newline-separated, trailing newline).
+    let sessionToJsonl (file: SessionFile) : string =
+        let meta =
+            writeJson (fun writer ->
+                writer.WriteStartObject()
+                writer.WriteNumber("schemaVersion", SchemaVersion)
+                match file.SessionId with
+                | Some sid -> writer.WriteString("sessionId", sid)
+                | None -> writer.WriteNull("sessionId")
+                match file.LatestResponseStart with
+                | Some (ChunkId id) ->
+                    writer.WriteString("latestResponseStart", id)
+                | None -> writer.WriteNull("latestResponseStart")
+                match file.CurrentRequest with
+                | Some (ChunkId id) ->
+                    writer.WriteString("currentRequest", id)
+                | None -> writer.WriteNull("currentRequest")
+                writer.WriteEndObject())
+        let chunkLines = file.Chunks |> List.map chunkToJson
+        String.concat "\n" (meta :: chunkLines) + "\n"
+
+    // --- reading -----------------------------------------------------
+
+    let private tryStr (el: JsonElement) (name: string) : string option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.String then
+            match v.GetString() with
+            | null -> None
+            | s -> Some s
+        else None
+
+    let private tryInt (el: JsonElement) (name: string) : int option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.Number then
+            let ok, i = v.TryGetInt32()
+            if ok then Some i else None
+        else None
+
+    let private tryBool (el: JsonElement) (name: string) : bool option =
+        let found, v = el.TryGetProperty(name)
+        if not found then None
+        elif v.ValueKind = JsonValueKind.True then Some true
+        elif v.ValueKind = JsonValueKind.False then Some false
+        else None
+
+    let private parseKind (el: JsonElement) : Result<ChunkKind, string> =
+        match tryStr el "kind" with
+        | Some "heading" ->
+            match tryInt el "level" with
+            | Some level -> Ok (Heading level)
+            | None -> Error "heading without a level"
+        | Some "paragraph" -> Ok Paragraph
+        | Some "list" ->
+            Ok (ListBlock (tryBool el "ordered" |> Option.defaultValue false))
+        | Some "listItem" -> Ok ListItem
+        | Some "code" -> Ok (CodeBlock (tryStr el "language"))
+        | Some "quote" -> Ok BlockQuote
+        | Some "break" -> Ok ThematicBreak
+        | Some "request" -> Ok UserRequest
+        | Some "toolUse" ->
+            Ok (ToolUse (tryStr el "name" |> Option.defaultValue ""))
+        | Some "toolResult" ->
+            Ok (ToolResult (tryBool el "isError" |> Option.defaultValue false))
+        | Some "agentError" -> Ok AgentError
+        | Some "note" -> Ok SystemNote
+        | Some other -> Error (sprintf "unknown chunk kind '%s'" other)
+        | None -> Error "chunk line without a kind"
+
+    let private parseChunkLine (line: string) : Result<Chunk.Chunk, string> =
+        try
+            use doc = JsonDocument.Parse(line)
+            let root = doc.RootElement
+            match tryStr root "id", parseKind root with
+            | None, _ -> Error "chunk line without an id"
+            | _, Error e -> Error e
+            | Some id, Ok kind ->
+                match tryInt root "captureSeq", tryInt root "authoredIndex" with
+                | Some seq, Some authored ->
+                    Ok { Id = ChunkId id
+                         Kind = kind
+                         Text = tryStr root "text" |> Option.defaultValue ""
+                         CaptureSeq = seq
+                         AuthoredIndex = authored
+                         Parent = tryStr root "parent" |> Option.map ChunkId }
+                | _ -> Error "chunk line without capture/authored order"
+        with :? JsonException as ex ->
+            Error (sprintf "malformed chunk line: %s" ex.Message)
+
+    /// Parse JSONL text back to a `SessionFile`. The first
+    /// non-blank line must be the meta object with a supported
+    /// schema version.
+    let parseJsonl (text: string) : Result<SessionFile, string> =
+        let lines =
+            text.Split('\n')
+            |> Array.map (fun l -> l.TrimEnd('\r'))
+            |> Array.filter (fun l -> not (String.IsNullOrWhiteSpace l))
+            |> List.ofArray
+        match lines with
+        | [] -> Error "empty session file"
+        | metaLine :: chunkLines ->
+            try
+                use doc = JsonDocument.Parse(metaLine)
+                let meta = doc.RootElement
+                match tryInt meta "schemaVersion" with
+                | None -> Error "missing schemaVersion"
+                | Some v when v > SchemaVersion ->
+                    Error (
+                        sprintf
+                            "session schemaVersion %d is newer than this build supports (%d)"
+                            v SchemaVersion)
+                | Some _ ->
+                    let folded =
+                        ((Ok []), chunkLines)
+                        ||> List.fold (fun acc line ->
+                            match acc with
+                            | Error e -> Error e
+                            | Ok chunks ->
+                                match parseChunkLine line with
+                                | Ok chunk -> Ok (chunks @ [ chunk ])
+                                | Error e -> Error e)
+                    match folded with
+                    | Error e -> Error e
+                    | Ok chunks ->
+                        Ok { SessionId = tryStr meta "sessionId"
+                             LatestResponseStart =
+                                tryStr meta "latestResponseStart"
+                                |> Option.map ChunkId
+                             CurrentRequest =
+                                tryStr meta "currentRequest"
+                                |> Option.map ChunkId
+                             Chunks = chunks }
+            with :? JsonException as ex ->
+                Error (sprintf "malformed meta line: %s" ex.Message)

--- a/src/Engine.Core/ChunkTree.fs
+++ b/src/Engine.Core/ChunkTree.fs
@@ -128,3 +128,43 @@ module ChunkTree =
         |> Map.toList
         |> List.map snd
         |> List.sortBy (fun c -> c.CaptureSeq)
+
+    /// ADR 0013 N4 — rebuild a tree from previously-serialized
+    /// chunks (capture order), VALIDATING the structural
+    /// invariants as it goes: parents must precede their
+    /// children, capture order must be strictly increasing,
+    /// ids must be unique, and each authored index must match
+    /// its arrival position among its siblings. A corrupt file
+    /// is a typed `Error`, never a crash and never a silently
+    /// wrong tree.
+    let restore (chunks: Chunk.Chunk list) : Result<Tree, string> =
+        let rec go (tree: Tree) (remaining: Chunk.Chunk list) =
+            match remaining with
+            | [] -> Ok tree
+            | chunk :: rest ->
+                let parentMissing =
+                    match chunk.Parent with
+                    | None -> false
+                    | Some pid -> not (tree.ById |> Map.containsKey pid)
+                if parentMissing then
+                    Error "restore: a chunk's parent does not precede it"
+                elif tree.ById |> Map.containsKey chunk.Id then
+                    Error "restore: duplicate chunk id"
+                elif chunk.CaptureSeq < tree.NextCaptureSeq then
+                    Error "restore: capture order is not strictly increasing"
+                else
+                    let siblings =
+                        match tree.Children |> Map.tryFind chunk.Parent with
+                        | Some ids -> ids
+                        | None -> []
+                    if chunk.AuthoredIndex <> List.length siblings then
+                        Error "restore: authored index inconsistent with sibling order"
+                    else
+                        go
+                            { ById = tree.ById |> Map.add chunk.Id chunk
+                              Children =
+                                tree.Children
+                                |> Map.add chunk.Parent (siblings @ [ chunk.Id ])
+                              NextCaptureSeq = chunk.CaptureSeq + 1 }
+                            rest
+        go empty chunks

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -81,6 +81,11 @@
       dispatch / conflict checks / generated help / overrides.
     -->
     <Compile Include="KeyMap.fs" />
+    <!--
+      ADR 0013 N4 — session JSONL (schema v1): meta line +
+      chunks in capture order; tolerant typed-error reader.
+    -->
+    <Compile Include="ChunkSerde.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.Unit/ChunkSerdeTests.fs
+++ b/tests/Tests.Unit/ChunkSerdeTests.fs
@@ -1,0 +1,139 @@
+module PtySpeak.Tests.Unit.ChunkSerdeTests
+
+open Xunit
+open FsCheck.Xunit
+open Engine.Core
+open Engine.Core.Chunk
+open Engine.Core.ChunkSerde
+
+// ---------------------------------------------------------------------
+// ADR 0013 N4 — session JSONL contract: round-trip fidelity
+// (example-based AND property-based over arbitrary trees),
+// schema gating, tolerant typed errors, restore validation.
+// ---------------------------------------------------------------------
+
+let private ok r =
+    match r with
+    | Ok v -> v
+    | Error e -> failwithf "unexpected Error: %s" e
+
+/// Same scripted-builder as ChunkTreePropertyTests: bytes pick
+/// parents, kinds rotate through the vocabulary.
+let private kinds : ChunkKind list =
+    [ Heading 1; Paragraph; ListBlock true; ListItem
+      CodeBlock (Some "fsharp"); CodeBlock None; BlockQuote
+      ThematicBreak; UserRequest; ToolUse "Bash"
+      ToolResult false; ToolResult true; AgentError; SystemNote ]
+
+let private build (choices: byte list) : ChunkTree.Tree =
+    ((ChunkTree.empty, []), choices)
+    ||> List.fold (fun (tree, ids) choice ->
+        let parent =
+            match ids with
+            | [] -> None
+            | _ when int choice % (List.length ids + 1) = 0 -> None
+            | _ -> ids |> List.tryItem (int choice % List.length ids)
+        let kind = kinds.[int choice % List.length kinds]
+        match ChunkTree.append parent kind (sprintf "t%d" (int choice)) tree with
+        | Ok (chunk, tree') -> (tree', ids @ [ chunk.Id ])
+        | Error _ -> (tree, ids))
+    |> fst
+
+let private sessionOf (tree: ChunkTree.Tree) : SessionFile =
+    { SessionId = Some "sid-1"
+      LatestResponseStart =
+        ChunkTree.inCaptureOrder tree
+        |> List.tryLast
+        |> Option.map (fun c -> c.Id)
+      CurrentRequest = None
+      Chunks = ChunkTree.inCaptureOrder tree }
+
+[<Fact>]
+let ``a session round-trips through jsonl exactly`` () =
+    let req, tree = ok (ChunkTree.append None UserRequest "do it" ChunkTree.empty)
+    let _, tree = ok (ChunkTree.append (Some req.Id) (Heading 2) "Plan" tree)
+    let _, tree = ok (ChunkTree.append (Some req.Id) (CodeBlock (Some "py")) "x=1\n" tree)
+    let original = sessionOf tree
+    let parsed = ok (parseJsonl (sessionToJsonl original))
+    Assert.Equal(original.SessionId, parsed.SessionId)
+    Assert.Equal(original.LatestResponseStart, parsed.LatestResponseStart)
+    Assert.Equal<Chunk.Chunk list>(original.Chunks, parsed.Chunks)
+
+[<Fact>]
+let ``restore rebuilds an identical navigable tree`` () =
+    let req, tree = ok (ChunkTree.append None UserRequest "r" ChunkTree.empty)
+    let kid, tree = ok (ChunkTree.append (Some req.Id) Paragraph "p" tree)
+    let parsed = ok (parseJsonl (sessionToJsonl (sessionOf tree)))
+    let restored = ok (ChunkTree.restore parsed.Chunks)
+    Assert.Equal(ChunkTree.count tree, ChunkTree.count restored)
+    Assert.Equal(
+        Some kid.Id,
+        ChunkTree.firstChild req.Id restored |> Option.map (fun c -> c.Id))
+
+[<Property>]
+let ``round-trip preserves every chunk for arbitrary trees`` (choices: byte list) =
+    let tree = build choices
+    let parsed = parseJsonl (sessionToJsonl (sessionOf tree))
+    match parsed with
+    | Error _ -> false
+    | Ok file ->
+        match ChunkTree.restore file.Chunks with
+        | Error _ -> false
+        | Ok restored ->
+            ChunkTree.inCaptureOrder restored = ChunkTree.inCaptureOrder tree
+
+[<Fact>]
+let ``special characters survive the trip`` () =
+    let _, tree =
+        ok (ChunkTree.append
+                None Paragraph
+                "quotes \" backslash \\ newline \n tab \t unicode ⏎"
+                ChunkTree.empty)
+    let parsed = ok (parseJsonl (sessionToJsonl (sessionOf tree)))
+    Assert.Equal(
+        "quotes \" backslash \\ newline \n tab \t unicode ⏎",
+        parsed.Chunks.Head.Text)
+
+[<Fact>]
+let ``a newer schema version is a typed error`` () =
+    match parseJsonl "{\"schemaVersion\":99}\n" with
+    | Error e -> Assert.Contains("newer", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``a corrupt chunk line is a typed error not a crash`` () =
+    let text = "{\"schemaVersion\":1,\"sessionId\":null,\"latestResponseStart\":null,\"currentRequest\":null}\n{not json"
+    match parseJsonl text with
+    | Error e -> Assert.Contains("malformed", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``an empty file is a typed error`` () =
+    match parseJsonl "" with
+    | Error e -> Assert.Contains("empty", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``restore rejects an orphan chunk`` () =
+    let chunk : Chunk.Chunk =
+        { Id = newId ()
+          Kind = Paragraph
+          Text = "orphan"
+          CaptureSeq = 0
+          AuthoredIndex = 0
+          Parent = Some (newId ()) }
+    match ChunkTree.restore [ chunk ] with
+    | Error e -> Assert.Contains("parent", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``restore rejects out-of-order capture sequence`` () =
+    let a : Chunk.Chunk =
+        { Id = newId (); Kind = Paragraph; Text = "a"
+          CaptureSeq = 5; AuthoredIndex = 0; Parent = None }
+    let b : Chunk.Chunk =
+        { Id = newId (); Kind = Paragraph; Text = "b"
+          CaptureSeq = 5; AuthoredIndex = 1; Parent = None }
+    match ChunkTree.restore [ a; b ] with
+    | Error e -> Assert.Contains("capture", e)
+    | Ok _ -> failwith "expected Error"

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -111,6 +111,7 @@
     <Compile Include="EngineDiagnosticsTests.fs" />
     <Compile Include="NotebookTests.fs" />
     <Compile Include="KeyMapTests.fs" />
+    <Compile Include="ChunkSerdeTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Cycle 54 PR-5 ([ADR 0013](docs/adr/0013-computational-notebook-authored-layer.md) N4) — **session persistence**:

- **`ChunkSerde.fs`** — the session as schema-v1 JSONL: one meta line (`schemaVersion`, the participant session id that `--resume` rides on, the cursor anchors) + one chunk per line in capture order; locked key order via hand-written `Utf8JsonWriter` (the IOCELL-SCHEMA discipline); tolerant reader where malformed lines, missing fields, unknown kinds, and newer schemas are all **typed errors**, never crashes.
- **`ChunkTree.restore`** — rebuilds a tree from chunk records while **re-validating the structural invariants** (parents precede children, strictly increasing capture order, unique ids, authored-index/sibling consistency). A corrupt or hand-edited file can produce a typed error but never a silently wrong tree.
- **Tests**: example round-trips, a **property-based round-trip over arbitrary trees** exercising all 14 chunk kinds (serialize → parse → restore → identical capture order), special-character fidelity, schema gating, corrupt-line/empty-file errors, and restore's orphan + out-of-order rejections.

Host auto-save/open-last lands with the integration PR.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_