### PR TITLE
feat(engine): exploration verbs — find, structure summary, digit direct-address, Escape stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16014,6 +16014,22 @@ ring) follow.
   the ADR 0013 N4 gap found in audit — previously the
   notebook was lost on restart.
 
+### Cycle 54 PR-10 (2026-06-12): exploration verbs
+
+- **Added**: three verbs for fast computational exploration —
+  **find** (`f`: type a query, jump to the next chunk
+  containing it, case-insensitive, capture-order forward with
+  wrap; Enter alone repeats the last search;
+  `Navigator.findNext`); **structure summary** (`z`: "Contains
+  2 paragraphs, 1 code block." — data at hand to decide the
+  next move without reading anything;
+  `ChunkNarration.summarizeChildren`, honest singulars);
+  **direct address** (digits `1`–`9`, hardwired like the
+  arrows: jump to the Nth item at the current level;
+  `Navigator.nthSibling`). **Escape** is a hardwired stop
+  alias — silence survives any remapping. Tests pin all
+  three incl. wrap-around, no-match edges, and singulars.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/src/Engine.Core/ChunkNarration.fs
+++ b/src/Engine.Core/ChunkNarration.fs
@@ -158,6 +158,43 @@ module ChunkNarration =
             inside
             (List.length ancestors + 1)
 
+    /// The structure below the focused chunk as counts by kind
+    /// — data at hand to decide the next move without reading
+    /// any of it. Direct children only (descend to drill).
+    let summarizeChildren
+            (tree: ChunkTree.Tree)
+            (chunk: Chunk.Chunk)
+            : string =
+        let children = ChunkTree.children (Some chunk.Id) tree
+        if List.isEmpty children then
+            "Nothing inside."
+        else
+            let pluralLabel (kind: Chunk.ChunkKind) : string =
+                match kind with
+                | Chunk.Heading _ -> "sections"
+                | Chunk.Paragraph -> "paragraphs"
+                | Chunk.ListBlock _ -> "lists"
+                | Chunk.ListItem -> "list items"
+                | Chunk.CodeBlock _ -> "code blocks"
+                | Chunk.BlockQuote -> "quotes"
+                | Chunk.ThematicBreak -> "separators"
+                | Chunk.UserRequest -> "requests"
+                | Chunk.ToolUse _ -> "tool calls"
+                | Chunk.ToolResult _ -> "tool results"
+                | Chunk.AgentError -> "agent errors"
+                | Chunk.SystemNote -> "notes"
+            let part (label: string, group: Chunk.Chunk list) =
+                let n = List.length group
+                let word =
+                    if n = 1 then label.TrimEnd('s') else label
+                sprintf "%d %s" n word
+            let counts =
+                children
+                |> List.groupBy (fun c -> pluralLabel c.Kind)
+                |> List.map part
+                |> String.concat ", "
+            sprintf "Contains %s." counts
+
     /// ADR 0012 S5 — `describe` bounded for navigation reads:
     /// a long body (a big code block, a wall of tool output) is
     /// cut at `maxChars` with an honest marker telling the

--- a/src/Engine.Core/KeyMap.fs
+++ b/src/Engine.Core/KeyMap.fs
@@ -29,6 +29,8 @@ module KeyMap =
         | LastSibling
         | Repeat
         | Where
+        | Find
+        | StructureSummary
         | Pin
         | Rerun
         | ToggleNotebook
@@ -63,6 +65,8 @@ module KeyMap =
         | LastSibling -> "last_sibling"
         | Repeat -> "repeat"
         | Where -> "where"
+        | Find -> "find"
+        | StructureSummary -> "structure_summary"
         | Pin -> "pin"
         | Rerun -> "rerun"
         | ToggleNotebook -> "toggle_notebook"
@@ -117,6 +121,10 @@ module KeyMap =
             Description = "repeat in full" }
           { Verb = Where; Key = 'w'; Modes = both
             Description = "where am I" }
+          { Verb = Find; Key = 'f'; Modes = [ Transcript ]
+            Description = "find text from here (Enter alone repeats the last search)" }
+          { Verb = StructureSummary; Key = 'z'; Modes = [ Transcript ]
+            Description = "what is inside the focused chunk" }
           { Verb = Pin; Key = 'p'; Modes = [ Transcript ]
             Description = "pin the focused chunk to the notebook" }
           { Verb = Rerun; Key = 'y'; Modes = [ Transcript ]

--- a/src/Engine.Core/Navigator.fs
+++ b/src/Engine.Core/Navigator.fs
@@ -106,6 +106,50 @@ module Navigator =
             state
             tree
 
+    /// Jump to the 1-based Nth sibling at the focused chunk's
+    /// level (the digit keys — direct address within a row).
+    let nthSibling (n: int) (state: State) (tree: ChunkTree.Tree) : State * Move =
+        moveVia
+            (fun id t ->
+                match ChunkTree.tryFind id t with
+                | None -> None
+                | Some chunk ->
+                    ChunkTree.children chunk.Parent t
+                    |> List.tryItem (n - 1))
+            (sprintf "there is no item %d at this level" n)
+            state
+            tree
+
+    /// Find the next chunk whose text contains `query`
+    /// (case-insensitive), searching capture order forward from
+    /// the focused chunk and wrapping; the §6.2 exploration
+    /// companion — jump by content when structure isn't enough.
+    let findNext (query: string) (state: State) (tree: ChunkTree.Tree) : State * Move =
+        let all = ChunkTree.inCaptureOrder tree
+        if List.isEmpty all then
+            state, Edge "nothing to search yet"
+        else
+            let matches (chunk: Chunk.Chunk) =
+                chunk.Text.Contains(
+                    query,
+                    System.StringComparison.OrdinalIgnoreCase)
+            let startIndex =
+                match state.Current with
+                | None -> -1
+                | Some id ->
+                    all
+                    |> List.tryFindIndex (fun c -> c.Id = id)
+                    |> Option.defaultValue -1
+            let total = List.length all
+            let found =
+                Seq.init total (fun offset ->
+                    all.[(startIndex + 1 + offset) % total])
+                |> Seq.tryFind matches
+            match found with
+            | Some chunk ->
+                { state with Current = Some chunk.Id }, Moved chunk
+            | None -> state, Edge (sprintf "no match for %s" query)
+
     /// The focused chunk, for re-narration (§6.2).
     let current (state: State) (tree: ChunkTree.Tree) : Chunk.Chunk option =
         state.Current

--- a/src/Engine.Host/Program.fs
+++ b/src/Engine.Host/Program.fs
@@ -502,6 +502,7 @@ let main _argv =
 
     // --- verb dispatch ------------------------------------------------------
     let mutable running = true
+    let mutable lastFindQuery : string option = None
 
     let runVerb (verb: KeyMap.Verb) =
         let mode = lock gate (fun () -> state.Mode)
@@ -581,6 +582,27 @@ let main _argv =
                 | Some (n, m) ->
                     speakNow (sprintf "Cell %d of %d, in the notebook." n m)
                 | None -> notebookEmptyHint ()
+        | KeyMap.Find ->
+            let query =
+                match readLine "find> " with
+                | Some text ->
+                    lastFindQuery <- Some text
+                    Some text
+                | None -> lastFindQuery
+            match query with
+            | None -> speakNow "Type something to find."
+            | Some text ->
+                navigate SpatialCue.Jump (Navigator.findNext text)
+        | KeyMap.StructureSummary ->
+            let summary =
+                lock gate (fun () ->
+                    Navigator.current state.Nav state.Session.Tree
+                    |> Option.map (fun c ->
+                        ChunkNarration.summarizeChildren
+                            state.Session.Tree c))
+            match summary with
+            | Some text -> speakNow text
+            | None -> speakNow "Nothing is focused."
         | KeyMap.Pin ->
             let pinned =
                 lock gate (fun () ->
@@ -707,6 +729,17 @@ let main _argv =
             runVerb KeyMap.Descend
         | ConsoleKey.LeftArrow when mode = KeyMap.Transcript ->
             runVerb KeyMap.Ascend
+        | ConsoleKey.Escape ->
+            // Hardwired stop alias — silence must be a reflex
+            // that survives any remapping.
+            runVerb KeyMap.Stop
+        | _ when
+            mode = KeyMap.Transcript
+            && key.KeyChar >= '1' && key.KeyChar <= '9' ->
+            // Direct address: jump to the Nth item at this
+            // level (hardwired, like the arrows).
+            let n = int key.KeyChar - int '0'
+            navigate SpatialCue.Jump (Navigator.nthSibling n)
         | _ ->
             match KeyMap.tryFind mode key.KeyChar bindings with
             | Some verb -> runVerb verb

--- a/tests/Tests.Unit/ChunkNarrationTests.fs
+++ b/tests/Tests.Unit/ChunkNarrationTests.fs
@@ -114,6 +114,21 @@ let ``the structure prefix survives the cut`` () =
         describeCappedSolo 80 (CodeBlock (Some "fsharp")) longCode
     Assert.StartsWith("Code block, fsharp, ", rendered)
 
+[<Fact>]
+let ``summarizeChildren counts kinds with honest singulars`` () =
+    let h, tree = ok (ChunkTree.append None (Heading 1) "Plan" ChunkTree.empty)
+    let _, tree = ok (ChunkTree.append (Some h.Id) Paragraph "a" tree)
+    let _, tree = ok (ChunkTree.append (Some h.Id) Paragraph "b" tree)
+    let _, tree = ok (ChunkTree.append (Some h.Id) (CodeBlock None) "x" tree)
+    Assert.Equal(
+        "Contains 2 paragraphs, 1 code block.",
+        ChunkNarration.summarizeChildren tree h)
+
+[<Fact>]
+let ``summarizeChildren on a leaf says nothing inside`` () =
+    let p, tree = ok (ChunkTree.append None Paragraph "leaf" ChunkTree.empty)
+    Assert.Equal("Nothing inside.", ChunkNarration.summarizeChildren tree p)
+
 // --- ADR 0012 S2 — positional orientation ---------------------------
 
 /// req ── [p1; heading ── [inner]; p2]

--- a/tests/Tests.Unit/KeyMapTests.fs
+++ b/tests/Tests.Unit/KeyMapTests.fs
@@ -45,10 +45,13 @@ let ``help is generated from the table and covers every binding`` () =
 
 [<Fact>]
 let ``an override moves a verb to a new key`` () =
+    // 'Z' (uppercase) is free in both modes; lowercase 'z' is
+    // structure_summary since the exploration-verbs PR — the
+    // conflict path for it is covered below.
     let bindings, warnings =
-        withOverrides (Map.ofList [ "pin", 'z' ]) defaults
+        withOverrides (Map.ofList [ "pin", 'Z' ]) defaults
     Assert.Empty(warnings)
-    Assert.Equal(Some Pin, tryFind Transcript 'z' bindings)
+    Assert.Equal(Some Pin, tryFind Transcript 'Z' bindings)
     Assert.Equal(None, tryFind Transcript 'p' bindings)
 
 [<Fact>]

--- a/tests/Tests.Unit/NavigatorTests.fs
+++ b/tests/Tests.Unit/NavigatorTests.fs
@@ -150,6 +150,39 @@ let ``first and last sibling jump within the level`` () =
     movedTo f.P1.Id m3
 
 [<Fact>]
+let ``nth sibling addresses the level directly and edges honestly`` () =
+    let f = fixture ()
+    let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree
+    let s1, m1 = Navigator.nthSibling 3 s0 f.Tree
+    movedTo f.P2.Id m1
+    let _, m2 = Navigator.nthSibling 9 s1 f.Tree
+    match m2 with
+    | Edge text -> Assert.Contains("9", text)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``findNext searches forward case-insensitively and wraps`` () =
+    let f = fixture ()
+    // Focus the last paragraph; "ALPHA" lives earlier (item1) —
+    // the search must wrap and still find it.
+    let s0, _ = Navigator.focus f.P2.Id Navigator.initial f.Tree
+    let s1, m1 = Navigator.findNext "ALPHA" s0 f.Tree
+    movedTo f.Item1.Id m1
+    // No match: an Edge naming the query, focus unchanged.
+    let s2, m2 = Navigator.findNext "zebra" s1 f.Tree
+    match m2 with
+    | Edge text ->
+        Assert.Contains("zebra", text)
+        Assert.Equal(Some f.Item1.Id, s2.Current)
+    | other -> failwithf "expected Edge, got %A" other
+
+[<Fact>]
+let ``findNext with no focus starts from the beginning`` () =
+    let f = fixture ()
+    let _, move = Navigator.findNext "first" Navigator.initial f.Tree
+    movedTo f.P1.Id move
+
+[<Fact>]
 let ``anchors nest as a stack`` () =
     let f = fixture ()
     let s0, _ = Navigator.focus f.P1.Id Navigator.initial f.Tree


### PR DESCRIPTION
## Summary

Cycle 54 PR-10 — **exploration verbs**: the keys that make the tree an instrument for fast computational exploration.

- **Find** (`f`, `Navigator.findNext`): type a query, jump to the next chunk containing it — case-insensitive, capture-order forward from focus, **wrapping**; Enter on an empty find prompt repeats the last search. Jump by *content* when structure isn't enough.
- **Structure summary** (`z`, `ChunkNarration.summarizeChildren`): "Contains 2 paragraphs, 1 code block." — the data-at-hand to decide the next move without reading anything; honest singulars.
- **Direct address** (digits `1`–`9`, hardwired like the arrows, `Navigator.nthSibling`): jump straight to the Nth item at the current level — the heading announced "9 items inside"? Press `4`.
- **Escape** is a hardwired stop alias: silence is a reflex that survives any remapping.

Tests pin wrap-around search, no-match edges (focus unchanged, query named), nth-sibling addressing + out-of-range edges, summary counts and singulars. KeyMap rows for `f`/`z` (transcript mode); conflict-checking covers them automatically.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_