### PR TITLE
docs: ADR 0013/0014 ship notes + docs-corpus CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16030,6 +16030,27 @@ ring) follow.
   alias — silence survives any remapping. Tests pin all
   three incl. wrap-around, no-match edges, and singulars.
 
+### Cycle 54 docs corpus + closure (2026-06-12)
+
+- **Added (docs)**: the engine documentation corpus under
+  [`docs/engine/`](docs/engine/) — `USER-GUIDE` (new-user
+  onboarding), `WORKFLOWS` (investigation loop / experiment
+  loop / narrative building / domain flow / triage /
+  listening posture), `KEYBOARD-REFERENCE` (both modes +
+  rebinding rules, mirroring the KeyMap table),
+  `CONFIGURATION` (every key + the degradation contract),
+  `TROUBLESHOOTING` (everything diagnosable by ear),
+  `DEVELOPMENT-GUIDE` (worked recipes: add a verb / chunk
+  kind / participant / bus consumer / config key; field
+  debugging; release checklist), and the eleven-chapter
+  internals `TEXTBOOK` (00 overview → 10 host). *(Process
+  note: the corpus rode into main with #470's commit rather
+  than its own PRs — an over-broad `git add -A`; content
+  reviewed and brought current in #472/#473.)*
+- **Changed (docs)**: ADRs 0013/0014 → Implemented &
+  CI-green with per-PR ship notes; `ENGINE-PHASE0.md` +
+  `P0-ENGINE-1` extended to acceptance steps 10–12.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/docs/adr/0013-computational-notebook-authored-layer.md
+++ b/docs/adr/0013-computational-notebook-authored-layer.md
@@ -133,3 +133,10 @@ other chunk kind it explains itself instead of guessing.
 - 2026-06-12: authored; implementation lands in this cycle
   (serde → auto-save/restore → notebook model → host mode →
   export → rerun), each its own PR.
+- 2026-06-12 (same session): **Implemented & CI-green** —
+  #464 notebook model · #466 session serde + validated
+  restore · #468 host integration (mode, editor verbs,
+  export, rerun, auto-save/`o` restore) · #470 notebook
+  serde + restore (closing the N4 notebook-persistence gap
+  found in audit). The extended `P0-ENGINE-1` walk (steps
+  10–11) is the ratification gate.

--- a/docs/adr/0014-engine-config-keymap-speech-diagnostics.md
+++ b/docs/adr/0014-engine-config-keymap-speech-diagnostics.md
@@ -122,3 +122,13 @@ keystroke, not a config edit.
 - 2026-06-12: authored; implementation lands in this cycle
   (config → diagnostics → keymap → speech controls → host
   integration), each its own PR.
+- 2026-06-12 (same session): **Implemented & CI-green** —
+  #463 engine.toml + diagnostics ring · #465 keymap · #467
+  `SetRate` + voice selection · #468 host integration · #471
+  exploration verbs (find / structure summary / digit
+  direct-address / hardwired Escape stop) on the same table.
+  One CI failure in the whole cycle (#471 first run): a test
+  fixture rebinding onto the newly-taken `z` — the conflict
+  checker working as designed; fixture moved to a free key.
+  The extended `P0-ENGINE-1` walk (step 12) is the
+  ratification gate.


### PR DESCRIPTION
## Summary

Docs closure C3:

- **ADR 0013 + ADR 0014 → Implemented & CI-green** with per-PR ship notes (#463–#471), including the honest record of the cycle's one CI failure (a test fixture colliding with the newly-taken `z` key — the conflict checker doing its job; fixture moved).
- **Consolidated CHANGELOG entry** for the engine documentation corpus (`docs/engine/`: user guide, workflows, keyboard reference, configuration, troubleshooting, development guide, 11-chapter textbook), with a transparent process note: the corpus rode into main with #470's commit via an over-broad `git add -A` rather than its own PRs; content was reviewed and brought current in #472/#473.

Docs-only — fast lane.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_