### PR TITLE
docs: Cycle 54 closure — handoff/CLAUDE.md ship blocks + checkpoint staged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16051,6 +16051,14 @@ ring) follow.
   CI-green with per-PR ship notes; `ENGINE-PHASE0.md` +
   `P0-ENGINE-1` extended to acceptance steps 10–12.
 
+### Cycle 54 closure (2026-06-12)
+
+- **Changed (docs)**: SESSION-HANDOFF + CLAUDE.md carry the
+  Cycle 54 ship block; `baseline/cycle-54-launch-readiness`
+  staged in CHECKPOINTS (tag push needs the maintainer's
+  workstation); README / ARCHITECTURE / DOC-MAP reflect the
+  engine corpus and the six new Engine.Core modules.
+
 ## [0.0.1-preview.18] — 2026-04-28
 
 First preview cut from the Stage-3b state of `main`. The window now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1084,7 +1084,16 @@ points at the cycle headline.
   `w` where-verb breadcrumb · S3 spatial signatures for
   every bus event (per-kind pitch, attention-contract stage
   layout) · S4 `Engine.Audio` stereo renderer · S5
-  attention-layer audit fixes.
+  attention-layer audit fixes. **Cycle 54 (2026-06-12,
+  #462–#475): launch-readiness shipped CI-green** — ADRs
+  0013/0014: the computational notebook (authored layer,
+  markdown export, notebook mode) · session + notebook
+  persistence (validated restore, `--resume` continuity) ·
+  engine.toml + declarative keymap + speech controls ·
+  ear-first diagnostics · exploration verbs (find /
+  structure summary / digits / rerun) · FsCheck law suites ·
+  the `docs/engine/` corpus (user guide → 11-chapter
+  textbook + development guide).
 - **Next** = **the Phase 0 LOCAL DOGFOOD on the maintainer's
   machine** — run instructions + acceptance walk in
   [`docs/ENGINE-PHASE0.md`](docs/ENGINE-PHASE0.md) (matrix row

--- a/docs/CHECKPOINTS.md
+++ b/docs/CHECKPOINTS.md
@@ -36,6 +36,8 @@ with the release workflow.
 
 | `baseline/phase-0-interaction-engine` | [#443](https://github.com/KyleKeane/pty-speak/pull/443)–[#454](https://github.com/KyleKeane/pty-speak/pull/454) | _(no release; engine runs from source — see [`docs/ENGINE-PHASE0.md`](ENGINE-PHASE0.md))_ | RELAUNCH-SPEC §13 Phase 0 ship (Cycle 53, autonomous session 2026-06-11; ADR 0011): the interaction engine's local bootstrap — `Engine.Core` (chunk-tree model, Claude CLI stream-json parser, Markdig chunker, ingest fold, instance-scoped engine bus, navigation verbs, canonical narration, attention contract, `ISpeechSink`), `Engine.Participants` (CLI runner), `Engine.Voice` (SAPI self-voicing sink), `Engine.Host` (console host). All 12 PRs first-run CI-green; chunk-tree invariants FsCheck-guarded; portability lint extended to `Engine.Core`. Maintainer dogfood (`P0-ENGINE-1`) pending — this checkpoint is the pre-dogfood code-complete state. Anchor commit is PR #454's squash (`2deae451bfa80e4706373c69b51c79f94ad2b7fa`). |
 
+| `baseline/cycle-54-launch-readiness` | [#462](https://github.com/KyleKeane/pty-speak/pull/462)–[#475](https://github.com/KyleKeane/pty-speak/pull/475) | _(no release; engine runs from source — [`docs/engine/USER-GUIDE.md`](engine/USER-GUIDE.md))_ | Cycle 54 ship (2026-06-12; ADRs 0013/0014): the audio-only computational notebook complete — authored layer + markdown export, session/notebook persistence with validated restore and `--resume` continuity, engine.toml + declarative keymap + speech controls, ear-first diagnostics, exploration verbs, FsCheck law suites, and the full `docs/engine/` corpus. The pre-dogfood launch-candidate state; `P0-ENGINE-1` steps 1–12 pending. |
+
 ## Pending checkpoint tags
 
 Tags listed in the table above that have **not yet been pushed to
@@ -50,6 +52,7 @@ stays accurate.
 
 | Tag | Push commands |
 |---|---|
+| `baseline/cycle-54-launch-readiness` | <pre>git fetch origin main<br>git tag -a baseline/cycle-54-launch-readiness \\<br>  a1ba1852f3f35363b07acc02d315894495bbfa66 \\<br>  -m "Cycle 54 ship: the audio-only computational notebook (ADRs 0013/0014) — notebook, persistence, config, keymap, diagnostics, exploration verbs, docs corpus; pre-dogfood"<br>git push origin baseline/cycle-54-launch-readiness</pre> |
 | `baseline/phase-0-interaction-engine` | <pre>git fetch origin main<br>git tag -a baseline/phase-0-interaction-engine \\<br>  2deae451bfa80e4706373c69b51c79f94ad2b7fa \\<br>  -m "Phase 0 ship: RELAUNCH-SPEC interaction-engine local bootstrap (ADR 0011) — Engine.Core/Participants/Voice/Host, CI-green, pre-dogfood"<br>git push origin baseline/phase-0-interaction-engine</pre> |
 | `baseline/stage-0-ci-release` | <pre>git fetch origin main<br>git tag -a baseline/stage-0-ci-release \\<br>  8c261b75cafffa223af07464b298621d934b4f22 \\<br>  -m "Stage 0 ship: CI + release pipeline working; v0.0.1-preview.15 shipped from this state"<br>git push origin baseline/stage-0-ci-release</pre> |
 | `baseline/stage-1-conpty-hello-world` | <pre>git fetch origin main<br>git tag -a baseline/stage-1-conpty-hello-world \\<br>  c245564469a4f8f2f920ab1ee212b2e2cceac0c3 \\<br>  -m "Stage 1 ship: Terminal.Pty library; ConPtyHost spawns cmd.exe under ConPTY"<br>git push origin baseline/stage-1-conpty-hello-world</pre> |

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -39,6 +39,30 @@ and serves the decision-trail role this file used to overload.
 > Nothing existing deleted or modified — the WPF app keeps
 > shipping; the §4.2 freeze on terminal-scraping heuristics
 > stands.
+> **2026-06-12 evening addendum — CYCLE 54 (launch-readiness)
+> SHIPPED on top (#462–#475, CI-green; one CI failure all
+> cycle, a keymap test fixture, fixed):** ADRs 0013 + 0014 —
+> the **computational notebook** (authored layer over the
+> capture tree: pin / narrative / section / reorder / remove /
+> markdown export that is provably re-ingestable; notebook
+> mode `n`), **session + notebook persistence** (schema-v1
+> JSONL, validated restore, auto-save, `o` reopens with CLI
+> `--resume` continuity), **engine.toml** (warn-and-default;
+> participant path, rate/voice, narration cap, cue gain,
+> `[keys]` rebinding), the **declarative conflict-checked
+> keymap** with generated help, **speech controls** (`+`/`-`
+> live rate; voice selection), the **ear-first diagnostics
+> path** (`d`: spoken summary + dump file; per-run event
+> log), **exploration verbs** (`f` find with wrap, `z`
+> structure summary, digits direct-address, `t`/`e`, `y`
+> rerun, hardwired Escape stop), notebook-persistence gap
+> closed, FsCheck law suites (outline/attention/ingest/
+> serde), and the docs corpus (`docs/engine/`: user guide,
+> workflows, keyboard reference, configuration,
+> troubleshooting, development guide, 11-chapter textbook).
+> `P0-ENGINE-1` now has acceptance steps 1–12 and remains
+> THE open gate.
+>
 > **2026-06-12 addendum — ADR 0012 SHIPPED on top (#456–#461,
 > CI-green):** S1 heading-scoped semantic outline at ingest
 > (top-level nav = section-to-section; descend enters a


### PR DESCRIPTION
## Summary

Docs closure C5 — the cycle-closure audit (per the CLAUDE.md discipline):

- **SESSION-HANDOFF**: the Cycle 54 ship block (everything #462–#475, the one fixed CI failure recorded honestly) sits atop the current-state section; `P0-ENGINE-1` steps 1–12 named as THE open gate.
- **CLAUDE.md** Current sequencing: the Cycle 54 line added.
- **CHECKPOINTS**: `baseline/cycle-54-launch-readiness` row + staged tag-push commands (anchor = #475's squash; tag pushes need the maintainer's workstation).
- CHANGELOG closure note.

Docs-only — fast lane. This closes the launch-readiness cycle.

https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgvtNooRPSTgFcfrXe4qE)_