### PR TITLE
docs(engine): document the exploration verbs; fix rebinding examples

### DIFF
--- a/docs/engine/CONFIGURATION.md
+++ b/docs/engine/CONFIGURATION.md
@@ -58,7 +58,7 @@ for the verb names and the conflict rules.
 
 ```toml
 [keys]
-pin = "z"
+pin = "P"
 ```
 
 ## A complete example
@@ -81,7 +81,7 @@ enabled = true
 gain = 0.7
 
 [keys]
-pin = "z"
+pin = "P"
 rerun = "Y"
 ```
 

--- a/docs/engine/KEYBOARD-REFERENCE.md
+++ b/docs/engine/KEYBOARD-REFERENCE.md
@@ -38,6 +38,9 @@ any remapping.
 | `e` | last item at this level | |
 | `r` | repeat in full | the uncapped read of the focused chunk |
 | `w` | where am I | kind, position, ancestor trail, depth |
+| `f` | find text from here | case-insensitive, forward with wrap; Enter alone repeats the last search |
+| `z` | what is inside | "Contains 2 paragraphs, 1 code block." — structure without content |
+| `1`–`9` | jump to the Nth item at this level | hardwired, like the arrows |
 | `p` | pin to the notebook | appends a live reference |
 | `y` | rerun the focused request | re-issues that request text as a new turn |
 | `n` | switch to the notebook | |
@@ -45,7 +48,7 @@ any remapping.
 | `o` | open the last saved session | restores tree + conversation continuity |
 | `d` | diagnostics | speaks the summary; writes + names the dump file |
 | `+` / `-` | speech rate up / down | SAPI −10…+10, confirmed aloud |
-| `s` | stop speech | cancels AND clears everything queued |
+| `s` / Escape | stop speech | cancels AND clears everything queued; Escape is hardwired |
 | `?` | speak the key list | generated from the table |
 | `q` | quit | |
 
@@ -75,7 +78,7 @@ Any verb can move to any single printable character via
 
 ```toml
 [keys]
-pin = "z"
+pin = "P"
 notebook_remove = "X"
 ```
 
@@ -88,7 +91,7 @@ Rules (all enforced, all spoken at startup if violated):
   conflict-free by construction.
 - A verb bound only in one mode may reuse a character that the
   other mode uses for something else (the modes never overlap).
-- Arrow keys cannot be unbound.
+- Arrow keys, the digits, and Escape cannot be unbound.
 
 ## Design notes (why these keys)
 

--- a/docs/engine/USER-GUIDE.md
+++ b/docs/engine/USER-GUIDE.md
@@ -71,7 +71,13 @@ items." and `l` walks into the items. Every move ends with
 its position — "…, 2 of 5" — so you always know where you are
 in the row, and `w` speaks the full breadcrumb: what you're
 on, its position, every ancestor, and the depth. `t` and `e`
-jump to the first and last item at the current level. You can
+jump to the first and last item at the current level; the
+digits `1`–`9` jump straight to the Nth item ("9 items
+inside"? press `4`); `z` answers "what's in here?" with
+counts ("Contains 2 paragraphs, 1 code block.") so you can
+decide before descending; and `f` finds text anywhere ahead
+of you, wrapping — press `f` then Enter to repeat the last
+search. You can
 never fall out of the content: at an edge the engine says so,
 plays a dull tone on the side you bumped, and stays put.
 


### PR DESCRIPTION
## Summary

Docs closure C1: the engine documentation corpus (which landed with #470) predates the exploration verbs of #471 — this brings it current:

- `KEYBOARD-REFERENCE.md`: rows for `f` (find, wrap, repeat-last), `z` (structure summary), digits `1`–`9` (direct address, hardwired), Escape as the hardwired stop alias; "cannot be unbound" list updated.
- `USER-GUIDE.md` § Hearing structure: the same verbs in narrative form.
- Rebinding examples in the keyboard reference and `CONFIGURATION.md` moved off `z` (now taken by structure-summary) to `P` — the example as written would itself have triggered the conflict warning.

Docs-only — fast lane.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_