### PR TITLE
feat(engine): notebook persistence — serde + host save/restore (ADR 0013 N4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15999,6 +15999,21 @@ ring) follow.
   seal count, and tree capture order equals seal-announcement
   order.
 
+### Cycle 54 PR-9 (2026-06-12): notebook persistence
+
+- **Added**: `Engine.Core/NotebookSerde.fs` — the authored
+  sequence as schema-v1 JSONL (pinned cells serialize their
+  chunk id ONLY — reference-not-copy survives the disk; the
+  session file carries the content). Tolerant typed-error
+  reader; round-trip + reference-semantics + schema-gate
+  tests. **Host**: every save now writes
+  `notebook-latest.jsonl` beside the session; `o` restores
+  the notebook with the session (cell count announced; a
+  corrupt notebook file degrades to an empty notebook with a
+  spoken note, never blocking the session restore). Closes
+  the ADR 0013 N4 gap found in audit — previously the
+  notebook was lost on restart.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/engine/TEXTBOOK-07-NOTEBOOK.md
+++ b/docs/engine/TEXTBOOK-07-NOTEBOOK.md
@@ -1,0 +1,60 @@
+# Engine textbook, chapter 7 — the notebook
+
+> File: `src/Engine.Core/Notebook.fs`. Tests: `NotebookTests`.
+> Decision: ADR 0013; spec §5.3 (capture vs authored), §6.3
+> (editor verbs), §3 (the Wolfram notebook as reference).
+
+## Two layers, never collapsed
+
+The spec's sharpest design sentence: *the chat-log is what
+flows in; the notebook is what the maintainer thinks in.* The
+capture tree (chapters 1–3) is the immutable record of what
+happened; the notebook is the **authored** sequence the user
+curates out of it. Spec §14.5 forbids collapsing them, and the
+model enforces that structurally: a notebook cell is one of —
+
+- `PinnedChunk of ChunkId` — a **reference** into the capture
+  tree. Never a copy: narration and export render through the
+  live tree (the tested proof: pin a heading, append a child
+  to it afterwards, and the pinned cell announces the new
+  count). No notebook operation writes the tree.
+- `Narrative of text` — the user's own words, the connective
+  tissue an agent never wrote.
+- `SectionHeader of title` — the higher-order structure of the
+  computational narrative.
+
+## Editing by ear is total
+
+`pin`, `addNarrative`, `addSection`, `moveUp`, `moveDown`,
+`removeAt` — all pure, all **total**. Out-of-range indices are
+no-ops that *report* (`Notebook * bool`), because the host
+must cue an edge exactly like tree navigation: a blind editor
+discovers boundaries by bumping them, and a bump must be a
+sound, never an exception.
+
+## Export: markdown as the interchange form
+
+`toMarkdown` renders the sequence: sections become `##`,
+narrative becomes prose, and pinned chunks render by kind —
+headings demote to `###`, code re-fences with its language
+tag, **lists re-render from the live tree's items**, requests
+and tool calls/results are labelled and fenced. Two properties
+make this the Wolfram lesson honestly adapted:
+
+1. **Publishable**: the export reads top-to-bottom as a
+   document — the deliverable of an exploration session.
+2. **Re-ingestable** (tested): feeding the export through the
+   engine's own `MarkdownChunker` reproduces typed structure.
+   Where Wolfram has one language for interface and data, this
+   engine's interchange form is typed markdown — the one
+   structure every participant already speaks — so a narrative
+   composed today literally seeds tomorrow's conversation
+   ("flows into new domains").
+
+## What is deliberately v2
+
+Inline editing of narrative text, split/merge/re-segment,
+anchored re-issue *with modifications*, multiple notebooks.
+The model needs no migration for any of them (cells have ids;
+the sequence is ordered), which is the ADR 0013 test of having
+modelled the v1 correctly.

--- a/docs/engine/TEXTBOOK-08-CONFIG-KEYMAP.md
+++ b/docs/engine/TEXTBOOK-08-CONFIG-KEYMAP.md
@@ -1,0 +1,75 @@
+# Engine textbook, chapter 8 — configuration and the keymap
+
+> Files: `src/Engine.Core/EngineConfig.fs`, `KeyMap.fs`.
+> Tests: `EngineConfigTests`, `KeyMapTests`. Decision: ADR
+> 0014 C1/C2. User-facing references:
+> [`CONFIGURATION.md`](CONFIGURATION.md),
+> [`KEYBOARD-REFERENCE.md`](KEYBOARD-REFERENCE.md).
+
+## EngineConfig — the warn-and-default discipline
+
+The parse contract is a single sentence: **no input text can
+crash the parse or silently change behaviour.** Every
+degradation — malformed TOML, a wrong-typed value, an
+out-of-range number, a multi-character key override, a newer
+schema — produces the default *plus a typed warning string*
+that the host speaks (as a count, with `d` for detail) and
+records in diagnostics. Unknown sections and keys are
+*silently* ignored — that asymmetry is deliberate forward
+compatibility: an older build must not nag about keys a newer
+build added; true incompatibility is what the
+`schema_version` gate is for (a newer version rejects the
+file whole, because half-reading a future format is worse
+than defaults).
+
+Implementation inherits `Terminal.Core.Config`'s hard-won
+Tomlyn patterns: the non-throwing `Toml.Parse → HasErrors →
+ToModel` entry, and tuple-deconstructed `TryGetValue` matches
+(`| true, (:? int64 as i)`) that sidestep the F# 9
+`byref<obj | null>` friction. TOML quirks handled: integers
+box as `int64`; a gain of `1` is accepted as `1.0`.
+
+## KeyMap — one table, four derivations
+
+Every verb is a case of `Verb`; the bindings are one list of
+`{ Verb; Key; Modes; Description }`. From that single table
+derive, with no second source of truth anywhere:
+
+1. **Dispatch** — `tryFind mode keyChar` is the host's entire
+   key decoding.
+2. **Conflict checking** — `validate` groups per mode; the
+   defaults are CI-asserted conflict-free, so a developer
+   adding a verb on a taken key cannot merge.
+3. **Generated help** — `helpFor mode` concatenates the
+   table; `?` is incapable of drifting from behaviour, and
+   the test asserts help covers every binding.
+4. **User overrides** — `withOverrides` applies `[keys]`
+   entries one at a time, re-validating after each; a
+   collision (in any *shared* mode) warns and keeps the
+   default, so the map stays conflict-free under arbitrary
+   user input. Cross-mode-disjoint reuse is legitimately
+   allowed (tested).
+
+`verbName` gives each verb its stable `snake_case` config
+name; the compiler's exhaustiveness check on that function is
+the mechanism that forces a new verb to become documentable.
+
+## The mode model
+
+Two modes (`Transcript` / `NotebookMode`) — which sequence the
+cursor walks — and a binding declares the modes it lives in.
+Shared verbs (`Modes = both`) occupy one key in both tables;
+mode-local verbs may reuse each other's characters. Arrow
+keys are deliberately **outside** the table: hardwired in the
+host to the four tree moves as the fallback that survives any
+remapping experiment — an instrument whose user can lock
+themselves out of moving has failed.
+
+## Why a table and not a config-DSL
+
+A bindings *language* (chords, sequences, modifiers) is
+power the v1 surface doesn't need and a failure mode the
+audio-only user can't debug by ear. One printable character
+per verb, validated, spoken on `?` — every property of the
+system stays literally speakable, which is the design test
+this whole layer answers to.

--- a/docs/engine/TEXTBOOK-09-PERSISTENCE-DIAGNOSTICS.md
+++ b/docs/engine/TEXTBOOK-09-PERSISTENCE-DIAGNOSTICS.md
@@ -1,0 +1,69 @@
+# Engine textbook, chapter 9 — persistence and diagnostics
+
+> Files: `src/Engine.Core/ChunkSerde.fs`, `ChunkTree.fs`
+> (`restore`), `EngineDiagnostics.fs`. Tests:
+> `ChunkSerdeTests`, `EngineDiagnosticsTests`. Decisions: ADR
+> 0013 N4, ADR 0014 C4; precedent: `docs/IOCELL-SCHEMA.md`.
+
+## The session wire format (schema v1)
+
+A session file is JSONL: one **meta line** — `schemaVersion`,
+the participant session id (the thing `--resume` rides on, so
+a restored session *continues the conversation*), and the two
+cursor anchors — followed by **one chunk per line in capture
+order**. Keys are written in a locked order by a hand-rolled
+`Utf8JsonWriter` emitter (no reflection serializer: the format
+is a contract, not an implementation detail), and kinds
+serialize as a tag plus their payload fields (`heading` +
+`level`, `code` + `language`, `toolUse` + `name`, …).
+
+The reader is the mirror discipline of the stream parser
+(chapter 2): every failure — malformed line, missing field,
+unknown kind tag, newer schema, empty file — is a **typed
+`Error` string**, never an exception, so the host can speak
+exactly what is wrong with a file. New optional fields are
+additive within a version; `schemaVersion` bumps only when an
+old build would *misinterpret* a new file, and old readers
+stay (one-way migration, the IOCELL-SCHEMA rule).
+
+## restore — never a silently wrong tree
+
+`ChunkTree.restore` lives inside the tree module (it needs
+the private representation) and **re-validates every
+structural invariant while rebuilding**: parents must precede
+children, capture order strictly increases, ids are unique,
+and each authored index equals its arrival position among its
+siblings. The threat model is not malice — it is a hand-edited
+file, a partial write, a future bug — and the failure posture
+is the engine's universal one: a typed error the user hears,
+never a crash, and **never a plausible-looking wrong tree**
+(which would be worse than either).
+
+The round-trip law is property-tested: for arbitrary
+generated trees over all fourteen chunk kinds,
+`serialize → parse → restore` reproduces the exact capture
+order.
+
+## EngineDiagnostics — triage by ear
+
+The design constraint is unusual and absolute: the user who
+must produce the bug report **cannot read a console**. So:
+
+- A thread-safe bounded **ring** (default 500 entries) records
+  everything: every bus event (via `describeEvent`, with
+  bodies clipped to 80 chars — diagnostics traces *shape*; the
+  session file holds content), turn outcomes, config
+  warnings, host errors.
+- Counts are **lifetime**, kept outside the ring, so eviction
+  never lies about volume ("note 4,012" stays honest after
+  the entries scrolled away).
+- `Summary()` is the one-breath spoken triage: uptime, counts
+  by category, and the last error verbatim.
+- `Dump()` is the bug-report artifact: ISO-stamped,
+  grep-friendly, one line per entry, written to a file whose
+  path is spoken.
+
+Beside the dump, the host appends a **session event log** —
+one line per bus event as it happened — which is the replay of
+what the user heard; diffing it against expectations is the
+field-debugging recipe (development guide §9).

--- a/docs/engine/TEXTBOOK-10-HOST.md
+++ b/docs/engine/TEXTBOOK-10-HOST.md
@@ -1,0 +1,73 @@
+# Engine textbook, chapter 10 — the host
+
+> File: `src/Engine.Host/Program.fs` (the one imperative
+> file). Decisions: ADR 0011 E8/E9, 0013 N2, 0014 integration.
+
+## The shape: one lock, three threads, zero shared decisions
+
+The host owns ALL mutable state in one record (`HostState`:
+session, navigator, notebook + its cursor, mode, the attention
+queue, the speaking flag, turn-in-flight, rate) behind **one
+lock**. Three threads touch it:
+
+- the **console thread** — the key loop, verbs, compose lines;
+- the **turn thread** — one background thread per turn,
+  folding participant events through `Ingest` and publishing;
+- **audio callbacks** — `UtteranceCompleted` (the drain) and
+  NAudio's playback thread (never touches state).
+
+The discipline that keeps this trivially safe: every lock
+section is a *pure-function call plus field assignment* —
+decisions happen in Engine.Core on immutable values; the lock
+only swaps which value the fields hold. No lock is ever held
+across I/O, speech, or a publish.
+
+## The speech drain
+
+The host speaks at most one utterance at a time: `speakNext`
+dequeues (foreground first, ambient otherwise) only when not
+already speaking; `UtteranceCompleted` — which SAPI fires for
+finished *and cancelled* utterances — clears the flag and
+drains again. This tiny protocol is what makes the attention
+queue's ordering guarantees real at the audio device.
+`speakNow` (every user-initiated read) cancels current speech,
+supersedes stale queued foreground, keeps ambient, then
+drains.
+
+## Turns
+
+`startTurn` captures the request (pure), publishes, then runs
+the participant on a background thread; each incoming
+`AgentEvent` folds under the lock and publishes outside it.
+The turn thread ends by clearing the in-flight flag,
+publishing any process-level failure as an ambient note, and
+**auto-saving the session**. Compose and rerun refuse while a
+turn is in flight (one conversation, one turn — a v1
+simplification the bus does not require).
+
+## Files
+
+Everything lives under `%LOCALAPPDATA%\PtySpeak\`:
+`engine.toml`; `engine-sessions\` (per-run session snapshots +
+`session-latest.jsonl` + per-run event logs + notebook
+exports); `engine-diagnostics\` (dump files). All writes are
+try/with + diagnostics-recorded — a full disk degrades to a
+spoken warning, never a crash.
+
+## The key loop
+
+Four hardwired arrow arms (transcript safety net), then one
+table lookup: `KeyMap.tryFind mode key.KeyChar bindings →
+runVerb`. `runVerb` is the only mode-aware code: movement
+verbs route to the navigator or the notebook cursor; everything
+else is mode-shared. Unbound keys are silently ignored —
+random keyboard contact must not produce noise.
+
+## What the host deliberately does NOT do
+
+No parsing, no chunking, no sealing rules, no narration
+strings (beyond prompts/confirmations), no cue choices, no
+queue policy, no serialization — each of those is a tested
+core module. The integration test of the architecture is this
+file's diff history: every feature cycle so far changed the
+host by *wiring*, not by *logic*.

--- a/src/Engine.Core/Engine.Core.fsproj
+++ b/src/Engine.Core/Engine.Core.fsproj
@@ -86,6 +86,7 @@
       chunks in capture order; tolerant typed-error reader.
     -->
     <Compile Include="ChunkSerde.fs" />
+    <Compile Include="NotebookSerde.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Engine.Core/NotebookSerde.fs
+++ b/src/Engine.Core/NotebookSerde.fs
@@ -1,0 +1,136 @@
+namespace Engine.Core
+
+open System
+open System.Text.Json
+open Engine.Core.Notebook
+
+/// ADR 0013 N4 — notebook persistence: the authored sequence
+/// as schema-v1 JSONL (meta line + one cell per line), same
+/// discipline as `ChunkSerde`: locked key order, tolerant
+/// typed-error reader, one-way migrations. Pinned cells
+/// serialize their chunk id only — the content stays in the
+/// session file (reference-not-copy survives the disk).
+module NotebookSerde =
+
+    [<Literal>]
+    let SchemaVersion = 1
+
+    let private writeJson (write: Utf8JsonWriter -> unit) : string =
+        use stream = new IO.MemoryStream()
+        use writer =
+            new Utf8JsonWriter(stream, JsonWriterOptions(Indented = false))
+        write writer
+        writer.Flush()
+        Text.Encoding.UTF8.GetString(stream.ToArray())
+
+    let private cellToJson (cell: Cell) : string =
+        writeJson (fun writer ->
+            writer.WriteStartObject()
+            writer.WriteString("id", cell.Id)
+            match cell.Content with
+            | PinnedChunk (Chunk.ChunkId chunkId) ->
+                writer.WriteString("cell", "pinned")
+                writer.WriteString("chunk", chunkId)
+            | Narrative text ->
+                writer.WriteString("cell", "narrative")
+                writer.WriteString("text", text)
+            | SectionHeader title ->
+                writer.WriteString("cell", "section")
+                writer.WriteString("title", title)
+            writer.WriteEndObject())
+
+    /// The whole notebook → JSONL (meta + cells, trailing
+    /// newline).
+    let toJsonl (notebook: Notebook) : string =
+        let meta =
+            writeJson (fun writer ->
+                writer.WriteStartObject()
+                writer.WriteNumber("schemaVersion", SchemaVersion)
+                writer.WriteNumber("cellCount", count notebook)
+                writer.WriteEndObject())
+        let lines = notebook.Cells |> List.map cellToJson
+        String.concat "\n" (meta :: lines) + "\n"
+
+    let private tryStr (el: JsonElement) (name: string) : string option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.String then
+            match v.GetString() with
+            | null -> None
+            | s -> Some s
+        else None
+
+    let private tryInt (el: JsonElement) (name: string) : int option =
+        let found, v = el.TryGetProperty(name)
+        if found && v.ValueKind = JsonValueKind.Number then
+            let ok, i = v.TryGetInt32()
+            if ok then Some i else None
+        else None
+
+    let private parseCellLine (line: string) : Result<Cell, string> =
+        try
+            use doc = JsonDocument.Parse(line)
+            let root = doc.RootElement
+            match tryStr root "id" with
+            | None -> Error "notebook cell without an id"
+            | Some id ->
+                match tryStr root "cell" with
+                | Some "pinned" ->
+                    match tryStr root "chunk" with
+                    | Some chunkId ->
+                        Ok { Id = id
+                             Content = PinnedChunk (Chunk.ChunkId chunkId) }
+                    | None -> Error "pinned cell without a chunk id"
+                | Some "narrative" ->
+                    Ok { Id = id
+                         Content =
+                            Narrative (
+                                tryStr root "text"
+                                |> Option.defaultValue "") }
+                | Some "section" ->
+                    Ok { Id = id
+                         Content =
+                            SectionHeader (
+                                tryStr root "title"
+                                |> Option.defaultValue "") }
+                | Some other ->
+                    Error (sprintf "unknown notebook cell kind '%s'" other)
+                | None -> Error "notebook cell without a kind"
+        with :? JsonException as ex ->
+            Error (sprintf "malformed notebook line: %s" ex.Message)
+
+    /// Parse JSONL text back to a notebook. Typed errors,
+    /// never a crash; an empty file is the empty notebook's
+    /// honest serialization, not an error.
+    let parseJsonl (text: string) : Result<Notebook, string> =
+        let lines =
+            text.Split('\n')
+            |> Array.map (fun l -> l.TrimEnd('\r'))
+            |> Array.filter (fun l -> not (String.IsNullOrWhiteSpace l))
+            |> List.ofArray
+        match lines with
+        | [] -> Error "empty notebook file"
+        | metaLine :: cellLines ->
+            try
+                use doc = JsonDocument.Parse(metaLine)
+                match tryInt doc.RootElement "schemaVersion" with
+                | None -> Error "missing schemaVersion"
+                | Some v when v > SchemaVersion ->
+                    Error (
+                        sprintf
+                            "notebook schemaVersion %d is newer than this build supports (%d)"
+                            v SchemaVersion)
+                | Some _ ->
+                    let folded =
+                        ((Ok []), cellLines)
+                        ||> List.fold (fun acc line ->
+                            match acc with
+                            | Error e -> Error e
+                            | Ok cells ->
+                                match parseCellLine line with
+                                | Ok cell -> Ok (cells @ [ cell ])
+                                | Error e -> Error e)
+                    match folded with
+                    | Error e -> Error e
+                    | Ok cells -> Ok { Cells = cells }
+            with :? JsonException as ex ->
+                Error (sprintf "malformed notebook meta line: %s" ex.Message)

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -46,6 +46,8 @@ let main _argv =
     let configPath = Path.Combine(dataRoot, "engine.toml")
     let latestSessionPath =
         Path.Combine(sessionsDir, "session-latest.jsonl")
+    let latestNotebookPath =
+        Path.Combine(sessionsDir, "notebook-latest.jsonl")
     let runStamp = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")
 
     // --- config + keymap (ADR 0014 C1/C2) ------------------------------
@@ -181,6 +183,13 @@ let main _argv =
                         sprintf "session-%s.jsonl" runStamp),
                     text)
                 File.WriteAllText(latestSessionPath, text)
+                // The notebook persists beside the session
+                // (ADR 0013 N4) — references stay valid because
+                // the session file carries every chunk.
+                let notebookText =
+                    lock gate (fun () ->
+                        NotebookSerde.toJsonl state.Notebook)
+                File.WriteAllText(latestNotebookPath, notebookText)
                 if announce then
                     speakNow (
                         sprintf "Saved, %d chunks."
@@ -189,6 +198,21 @@ let main _argv =
                 diag.Record "error" (sprintf "save failed: %s" ex.Message)
                 if announce then
                     speakNow "Save failed; press d for details."
+
+    // Helpers extracted so the restore match arms stay single
+    // expressions (the sequence-in-match-arm gotcha).
+    let applyRestoredNotebook (notebook: Notebook.Notebook) : string =
+        lock gate (fun () ->
+            state.Notebook <- notebook
+            state.NotebookIndex <-
+                min state.NotebookIndex (Notebook.count notebook - 1))
+        if Notebook.count notebook > 0 then
+            sprintf " Notebook restored, %d cells." (Notebook.count notebook)
+        else ""
+
+    let notebookRestoreFailure (detail: string) : string =
+        diag.Record "error" (sprintf "notebook restore: %s" detail)
+        " The notebook file could not be read; starting with an empty notebook."
 
     let openLastSession () =
         if not (File.Exists latestSessionPath) then
@@ -209,6 +233,15 @@ let main _argv =
                 diag.Record "error" (sprintf "session restore: %s" e)
                 speakNow (sprintf "Could not open the last session: %s" e)
             | Ok (file, tree) ->
+                let notebookNote =
+                    if File.Exists latestNotebookPath then
+                        try
+                            match NotebookSerde.parseJsonl
+                                      (File.ReadAllText latestNotebookPath) with
+                            | Ok notebook -> applyRestoredNotebook notebook
+                            | Error e -> notebookRestoreFailure e
+                        with ex -> notebookRestoreFailure ex.Message
+                    else ""
                 lock gate (fun () ->
                     state.Session <-
                         { Tree = tree
@@ -218,9 +251,10 @@ let main _argv =
                           InFlightCount = 0 }
                     state.Nav <- Navigator.initial)
                 speakNow (
-                    sprintf
+                    (sprintf
                         "Session restored, %d chunks. Press g to jump to the latest response."
                         (ChunkTree.count tree))
+                    + notebookNote)
 
     // --- participant turns ------------------------------------------------
     let publishAll (events: EngineEvent list) =

--- a/tests/Tests.Unit/NotebookSerdeTests.fs
+++ b/tests/Tests.Unit/NotebookSerdeTests.fs
@@ -1,0 +1,68 @@
+module PtySpeak.Tests.Unit.NotebookSerdeTests
+
+open Xunit
+open Engine.Core
+open Engine.Core.Notebook
+
+// ---------------------------------------------------------------------
+// ADR 0013 N4 — notebook JSONL: round-trip, pinned ids survive
+// as references, schema gating, typed errors.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``a notebook round-trips through jsonl exactly`` () =
+    let chunkId = Chunk.newId ()
+    let original =
+        empty
+        |> addSection "Findings"
+        |> pin chunkId
+        |> addNarrative "with \"quotes\" and\nnewlines"
+    match NotebookSerde.parseJsonl (NotebookSerde.toJsonl original) with
+    | Ok restored ->
+        Assert.Equal(3, count restored)
+        Assert.Equal<Cell list>(original.Cells, restored.Cells)
+    | Error e -> failwithf "unexpected Error: %s" e
+
+[<Fact>]
+let ``a pinned cell still points at the same chunk after the trip`` () =
+    let chunk, tree =
+        match ChunkTree.append None Chunk.Paragraph "kept" ChunkTree.empty with
+        | Ok v -> v
+        | Error e -> failwith e
+    let restored =
+        match NotebookSerde.parseJsonl
+                  (NotebookSerde.toJsonl (empty |> pin chunk.Id)) with
+        | Ok nb -> nb
+        | Error e -> failwith e
+    // Renders through the live tree — reference semantics held.
+    Assert.Equal<string list>(
+        [ "Pinned: kept" ],
+        restored.Cells |> List.map (describeCell tree))
+
+[<Fact>]
+let ``the empty notebook round-trips`` () =
+    match NotebookSerde.parseJsonl (NotebookSerde.toJsonl empty) with
+    | Ok restored -> Assert.Equal(0, count restored)
+    | Error e -> failwithf "unexpected Error: %s" e
+
+[<Fact>]
+let ``a newer schema version is a typed error`` () =
+    match NotebookSerde.parseJsonl "{\"schemaVersion\":99}\n" with
+    | Error e -> Assert.Contains("newer", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``a corrupt cell line is a typed error`` () =
+    match NotebookSerde.parseJsonl
+              "{\"schemaVersion\":1,\"cellCount\":1}\n{nope" with
+    | Error e -> Assert.Contains("malformed", e)
+    | Ok _ -> failwith "expected Error"
+
+[<Fact>]
+let ``an unknown cell kind is a typed error`` () =
+    let text =
+        "{\"schemaVersion\":1,\"cellCount\":1}\n"
+        + "{\"id\":\"x\",\"cell\":\"hologram\"}"
+    match NotebookSerde.parseJsonl text with
+    | Error e -> Assert.Contains("hologram", e)
+    | Ok _ -> failwith "expected Error"

--- a/tests/Tests.Unit/Tests.Unit.fsproj
+++ b/tests/Tests.Unit/Tests.Unit.fsproj
@@ -113,6 +113,7 @@
     <Compile Include="KeyMapTests.fs" />
     <Compile Include="ChunkSerdeTests.fs" />
     <Compile Include="EnginePropertyTests.fs" />
+    <Compile Include="NotebookSerdeTests.fs" />
     <Compile Include="ClaudeCliTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Cycle 54 PR-9 — **notebook persistence**, closing a real gap the audit found: [ADR 0013](docs/adr/0013-computational-notebook-authored-layer.md) N4 specifies the notebook persists beside the session, but until now it was lost on restart.

- **`NotebookSerde.fs`** — the authored sequence as schema-v1 JSONL. Pinned cells serialize **their chunk id only** — reference-not-copy survives the disk, because the session file already carries every chunk; narrative and section cells carry their text. Tolerant typed-error reader (malformed lines, unknown cell kinds, newer schema), same discipline as `ChunkSerde`.
- **Host**: every save (auto + `v`) now writes `notebook-latest.jsonl` beside the session; `o` restores the notebook together with the session, announcing the cell count. A corrupt notebook file degrades to an empty notebook with a spoken note — it can never block the session restore.
- Tests: round-trip exactness, reference semantics after the trip (a restored pin still renders through the live tree), empty-notebook round-trip, schema gate, corrupt-line and unknown-kind typed errors.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_