### PR TITLE
feat(engine-host): full integration — keymap, notebook mode, persistence, diagnostics, speech controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15965,6 +15965,26 @@ ring) follow.
   design). Host integration of config/keymap/notebook/
   persistence lands next.
 
+### Cycle 54 PR-7 (2026-06-12): host integration — the full instrument
+
+- **Changed**: `Engine.Host/Program.fs` rewired end-to-end:
+  key dispatch is now the KeyMap TABLE (user `[keys]`
+  overrides applied; arrows hardwired); `engine.toml` drives
+  participant path, speech rate/voice, narration cap, cue
+  enable + master gain; **notebook mode** (`n`) with pin /
+  navigate / reorder / remove / insert narrative + section /
+  markdown export (path spoken); **session persistence** —
+  auto-save after every turn + on quit, `v` manual save
+  (per-run snapshot + `session-latest.jsonl`), `o` restores
+  the tree AND the CLI `--resume` continuity, with typed
+  spoken errors on corrupt files; **diagnostics** — every bus
+  event recorded to the ring + the per-run session event log,
+  `d` speaks the summary and writes + names the dump file;
+  **speech controls** — `+`/`-` live rate with confirmation;
+  startup speaks config-warning count, voice note, and a
+  previous-session offer; `t`/`e` level jumps and `y` rerun
+  (of a focused request, anchored where it was) wired.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -1,77 +1,92 @@
 module Engine.Host.Program
 
-// RELAUNCH-SPEC §13 Phase 0 / ADR 0011 E8 — the local
-// bootstrap host. Wires: console keyboard → navigation verbs +
-// compose loop → Claude CLI participant → ingest → chunk tree →
-// engine event bus → attention router → self-voicing SAPI sink.
+// RELAUNCH-SPEC §13 / ADRs 0011–0014 — the engine host: the
+// one imperative file. Wires console keys (KeyMap table) →
+// verbs over the transcript (capture tree) or the notebook
+// (authored layer) → the Claude CLI participant → ingest →
+// the universal event bus → attention/speech + spatial cues +
+// diagnostics → session persistence.
 //
-// Keyboard model (E8 — keyboard-first; speech input arrives via
-// OS dictation into the same compose line):
-//
-//   c       compose a request (type a line, Enter sends)
-//   b       branch: compose anchored at the focused chunk
-//   a       return to anchor
-//   g       jump to the start of the latest response
-//   j / ↓   next chunk        k / ↑   previous chunk
-//   l / →   descend into chunk  h / ←  ascend to parent
-//   r       re-narrate the focused chunk (full body)
-//   w       where am I — breadcrumb + position + depth
-//   s       stop speech
-//   ?       speak the key list
-//   q       quit
-//
-// Everything spoken goes through the attention queue
-// (foreground strict FIFO; ambient coalesced) into the
-// self-voicing sink — no console-output dependence; the printed
-// mirror text is a debugging convenience only.
+// All decisions live in Engine.Core (pure, tested); this file
+// owns ONLY: mutable state behind one lock, threads, files,
+// and the audio devices. The key surface is the KeyMap table —
+// see docs/engine/KEYBOARD-REFERENCE.md; ? speaks it.
 
 open System
+open System.IO
 open System.Threading
 open Engine.Core
 open Engine.Core.EngineEvent
 open Engine.Participants
 
-/// Shared mutable host state, all guarded by one lock: the
-/// console thread (navigation, compose) and the turn thread
-/// (participant events) both touch it.
+/// Shared mutable host state, guarded by one lock: the console
+/// thread (verbs, compose) and the turn thread (participant
+/// events) both touch it.
 type private HostState =
     { mutable Session: Ingest.Session
       mutable Nav: Navigator.State
+      mutable Notebook: Notebook.Notebook
+      mutable NotebookIndex: int
+      mutable Mode: KeyMap.Mode
       mutable Queue: Attention.Queue
       mutable Speaking: bool
-      mutable TurnInFlight: bool }
-
-let private helpText =
-    "Keys: c compose. b branch at focus. a return to anchor. "
-    + "g latest response. j next. k previous. l descend. "
-    + "h ascend. r repeat. w where am I. s stop speech. q quit."
+      mutable TurnInFlight: bool
+      mutable Rate: int }
 
 [<EntryPoint>]
 let main _argv =
+    // --- paths ---------------------------------------------------------
+    let dataRoot =
+        Path.Combine(
+            Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData),
+            "PtySpeak")
+    let sessionsDir = Path.Combine(dataRoot, "engine-sessions")
+    let diagnosticsDir = Path.Combine(dataRoot, "engine-diagnostics")
+    let configPath = Path.Combine(dataRoot, "engine.toml")
+    let latestSessionPath =
+        Path.Combine(sessionsDir, "session-latest.jsonl")
+    let runStamp = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")
+
+    // --- config + keymap (ADR 0014 C1/C2) ------------------------------
+    let config, configWarnings = EngineConfig.load configPath
+    let bindings, keyWarnings =
+        KeyMap.withOverrides config.KeyOverrides KeyMap.defaults
+    let startupWarnings = configWarnings @ keyWarnings
+
+    // --- diagnostics (ADR 0014 C4) --------------------------------------
+    let diag = EngineDiagnostics.Ring()
+    startupWarnings |> List.iter (fun w -> diag.Record "config" w)
+
     let gate = obj ()
     let state : HostState =
         { Session = Ingest.empty
           Nav = Navigator.initial
+          Notebook = Notebook.empty
+          NotebookIndex = -1
+          Mode = KeyMap.Transcript
           Queue = Attention.empty
           Speaking = false
-          TurnInFlight = false }
+          TurnInFlight = false
+          Rate = config.SpeechRate }
     let bus = EngineBus()
-    use sink = new Engine.Voice.SapiSink(0, None)
+    use sink = new Engine.Voice.SapiSink(config.SpeechRate, config.VoiceName)
     let speech = sink :> ISpeechSink
 
     let claudeConfig : ClaudeCli.Config =
         let fromEnv =
-            Environment.GetEnvironmentVariable "ENGINE_CLAUDE_PATH"
-        match fromEnv with
-        | null ->
-            { ClaudeCli.defaultConfig with ExecutablePath = "claude.cmd" }
-        | v when String.IsNullOrWhiteSpace v ->
-            { ClaudeCli.defaultConfig with ExecutablePath = "claude.cmd" }
-        | v ->
-            { ClaudeCli.defaultConfig with ExecutablePath = v }
+            match Environment.GetEnvironmentVariable "ENGINE_CLAUDE_PATH" with
+            | null -> None
+            | v when String.IsNullOrWhiteSpace v -> None
+            | v -> Some v
+        let resolved =
+            config.ClaudeExecutable
+            |> Option.orElse fromEnv
+            |> Option.defaultValue "claude.cmd"
+        { ClaudeCli.defaultConfig with ExecutablePath = resolved }
 
-    // --- speech drain ------------------------------------------------
-    let rec speakNext () =
+    // --- speech drain ----------------------------------------------------
+    let speakNext () =
         let toSpeak =
             lock gate (fun () ->
                 if state.Speaking then None
@@ -97,10 +112,8 @@ let main _argv =
             state.Queue <- Attention.enqueue utterance state.Queue)
         speakNext ()
 
-    /// A user-initiated read preempts whatever is being spoken
-    /// AND whatever narrative was queued (ADR 0012 S5): cancel
-    /// first, drop stale pending foreground, then queue this.
-    /// Ambient survives — awareness is not the user's target.
+    /// User-initiated speech: cancel, supersede stale pending
+    /// foreground, keep ambient (ADR 0012 S5).
     let speakNow (text: string) =
         speech.CancelAll ()
         lock gate (fun () ->
@@ -110,24 +123,106 @@ let main _argv =
                     (Attention.clearForeground state.Queue))
         speakNext ()
 
-    // --- bus → attention --------------------------------------------
+    // --- spatial cues (config-gated, master gain — ADR 0014 C1) ---------
+    let playCue (cue: SpatialCue.Cue) =
+        if config.CuesEnabled then
+            Engine.Audio.SpatialPlayer.play
+                { cue with Gain = cue.Gain * config.CueGain }
+
+    // --- bus consumers ---------------------------------------------------
     bus.Subscribe(fun ev ->
         match Attention.route ev with
         | Some utterance -> enqueue utterance
         | None -> ())
     |> ignore
 
-    // --- bus → spatial stage (ADR 0012 S3/S4) -------------------------
-    // The second universal-event-bus consumer: every event
-    // renders as its deterministic stereo-stage signature, in
-    // parallel with (never gating) speech.
     bus.Subscribe(fun ev ->
         match SpatialCue.forEvent ev with
-        | Some cue -> Engine.Audio.SpatialPlayer.play cue
+        | Some cue -> playCue cue
         | None -> ())
     |> ignore
 
-    // --- participant turn -------------------------------------------
+    // Diagnostics + the session event log (ADR 0014 C4): one
+    // line per bus event — the replay of what the user heard.
+    let eventLogPath =
+        Path.Combine(sessionsDir, sprintf "events-%s.log" runStamp)
+    bus.Subscribe(fun ev ->
+        let category, message = EngineDiagnostics.describeEvent ev
+        diag.Record category message
+        try
+            Directory.CreateDirectory(sessionsDir) |> ignore
+            File.AppendAllText(
+                eventLogPath,
+                sprintf
+                    "%s [%s] %s\n"
+                    (DateTime.UtcNow.ToString("o"))
+                    category
+                    message)
+        with _ -> ())
+    |> ignore
+
+    // --- session persistence (ADR 0013 N4) -------------------------------
+    let saveSession (announce: bool) =
+        let file : ChunkSerde.SessionFile =
+            lock gate (fun () ->
+                { SessionId = state.Session.SessionId
+                  LatestResponseStart = state.Session.LatestResponseStart
+                  CurrentRequest = state.Session.CurrentRequest
+                  Chunks = ChunkTree.inCaptureOrder state.Session.Tree })
+        if List.isEmpty file.Chunks then
+            if announce then speakNow "Nothing to save yet."
+        else
+            try
+                Directory.CreateDirectory(sessionsDir) |> ignore
+                let text = ChunkSerde.sessionToJsonl file
+                File.WriteAllText(
+                    Path.Combine(
+                        sessionsDir,
+                        sprintf "session-%s.jsonl" runStamp),
+                    text)
+                File.WriteAllText(latestSessionPath, text)
+                if announce then
+                    speakNow (
+                        sprintf "Saved, %d chunks."
+                            (List.length file.Chunks))
+            with ex ->
+                diag.Record "error" (sprintf "save failed: %s" ex.Message)
+                if announce then
+                    speakNow "Save failed; press d for details."
+
+    let openLastSession () =
+        if not (File.Exists latestSessionPath) then
+            speakNow "No saved session found."
+        else
+            let restored =
+                try
+                    match ChunkSerde.parseJsonl
+                              (File.ReadAllText latestSessionPath) with
+                    | Error e -> Error e
+                    | Ok file ->
+                        match ChunkTree.restore file.Chunks with
+                        | Error e -> Error e
+                        | Ok tree -> Ok (file, tree)
+                with ex -> Error ex.Message
+            match restored with
+            | Error e ->
+                diag.Record "error" (sprintf "session restore: %s" e)
+                speakNow (sprintf "Could not open the last session: %s" e)
+            | Ok (file, tree) ->
+                lock gate (fun () ->
+                    state.Session <-
+                        { Tree = tree
+                          SessionId = file.SessionId
+                          CurrentRequest = file.CurrentRequest
+                          LatestResponseStart = file.LatestResponseStart
+                          InFlightCount = 0 }
+                    state.Nav <- Navigator.initial)
+                speakNow (
+                    sprintf
+                        "Session restored, %d chunks. Press g to jump to the latest response."
+                        (ChunkTree.count tree))
+
+    // --- participant turns ------------------------------------------------
     let publishAll (events: EngineEvent list) =
         events |> List.iter (fun e -> bus.Publish e)
 
@@ -167,25 +262,22 @@ let main _argv =
                 bus.Publish(
                     EngineNote (
                         sprintf
-                            "Could not run the participant: %s. Set ENGINE_CLAUDE_PATH to the claude executable."
+                            "Could not run the participant: %s. Set ENGINE_CLAUDE_PATH or [participant] claude_executable."
                             message))
+            // Auto-save after every turn (ADR 0013 N4).
+            saveSession false
         let thread = Thread(worker)
         thread.IsBackground <- true
         thread.Start()
 
-    // --- navigation --------------------------------------------------
-    // Navigation reads are bounded (ADR 0012 S5); `r` reads
-    // the full body.
-    let moveReadCapChars = 600
-
+    // --- transcript narration ---------------------------------------------
     let narrateMove (move: Navigator.Move) =
         match move with
         | Navigator.Moved chunk ->
-            // ADR 0012 S2 — moves carry their position.
             let text =
                 lock gate (fun () ->
                     ChunkNarration.describeAt
-                        moveReadCapChars
+                        config.MoveReadCapChars
                         state.Session.Tree
                         chunk)
             speakNow text
@@ -203,19 +295,15 @@ let main _argv =
                 let nav', move = verb state.Nav state.Session.Tree
                 state.Nav <- nav'
                 move)
-        // Direction-coded cue first (instant, non-verbal),
-        // then the spoken read (ADR 0012 S3).
         let moved =
             match move with
             | Navigator.Moved _ -> true
             | _ -> false
-        Engine.Audio.SpatialPlayer.play (SpatialCue.forNav direction moved)
+        playCue (SpatialCue.forNav direction moved)
         narrateMove move
 
-    /// Returns true when a turn was actually started — the
-    /// branch path pushes its anchor only on success, so an
-    /// aborted compose (busy / empty line) leaves no stale
-    /// anchor on the stack.
+    /// Returns true when a turn actually started — the branch
+    /// path pushes its anchor only on success.
     let compose (anchor: Chunk.ChunkId option) : bool =
         let busy = lock gate (fun () -> state.TurnInFlight)
         if busy then
@@ -233,21 +321,159 @@ let main _argv =
                 startTurn line anchor
                 true
 
-    // --- main key loop -----------------------------------------------
-    enqueue (Attention.Foreground (
-        "Engine ready. " + helpText))
+    /// Read one line for a notebook insertion ("" = aborted).
+    let readLine (promptLabel: string) : string option =
+        speech.CancelAll ()
+        Console.Write(promptLabel)
+        match Console.ReadLine() with
+        | null -> None
+        | line when String.IsNullOrWhiteSpace line -> None
+        | line -> Some line
 
+    // --- notebook verbs (ADR 0013 N2) --------------------------------------
+    let describeNotebookCell (index: int) : string option =
+        lock gate (fun () ->
+            Notebook.tryItem index state.Notebook
+            |> Option.map (fun cell ->
+                sprintf
+                    "%s — %d of %d."
+                    (Notebook.describeCell state.Session.Tree cell)
+                    (index + 1)
+                    (Notebook.count state.Notebook)))
+
+    let notebookEmptyHint () =
+        speakNow "The notebook is empty. Press p in the transcript to pin a chunk."
+
+    let notebookStep (delta: int) (direction: SpatialCue.NavDirection) =
+        let outcome =
+            lock gate (fun () ->
+                let count = Notebook.count state.Notebook
+                if count = 0 then None
+                else
+                    let target = state.NotebookIndex + delta
+                    if target < 0 || target >= count then
+                        Some (state.NotebookIndex, false)
+                    else
+                        state.NotebookIndex <- target
+                        Some (target, true))
+        match outcome with
+        | None ->
+            playCue (SpatialCue.forNav direction false)
+            notebookEmptyHint ()
+        | Some (index, moved) ->
+            playCue (SpatialCue.forNav direction moved)
+            if moved then
+                describeNotebookCell index |> Option.iter speakNow
+            else
+                speakNow (if delta > 0 then "no next cell" else "no previous cell")
+
+    let notebookJump (toLast: bool) =
+        let outcome =
+            lock gate (fun () ->
+                let count = Notebook.count state.Notebook
+                if count = 0 then None
+                else
+                    let target = if toLast then count - 1 else 0
+                    state.NotebookIndex <- target
+                    Some target)
+        match outcome with
+        | None -> notebookEmptyHint ()
+        | Some index ->
+            playCue (SpatialCue.forNav (if toLast then SpatialCue.Next else SpatialCue.Previous) true)
+            describeNotebookCell index |> Option.iter speakNow
+
+    let notebookReorder (up: bool) =
+        let outcome =
+            lock gate (fun () ->
+                let index = state.NotebookIndex
+                let notebook', moved =
+                    if up then Notebook.moveUp index state.Notebook
+                    else Notebook.moveDown index state.Notebook
+                state.Notebook <- notebook'
+                if moved then
+                    state.NotebookIndex <- if up then index - 1 else index + 1
+                (state.NotebookIndex, moved, Notebook.count notebook'))
+        let index, moved, count = outcome
+        playCue (
+            SpatialCue.forNav
+                (if up then SpatialCue.Previous else SpatialCue.Next)
+                moved)
+        if count = 0 then notebookEmptyHint ()
+        elif moved then
+            speakNow (
+                sprintf "%s. Cell %d of %d."
+                    (if up then "Moved up" else "Moved down")
+                    (index + 1) count)
+        else
+            speakNow (if up then "Already first." else "Already last.")
+
+    let notebookRemove () =
+        let outcome =
+            lock gate (fun () ->
+                let notebook', removed =
+                    Notebook.removeAt state.NotebookIndex state.Notebook
+                state.Notebook <- notebook'
+                let count = Notebook.count notebook'
+                if removed then
+                    state.NotebookIndex <- min state.NotebookIndex (count - 1)
+                (removed, count))
+        match outcome with
+        | true, count ->
+            speakNow (sprintf "Removed. %d cells remain." count)
+        | false, 0 -> notebookEmptyHint ()
+        | false, _ -> speakNow "Nothing is selected."
+
+    let notebookInsert (asSection: bool) =
+        let label = if asSection then "section title> " else "narrative> "
+        match readLine label with
+        | None -> speakNow "Nothing added."
+        | Some text ->
+            let count =
+                lock gate (fun () ->
+                    state.Notebook <-
+                        if asSection then Notebook.addSection text state.Notebook
+                        else Notebook.addNarrative text state.Notebook
+                    let count = Notebook.count state.Notebook
+                    state.NotebookIndex <- count - 1
+                    count)
+            speakNow (
+                sprintf "%s added. Cell %d of %d."
+                    (if asSection then "Section" else "Narrative")
+                    count count)
+
+    let exportNotebook () =
+        let rendered =
+            lock gate (fun () ->
+                if Notebook.count state.Notebook = 0 then None
+                else
+                    Some (
+                        Notebook.toMarkdown
+                            state.Session.Tree
+                            state.Notebook))
+        match rendered with
+        | None -> notebookEmptyHint ()
+        | Some markdown ->
+            try
+                Directory.CreateDirectory(sessionsDir) |> ignore
+                let path =
+                    Path.Combine(
+                        sessionsDir,
+                        sprintf "notebook-%s.md"
+                            (DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")))
+                File.WriteAllText(path, markdown + "\n")
+                speakNow (sprintf "Notebook exported to %s" path)
+            with ex ->
+                diag.Record "error" (sprintf "export failed: %s" ex.Message)
+                speakNow "Export failed; press d for details."
+
+    // --- verb dispatch ------------------------------------------------------
     let mutable running = true
-    while running do
-        let key = Console.ReadKey(true)
-        match key.Key with
-        | ConsoleKey.Q -> running <- false
-        | ConsoleKey.C -> compose None |> ignore
-        | ConsoleKey.B ->
-            // Branch: anchor at the focused chunk (§5.1); the
-            // anchor stack remembers where to return. Pushed
-            // only when the branch request is actually sent —
-            // an aborted compose must not leave a stale anchor.
+
+    let runVerb (verb: KeyMap.Verb) =
+        let mode = lock gate (fun () -> state.Mode)
+        match verb with
+        | KeyMap.Compose -> compose None |> ignore
+        | KeyMap.Branch ->
             let anchor = lock gate (fun () -> state.Nav.Current)
             match anchor with
             | Some id ->
@@ -256,48 +482,202 @@ let main _argv =
                         state.Nav <- Navigator.pushAnchor state.Nav)
             | None ->
                 speakNow "Focus a chunk first, then press b to branch from it."
-        | ConsoleKey.A ->
+        | KeyMap.ReturnAnchor ->
             navigate SpatialCue.ReturnToAnchor Navigator.returnToAnchor
-        | ConsoleKey.G ->
-            let latest = lock gate (fun () -> state.Session.LatestResponseStart)
+        | KeyMap.JumpLatest ->
+            let latest =
+                lock gate (fun () -> state.Session.LatestResponseStart)
             navigate SpatialCue.Jump (Navigator.jumpToLatestResponse latest)
-        | ConsoleKey.J | ConsoleKey.DownArrow ->
-            navigate SpatialCue.Next Navigator.next
-        | ConsoleKey.K | ConsoleKey.UpArrow ->
-            navigate SpatialCue.Previous Navigator.previous
-        | ConsoleKey.L | ConsoleKey.RightArrow ->
+        | KeyMap.Next ->
+            if mode = KeyMap.Transcript then
+                navigate SpatialCue.Next Navigator.next
+            else notebookStep 1 SpatialCue.Next
+        | KeyMap.Previous ->
+            if mode = KeyMap.Transcript then
+                navigate SpatialCue.Previous Navigator.previous
+            else notebookStep -1 SpatialCue.Previous
+        | KeyMap.Descend ->
             navigate SpatialCue.Descend Navigator.descend
-        | ConsoleKey.H | ConsoleKey.LeftArrow ->
+        | KeyMap.Ascend ->
             navigate SpatialCue.Ascend Navigator.ascend
-        | ConsoleKey.R ->
-            let chunk =
+        | KeyMap.FirstSibling ->
+            if mode = KeyMap.Transcript then
+                navigate SpatialCue.Previous Navigator.firstSibling
+            else notebookJump false
+        | KeyMap.LastSibling ->
+            if mode = KeyMap.Transcript then
+                navigate SpatialCue.Next Navigator.lastSibling
+            else notebookJump true
+        | KeyMap.Repeat ->
+            if mode = KeyMap.Transcript then
+                let text =
+                    lock gate (fun () ->
+                        Navigator.current state.Nav state.Session.Tree
+                        |> Option.map (fun c ->
+                            ChunkNarration.describe state.Session.Tree c))
+                match text with
+                | Some t -> speakNow t
+                | None -> speakNow "Nothing is focused."
+            else
+                let text =
+                    lock gate (fun () ->
+                        Notebook.tryItem state.NotebookIndex state.Notebook
+                        |> Option.map (fun cell ->
+                            Notebook.describeCell state.Session.Tree cell))
+                match text with
+                | Some t -> speakNow t
+                | None -> notebookEmptyHint ()
+        | KeyMap.Where ->
+            if mode = KeyMap.Transcript then
+                let located =
+                    lock gate (fun () ->
+                        Navigator.current state.Nav state.Session.Tree
+                        |> Option.map (fun c ->
+                            ChunkNarration.locate state.Session.Tree c))
+                match located with
+                | Some text -> speakNow text
+                | None -> speakNow "Nothing is focused."
+            else
+                let position =
+                    lock gate (fun () ->
+                        let count = Notebook.count state.Notebook
+                        if count = 0 then None
+                        else Some (state.NotebookIndex + 1, count))
+                match position with
+                | Some (n, m) ->
+                    speakNow (sprintf "Cell %d of %d, in the notebook." n m)
+                | None -> notebookEmptyHint ()
+        | KeyMap.Pin ->
+            let pinned =
+                lock gate (fun () ->
+                    match state.Nav.Current with
+                    | Some id ->
+                        state.Notebook <- Notebook.pin id state.Notebook
+                        Some (Notebook.count state.Notebook)
+                    | None -> None)
+            match pinned with
+            | Some count ->
+                speakNow (
+                    sprintf "Pinned. %d cells in the notebook." count)
+            | None -> speakNow "Focus a chunk first, then press p to pin it."
+        | KeyMap.Rerun ->
+            let request =
                 lock gate (fun () ->
                     Navigator.current state.Nav state.Session.Tree
-                    |> Option.map (fun c ->
-                        ChunkNarration.describe state.Session.Tree c))
-            match chunk with
-            | Some text -> speakNow text
-            | None -> speakNow "Nothing is focused."
-        | ConsoleKey.W ->
-            // ADR 0012 S2 — the where-verb: breadcrumb +
-            // position + depth, from the tree (never drifts).
-            let located =
+                    |> Option.bind (fun c ->
+                        match c.Kind with
+                        | Chunk.UserRequest -> Some (c.Text, c.Parent)
+                        | _ -> None))
+            match request with
+            | Some (text, parent) ->
+                let busy = lock gate (fun () -> state.TurnInFlight)
+                if busy then
+                    speakNow "A response is still in progress. Wait for it to complete."
+                else
+                    speakNow (sprintf "Rerunning: %s" text)
+                    startTurn text parent
+            | None ->
+                speakNow
+                    "Focus a request to rerun it. Requests announce as: Your request."
+        | KeyMap.ToggleNotebook ->
+            let announcement =
                 lock gate (fun () ->
-                    Navigator.current state.Nav state.Session.Tree
-                    |> Option.map (fun c ->
-                        ChunkNarration.locate state.Session.Tree c))
-            match located with
-            | Some text -> speakNow text
-            | None -> speakNow "Nothing is focused."
-        | ConsoleKey.S ->
-            // Stop means stop (ADR 0012 S5): silence the
-            // current utterance AND everything queued behind
-            // it — nothing may resume speaking after a stop.
+                    match state.Mode with
+                    | KeyMap.Transcript ->
+                        state.Mode <- KeyMap.NotebookMode
+                        let count = Notebook.count state.Notebook
+                        if count = 0 then
+                            "Notebook. It is empty — press n for the transcript, or pin chunks with p there."
+                        else
+                            state.NotebookIndex <-
+                                max 0 (min state.NotebookIndex (count - 1))
+                            sprintf "Notebook, %d cells." count
+                    | KeyMap.NotebookMode ->
+                        state.Mode <- KeyMap.Transcript
+                        "Transcript.")
+            speakNow announcement
+        | KeyMap.NotebookMoveUp -> notebookReorder true
+        | KeyMap.NotebookMoveDown -> notebookReorder false
+        | KeyMap.NotebookRemove -> notebookRemove ()
+        | KeyMap.NotebookNarrative -> notebookInsert false
+        | KeyMap.NotebookSection -> notebookInsert true
+        | KeyMap.ExportNotebook -> exportNotebook ()
+        | KeyMap.SaveSession -> saveSession true
+        | KeyMap.OpenLastSession ->
+            let busy = lock gate (fun () -> state.TurnInFlight)
+            if busy then
+                speakNow "A response is still in progress. Wait for it to complete."
+            else openLastSession ()
+        | KeyMap.Diagnostics ->
+            let summary = diag.Summary()
+            let pathNote =
+                try
+                    Directory.CreateDirectory(diagnosticsDir) |> ignore
+                    let path =
+                        Path.Combine(
+                            diagnosticsDir,
+                            sprintf "dump-%s.txt"
+                                (DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")))
+                    File.WriteAllText(path, diag.Dump() + "\n")
+                    sprintf " Dump written to %s" path
+                with _ -> " Dump could not be written."
+            speakNow (summary + pathNote)
+        | KeyMap.RateUp | KeyMap.RateDown ->
+            let rate =
+                lock gate (fun () ->
+                    let delta = if verb = KeyMap.RateUp then 1 else -1
+                    state.Rate <- max -10 (min 10 (state.Rate + delta))
+                    state.Rate)
+            speech.SetRate rate
+            speakNow (sprintf "Rate %d." rate)
+        | KeyMap.Stop ->
             lock gate (fun () ->
                 state.Queue <- Attention.clear state.Queue)
             speech.CancelAll ()
-        | _ when key.KeyChar = '?' -> speakNow helpText
-        | _ -> ()
+        | KeyMap.Help ->
+            speakNow (KeyMap.helpFor mode bindings)
+        | KeyMap.Quit -> running <- false
 
+    // --- startup -------------------------------------------------------------
+    match sink.VoiceNote with
+    | Some note -> diag.Record "config" note
+    | None -> ()
+
+    let startupExtras =
+        [ if not (List.isEmpty startupWarnings) then
+            yield
+                sprintf
+                    "%d configuration warning%s; press d for details."
+                    (List.length startupWarnings)
+                    (if List.length startupWarnings = 1 then "" else "s")
+          match sink.VoiceNote with
+          | Some note -> yield note
+          | None -> ()
+          if File.Exists latestSessionPath then
+            yield "A previous session is available. Press o to reopen it." ]
+
+    enqueue (
+        Attention.Foreground (
+            "Engine ready. " + KeyMap.helpFor KeyMap.Transcript bindings))
+    startupExtras
+    |> List.iter (fun text -> enqueue (Attention.Foreground text))
+
+    // --- key loop --------------------------------------------------------------
+    while running do
+        let key = Console.ReadKey(true)
+        let mode = lock gate (fun () -> state.Mode)
+        match key.Key with
+        | ConsoleKey.DownArrow -> runVerb KeyMap.Next
+        | ConsoleKey.UpArrow -> runVerb KeyMap.Previous
+        | ConsoleKey.RightArrow when mode = KeyMap.Transcript ->
+            runVerb KeyMap.Descend
+        | ConsoleKey.LeftArrow when mode = KeyMap.Transcript ->
+            runVerb KeyMap.Ascend
+        | _ ->
+            match KeyMap.tryFind mode key.KeyChar bindings with
+            | Some verb -> runVerb verb
+            | None -> ()
+
+    saveSession false
     speech.CancelAll ()
     0


### PR DESCRIPTION
## Summary

Cycle 54 PR-7 — **the host becomes the full instrument** (ADRs 0013 N2/N4/N5 + 0014 C1–C4 integrated):

- **Table-driven keys**: dispatch is `KeyMap.tryFind` over the user-overridden table; arrows stay hardwired; `?` speaks the generated help for the current mode.
- **Notebook mode** (`n`): walk cells with the same movement keys; `p` pins from the transcript; `[`/`]` reorder with moved/edge honesty; `x` remove; `i`/`u` insert narrative/section (typed lines); `m` exports markdown and speaks the path; `t`/`e` jump first/last cell.
- **Sessions**: auto-save after every turn and on quit (per-run snapshot + `session-latest.jsonl`); `v` saves on demand; `o` restores the tree **and** the CLI `--resume` id (the conversation continues across restarts); corrupt files produce spoken typed errors.
- **Diagnostics**: every bus event → the ring + a per-run session event log; `d` speaks the one-breath summary and writes + names the dump file.
- **Config applied**: participant path (config → env → default), initial rate + voice (with the voice-miss note spoken once), narration cap, cue master switch + gain multiplier.
- **Speech controls**: `+`/`-` live rate, confirmed aloud.
- **Rerun** (`y`): re-issues a focused request anchored where it lived.
- Startup announces config-warning count and offers the previous session.

All decisions remain in tested Engine.Core modules; this file stays the one imperative seam.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_